### PR TITLE
Use https:// links for the SignIn and SignUp pages.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,18 @@
             <% else %>
               <ul id="signed_out">
                 <li id="all-gems"><%= link_to "all gems", rubygems_url %></li>
-                <li id="sign-in"><%= link_to "sign in", sign_in_path %></li>
-                <li id="sign-up"><%= link_to "sign up", sign_up_path %></li>
+
+                <li id="sign-in">
+                  <a href="<%= url_for :controller => 'clearance/sessions',
+                                       :action => 'sign_in',
+                                       :protocol => 'https' %>">sign in</a>
+                </li>
+
+                <li id="sign-up">
+                  <a href="<%= url_for :controller => 'clearance/users',
+                                       :action => 'sign_up',
+                                       :protocol => 'https' %>">sign up</a>
+                </li>
               </ul>
             <% end %>
           </div>


### PR DESCRIPTION
The HTML for the SignIn and SignUp pages should also be transmitted over SSL. This also ensures that the forms will submit the user's credentials over SSL as well.
