### PR TITLE
Fix errors in the atom feed

### DIFF
--- a/app/views/versions/feed.atom.builder
+++ b/app/views/versions/feed.atom.builder
@@ -13,13 +13,12 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
 
   @versions.each do |version|
     xml.entry do
-      xml.title     version.to_title
-      xml.platform  version.platform
-      xml.link      "rel" => "alternate", "href" => rubygem_url(version.rubygem, version.slug)
-      xml.id        rubygem_url(version.rubygem, :version => version.number)
+      xml.title     "#{version.to_title}#{" " + version.platform if version.platformed?}"
+      xml.link      "rel" => "alternate", "href" => rubygem_version_url(version.rubygem, version.slug)
+      xml.id        rubygem_version_url(version.rubygem, version.slug)
       xml.updated   version.created_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-      xml.author    { h(version.authors) }
-      xml.summary   h(version.summary)
+      xml.author    {|author| author.name h(version.authors) }
+      xml.summary   version.summary if version.summary?
       xml.content   "type" => "html" do
         xml.text!   h(version.description)
       end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -162,18 +162,33 @@ class RubygemsControllerTest < ActionController::TestCase
 
   context "On GET to index as an atom feed" do
     setup do
-      @versions = (1..3).map { |n| Factory(:version, :created_at => n.hours.ago) }
-      # just to make sure one has a different platform
-      @versions.last.update_attributes(:platform => "win32")
+      @versions = (1..2).map { |n| Factory(:version, :created_at => n.hours.ago) }
+      # just to make sure one has a different platform and a summary
+      @versions << Factory(:version, :created_at => 3.hours.ago, :platform => "win32", :summary => "&")
       get :index, :format => "atom"
     end
 
     should respond_with :success
     should assign_to(:versions) { @versions }
-    should "render posts with titles and platform-specific links" do
+
+    should "render posts with platform-specific titles and links of all subscribed versions" do
       @versions.each do |v|
-        assert_contain v.to_title
-        assert_have_selector "link[href='#{rubygem_url(v.rubygem, v.slug)}']"
+        assert_select "entry > title", :count => 1, :text => (v.platformed? ? "#{v.to_title} #{v.platform}" : v.to_title)
+        assert_select "entry > link[href='#{rubygem_version_url(v.rubygem, v.slug)}']", :count => 1
+        assert_select "entry > id", :count => 1, :text => rubygem_version_url(v.rubygem, v.slug)
+      end
+    end
+
+    should "render valid entry authors" do
+      @versions.each do |v|
+        assert_select "entry > author > name", :text => v.authors
+      end
+    end
+
+    should "render entry summaries only for versions with summaries" do
+      assert_select "entry > summary", :count => @versions.select {|v| v.summary? }.size
+      @versions.each do |v|
+        assert_select "entry > summary", :text => ERB::Util.h(v.summary) if v.summary?
       end
     end
   end


### PR DESCRIPTION
Originally this issue was opened
http://github.com/rubygems/gemcutter/issues/181

And this commit was merged but it did not fix the problem as outlined in the comments
http://github.com/rubygems/gemcutter/commit/985ad307024417653bc179103829ab6c89e431d6

This pull request fixes the following issues:
- Add platform in title if needed
- Fix undefined entry element: platform validation error
- Fix link url to point to the specific rubygem version (currently points to /gems/rspec?format=2.0.0)
- Fix multiple entries with the same id validation error (currently points to /gems/rspec?version=2.0.0)
- Fix missing author element: name validation error (also fixes the authors text not getting output)
- Fix summary should not be blank validation warning
- Fix double escaped version summary
