### PR TITLE
'Date since' of versions seems to be wrong

### DIFF
--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -1,6 +1,6 @@
 <% @title = "all versions of #{@rubygem.name}" %>
 <p>
-<%= @versions.size %> versions since <%= @rubygem.versions.last.built_at_date %>
+<%= @versions.size %> versions since <%= @rubygem.versions.first.built_at_date %>
 </p>
 <div class="versions">
   <ol>


### PR DESCRIPTION
Not sure if this is the right way either but when I go to any rubygems page it shows versions since <latest gem pushed> so if say the first version was April 1 and I pushed one October 10, it'd say 2 versions since October 10
