### PR TITLE
Small change to gem versions template, fixes incorrect 'X versions since [date]' text.

### DIFF
--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -1,6 +1,6 @@
 <% @title = "all versions of #{@rubygem.name}" %>
 <p>
-<%= @versions.size %> versions since <%= @rubygem.versions.last.built_at_date %>
+<%= @versions.size %> versions since <%= @rubygem.versions.first.built_at_date %>
 </p>
 <div class="versions">
   <ol>


### PR DESCRIPTION
The gems versions pages were showing text like this:

```
4 versions since October 6, 2010

0.1.4 October 6, 2010
0.1.3 August 23, 2010
0.1.2 August 20, 2010
0.1.1 August 19, 2010
```

This should say '4 versions since August 19, 2010', so I made a very small change to the template to get the first date instead of the last.
