### PR TITLE
Fix typo

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -62,10 +62,10 @@ class Pusher
     @spec = Gem::Format.from_io(body).spec
   rescue Gem::Package::FormatError
     notify("RubyGems.org cannot process this gem.\nPlease try rebuilding it" +
-           "and installing it locally to make sure it's valid.", 422)
+           " and installing it locally to make sure it's valid.", 422)
   rescue Exception => e
     notify("RubyGems.org cannot process this gem.\nPlease try rebuilding it" +
-           "and installing it locally to make sure it's valid.\n" +
+           " and installing it locally to make sure it's valid.\n" +
            "Error:\n#{e.message}\n#{e.backtrace.join("\n")}", 422)
   end
 


### PR DESCRIPTION
I got the following error message:

```
Please try rebuilding itand installing it locally to make sure it's valid.
```

Noticed the typo 'itand'. I added a space in between 'it' and 'and'.

Let me know if I am missing something.

Thanks!
Bryan
