### PR TITLE
Treat Gravatar URLs as safe HTML

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
   end
 
   def gravatar(size, id = "gravatar", user = current_user)
-    image_tag(user.gravatar_url(:size => size, :secure => request.ssl?), :id => id, :width => size, :height => size)
+    image_tag(user.gravatar_url(:size => size, :secure => request.ssl?).html_safe, :id => id, :width => size, :height => size)
   end
 
   def ssl_url_for(options = {})


### PR DESCRIPTION
This fixes invalid rating and size parameters that lead to incorrect image sizes (e.g. pixelated images) and unavailable PG-rated Gravatars.
