### PR TITLE
SimpleMarkup is html safe

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -9,7 +9,7 @@ module RubygemsHelper
 
   def simple_markup(text)
     if text =~ /^==+ [A-Z]/
-      SM::SimpleMarkup.new.convert(text, SM::ToHtml.new)
+      SM::SimpleMarkup.new.convert(text, SM::ToHtml.new).html_safe
     else
       content_tag :p, text
     end


### PR DESCRIPTION
This was obviously forgotten while during migration to Rails 3.

If we chose to render the text from plain RDoc to HTML it should be at least outputted as we rendered it and not be HTML escaped by ERB again.

For long term, it should be considered, if also other variants of Markup (Markdown, Textile, ...) should be allowed.

The current solution has the advantage that it is quite Spam-resistant because no links are generated.
