### PR TITLE
Versions api

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::VersionsController < Api::BaseController
+  before_filter :find_gem,                  :only => [:show]
+
+  def show
+    if @rubygem.hosted?
+      respond_to do |wants|
+        wants.any(:json, :all) { render :json => @rubygem.versions.by_position }
+        wants.xml  { render :xml  => @rubygem.versions.by_position }
+      end
+    else
+      render :text => "This gem does not exist.", :status => :not_found
+    end
+  end
+
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -214,4 +214,27 @@ class Version < ActiveRecord::Base
       end
     end
   end
+  
+  def payload
+    {
+      "built_at"        => built_at,
+      "number"          => number,
+      "prerelease"      => prerelease,
+      "full_name"       => full_name,
+      "authors"         => authors,
+      "description"     => description,
+      "downloads_count" => downloads_count,
+      "latest"          => latest,
+      "rubygem"         => rubygem.name,
+      "platform"        =>"ruby"
+    }
+  end
+
+  def as_json(options = {})
+    payload
+  end
+
+  def to_xml(options = {})
+    payload.to_xml(options.merge(:root => "version"))
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Gemcutter::Application.routes.draw do
         end
         constraints :rubygem_id => RUBYGEM_NAME_MATCHER do
           resource :owners, :only => [:show, :create, :destroy]
+          resource :versions, :only => [:show]
         end
       end
 

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -83,3 +83,7 @@ When 'I list the gems with my api key' do
   api_key_header
   visit api_v1_rubygems_path, :get
 end
+
+When /I list the versions of the rubygem "([^\"]*)"/ do |rubygem_name|
+  visit api_v1_rubygem_versions_path(:rubygem_id => rubygem_name), :get
+end

--- a/features/versions_api.feature
+++ b/features/versions_api.feature
@@ -1,0 +1,10 @@
+Feature: List gem versions API
+  In order to see all the versions of a specific gem
+  An API consumer
+  Should be able to fetch them
+
+    Scenario: API consumer fetches list of versions for a gem
+      Given a rubygem exists with name "MyGem" and version "1.0.0"
+      When I list the versions of the rubygem "MyGem"
+      Then I should see "MyGem-1.0.0"
+      And I should see "Some awesome gem"

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -1,0 +1,33 @@
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'test_helper')
+
+class Api::V1::VersionsControllerTest < ActionController::TestCase
+
+  context "On GET to show with json for a gem that's hosted" do
+    setup do
+      @rubygem = Factory(:rubygem)
+      Factory(:version, :rubygem => @rubygem)
+      get :show, :rubygem_id => @rubygem.to_param, :format => "json"
+    end
+
+    should assign_to(:rubygem) { @rubygem }
+    should respond_with :success
+    should "return a json hash" do
+      assert_not_nil JSON.parse(@response.body)
+    end
+  end
+
+  context "On GET to show with xml for a gem that's hosted" do
+    setup do
+      @rubygem = Factory(:rubygem)
+      Factory(:version, :rubygem => @rubygem)
+      get :show, :rubygem_id => @rubygem.to_param, :format => "xml"
+    end
+
+    should assign_to(:rubygem) { @rubygem }
+    should respond_with :success
+    should "return a json hash" do
+      assert_not_nil Nokogiri.parse(@response.body).root
+    end
+  end
+  
+end


### PR DESCRIPTION
According to Issue #200, I went ahead and implemented a versions API. I had a look at the tests available for the existing API and implemented those for the new API method accordingly.

The only method added is:

/api/v1/gems/rspec-core/versions(.json|.xml)

The json/xml representation is built from the version model via payload, similar to the other APIs.
