### PR TITLE
Date current

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -42,13 +42,13 @@ class Download
   end
 
   def self.counts_by_day_for_versions(versions, days)
-    dates = (days.days.ago.to_date...Date.today).map &:to_s
+    dates = (days.days.ago.to_date...Date.current).map &:to_s
 
     versions.inject({}) do |downloads, version|
       $redis.hmget(self.history_key(version), *dates).each_with_index do |count, idx|
         downloads["#{version.id}-#{dates[idx]}"] = count.to_i
       end
-      downloads["#{version.id}-#{Date.today}"] = self.today(version)
+      downloads["#{version.id}-#{Date.current}"] = self.today(version)
       downloads
     end
   end

--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -33,7 +33,7 @@ namespace "gemcutter:downloads" do
 
     puts "*" * 80
 
-    Dl.created_at_inside(Date.today.to_datetime, Date.today.to_datetime + 1.day).group_by(&:version_id).each do |version_id, downloads|
+    Dl.created_at_inside(Date.current.to_datetime, Date.current.to_datetime + 1.day).group_by(&:version_id).each do |version_id, downloads|
       name  = vmap[version_id].full_name
       count = downloads.size
       puts ">>> #{name}: #{count}"

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -119,9 +119,9 @@ class DownloadTest < ActiveSupport::TestCase
     Download.incr(@rubygem_1, @version_2.full_name)
 
     downloads = {
-      "#{@version_1.id}-#{2.days.ago.to_date}" => 0, "#{@version_1.id}-#{Date.yesterday}" => 1, "#{@version_1.id}-#{Date.today}" => 1,
-      "#{@version_2.id}-#{2.days.ago.to_date}" => 0, "#{@version_2.id}-#{Date.yesterday}" => 1, "#{@version_2.id}-#{Date.today}" => 1,
-      "#{@version_3.id}-#{2.days.ago.to_date}" => 0, "#{@version_3.id}-#{Date.yesterday}" => 1, "#{@version_3.id}-#{Date.today}" => 3 }
+      "#{@version_1.id}-#{2.days.ago.to_date}" => 0, "#{@version_1.id}-#{Date.yesterday}" => 1, "#{@version_1.id}-#{Date.current}" => 1,
+      "#{@version_2.id}-#{2.days.ago.to_date}" => 0, "#{@version_2.id}-#{Date.yesterday}" => 1, "#{@version_2.id}-#{Date.current}" => 1,
+      "#{@version_3.id}-#{2.days.ago.to_date}" => 0, "#{@version_3.id}-#{Date.yesterday}" => 1, "#{@version_3.id}-#{Date.current}" => 3 }
 
     assert_equal downloads, Download.counts_by_day_for_versions([@version_1, @version_2, @version_3], 2)
   end


### PR DESCRIPTION
Date.today is not aware of the configured timezone, but Date.yesterday and Fixnum#days.ago are. This can cause the tests to fail if the date in the local timezone is different to the UTC date. 

Date.today is replaced with Date.current with is aware of the configured time zone.
