### PR TITLE
Match search queries with non-consecutive words

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -27,7 +27,13 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.search(query)
-    where("versions.indexed and (upper(name) like upper(:query) or upper(versions.description) like upper(:query))", {:query => "%#{query.strip}%"}).
+    current_scope = Rubygem
+
+    query.split.each do |q|
+      current_scope = current_scope.where("versions.indexed and (upper(name) like upper(:query) or upper(versions.description) like upper(:query))", {:query => "%#{q.strip}%"})
+    end
+
+    current_scope.
     includes(:versions).
     order("rubygems.downloads desc")
   end

--- a/features/search.feature
+++ b/features/search.feature
@@ -39,6 +39,14 @@ Feature: Search
       And I press "Search"
       Then I should see "LDAP"
 
+    Scenario: Search without punctuation
+      Given a rubygem exists with a name of "sinatra-controllers"
+      And a version exists for the "sinatra-controllers" rubygem with a description of "sinatra stuff"
+      When I go to the homepage
+      And I fill in "query" with "sinatra controllers"
+      And I press "Search"
+      Then I should see "sinatra-controllers"
+
     Scenario: Exact match found
       Given a rubygem exists with a name of "paperclip"
       And a rubygem exists with a name of "foos-paperclip"

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -472,6 +472,11 @@ class RubygemTest < ActiveSupport::TestCase
       assert Rubygem.search('PIE').include?(@apple_pie)
     end
 
+    should "find rubygems with missing punctuation on #search" do
+      assert Rubygem.search('apple crisp').include?(@apple_crisp)
+      assert ! Rubygem.search('apple crisp').include?(@apple_pie)
+    end
+
     should "sort results by number of downloads, descending" do
       assert_equal [@apple_crisp, @apple_pie], Rubygem.search('apple')
     end


### PR DESCRIPTION
This fixes #280.  It also allows you to search for "activerecord mysql jdbc" to find "activerecord-jdbcmysql-adapter".
