### PR TITLE
Test suite fails with an AEST timezone

### DIFF
--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -13,8 +13,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
   should "show a nice formatted date" do
     Timecop.travel(Date.parse("2011-03-18")) do
-      version = Factory.build(:version, :built_at => DateTime.now)
-      assert_equal "March 18, 2011", nice_date_for(version.built_at)
+      assert_equal "March 18, 2011", nice_date_for(DateTime.now)
     end
   end
 


### PR DESCRIPTION
I'm based in Australia and my computer is running on an AEST timezone.

When I run the gemcutter unit tests I get the following failure:

```
1) Failure: test: RubygemsHelper should show a nice formatted date. (RubygemsHelperTest)
[test/unit/helpers/rubygems_helper_test.rb:17:in `__bind_1305962919_944077'
 test/unit/helpers/rubygems_helper_test.rb:15:in `__bind_1305962919_944077']:
<"March 18, 2011"> expected but was
<"March 17, 2011">.
```

If I switch my computer timezone to EST it passes.

I'm not sure why the test requires the use of factory girl but if I remove it, the test passes in both timezones.
