### PR TITLE
Removed redundant `handle` attr_accessible from user.rb

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ActiveRecord::Base
   include Clearance::User
   is_gravtastic :default => "retro"
 
-  attr_accessible :handle, :password_confirmation, :password, :email
-  attr_accessible :website, :location, :bio
+  attr_accessible :bio, :email, :handle, :location, :password,
+                  :password_confirmation, :website 
 
   has_many :rubygems, :through    => :ownerships,
                       :conditions => { 'ownerships.approved' => true }


### PR DESCRIPTION
In `User` model `attr_accessible` was repeated (for 2 times) for `handle`, I've fix this. 
This change didn't crash any tests or features.
