### PR TITLE
Remove Syck DefaultKey noise from gemcutter

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -50,7 +50,7 @@ class Dependency < ActiveRecord::Base
   def payload
     {
       'name'         => name,
-      'requirements' => requirements
+      'requirements' => clean_requirements
     }
   end
 
@@ -63,7 +63,11 @@ class Dependency < ActiveRecord::Base
   end
 
   def to_s
-    "#{name} #{requirements}"
+    "#{name} #{clean_requirements}"
+  end
+
+  def clean_requirements
+    requirements.sub /#<YAML::Syck::DefaultKey[^>]*>/, "="
   end
 
   private
@@ -85,7 +89,9 @@ class Dependency < ActiveRecord::Base
   end
 
   def parse_gem_dependency
-    self.requirements = gem_dependency.requirements_list.join(', ')
+    reqs = gem_dependency.requirements_list.join(', ')
+    self.requirements = reqs.sub(/#<YAML::Syck::DefaultKey[^>]*>/, "=")
+
     self.scope = gem_dependency.type.to_s
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -226,7 +226,7 @@ class Version < ActiveRecord::Base
       spec.summary     = summary
 
       dependencies.each do |dep|
-        spec.add_dependency(dep.rubygem.name, dep.requirements.split(', '))
+        spec.add_dependency(dep.rubygem.name, dep.clean_requirements.split(', '))
       end
     end
   end

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -5,7 +5,7 @@
     <% dependencies.each do |dependency| %>
       <li>
         <a href="<%= rubygem_url(dependency.rubygem) %>">
-          <strong><%= dependency.rubygem.name %></strong> <%= dependency.requirements %>
+          <strong><%= dependency.rubygem.name %></strong> <%= dependency.clean_requirements %>
         </a>
       </li>
     <% end %>


### PR DESCRIPTION
Fixes behavior as seen on: http://rubygems.org/gems/rails/versions/3.0.8.rc3

This is mitigation code. The usage of clean_requirements can be removed once the database is fixed up to remove the Syck noise from the database itself.

The code in parse_gem_dependency should stay so that no new Syck noise is introduced.
