### PR TITLE
Create smaller index files, providing an indexing boost and a massive bundler performance boost

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -98,12 +98,12 @@ class Pusher
 
   def minimize_specs(data)
     names     = Hash.new { |h,k| h[k] = k }
-    versions  = Hash.new { |h,k| h[k] = k }
+    versions  = Hash.new { |h,k| h[k] = Gem::Version.new(k) }
     platforms = Hash.new { |h,k| h[k] = k }
 
     data.each do |row|
       row[0] = names[row[0]]
-      row[1] = versions[Gem::Version.new(row[1])]
+      row[1] = versions[row[1].strip]
       row[2] = platforms[row[2]]
     end
 


### PR DESCRIPTION
Here is a bit of data, the boost to bundler is far more drastic:

```
~/.gem/specs/rubygems.org%80 % du -sh specs.4.8 
4.0M    specs.4.8
~/.gem/specs/rubygems.org%80 % time ruby -rubygems -e 'Marshal.load(File.read("specs.4.8"))'
0.99s user 0.05s system 99% cpu 1.049 total
~/.gem/specs/rubygems.org%80 % ruby ~/optimize_specs.rb 
[:old_size, 4163437]
[:new_size, 533211]
~/.gem/specs/rubygems.org%80 % du -sh specs.4.8        
524K    specs.4.8
~/.gem/specs/rubygems.org%80 % time ruby -rubygems -e 'Marshal.load(File.read("specs.4.8"))'
0.05s user 0.01s system 95% cpu 0.054 total
```

It also halves the gzip'd size of the files.
