### PR TITLE
Change the session cookie to be accessible from all subdomains and HTTPS 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,6 +6,12 @@ Gemcutter::Application.configure do
   config.active_support.deprecation = :notify
   config.serve_static_assets = $rubygems_config[:asset_cacher]
   config.i18n.fallbacks = true
+  
+  config.action_dispatch.session = {
+    :domain => ".rubygems.org",
+    :secure => true
+  }
+
 end
 
 require Rails.root.join("config", "secret") if Rails.root.join("config", "secret.rb").file?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,7 +5,7 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, :key => '_test_session'
+Rails.application.config.session_store :cookie_store, :key => '_rubygems_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
Change the session cookie to be accessible from all subdomains and HTTPS only. This lets search.rubygems.org and other sites on rubygems.org subdomains have access to the user's session cookie.
