### PR TITLE
Rescue from exception while importing local gems, closes issue #292 and #293

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -127,9 +127,12 @@ namespace :gemcutter do
       puts "Processing #{gems.size} gems..."
       gems.each do |path|
         puts "Processing #{path}"
-        cutter = Pusher.new(nil, StringIO.new(File.open(path).read))
-
-        cutter.pull_spec and cutter.find and cutter.save
+        begin
+          cutter = Pusher.new(nil, StringIO.new(File.open(path).read))
+          cutter.pull_spec and cutter.find and cutter.save
+        rescue Exception => e
+          puts "Failed processing #{path}. Reason: #{e}"
+        end
       end
     end
 


### PR DESCRIPTION
I was getting a failure while trying to import gems from one of my local gems directory. 

An exception is raised somewhere around this lines.

```
  cutter.pull_spec and cutter.find and cutter.save
```

I was going to open a issue but realized there was already two issues pointing to the same situation, and indeed as the person there mentions it is raised when calling cutter.save.

Also I noticed that such a behavior was not constant, I mean, after running the task with the same parameter consecutively, the failures will disappear for some gems and continue for other ones.
