### PR TITLE
Have api/v1/gems/just_updated return gems rather than versions

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -52,8 +52,8 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def just_updated
-    @versions = Version.just_updated(50)
-    respond_with(@versions, :yamlish => true)
+    @rubygems = Version.just_updated(50).map(&:rubygem)
+    respond_with(@rubygems, :yamlish => true)
   end
 
   private

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -386,9 +386,9 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
   def should_return_just_updated_gems(gems)
     assert_equal 3, gems.length
     gems.each {|g| assert g.is_a?(Hash) }
-    assert_equal @version_2.number, gems[0]['number']
-    assert_equal @version_3.number, gems[1]['number']
-    assert_equal @version_4.number, gems[2]['number']
+    assert_equal @rubygem_1.attributes['name'], gems[0]['name']
+    assert_equal @rubygem_2.attributes['name'], gems[1]['name']
+    assert_equal @rubygem_3.attributes['name'], gems[2]['name']
   end
 
   context "No signed in-user" do
@@ -461,7 +461,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       should "return correct XML for just_updated gems" do
         get :just_updated, :format => :xml
-        gems = Hash.from_xml(Nokogiri.parse(@response.body).to_xml)['versions']
+        gems = Hash.from_xml(Nokogiri.parse(@response.body).to_xml)['rubygems']
         should_return_just_updated_gems(gems)
       end
     end


### PR DESCRIPTION
Currently api/v1/gems/just_updated returns the 50 most recent Versions. According to the spec, it "Pulls the 50 most recently updated gems. Returns an array of the XML or JSON representation of the gems." I've updated the code to match the spec (and be useful, as the version's JSON doesn't identity the gem that has been updated).
