### PR TITLE
Remove calls to the JSON gem API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rest-client', :require => 'rest_client'
 gem 'sinatra'
 gem 'will_paginate'
 gem 'xml-simple'
-gem 'yajl-ruby', :require => 'yajl/json_gem'
+gem 'yajl-ruby', :require => 'yajl'
 
 group :development do
   gem 'rails-erd'

--- a/config/initializers/yaml_renderer.rb
+++ b/config/initializers/yaml_renderer.rb
@@ -2,6 +2,6 @@
 # strip the object type (e.g. !ruby/ActiveRecord:Rubygem) from response
 # TODO: Remove :yamlish once we know how to strip object type with to_yaml
 ActionController::Renderers.add :yaml do |obj, options|
-  data = options[:yamlish] ?  JSON.load(obj.to_json).to_yaml : obj.to_yaml
+  data = options[:yamlish] ?  Yajl.load(obj.to_json).to_yaml : obj.to_yaml
   send_data data, :type => 'text/yaml'
 end

--- a/features/step_definitions/webhook_steps.rb
+++ b/features/step_definitions/webhook_steps.rb
@@ -19,7 +19,7 @@ Then /^the webhook "([^\"]*)" should receive a POST with gem "([^\"]*)" at versi
   WebMock.assert_requested(:post, web_hook_url, :times => 1)
 
   request = WebMock::RequestRegistry.instance.requested_signatures.hash.keys.first
-  json = ActiveSupport::JSON.decode(request.body)
+  json = Yajl.load(request.body)
 
   assert_equal gem_name, json["name"]
   assert_equal version_number, json["version"]
@@ -27,7 +27,7 @@ end
 
 Then /I should see "(.*)" under "(.*)" in (json|yaml)/ do |web_hook_url, gem_name, format|
   if format == "json"
-    data = ActiveSupport::JSON.decode(page.source)
+    data = Yajl.load(page.source)
   else
     data = YAML.load(page.source)
   end

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -70,7 +70,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
   context "on GET to show" do
     should_respond_to(:json) do |body|
-      JSON.parse body
+      Yajl.load body
     end
 
     should_respond_to(:yaml, :to_sym) do |body|

--- a/test/functional/api/v1/downloads_controller_test.rb
+++ b/test/functional/api/v1/downloads_controller_test.rb
@@ -21,7 +21,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse(body)['total']
+      Yajl.load(body)['total']
     end
 
     should_respond_to(:xml) do |body|
@@ -75,7 +75,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse body
+      Yajl.load body
     end
 
     should_respond_to(:xml) do |body|
@@ -146,7 +146,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse(body)['gems']
+      Yajl.load(body)['gems']
     end
 
     should_respond_to(:yaml) do |body|
@@ -178,7 +178,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse(body)['gems']
+      Yajl.load(body)['gems']
     end
 
     should_respond_to(:yaml) do |body|

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -36,7 +36,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
   end
 
   should_respond_to :json do |body|
-    JSON.parse body
+    Yajl.load body
   end
 
   should_respond_to :yaml do |body|

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -59,7 +59,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "On GET to show" do
       should_respond_to(:json) do |body|
-        JSON.parse body
+        Yajl.load body
       end
 
       should_respond_to(:yaml) do |body|
@@ -136,7 +136,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "On GET to index" do
       should_respond_to :json do |body|
-        JSON.parse body
+        Yajl.load body
       end
 
       should_respond_to :yaml do |body|
@@ -410,7 +410,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       should "return correct JSON for latest gems" do
         get :latest, :format => :json
-        should_return_latest_gems JSON.parse(@response.body)
+        should_return_latest_gems Yajl.load(@response.body)
       end
 
       should "return correct YAML for latest gems" do
@@ -442,7 +442,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       should "return correct JSON for just_updated gems" do
         get :just_updated, :format => :json
-        should_return_just_updated_gems JSON.parse(@response.body)
+        should_return_just_updated_gems Yajl.load(@response.body)
       end
 
       should "return correct YAML for just_updated gems" do

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -39,7 +39,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse body
+      Yajl.load body
     end
 
     should_respond_to(:xml) do |body|

--- a/test/functional/api/v1/versions/downloads_controller_test.rb
+++ b/test/functional/api/v1/versions/downloads_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::Versions::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse body
+      Yajl.load body
     end
 
     should_respond_to(:yaml) do |body|
@@ -156,7 +156,7 @@ class Api::V1::Versions::DownloadsControllerTest < ActionController::TestCase
       end
 
       should_respond_to(:json) do |body|
-        JSON.parse body
+        Yajl.load body
       end
 
       should_respond_to(:yaml) do |body|

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -48,7 +48,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      JSON.parse(body)
+      Yajl.load(body)
     end
 
     should_respond_to(:xml) do |body|
@@ -84,7 +84,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "give all releases" do
       get_show(@rubygem)
-      assert_equal 12, JSON.parse(@response.body).size
+      assert_equal 12, Yajl.load(@response.body).size
     end
   end
 end

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -130,7 +130,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         end
 
         should_respond_to(:json) do |body|
-          JSON.parse body
+          Yajl.load body
         end
 
         should_respond_to(:yaml) do |body|

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -16,7 +16,7 @@ class DependencyTest < ActiveSupport::TestCase
 
     should "return JSON" do
       @dependency.save
-      json = JSON.parse(@dependency.to_json)
+      json = Yajl.load(@dependency.to_json)
 
       assert_equal %w[name requirements], json.keys.sort
       assert_equal @dependency.rubygem.name, json["name"]

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -259,7 +259,7 @@ class RubygemTest < ActiveSupport::TestCase
       run_dep = Factory(:runtime_dependency, :version => version)
       dev_dep = Factory(:development_dependency, :version => version)
 
-      hash = JSON.parse(@rubygem.to_json)
+      hash = Yajl.load(@rubygem.to_json)
 
       assert_equal @rubygem.name, hash["name"]
       assert_equal @rubygem.downloads, hash["downloads"]
@@ -270,8 +270,8 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal "http://#{HOST}/gems/#{@rubygem.name}", hash["project_uri"]
       assert_equal "http://#{HOST}/gems/#{@rubygem.versions.most_recent.full_name}.gem", hash["gem_uri"]
 
-      assert_equal JSON.parse(dev_dep.to_json), hash["dependencies"]["development"].first
-      assert_equal JSON.parse(run_dep.to_json), hash["dependencies"]["runtime"].first
+      assert_equal Yajl.load(dev_dep.to_json), hash["dependencies"]["development"].first
+      assert_equal Yajl.load(run_dep.to_json), hash["dependencies"]["runtime"].first
     end
 
     should "return a bunch of xml" do
@@ -302,7 +302,7 @@ class RubygemTest < ActiveSupport::TestCase
       end
 
       should "return a bunch of JSON" do
-        hash = JSON.parse(@rubygem.to_json)
+        hash = Yajl.load(@rubygem.to_json)
 
         assert_equal @rubygem.linkset.home, hash["homepage_uri"]
         assert_equal @rubygem.linkset.wiki, hash["wiki_uri"]

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -86,7 +86,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "only have email when boiling down to JSON" do
-      json = JSON.parse(@user.to_json)
+      json = Yajl.load(@user.to_json)
       hash = {"email" => @user.email}
       assert_equal hash, json
     end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -74,7 +74,7 @@ class WebHookTest < ActiveSupport::TestCase
       {
         'url'           => @url,
         'failure_count' => @webhook.failure_count
-      }, ActiveSupport::JSON.decode(@webhook.to_json))
+      }, Yajl.load(@webhook.to_json))
     end
 
     should "show limited attributes for to_xml" do
@@ -144,7 +144,7 @@ class WebHookTest < ActiveSupport::TestCase
     end
 
     should "have gem properties encoded in JSON" do
-      payload = ActiveSupport::JSON.decode(@job.payload)
+      payload = Yajl.load(@job.payload)
       assert_equal "foogem",    payload['name']
       assert_equal "3.2.1",     payload['version']
       assert_equal "DESC",      payload["info"]
@@ -158,7 +158,7 @@ class WebHookTest < ActiveSupport::TestCase
       new_version = Factory(:version, :number => "2.0.0", :rubygem => @rubygem)
       new_hook    = Factory(:web_hook)
       job         = WebHookJob.new(new_hook.url, 'localhost:1234', @rubygem, new_version)
-      payload     = ActiveSupport::JSON.decode(job.payload)
+      payload     = Yajl.load(job.payload)
 
       assert_equal "foogem", payload['name']
       assert_equal "2.0.0",  payload['version']


### PR DESCRIPTION
This removes all calls to JSON.parse, JSON.load and also ActiveSupport::JSON.decode since it's super slow compared to yajl-ruby.

This is what I intended the deprecation warning from yajl-ruby about the JSON gem api compatibility layer going away to be for. `#to_json` is a broken API, and we should all stop using it. I've left the existing calls to `#to_json` since ActiveSupport will handle those. The places they're used seem kinda strange (lots of `JSON.parse(obj.to_json)` kinda stuff?) so I'll leave that up to you guys to remove. We should use `Yajl.dump(obj)` instead.

Tests are green for me locally, someone else mind giving it a run?
