### PR TITLE
Clean up plaintext gem descriptions

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -11,7 +11,7 @@ module RubygemsHelper
     if text =~ /^==+ [A-Z]/
       RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new).html_safe
     else
-      content_tag :p, text
+      content_tag :p, text, :class => 'description'
     end
   end
 

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -459,6 +459,10 @@ table {
   color: #000;
 }
 
+.main .info #markup .description {
+  white-space: pre;
+}
+
 .main .info .meta .admin {
   padding-bottom: 2em;
   border-bottom: 1px solid #B4AC99;


### PR DESCRIPTION
@tenderlove pointed out (Issue #377) that non-markdown descriptions look bad. Since they're plaintext, we can mark the description paragraph as pre-formatted.
