### PR TITLE
Issue #360 - Add a link to the rubygems git repo on the download page 

### DIFF
--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -7,6 +7,7 @@
   <li><%= link_to "tgz", "http://production.cf.rubygems.org/rubygems/rubygems-#{RUBYGEMS_VERSION}.tgz" %></li>
   <li><%= link_to "zip", "http://production.cf.rubygems.org/rubygems/rubygems-#{RUBYGEMS_VERSION}.zip" %></li>
   <li><%= link_to "gem", "http://production.cf.rubygems.org/rubygems/rubygems-update-#{RUBYGEMS_VERSION}.gem" %></li>
+  <li><%= link_to "git", "http://github.com/rubygems/rubygems" %></li>
 </ol>
 <p>
 Or, to upgrade to the latest RubyGems:


### PR DESCRIPTION
This throws a link next to the zip/tar/gem links that has a link to the git repository. I figured that would be the best place to put it. 
