### PR TITLE
Timecop.freeze timezone conversion.

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -67,7 +67,6 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.monthly_dates
-    (2..31).map { |n| puts n.days.ago }
     (2..31).map { |n| n.days.ago.to_date }.reverse
   end
 


### PR DESCRIPTION
When using Timecop.freeze with DateTime.parse(Date), Timecop is adjusting for the UTC offset even when provided with a UTC date.  For instance, 11/02/2010 00:00:00 +0000 is being frozen as 11/01/2010 23:00:00 +0000.

@evanphx please review, as I want to make sure I preserved the desired behavior of your new additions.

Locally passes after repro, waiting for travis build to confirm.
