### PR TITLE
Completed #359: Added GET owners/:handle/gems to the API

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::OwnersController < Api::BaseController
   skip_before_filter :verify_authenticity_token, :only => [:create, :destroy]
-  before_filter :authenticate_with_api_key, :except => :show
-  before_filter :verify_authenticated_user, :except => :show
-  before_filter :find_rubygem
-  before_filter :verify_gem_ownership, :except => :show
-  respond_to :yaml, :xml, :json, :only => :show
+  before_filter :authenticate_with_api_key, :except => [:show, :gems]
+  before_filter :verify_authenticated_user, :except => [:show, :gems]
+  before_filter :find_rubygem, :except => :gems
+  before_filter :verify_gem_ownership, :except => [:show, :gems]
+  respond_to :yaml, :xml, :json, :only => [:show, :gems]
 
   def show
     respond_with @rubygem.owners
@@ -28,6 +28,16 @@ class Api::V1::OwnersController < Api::BaseController
       end
     else
       render :text => 'Owner could not be found.', :status => :not_found
+    end
+  end
+
+  def gems
+    user = User.find_by_handle(params[:handle])
+    if user
+      rubygems = user.rubygems.with_versions
+      respond_with rubygems, :yamlish => true
+    else
+      render :text => "Owner could not be found.", :status => :not_found
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Gemcutter::Application.routes.draw do
         get :all, :on => :collection
       end
       constraints :id => Patterns::ROUTE_PATTERN, :format => /json|xml|yaml/ do
+        get 'owners/:handle/gems(.:format)', :to => 'owners#gems', :as => 'owners_gems', :constraints => {:handle => Patterns::ROUTE_PATTERN}
+
         # In Rails 3.1, the following line can be replaced with:
         # resources :downloads, :only => :show, :format => true
         get 'downloads/:id.:format', :to => 'downloads#show', :as => 'download'

--- a/features/gems_api.feature
+++ b/features/gems_api.feature
@@ -3,6 +3,25 @@ Feature: List gems API
   A gem owner
   Should be able to list their gems
 
+  Scenario: Anonymous user lists gems for owner
+    Given the following user exists:
+      | email            | handle     |
+      | user@example.com | myhandle |
+    And the following version exists:
+      | rubygem    | number |
+      | name: AGem | 1.0.0 |
+    And the following ownership exists:
+      | rubygem    | user                    |
+      | name: AGem | email: user@example.com |
+      | name: BGem | |
+    When I list the gems for owner "myhandle"
+    Then I should see "AGem"
+    And I should not see "BGem"
+
+  Scenario: Anonymous user lists gems for unknown user
+    When I list the gems for owner "nobody"
+    Then I should see "Owner could not be found."
+
   Scenario: Gem owner user lists their gems
     Given I am signed up as "original@owner.org"
     And I have an API key for "original@owner.org/password"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -59,6 +59,10 @@ When /^I download the rubygem "([^\"]*)" version "([^\"]*)" (\d+) times?$/ do |r
   end
 end
 
+When /^I list the gems for owner "([^\"]*)"$/ do |handle|
+  visit api_v1_owners_gems_path(:handle => handle, :format => 'json')
+end
+
 When 'I request "$url"' do |url|
   visit url
 end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -58,4 +58,12 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
              :format     => "json"}
     assert_recognizes(route, :path => '/api/v1/gems/rails/owners.json', :method => :delete)
   end
+
+  should "route GET gems" do
+    route = {:controller => 'api/v1/owners',
+             :action      => 'gems',
+             :handle      => 'example',
+             :format      => 'json'}
+    assert_recognizes(route, :path => '/api/v1/owners/example/gems.json', :method => :get)
+  end
 end


### PR DESCRIPTION
Submitting this for feedback. There are two cuke features for this in the gems_api.feature as that seemed the most logical place to put it. Also included an `assert_recognizes` for the route added.

Let me know what can be improved (esp. if a few more tests might be needed).
