### PR TITLE
Fix Issue #293 and Issue #294. All credits to mirell.

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -23,7 +23,7 @@ class Indexer
   end
 
   def directory
-    fog.directories.get($rubygems_config[:s3_bucket])
+    fog.directories.get($rubygems_config[:s3_bucket]) || fog.directories.create(:key => $rubygems_config[:s3_bucket])
   end
 
   private


### PR DESCRIPTION
Fresh pulls of rubygems.org fail on `rake gemcutter:import:process ~/.rvm/gems/ruby-1.9.3-p0/cache` as describe in Issue #293 and Issue #294. 

The fix from @mirell's (4ff7fde) if applied in `app/jobs/indexer.rb` resolves this issue and allow the rake task to complete successfully.

(Also close #293 and #294 if you pull this.)
