### PR TITLE
Bundler installation instructions use single quotes as opposed to double...

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -207,7 +207,7 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    %{gem "#{rubygem.name}", "~> #{number}"}
+    %{gem '#{rubygem.name}', '~> #{number}'}
   end
 
   def to_gem_version

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -231,7 +231,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "give version with twiddle-wakka for #to_bundler" do
-      assert_equal %{gem "#{@version.rubygem.name}", "~> #{@version.to_s}"}, @version.to_bundler
+      assert_equal %{gem '#{@version.rubygem.name}', '~> #{@version.to_s}'}, @version.to_bundler
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
....

Most ruby style guides prefer single quotes over double except in cases where
interpolation or special characters (e.g. \t or \n) are needed, which likely
isn't the case for Gemfiles.

Thanks for your consideration.
