### PR TITLE
Gemfile is a better word to indicate what the following line is for.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,7 @@ en:
         mail: Mailing List
         bugs: Bug Tracker
       versions_header: Versions
-      bundler_header: Bundler
+      bundler_header: Gemfile
       show_all_versions: "Show all versions (%{count} total)"
 
   searches:


### PR DESCRIPTION
I just pushed a new gem and was looking at the gem page.

I believe that it would be less confusing to say 'Gemfile' instead of 'Bundler' so that it indicates that the user will put that line into their 'Gemfile'.
