### PR TITLE
Compatibility with redis-rb 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'pg'
 gem 'rack'
 gem 'rack-maintenance', :require => 'rack/maintenance'
 gem 'rdoc'
-gem 'redis'
+gem 'redis', "3.0.0.rc2"
 gem 'rest-client', :require => 'rest_client'
 gem 'sinatra'
 gem 'validates_formatting_of', '>= 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
-    redis (2.2.2)
+    redis (3.0.0.rc2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rr (1.0.4)
@@ -269,7 +269,7 @@ DEPENDENCIES
   rails (~> 3.2.2)
   rails-erd
   rdoc
-  redis
+  redis (= 3.0.0.rc2)
   rest-client
   rr
   rvm

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -37,7 +37,7 @@ class Download
 
   def self.most_downloaded_today(n=5)
     items = $redis.zrevrange(today_key, 0, (n-1), :with_scores => true)
-    items.in_groups_of(2).collect do |full_name, downloads|
+    items.collect do |full_name, downloads|
       version = Version.find_by_full_name(full_name)
 
       [version, downloads.to_i]
@@ -46,7 +46,7 @@ class Download
 
   def self.most_downloaded_all_time(n=5)
     items = $redis.zrevrange(ALL_KEY, 0, (n-1), :with_scores => true)
-    items.in_groups_of(2).collect do |full_name, downloads|
+    items.collect do |full_name, downloads|
       version = Version.find_by_full_name(full_name)
       [version, downloads.to_i]
     end


### PR DESCRIPTION
This locks the dependency of redis-rb, but can serve as an example what needs to be fixed for redis-rb 3.0
