### PR TITLE
Fix chart time labels

### DIFF
--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -26,7 +26,7 @@ module ChartHelper
       range = [0, max]
 
       lc.axis :y, :range => range
-      lc.axis :x, :labels => downloads_over_time_labels
+      lc.axis :x, :labels => downloads_over_time_labels(days_ago)
       lc.grid :x_step         => 100.0 / 12.0,
               :y_step         => 100.0 / 15.0,
               :length_segment => 1,
@@ -35,8 +35,8 @@ module ChartHelper
     image_tag(chart.to_url(:chf => 'bg,s,FFFFFF00'), :alt => 'title')
   end
 
-  def downloads_over_time_labels
-    [60, 40, 20, 0].map { |t| t.days.ago.to_date }
+  def downloads_over_time_labels(days_ago = 90)
+    [days_ago, days_ago*2/3, days_ago/3, 0].map { |t| t.days.ago.to_date }
   end
 
   def downloads_over_time(versions, days_ago = 90)


### PR DESCRIPTION
This pull request should fix the wrong date labels on the download charts of all gems, see issue #418. It should also reduce the chance of this bug being reintroduced with future changes of the days_ago default value.

Note that the code has only been tested separately and not in a running Rails app.
