### PR TITLE
expose platform information in web hook payload

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -121,6 +121,7 @@ class Rubygem < ActiveRecord::Base
       'downloads'         => downloads,
       'version'           => version.number,
       'version_downloads' => version.downloads_count,
+      'platform'          => version.platform,
       'authors'           => version.authors,
       'info'              => version.info,
       'project_uri'       => "http://#{host_with_port}/gems/#{name}",

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -254,6 +254,7 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal @rubygem.downloads, hash["downloads"]
       assert_equal @rubygem.versions.most_recent.number, hash["version"]
       assert_equal @rubygem.versions.most_recent.downloads_count, hash["version_downloads"]
+      assert_equal @rubygem.versions.most_recent.platform, hash["platform"]
       assert_equal @rubygem.versions.most_recent.authors, hash["authors"]
       assert_equal @rubygem.versions.most_recent.info, hash["info"]
       assert_equal "http://#{HOST}/gems/#{@rubygem.name}", hash["project_uri"]

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -147,6 +147,7 @@ class WebHookTest < ActiveSupport::TestCase
       payload = MultiJson.load(@job.payload)
       assert_equal "foogem",    payload['name']
       assert_equal "3.2.1",     payload['version']
+      assert_equal 'ruby',      payload['platform']
       assert_equal "DESC",      payload["info"]
       assert_equal "AUTHORS",   payload["authors"]
       assert_equal 42,          payload["downloads"]


### PR DESCRIPTION
Any reason not to expose platform information in the payload? Would like to get the rdoc.info webhook for doc publishing wired up, so digging into this.
