### PR TITLE
Use explicit height for clippy instead of the default, issue #433.

### DIFF
--- a/app/views/rubygems/_clippy.html.erb
+++ b/app/views/rubygems/_clippy.html.erb
@@ -9,6 +9,7 @@
   <param name="wmode" value="transparent">
   <embed src="/<%= embed %>.swf"
          width="110"
+         height="32"
          name="clippy"
          quality="high"
          allowScriptAccess="always"


### PR DESCRIPTION
The default height for the embed element appears to be 150px, which causes some hiding of info if plug-ins are not enabled. I've added an explicit height so that info below the clippy does not get hidden. I chose 32px for the height, since that was the height of the enclosing object element for the "gem install" clippy. See issue #433 for before and after pictures.
