### PR TITLE
A Rake task for updating gems' download counts

### DIFF
--- a/test/rake/gemcutter_test.rb
+++ b/test/rake/gemcutter_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class GemcutterTest < ActiveSupport::TestCase
+  setup do
+    Rake.application.rake_require "lib/tasks/gemcutter", [Rails.root.to_s]
+    Rake::Task.define_task(:environment)
+  end
+
+  def run_rake_task(task_name)
+    Rake::Task["gemcutter:#{task_name}"].reenable
+    Rake.application.invoke_task "gemcutter:#{task_name}"
+  end
+
+  context "rubygems" do
+    setup do
+      @rubygems = create_list(:rubygem_with_downloads, 3, downloads: 0)
+    end
+
+    def update_download_counts
+      run_rake_task("rubygems:update_download_counts")
+    end
+
+    should "update download counts for all gems" do
+      @rubygems.each_with_index do |rubygem, download_count|
+        $redis.incrby "downloads:rubygem:#{rubygem.name}", download_count
+      end
+
+      update_download_counts
+
+      assert_equal 0, @rubygems[0].reload["downloads"]
+      assert_equal 1, @rubygems[1].reload["downloads"]
+      assert_equal 2, @rubygems[2].reload["downloads"]
+    end
+
+    teardown do
+      @rubygems.each(&:destroy)
+    end
+  end
+end


### PR DESCRIPTION
I noticed that you don't have a task for that. I also noticed that rubygem records are updated very rarely with their number of downloads. Hopefully, now that you have this task, you can put it as a scheduled task to be run regularly (at least once a month, if it's possible).

I'm aware how big the `rubygems` table is, so I was careful about the memory. I've also written the task in a way that only 1 SQL query is executed for updating all rubygems.
