### PR TITLE
Added license information to versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pkg/
 server/
 tmp/
 tags
+.idea

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -1,4 +1,12 @@
 module RubygemsHelper
+  def formatted_licenses(license_names)
+    if license_names.blank?
+      t(".no_licenses")
+    else
+      Array(license_names).join ", "
+    end
+  end
+
   def link_to_page(text, url)
     link_to(text, url, :rel => 'nofollow') if url.present?
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -7,6 +7,8 @@ class Version < ActiveRecord::Base
   after_create     :full_nameify!
   after_save       :reorder_versions
 
+  serialize :licenses
+
   validates :number,   :format => {:with => /\A#{Gem::Version::VERSION_PATTERN}\z/}
   validates :platform, :format => {:with => Rubygem::NAME_PATTERN}
 
@@ -141,6 +143,7 @@ class Version < ActiveRecord::Base
       :authors     => spec.authors,
       :description => spec.description,
       :summary     => spec.summary,
+      :licenses    => spec.licenses,
       :built_at    => spec.date,
       :indexed     => true
     )
@@ -183,6 +186,7 @@ class Version < ActiveRecord::Base
       'summary'         => summary,
       'platform'        => platform,
       'prerelease'      => prerelease,
+      'licenses'        => licenses
     }
   end
 

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -31,7 +31,7 @@
 
       <% if @latest_version.indexed %>
         <div class="who">
-          <div class="authors">
+          <div class="authors info-item">
             <% if @latest_version.authors.present? %>
               <h5><%= t '.authors_header' %></h5>
               <p><%= @latest_version.authors %></p>
@@ -50,12 +50,16 @@
           <% end %>
 
           <% if @rubygem.owners.present? %>
-            <div class="owners">
+            <div class="owners info-item">
               <h5><%= t '.owners_header' %></h5>
               <p><%= links_to_owners(@rubygem) %></p>
             </div>
           <% end %>
 
+          <div class="licenses info-item">
+            <h5><%= t '.licenses_header' %></h5>
+            <p><%= formatted_licenses @latest_version.licenses %></p>
+          </div>
         </div>
 
         <% if @rubygem.linkset.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
       versions_header: Versions
       bundler_header: Gemfile
       show_all_versions: "Show all versions (%{count} total)"
+      licenses_header: Licenses
+      no_licenses: N/A
 
   searches:
     show:

--- a/db/migrate/20120904155203_add_license_to_versions.rb
+++ b/db/migrate/20120904155203_add_license_to_versions.rb
@@ -1,0 +1,5 @@
+class AddLicenseToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :licenses, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(:version => 20120916165331) do
     t.integer  "position"
     t.boolean  "latest"
     t.string   "full_name"
+    t.string   "licenses"
   end
 
   add_index "versions", ["built_at"], :name => "index_versions_on_built_at"

--- a/features/gems_api.feature
+++ b/features/gems_api.feature
@@ -5,15 +5,15 @@ Feature: List gems API
 
   Scenario: Anonymous user lists gems for owner
     Given the following user exists:
-      | email            | handle     |
+      | email            | handle   |
       | user@example.com | myhandle |
     And the following version exists:
       | rubygem    | number |
-      | name: AGem | 1.0.0 |
+      | name: AGem | 1.0.0  |
     And the following ownership exists:
       | rubygem    | user                    |
       | name: AGem | email: user@example.com |
-      | name: BGem | |
+      | name: BGem |                         |
     When I list the gems for owner "myhandle"
     Then I should see "AGem"
     And I should not see "BGem"
@@ -33,3 +33,10 @@ Feature: List gems API
       | name: MyGem | email: original@owner.org |
     When I list the gems with my API key
     Then I should see "MyGem"
+
+  Scenario: Gem versions include all gem version data
+    Given the following version exists:
+      | rubygem                  | number | licenses |
+      | name: testgemwithlicense | 1.0.0  | MIT      |
+    When I GET "/api/v1/versions/testgemwithlicense.json"
+    Then the JSON response should include all of the gem version metadata

--- a/features/push.feature
+++ b/features/push.feature
@@ -3,14 +3,33 @@ Feature: Push Gems
   A rubygem developer
   Should be able to push gems up to Gemcutter
 
-  Scenario: User pushes new gem
+  Scenario: User pushes new gem and sees metadata
     Given I am signed up as "email@person.com"
-    And I have a gem "RGem" with version "1.2.3"
+    And I have a gem "RGem" with version "1.2.3" and the following attributes:
+      | authors  | description  | license |
+      | John Doe | The best gem | MIT     |
     And I have an API key for "email@person.com/password"
     When I push the gem "RGem-1.2.3.gem" with my API key
     And I visit the gem page for "RGem"
     Then I should see "RGem"
     And I should see "1.2.3"
+    And I should see "John Doe"
+    And I should see "The best gem"
+    And I should see "MIT"
+
+  Scenario: User pushes new gem and sees metadata
+    Given I am signed up as "email@person.com"
+    And I have a gem "RGem" with version "1.2.3" and the following attributes:
+      | authors  | description  |
+      | John Doe | The best gem |
+    And I have an API key for "email@person.com/password"
+    When I push the gem "RGem-1.2.3.gem" with my API key
+    And I visit the gem page for "RGem"
+    Then I should see "RGem"
+    And I should see "1.2.3"
+    And I should see "John Doe"
+    And I should see "The best gem"
+    And I should see "N/A"
 
   Scenario: User pushes existing version of existing gem
     Given I am signed up as "email@person.com"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -11,6 +11,20 @@ When /^I push the fixture gem "([^\"]*)" with my API key$/ do |name|
   page.driver.post api_v1_rubygems_path, File.read(path), {"CONTENT_TYPE" => "application/octet-stream"}
 end
 
+When /^I GET "(.*?)"$/ do |url|
+  get url
+end
+
+Then /^the JSON response should include all of the gem version metadata$/ do
+  response = JSON.parse last_response.body
+
+  version = Version.first
+
+  version.payload.each do |attribute, value|
+    assert_equal value, response.first[attribute] unless attribute == "built_at"
+  end
+end
+
 When /^I push the gem "([^\"]*)" with my API key$/ do |name|
   api_key_header
   path = File.join(TEST_DIR, name)
@@ -81,3 +95,4 @@ end
 Then /the response should contain "([^"]+)"/ do |text|
   assert_match text, page.source
 end
+

--- a/features/step_definitions/gem_steps.rb
+++ b/features/step_definitions/gem_steps.rb
@@ -25,6 +25,14 @@ Given /^I have a gem "([^\"]*)" with version "([^\"]*)" and homepage "([^\"]*)"$
   build_gemspec(gemspec)
 end
 
+Given /^I have a gem "([^\"]*)" with version "([^\"]*)" and the following attributes:$/ do |name, version, table|
+  gemspec = new_gemspec(name, version, "Gemcutter", "ruby")
+  table.hashes.first.each do |key, value|
+    gemspec.send("#{key}=", value)
+  end
+  build_gemspec(gemspec)
+end
+
 Given /^I have a bad gem "([^\"]*)" with version "([^\"]*)"$/ do |name, version|
   gemspec = new_gemspec(name, version, "Bad Gem", "ruby")
   gemspec.name = eval(name)

--- a/features/support/gem_helper.rb
+++ b/features/support/gem_helper.rb
@@ -24,6 +24,7 @@ module GemHelper
       s.rubygems_version = %q{1.3.5}
       s.summary = "#{summary}"
       s.test_files = []
+      s.licenses = []
     end
 
     def gemspec.validate

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -641,17 +641,22 @@ table {
   border-bottom: 1px solid #B4AC99;
 }
 
-.main .info .meta .authors {
-  display: inline-block;
-  width: 50%;
-}
-
-.main .info .meta .owners h5 {
+.main .info .meta .info-item {
+  width: 100%;
   margin-top: 13px;
 }
 
-.main .info .meta .owners p {
+.main .info .meta .info-item:first-child {
+  margin-top: 0;
+}
+
+.main .info .meta .info-item p {
   width: 100%;
+}
+
+.main .info .meta .authors {
+  display: inline-block;
+  width: 50%;
 }
 
 .main .info .meta .owners img {

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -80,6 +80,7 @@ FactoryGirl.define do
     indexed true
     number
     platform "ruby"
+    licenses "MIT"
     rubygem
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,6 +77,7 @@ def gem_spec(opts = {})
     s.authors = ["Joe User"]
     s.description = %q{This is my awesome gem.}
     s.email = %q{joe@user.com}
+    s.licenses = %w(MIT BSD)
     s.files = [
       "README.textile",
       "Rakefile",

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -11,7 +11,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       json = @version.as_json
-      assert_equal %w[number built_at summary description authors platform prerelease downloads_count].map(&:to_s).sort, json.keys.sort
+      assert_equal %w[number built_at summary description authors platform prerelease downloads_count licenses].map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
       assert_equal @version.description, json["description"]
@@ -20,6 +20,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.platform, json["platform"]
       assert_equal @version.prerelease, json["prerelease"]
       assert_equal @version.summary, json["summary"]
+      assert_equal @version.licenses, json["licenses"]
     end
   end
 
@@ -30,7 +31,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
-      assert_equal %w[number built-at summary description authors platform prerelease downloads-count].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
+      assert_equal %w[number built-at summary description authors platform prerelease downloads-count licenses].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
       assert_equal @version.authors, xml.at_css("authors").content
       assert_equal @version.built_at.to_i, xml.at_css("built-at").content.to_time.to_i
       assert_equal @version.description, xml.at_css("description").content
@@ -39,6 +40,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.platform, xml.at_css("platform").content
       assert_equal @version.prerelease.to_s, xml.at_css("prerelease").content
       assert_equal @version.summary.to_s, xml.at_css("summary").content
+      assert_equal @version.licenses, xml.at_css("licenses").content
     end
   end
 
@@ -459,7 +461,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a Gem::Specification" do
     setup do
-      @spec    = gem_specification_from_gem_fixture('test-0.0.0')
+      @spec    = gem_spec
       @version = build(:version)
     end
 
@@ -476,10 +478,10 @@ class VersionTest < ActiveSupport::TestCase
       @version.update_attributes_from_gem_specification!(@spec)
 
       assert @version.indexed
-      assert_equal @spec.authors.join(', '), @version.authors
-      assert_equal @spec.description,        @version.description
-      assert_equal @spec.summary,            @version.summary
-      assert_equal @spec.date,               @version.built_at
+      assert_equal @spec.authors.join(', '),  @version.authors
+      assert_equal @spec.description,         @version.description
+      assert_equal @spec.summary,             @version.summary
+      assert_equal @spec.date,                @version.built_at
     end
   end
 


### PR DESCRIPTION
The license is stored in the database upon creation of a new version. It is then made visible on the web and via the API. This addresses #363.

Existing gem versions will still need to have their license information backfilled, per #422.
