### PR TITLE
Allow some failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ language: ruby
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 1.9.3
 rvm:
+  - 1.9.3-p0
   - 1.9.3
   - ruby-head
 script: bundle exec rake db:create db:migrate db:test:prepare default


### PR DESCRIPTION
Allow 1.9.3-head failures for now, but not 1.9.3-p0 since that's the
deployment version.
