### PR TITLE
Fix broken discussion link in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -95,7 +95,7 @@
           <li><%= link_to t('.footer.status'), "http://status.rubygems.org" %></li>
           <li><%= link_to t('.footer.uptime'), "http://uptime.rubygems.org" %></li>
           <li><%= link_to t('.footer.source_code'), "http://github.com/rubygems/rubygems.org" %></li>
-          <li><%= link_to t('.footer.discussion_forum'), "http://groups.google.com/group/gemcutter" %></li>
+          <li><%= link_to t('.footer.discussion_forum'), "http://groups.google.com/group/rubygems-org" %></li>
           <li><%= link_to t('.footer.statistics'), stats_url %></li>
           <li><%= link_to t('.footer.about'), page_url("about") %></li>
         </ul>


### PR DESCRIPTION
Group was renamed from Gemcutter to Rubygems.org.
