### PR TITLE
Returns 404 on /api/v1/gems#show for unknown gem with all formats types.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
         format.html do
           render :file => "public/404", :status => :not_found, :layout => false, :formats => [:html]
         end
-        format.json do
+        format.any do
           render :text => "This rubygem could not be found.", :status => :not_found
         end
       end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -403,5 +403,20 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
     end
 
+    %w[json xml yaml].each do |format|
+      context "on GET to show for an unknown gem with #{format} format" do
+        setup do
+          get :show, :id => "rials", :format => format
+        end
+
+        should "return a 404" do
+          assert_response :not_found
+        end
+
+        should "say gem could not be found" do
+          assert_equal "This rubygem could not be found.", @response.body
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #443

Proudly brought to you by:

@jfoy
@fnichol
