### PR TITLE
Fixes tests: resets current directory in gemcutter After block.

### DIFF
--- a/features/support/gemcutter.rb
+++ b/features/support/gemcutter.rb
@@ -16,5 +16,6 @@ end
 
 After do
   FileUtils.rm_rf(TEST_DIR)
+  Dir.chdir(Rails.root)
   $redis.flushdb
 end


### PR DESCRIPTION
The Before was making a temp directory and chdir'ing into it and the
After was removing the temp directory, but it never changed back
out of the (now missing) temp directory. Subsequent tests failed
in the C `getcwd` function because CWD no longer existed.

Fixed with @jaredonline. Issue on branch #463.
