### PR TITLE
Respect caching headers for api/versions.

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -3,7 +3,10 @@ class Api::V1::VersionsController < Api::BaseController
 
   def show
     if rubygem = Rubygem.find_by_name(params[:id]) and rubygem.public_versions.count.nonzero?
-      respond_with(rubygem.public_versions, :yamlish => true)
+
+      if stale?(rubygem)
+        respond_with(rubygem.public_versions, :yamlish => true)
+      end
     else
       render :text => "This rubygem could not be found.", :status => 404
     end


### PR DESCRIPTION
This implements the enhancement requested in #436. Nothing fancy, just uses the Rails API for Last-Modified/If-Modified-Since.

All tests passing, happy to update if I botched a style thing.
