### PR TITLE
Display external requirements for gem versions

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -8,6 +8,7 @@ class Version < ActiveRecord::Base
   after_save       :reorder_versions
 
   serialize :licenses
+  serialize :requirements
 
   validates :number,   :format => {:with => /\A#{Gem::Version::VERSION_PATTERN}\z/}
   validates :platform, :format => {:with => Rubygem::NAME_PATTERN}
@@ -144,6 +145,7 @@ class Version < ActiveRecord::Base
       :description => spec.description,
       :summary     => spec.summary,
       :licenses    => spec.licenses,
+      :requirements    => spec.requirements,
       :built_at    => spec.date,
       :indexed     => true
     )
@@ -186,7 +188,8 @@ class Version < ActiveRecord::Base
       'summary'         => summary,
       'platform'        => platform,
       'prerelease'      => prerelease,
-      'licenses'        => licenses
+      'licenses'        => licenses,
+      'requirements'    => requirements
     }
   end
 

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -100,6 +100,18 @@
 
       <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime } %>
       <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development } %>
+
+      <% if @latest_version.requirements.present? %>
+        <div class="dependencies requirements_dependencies">
+          <h5><%= t '.requirements_header' %></h5>
+		  <ol>
+		    <% Array(@latest_version.requirements).each do |requirement| %>
+			  <li><%= requirement %></li>
+		    <% end %>
+	  	  </ol>
+        </div>
+      <% end %>
+
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
       show_all_versions: "Show all versions (%{count} total)"
       licenses_header: Licenses
       no_licenses: N/A
+      requirements_header: Requirements
 
   searches:
     show:

--- a/db/migrate/20121220014214_add_requirements_to_versions.rb
+++ b/db/migrate/20121220014214_add_requirements_to_versions.rb
@@ -1,0 +1,9 @@
+class AddRequirementsToVersions < ActiveRecord::Migration
+  def self.up
+    add_column :versions, :requirements, :string
+  end
+
+  def self.down
+    add_column :versions, :requirements, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121124000000) do
+ActiveRecord::Schema.define(:version => 20121220014214) do
 
   create_table "announcements", :force => true do |t|
     t.text     "body"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(:version => 20121124000000) do
     t.boolean  "latest"
     t.string   "full_name"
     t.string   "licenses"
+    t.string   "requirements"
   end
 
   add_index "versions", ["built_at"], :name => "index_versions_on_built_at"

--- a/features/push.feature
+++ b/features/push.feature
@@ -6,8 +6,8 @@ Feature: Push Gems
   Scenario: User pushes new gem and sees metadata
     Given I am signed up as "email@person.com"
     And I have a gem "RGem" with version "1.2.3" and the following attributes:
-      | authors  | description  | license |
-      | John Doe | The best gem | MIT     |
+      | authors  | description  | license | requirements |
+      | John Doe | The best gem | MIT     | Opencv       |
     And I have an API key for "email@person.com/password"
     When I push the gem "RGem-1.2.3.gem" with my API key
     And I visit the gem page for "RGem"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -81,6 +81,7 @@ FactoryGirl.define do
     number
     platform "ruby"
     licenses "MIT"
+    requirements "Opencv"
     rubygem
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,6 +78,7 @@ def gem_spec(opts = {})
     s.description = %q{This is my awesome gem.}
     s.email = %q{joe@user.com}
     s.licenses = %w(MIT BSD)
+    s.requirements = %w(Opencv)
     s.files = [
       "README.textile",
       "Rakefile",

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -11,7 +11,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       json = @version.as_json
-      assert_equal %w[number built_at summary description authors platform prerelease downloads_count licenses].map(&:to_s).sort, json.keys.sort
+      assert_equal %w[number built_at summary description authors platform prerelease downloads_count licenses requirements].map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
       assert_equal @version.description, json["description"]
@@ -21,6 +21,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.prerelease, json["prerelease"]
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
+      assert_equal @version.requirements, json["requirements"]
     end
   end
 
@@ -31,7 +32,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
-      assert_equal %w[number built-at summary description authors platform prerelease downloads-count licenses].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
+      assert_equal %w[number built-at summary description authors platform prerelease downloads-count licenses requirements].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
       assert_equal @version.authors, xml.at_css("authors").content
       assert_equal @version.built_at.to_i, xml.at_css("built-at").content.to_time.to_i
       assert_equal @version.description, xml.at_css("description").content
@@ -41,6 +42,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.prerelease.to_s, xml.at_css("prerelease").content
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
+      assert_equal @version.requirements, xml.at_css("requirements").content
     end
   end
 


### PR DESCRIPTION
Displays external gem requirements in the same area as dependencies. Should close #489
