### PR TITLE
Show summary and description; always Markdown

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -17,10 +17,14 @@ module RubygemsHelper
 
   def simple_markup(text)
     if text =~ /^==+ [A-Z]/
-      RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new).html_safe
+      markup_text(text)
     else
       content_tag :p, text
     end
+  end
+
+  def markup_text(text)
+    RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new).html_safe
   end
 
   def subscribe_link(rubygem)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -135,7 +135,21 @@ class Version < ActiveRecord::Base
   end
 
   def info
-    [ description, summary, "This rubygem does not have a description or summary." ].detect(&:present?)
+    text_or_apology_for :summary, :description
+  end
+
+  def summary_or_apology
+    text_or_apology_for :summary
+  end
+
+  def description_or_apology
+    text_or_apology_for :description
+  end
+
+  def text_or_apology_for *attrs
+    apology = "This rubygem does not have a #{attrs.map(&:to_s).join ' or '}."
+    candidates = attrs.map { |e| send e } + [ apology ]
+    candidates.detect(&:present?)
   end
 
   def update_attributes_from_gem_specification!(spec)

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -8,7 +8,12 @@
 <% else %>
   <% if @latest_version.indexed %>
     <div id="markup">
-      <%= simple_markup(@latest_version.info) %>
+      <div id="gem_summary">
+        <%= markup_text(@latest_version.summary_or_apology) %>
+      </div>
+      <div id="gem_description">
+        <%= markup_text(@latest_version.description_or_apology) %>
+      </div>
     </div>
 
     <div class="border">

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -534,14 +534,16 @@ table {
   list-style: inside disc;
 }
 
+#gem_summary {
+  border-bottom: 1px solid #DAD0BD;
+}
 
 .main .info p {
   color: #5e543e;
   margin: 1.5em 36px;
 }
 
-.main .info p a:hover {
-  text-decoration: underline;
+.main .info p a:hover { text-decoration: underline;
 }
 
 .main .info .pitch {

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -244,24 +244,29 @@ class VersionTest < ActiveSupport::TestCase
     should "have description for info" do
       @version.description = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.description_or_apology
     end
 
     should "have summary for info if description does not exist" do
       @version.description = nil
       @version.summary = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.summary_or_apology
     end
 
     should "have summary for info if description is blank" do
       @version.description = ""
       @version.summary = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.summary_or_apology
     end
 
     should "have some text for info if neither summary or description exist" do
       @version.description = nil
       @version.summary = nil
-      assert_equal "This rubygem does not have a description or summary.", @version.info
+      assert_equal "This rubygem does not have a summary or description.", @version.info
+      assert_equal 'This rubygem does not have a summary.', @version.summary_or_apology
+      assert_equal 'This rubygem does not have a description.', @version.description_or_apology
     end
 
     context "when yanked" do


### PR DESCRIPTION
As a new gem author, I was pretty puzzled by the contrast between:
- The specification docs, which say: "The description should be more detailed than the summary." ( http://guides.rubygems.org/specification-reference/#summary 
- The actual output on the site, which only shows the summary if both are present.

Additionally, it seems like many people try to put line breaks in these fields, but the site just puts them all in a `<p>` unless the text happens to match the very specific regex: `/^==/`

So this patch should rectify both. I hope you like it, but if not, let's talk about the options. Thanks!
