### PR TITLE
Display summary and description

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -135,7 +135,26 @@ class Version < ActiveRecord::Base
   end
 
   def info
-    [ description, summary, "This rubygem does not have a description or summary." ].detect(&:present?)
+    text_or_apology_for :summary, :description
+  end
+
+  def summary_or_apology
+    text_or_apology_for :summary
+  end
+
+  def description_or_apology
+    desc = text_or_apology_for :description
+    if summary
+      desc.sub summary, ''
+    else
+      desc
+    end
+  end
+
+  def text_or_apology_for *attrs
+    apology = "This rubygem does not have a #{attrs.map(&:to_s).join ' or '}."
+    candidates = attrs.map { |e| send e } + [ apology ]
+    candidates.detect(&:present?)
   end
 
   def update_attributes_from_gem_specification!(spec)

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -8,7 +8,12 @@
 <% else %>
   <% if @latest_version.indexed %>
     <div id="markup">
-      <%= simple_markup(@latest_version.info) %>
+      <div id="gem_summary">
+        <%= simple_markup(@latest_version.summary_or_apology) %>
+      </div>
+      <div id="gem_description">
+        <%= simple_markup(@latest_version.description_or_apology) %>
+      </div>
     </div>
 
     <div class="border">

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -534,6 +534,9 @@ table {
   list-style: inside disc;
 }
 
+#gem_summary {
+  border-bottom: 1px solid #DAD0BD;
+}
 
 .main .info p {
   color: #5e543e;

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -244,24 +244,35 @@ class VersionTest < ActiveSupport::TestCase
     should "have description for info" do
       @version.description = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.description_or_apology
     end
 
     should "have summary for info if description does not exist" do
       @version.description = nil
       @version.summary = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.summary_or_apology
     end
 
     should "have summary for info if description is blank" do
       @version.description = ""
       @version.summary = @info
       assert_equal @info, @version.info
+      assert_equal @info, @version.summary_or_apology
+    end
+
+    should "filter out the bad habit of putting the summary in the desc" do
+      @version.description = @info + 'etc.'
+      @version.summary = @info
+      assert_equal 'etc.', @version.description_or_apology
     end
 
     should "have some text for info if neither summary or description exist" do
       @version.description = nil
       @version.summary = nil
-      assert_equal "This rubygem does not have a description or summary.", @version.info
+      assert_equal "This rubygem does not have a summary or description.", @version.info
+      assert_equal 'This rubygem does not have a summary.', @version.summary_or_apology
+      assert_equal 'This rubygem does not have a description.', @version.description_or_apology
     end
 
     context "when yanked" do


### PR DESCRIPTION
As a new gem author, I was pretty puzzled by the contrast between:
- The specification docs, which say: "The description should be more detailed than the summary." ( http://guides.rubygems.org/specification-reference/#summary 
- The actual output on the site, which only shows the summary if both are present.

This patch takes into account the reality that many authors have been working around the current `show` logic by putting what should be in the description in the summary: it removes the 'summary' match from the 'description' output.

Thanks!
