### PR TITLE
Tweak .sponsor_logo to Display in Chrome

### DIFF
--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -1023,7 +1023,7 @@ table {
   position: relative;
   width: 70px;
   height: 70px;
-  display: inline;
+  display: inline !important;
   margin-left: 7px;
   top: -30px;
 }


### PR DESCRIPTION
Added an `!inline` property to .sponsor_logo display property to help ensure
that the sponsor images display properly in Chrome.

Here's what I tried before reverting using `!important`: https://gist.github.com/7a76bac66fb032e01a7b

This is for rubygems/rubygems.org#524
