### PR TITLE
Adds Vagrant setup for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 *.sql
 *.swp
 *~
+.apt-cache
 .bundle
 .sass-cache/
+.vagrant
 _site/
 bench/
 bin/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant::Config.run do |config|
+  config.vm.host_name = "rubygems"
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.network :hostonly, "192.168.33.100"
+  config.vm.forward_port 3000, 3000
+  config.vm.customize ["modifyvm", :id, "--memory", 1024]
+  config.vm.share_folder "v-root", "/vagrant", ".", :nfs => !(ENV["OS"] =~ /windows/i)
+  if File.directory?(File.expand_path("./.apt-cache/partial/"))
+    config.vm.share_folder "apt-cache", "/var/cache/apt/archives", "./.apt-cache", :owner => "root", :group => "root"
+  end 
+  config.vm.provision :shell, :path => "script/vagrant-keep-agent-forwarding"
+  config.vm.provision :shell, :path => "script/vagrant-provision"
+end

--- a/script/vagrant-keep-agent-forwarding
+++ b/script/vagrant-keep-agent-forwarding
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Ensure that SSH_AUTH_SOCK is kept
+echo "Defaults env_keep+=\"SSH_AUTH_SOCK\"" > "/etc/sudoers.d/keep_ssh_auth_sock"
+chmod 0440 /etc/sudoers.d/keep_ssh_auth_sock

--- a/script/vagrant-provision
+++ b/script/vagrant-provision
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update > /dev/null
+apt-get -y install autoconf automake bison build-essential curl g++ git-core libc6-dev libreadline6 libreadline6-dev libsqlite3-dev libssl-dev libtool libxml2-dev libxslt-dev libyaml-dev ncurses-dev nodejs openjdk-7-jdk openjdk-7-jre-headless openssl pkg-config postgresql-9.1 postgresql-server-dev-9.1 redis-server sqlite3 subversion unzip xvfb zlib1g zlib1g-dev
+
+if [ ! -f $HOME/.postgresql_setup_done ]; then
+  # Setup vagrant and root users for PostgreSQL
+  sudo -u postgres createuser -s vagrant
+  sudo -u postgres createdb -O vagrant vagrant
+  sudo -u postgres createuser -s root
+  sudo -u postgres createdb -O root root
+
+  # Grant access to PostgreSQL for the vagrant and root users inside the Vagrant box
+  cat > "/etc/postgresql/9.1/main/pg_hba.conf" <<EOF
+  # TYPE  DATABASE        USER            ADDRESS                 METHOD
+  local   all             postgres                                peer
+  local   all             vagrant                                 ident
+  local   all             root                                    ident
+  host    all             vagrant         127.0.0.1/32            trust
+  host    all             root            127.0.0.1/32            trust
+EOF
+
+  service postgresql restart
+
+  touch $HOME/.postgresql_setup_done
+fi
+
+if [ ! -f $HOME/.redis_setup_done ]; then
+  # Setup env for the application to use Redis
+  echo 'export REDISTOGO_URL="redis://localhost:6379"' >> /etc/profile.d/redis.sh 
+  echo 'export REDISTOGO_URL="redis://localhost:6379"' >> /etc/zsh/zprofile
+  touch $HOME/.redis_setup_done
+fi
+
+# Use chruby to manage Rubies (and ruby-build to build them)
+if [ -f "/usr/local/share/chruby/chruby.sh" ]; then
+  echo 'chruby already present'
+else
+  # Download and install chruby
+  echo 'chruby not yet installed, installing now...'
+  wget -O chruby-0.3.2.tar.gz https://github.com/postmodern/chruby/archive/v0.3.2.tar.gz
+  tar -xzvf chruby-0.3.2.tar.gz
+  cd chruby-0.3.2/
+  make install
+  # Add to global profile (enabling chruby for all bash users)
+  echo '[ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ] || return' >> /etc/profile.d/chruby.sh
+  echo "source /usr/local/share/chruby/chruby.sh" >> /etc/profile.d/chruby.sh
+  # Add to global zprofile (enabling chruby for all zsh users)
+  echo "source /usr/local/share/chruby/chruby.sh" >> /etc/zsh/zprofile
+  # Install ruby-build
+  cd
+  git clone git://github.com/sstephenson/ruby-build.git
+  cd ruby-build
+  ./install.sh
+  # Use ruby-build to install MRI and JRuby
+  ruby-build 1.9.3-p374 /opt/rubies/ruby-1.9.3-p374
+  # Set ruby-1.9 as the global default for bash users
+  echo "chruby ruby-1.9" >> /etc/profile.d/chruby.sh
+  # Set ruby-1.9 as the global default for zsh users
+  echo "chruby ruby-1.9" >> /etc/zsh/zprofile
+fi
+
+cd /vagrant
+
+# Setup the bundle
+source /usr/local/share/chruby/chruby.sh 
+chruby ruby-1.9 && gem install bundler && bundle
+
+if [ ! -f config/database.yml ]; then
+  echo "Copying database.yml.example over"
+  cp config/database.yml.example config/database.yml
+
+  bundle exec rake db:create:all db:drop:all db:setup
+  bundle exec rake db:test:prepare
+fi


### PR DESCRIPTION
Vagrant setup based on the Development Setup on the wiki.

The setup contains:
- Ruby 1.9.3 managed with chruby and built with ruby-build
- PostgreSQL
- Redis

Port 3000 is forwarded to your localhost, so when running 'rails s' on
the vm you can visit http://localhost:3000 on your own machine to visit
the app.

When on Linux or Mac OS X NFS is used to share the source directory
between your machine and the Vagrant box. To use NFS the machine must
have an IP address, it is given 192.168.33.100 (also on Windows).

If you create the directory .apt-cache/partial in your source directory
the aptitude cache will be shared there between your machine and the
Vagrant box. This means you won't have to redownload all packages from
apt between box rebuilds.
