### PR TITLE
Make Sponsor Text Clickable Links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -107,29 +107,29 @@
 
             <div class="row">
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Supported by</span>
+              <li id="rubycentral" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Supported by', 'http://rubycentral.org', :title => 'Ruby Central' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/rubycentral.png', :alt => 'Ruby Central'), "http://rubycentral.org", :class => 'bottom' %>
                 </div>
               </li>
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Hosted by</span>
+              <li id="bluebox" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Hosted by', 'http://bluebox.net', :title => 'Bluebox' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/bluebox.png', :alt => 'Bluebox'), "http://bluebox.net", :class => 'bottom' %>
                 </div>
               </li>
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Designed by</span>
+              <li id="thoughtbot" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Designed by', 'http://thoughtbot.com', :title => 'Thoughtbot' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/thoughtbot.png', :alt => 'Thoughtbot'), "http://thoughtbot.com", :class => 'bottom' %>
                 </div>
               </li>
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Resolved with</span>
+              <li id="dnsimple" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Resolved with', 'http://dnsimple.com', :title => 'dnsimple' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/dnsimple.png', :alt => 'dnsimple'), "http://dnsimple.com", :class => 'bottom' %>
                 </div>
@@ -139,30 +139,29 @@
 
             <div class="row">
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Optimized by</span>
+              <li id="newrelic" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Optimized by', 'http://newrelic.com', :title => 'New Relic' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/newrelic.png', :alt => 'New Relic'), "http://newrelic.com", :class => 'bottom' %>
                 </div>
               </li>
 
-              <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Tracking by</span>
+              <li id="gauges" class="sponsor">
+                <span class="sponsor_text"><%= link_to 'Tracking by', 'http://gaug.es', :title => 'Gauges' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/gauges.png', :alt => 'Gauges'), "http://gaug.es", :class => 'bottom' %>
                 </div>
               </li>
 
               <li id="stillalive" class="sponsor">
-                <span class="sponsor_text">Monitored by</span>
-
+                <span class="sponsor_text"><%= link_to 'Monitored by', 'http://stillalive.com', :title => 'StillAlive' %></span>
                 <div class="sponsor_logo">
                   <%= link_to image_tag('sponsors/stillalive_hover.png', :alt => 'StillAlive'), "http://stillalive.com", :class => 'bottom' %>
                   <%= link_to image_tag('sponsors/stillalive.png', :alt => 'StillAlive'), "http://stillalive.com", :class => 'top' %>
                 </div>
               </li>
 
-              <li id="stillalive" class="sponsor">
+              <li id="pending_sponsor" class="sponsor">
                 <span class="sponsor_text"></span>
 
                 <div class="sponsor_logo">


### PR DESCRIPTION
Provide clickable links for sponsor text for accessibility.
Add titles to sponsor text links.
Change CSS ids of sponsor divs to reflect unique sponsor.
Remove excess white space.

Addresses comment by @hron84 on [issue #524](https://github.com/rubygems/rubygems.org/issues/524#issuecomment-13383956). /cc @dwradcliffe 
