### PR TITLE
Rename Rubygem(s) to gem(s) in pagination

### DIFF
--- a/app/views/rubygems/index.html.erb
+++ b/app/views/rubygems/index.html.erb
@@ -6,7 +6,7 @@
   </ol>
 </div>
 <p class="entries">
-  <%= page_entries_info @gems, :entry_name => 'gem' %>
+<%= page_entries_info @gems, :entry_name => 'gem', :model => 'gem' %>
 </p>
 <div class="gems border">
   <ol>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <p class="entries">
-    <%= page_entries_info(@gems, :entry_name => 'gem').html_safe %>
+  <%= page_entries_info(@gems, :entry_name => 'gem', :model => 'gem').html_safe %>
   </p>
   <% if @gems.present? %>
     <div class="gems border">

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -189,6 +189,9 @@ class RubygemsControllerTest < ActionController::TestCase
     should "display uppercase A" do
       assert page.has_content?("starting with A")
     end
+    should "display 'gems' in pagination summary" do
+      assert page.has_content?("all #{@gems.count} gems")
+    end
   end
 
   context "On GET to index as an atom feed" do

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -47,5 +47,8 @@ class SearchesControllerTest < ActionController::TestCase
       assert ! page.has_content?(@brando.name)
       assert ! page.has_selector?("a[href='#{rubygem_path(@brando)}']")
     end
+    should "display 'gems' in pagination summary" do
+      assert page.has_content?("all 2 gems")
+    end
   end
 end


### PR DESCRIPTION
In both the gem index and search, the text "Displaying all x Rubygems"
is now "Displaying all x gems". will_paginate pluralizes it when
appropriate.

Also added assertions to existing tests in the rubygems and searches
controller test cases.
