### PR TITLE
Remove "group by all columns" on Rubygem.with_one_version

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -19,9 +19,8 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.with_one_version
-    select('rubygems.*').
     joins(:versions).
-    group(column_names.map { |name| "rubygems.#{name}" }.join(', ')).
+    group('rubygems.id').
     having('COUNT(versions.id) = 1')
   end
 


### PR DESCRIPTION
Is there any reason this query is the way it is?
I made some tests and this change brings some performance improvements, let me know what you think...

Signed-off-by: João Soares jsoaresgeral@gmail.com
