### PR TITLE
Allow User handles to start with numbers.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
   before_create :generate_api_key
 
   validates_uniqueness_of :handle, :allow_nil => true
-  validates_format_of :handle, :with => /\A[A-Za-z][A-Za-z_\-0-9]*\z/, :allow_nil => true
+  validates_format_of :handle, :with => /\A[A-Za-z0-9][A-Za-z_\-0-9]*\z/, :allow_nil => true
   validates_length_of :handle, :within => 3..15, :allow_nil => true
 
   def self.authenticate(who, password)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -10,7 +10,9 @@ class UserTest < ActiveSupport::TestCase
   context "validations" do
     context "handle" do
       should allow_value("CapsLOCK").for(:handle)
-      should_not allow_value("1abcde").for(:handle)
+      should allow_value("1337807").for(:handle)
+      should_not allow_value("_abcde").for(:handle)
+      should_not allow_value("-abcde").for(:handle)
       should_not allow_value("abc^%def").for(:handle)
       should_not allow_value("abc\n<script>bad").for(:handle)
 


### PR DESCRIPTION
The regex that validates user handles disallows a starting number, dash or underscore. I aspire to give all numbered users an opportunity to be seen as equals amongst their peers, but I'm happy to continue discriminating against the underscored and dashed.
