### PR TITLE
set the ssl_ca_path for fog

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,4 +24,6 @@ Gemcutter::Application.configure do
   # }
 end
 
+Excon.defaults[:ssl_ca_path]= "/etc/ssl/certs"
+
 require Rails.root.join("config", "secret") if Rails.root.join("config", "secret.rb").file?


### PR DESCRIPTION
Background: The Indexer job was failing this morning due to certificate problems:

```
Indexer failed with Excon::Errors::SocketError: Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, or `Excon.defaults[:ssl_verify_peer] = false` (less secure).
```

I added this to an initializer and the indexer job is working again. Since it's a different value for each OS, I figured it would be better to put in the production environment only.
