### PR TITLE
Bump to 2.0.2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ HOST             = $rubygems_config[:host]
 
 # DO NOT EDIT THIS LINE DIRECTLY
 # Instead, run: bundle exec rake gemcutter:rubygems:update VERSION=[version number] RAILS_ENV=[staging|production] S3_KEY=[key] S3_SECRET=[secret]
-RUBYGEMS_VERSION = "2.0.1"
+RUBYGEMS_VERSION = "2.0.2"
 
 module Gemcutter
   class Application < Rails::Application


### PR DESCRIPTION
Looks like we need to also run the rake task to complete this upgrade:

```
rake gemcutter:rubygems:update VERSION=2.0.2 RAILS_ENV=[staging|production] S3_KEY=[key] S3_SECRET=[secret]
```
