### PR TITLE
Redirect searches with a single exact match

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,6 +4,8 @@ class SearchesController < ApplicationController
     if params[:query]
       @gems = Rubygem.search(params[:query]).with_versions.paginate(:page => params[:page])
       @exact_match = Rubygem.name_is(params[:query]).with_versions.first
+
+      redirect_to rubygem_path(@exact_match) if @gems == [@exact_match]
     end
   end
 

--- a/features/search.feature
+++ b/features/search.feature
@@ -5,14 +5,17 @@ Feature: Search
 
   Scenario Outline: Search
     Given the following versions exist:
-      | rubygem          | description  |
-      | name: LDAP       | mail stuff   |
-      | name: twitter    | social junk  |
-      | name: beer_laser | amazing beer |
+      | rubygem           | description  |
+      | name: LDAP        | mail stuff   |
+      | name: ldap-plus   | more LDAP    |
+      | name: twitter     | social junk  |
+      | name: twitter-cli | command line |
+      | name: beer_laser  | amazing beer |
     When I go to the homepage
     And I fill in "query" with "<query>"
     And I press "Search"
-    Then I should see "<result>"
+    Then I should see "search for <query>"
+    And I should see "<result>"
 
     Examples:
       | query      | result       |
@@ -32,6 +35,15 @@ Feature: Search
     Then I should not see "Exact match"
     But I should see "foos-paperclip"
 
+  Scenario: Only one exact match found
+    Given the following version exists:
+      | rubygem          | description |
+      | name: beer_laser | amazing beer |
+    When I go to the homepage
+    And I fill in "query" with "beer_laser"
+    And I press "Search"
+    Then I should be on "beer_laser" rubygem page
+
   Scenario: The only pushed version of a gem is yanked
     Given the following version exists:
       | rubygem    | number | indexed |
@@ -43,9 +55,10 @@ Feature: Search
 
   Scenario: The most recent version of a gem is yanked
     Given the following versions exist:
-      | rubygem    | number | indexed |
-      | name: RGem | 1.2.1  | true    |
-      | name: RGem | 1.2.2  | false   |
+      | rubygem     | number | indexed |
+      | name: RGem  | 1.2.1  | true    |
+      | name: RGem  | 1.2.2  | false   |
+      | name: RGem2 | 2.0.0  | true    |
     When I go to the homepage
     And I fill in "query" with "RGem"
     And I press "Search"

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -51,4 +51,15 @@ class SearchesControllerTest < ActionController::TestCase
       assert page.has_content?("all 2 gems")
     end
   end
+
+  context 'on GET to show with search parameters with a single exact match' do
+    setup do
+      @sinatra = create(:rubygem, :name => "sinatra")
+      create(:version, :rubygem => @sinatra)
+      get :show, :query => "sinatra"
+    end
+
+    should respond_with :redirect
+    should redirect_to('the gem') { rubygem_path(@sinatra) }
+  end
 end


### PR DESCRIPTION
When a search results in only a single exact match, redirect to the gem page instead of showing the search results.
