### PR TITLE
removed binstubs from repository

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby-local-exec
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'rubygems'
-load Gem.bin_path('bundler', 'bundle')

--- a/bin/cap
+++ b/bin/cap
@@ -1,3 +1,0 @@
-#!/usr/bin/env ruby-local-exec
-require_relative '../config/boot'
-load Gem.bin_path('capistrano', 'cap')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby-local-exec
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby-local-exec
-require_relative '../config/boot'
-require 'rake'
-Rake.application.run


### PR DESCRIPTION
They're listed in `.gitignore` so they shouldn't be in the repo - and they break some things if you're using rvm instead of rbenv.
