### PR TITLE
Remove unnecessary vertical logo background image repetition

### DIFF
--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -91,7 +91,8 @@ table {
   height: 51px;
   text-indent: -9999px;
   text-decoration: none;
-  background: url(/images/logo.png)
+  background: url(/images/logo.png);
+  background-repeat: no-repeat;
 }
 
 .main {


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/61983/596565/404e06f8-cba4-11e2-8625-34076b204a58.jpg)

After:
![after](https://f.cloud.github.com/assets/61983/596567/4f53aa54-cba4-11e2-9302-c28c6d315260.jpg)
