### PR TITLE
Prefer simple quotes over double quotes for Gemfile version format

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -216,7 +216,7 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    %{gem "#{rubygem.name}", "~> #{number}"}
+    %{gem '#{rubygem.name}', '~> #{number}'}
   end
 
   def to_gem_version

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -264,7 +264,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "give version with twiddle-wakka for #to_bundler" do
-      assert_equal %{gem "#{@version.rubygem.name}", "~> #{@version.to_s}"}, @version.to_bundler
+      assert_equal %{gem '#{@version.rubygem.name}', '~> #{@version.to_s}'}, @version.to_bundler
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
I always make this switch after copying and pasting from a RubyGem page.

```
  gem "hola", "~> 0.0.0"
```

to

```
  gem 'hola', '~> 0.0.0'
```

Without any interpolation or escaping, using double quotes seems unnecessary.
