### PR TITLE
Update dependencies when gem is destroyed

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -14,6 +14,10 @@ class Dependency < ActiveRecord::Base
 
   attr_accessor :gem_dependency
 
+  def self.mark_unresolved_for(rubygem)
+    where(:unresolved_name => nil, :rubygem_id => rubygem.id).update_all(:unresolved_name => rubygem.name, :rubygem_id => nil)
+  end
+
   def self.development
     where(:scope => 'development')
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -13,6 +13,7 @@ class Rubygem < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
 
   after_create :update_unresolved
+  before_destroy :mark_unresolved
 
   def self.with_versions
     where("rubygems.id IN (SELECT rubygem_id FROM versions where versions.indexed IS true)")
@@ -269,6 +270,11 @@ class Rubygem < ActiveRecord::Base
       dependency.update_resolved(self)
     end
 
+    true
+  end
+
+  def mark_unresolved
+    Dependency.mark_unresolved_for(self)
     true
   end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -150,6 +150,16 @@ class RubygemTest < ActiveSupport::TestCase
         assert_equal versions.count, versions.uniq.count
       end
     end
+
+    should "update references in dependencies when destroyed" do
+      dependency = create(:dependency, :rubygem => @rubygem)
+
+      @rubygem.destroy
+
+      dependency.reload
+      assert_nil dependency.rubygem_id
+      assert_equal dependency.unresolved_name, @rubygem.name
+    end
   end
 
   context ".reverse_dependencies" do


### PR DESCRIPTION
This code makes sure `Dependency` records get the `unresolved_name` set when a `Rubygem` that they are referencing is destroyed.

Will hopefully help with preventing issues like #574.
I did not find any calls to `Rubygem#destroy` in the code, but I think it makes sense to have a complete destruction routine in place.
