### PR TITLE
Fix HTML markup in dependencies partial

### DIFF
--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -3,15 +3,15 @@
     <h5><%= t '.header', :title => dependencies.first.scope.titleize %></h5>
     <ol>
     <% dependencies.each do |dependency| %>
-      <% if rubygem = dependency.rubygem %>
       <li>
-        <a href="<%= rubygem_url(rubygem) %>">
-          <strong><%= rubygem.name %></strong> <%= dependency.clean_requirements %>
-        </a>
-        </li>
-      <% elsif name = dependency.unresolved_name %>
-        <strong><%= name %></strong> <%= dependency.clean_requirements %>
-      <% end %>
+        <% if rubygem = dependency.rubygem %>
+          <%= link_to rubygem_path(rubygem) do %>
+            <strong><%= rubygem.name %></strong> <%= dependency.clean_requirements %>
+          <% end %>
+        <% else %>
+          <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>
+        <% end %>
+      </li>
     <% end %>
     </ol>
   </div>

--- a/features/push.feature
+++ b/features/push.feature
@@ -75,6 +75,17 @@ Feature: Push Gems
     When I push the gem "badauthors-1.0.0.gem" with my API key
     Then I should see "Authors must be an Array of Strings"
 
+  Scenario: User pushes gem with a runtime dependency
+    Given I am signed up as "email@person.com"
+    And I have an API key for "email@person.com/password"
+    And I have a gem "knowndeps" with version "1.0.0" and runtime dependency "knowngem"
+    And a rubygem exists with name "knowngem" and version "0.0.0"
+    When I push the gem "knowndeps-1.0.0.gem" with my API key
+    And I visit the gem page for "knowndeps"
+    Then I should see "knowndeps"
+    And I should see "1.0.0"
+    And I should see "knowngem" as a runtime dependency
+
   Scenario: User pushes gem with unknown runtime dependency
     Given I am signed up as "email@person.com"
     And I have an API key for "email@person.com/password"
@@ -83,6 +94,7 @@ Feature: Push Gems
     And I visit the gem page for "unkdeps"
     Then I should see "unkdeps"
     And I should see "1.0.0"
+    And I should see "unknown" as a runtime dependency
 
   @wip
   Scenario: User pushes gem with missing :rubygems_version, :specification_version, :name, :version, :date, :summary, :require_paths

--- a/features/step_definitions/view_steps.rb
+++ b/features/step_definitions/view_steps.rb
@@ -16,6 +16,12 @@ Then /^I should see the version "([^\"]*)" featured$/ do |version_number|
   assert page.has_css?("h3:contains('#{version_number}')")
 end
 
+Then /^I should see "([^\"]*)" as a (\w+) dependency$/ do |dependency_name, dependency_scope|
+  page.within "##{dependency_scope}_dependencies li" do
+    assert page.has_content?(dependency_name)
+  end
+end
+
 Then /^I should see the following dependencies for "([^"]*)":$/ do |full_name, table|
   version = Version.find_by_full_name!(full_name)
 


### PR DESCRIPTION
Noticed `<li>` tag was not added for unresolved dependencies.

Also added a test scenario for pushing a gem with a dependency on an existing gem.
