### PR TITLE
Stringify platform sent to bundler webhook

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -82,7 +82,7 @@ class Pusher
     json = {
       "name"           => spec.name,
       "version"        => spec.version.to_s,
-      "platform"       => spec.platform,
+      "platform"       => spec.platform.to_s,
       "prerelease"     => !!spec.version.prerelease?,
       "rubygems_token" => @bundler_token
     }.to_json

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -112,6 +112,8 @@ class PusherTest < ActiveSupport::TestCase
     should "post info to the remote bundler API" do
       @cutter.pull_spec
 
+      stub(@cutter.spec).platform { Gem::Platform.new("x86-java1.6") }
+
       @cutter.bundler_api_url = "http://test.com"
 
       obj = Object.new
@@ -127,7 +129,7 @@ class PusherTest < ActiveSupport::TestCase
 
       assert_equal "test",  params["name"]
       assert_equal "0.0.0", params["version"]
-      assert_equal "ruby",  params["platform"]
+      assert_equal "x86-java-1.6", params["platform"]
       assert_equal false,   params["prerelease"]
     end
 


### PR DESCRIPTION
This addresses bundler/bundler-api#35 and bundler/bundler-api#36

The payload used to be [an interpolated string](https://github.com/rubygems/rubygems.org/commit/0739e08#L0L71). Several months ago it was converted to a Hash and `#to_json`'d. This creates the following payload:

```
{
  "name"=>"kafka-jars",
  "version"=>"0.8.0.pre1",
  "platform"=>{
    "cpu"=>nil,
    "os"=>"java",
    "version"=>nil
  },
  "prerelease"=>true,
  "rubygems_token"=>"tokenmeaway"
} 
```

With this patch, the payload is now corrected:

```
{
  "name"=>"kafka-jars",
  "version"=>"0.8.0.pre1",
  "platform"=>'java',
  "prerelease"=>true,
  "rubygems_token"=>"tokenmeaway"
} 
```
