### PR TITLE
Fix overlap of gem count over info by reducing 'download'  font size

### DIFF
--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -146,7 +146,7 @@ table {
 }
 
 .main .fold .count strong {
-  font-size: 2em;
+  font-size: 1.9em;
   padding-bottom: 5px;
   display: block;
 }


### PR DESCRIPTION
in the home page "of 60,827 gems cut since July 2009" is over lapping the box under it, so font size of 'downloads' is reduced in  .main .fold .count strong  to fix the bug
