### PR TITLE
Allow client side javascript to access rubygems API show action

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,6 @@
 class Api::BaseController < ApplicationController
   skip_before_filter :require_ssl
+  before_filter :enable_cross_origin_resource_sharing
 
   private
 
@@ -13,5 +14,10 @@ class Api::BaseController < ApplicationController
         :status => :bad_request
       false
     end
+  end
+
+  def enable_cross_origin_resource_sharing
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Request-Method'] = 'GET'
   end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -68,6 +68,13 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       should_respond_to(:xml) do |body|
         Hash.from_xml(Nokogiri.parse(body).to_xml)
       end
+
+      should "allow cross origin resource sharing" do
+        @rubygem = create(:rubygem)
+        get :show, :id => @rubygem.to_param, :format => :json
+        assert_equal @response.headers['Access-Control-Allow-Origin'], '*'
+        assert_equal @response.headers['Access-Control-Request-Method'], 'GET'
+      end
     end
 
     context "On GET to show for a gem that not hosted" do


### PR DESCRIPTION
When creating a new gem, I find myself wanting to know if there's already a gem with that name. I wrote a really basic page that uses client side JS to make a call to the rubygems api. It's really small and fast since it's pretty much just that javascript.

The only issue is that rubygems.org doesn't allow this kind of access. This pull request sets headers to allow client side javascript to access the rubygems show action.

You can check out the page I made at http://johncolvin.github.io/isthereagemnamed/. (I'm going to make it look much nicer)

Let me know what you think and thanks for all your work on rubygems!