### PR TITLE
Update gemcutter:import:process rake task to call Pusher#process

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -18,7 +18,7 @@ namespace :gemcutter do
         puts "Processing #{path}"
         cutter = Pusher.new(nil, File.open(path))
 
-        cutter.pull_spec and cutter.size_gem and cutter.find and cutter.save
+        cutter.process
       end
     end
   end


### PR DESCRIPTION
The task is currently out of sync with the Pusher class. Pusher#size_gem was removed [here](https://github.com/rubygems/rubygems.org/commit/ebbc2b629fa66ecee35a8a48a19a194d7059959b).
