### PR TITLE
Show full dependency tree for Versions (ported from gemlou.pe)

### DIFF
--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -1,0 +1,129 @@
+class Tree < ActiveRecord::Base
+
+  belongs_to :version
+
+  def tmpdir
+    "/tmp/#{self.id}"
+  end
+
+  def create_tmpdir
+    FileUtils.mkdir_p tmpdir
+  end
+
+  def name
+    version.rubygem.name
+  end
+
+  def number
+    version.number
+  end
+
+  def gemfile_string
+    %[source 'https://rubygems.org'\ngem '#{name}', '#{number}']
+  end
+
+  def gemfile_path
+    "#{tmpdir}/Gemfile"
+  end
+
+  def data_path
+    "#{tmpdir}/data.json"
+  end
+
+  def write_gemfile
+    create_tmpdir
+    File.open(gemfile_path, 'w') {|f| f.write(gemfile_string) }
+  end
+
+  def set_tree_data
+    self.tree_data = translate_specs.to_json
+  end
+
+  # This method shells out to a simple script to bust
+  # out of the bundler jail that is imposed by runing
+  # inside of the main rails app.
+  def capture_specs
+    Bundler.with_clean_env do
+      command = "#{Rails.root}/script/capture_specs.rb"
+      system command
+    end
+    self.data = File.open(data_path).read
+  end
+
+  
+  def prep_data
+    write_gemfile
+    current_dir = Dir.pwd
+    Dir.chdir tmpdir
+    
+    self.capture_specs
+    self.set_tree_data
+    self.state = 'ready'
+    self.save
+
+  rescue Errno::ENOENT => e
+    # This happens if bundler is unable to resolve.
+    # This should buble up for error reporting.
+    # Maybe it should be queued for retry?
+    self.state = "error"
+    self.save
+    raise e
+  ensure
+    cleanup
+    Dir.chdir current_dir
+  end
+
+  def data_json
+    JSON(data)
+  end
+
+  def keyed_specs
+    specs = {}
+    data_json.each do |d|
+      specs[d['name']] = d
+    end
+    specs
+  end
+
+  def translate_specs
+    weights = {:runtime => [],:development => []}
+    tree = build_tree(self.name,self.number,'',keyed_specs,weights)
+    self.runtime_weight = weights[:runtime].uniq.size
+    self.development_weight = weights[:development].uniq.size
+    tree
+  end
+
+  def build_tree(gem_name,requirement,type,spec_data,weights,already_included = [])
+    data = {
+      :name => gem_name,
+      :requirement => requirement,
+      :type => type,
+      :version => nil
+    }
+    unless type.blank?
+      weights[type.to_sym].push gem_name
+    end
+    spec = spec_data[gem_name]
+    if spec.nil?
+      # This happens for development deps of dependent gems.
+      # Since they wouldn't show up in Gemfile.lock for the 
+      # single gem, we don't care about them.
+      return data
+    end
+    data[:version] = spec['version']
+    already_included << gem_name
+    children = []
+    spec['dependencies'].each do |dep|
+      next if already_included.include? dep['name']
+      #next if dep['type'] == 'development'
+      children.push build_tree(dep['name'],dep['requirement'],dep['type'],spec_data,weights,already_included)
+    end
+    data[:children] = children
+    data
+  end
+
+  def cleanup
+    FileUtils.rm_r tmpdir
+  end
+
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,6 +1,7 @@
 class Version < ActiveRecord::Base
   belongs_to :rubygem
   has_many :dependencies, :order => 'rubygems.name ASC', :include => :rubygem, :dependent => :destroy
+  has_one :tree
 
   before_save      :update_prerelease
   after_validation :join_authors
@@ -248,6 +249,11 @@ class Version < ActiveRecord::Base
     command << " -v #{number}" if latest != self
     command << " --pre" if prerelease
     command
+  end
+
+  def prep_tree
+    tree = self.create_tree!
+    tree.prep_data
   end
 
   private

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -100,6 +100,7 @@
       </div>
     <% end %>
 
+      
       <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime } %>
       <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development } %>
 
@@ -113,6 +114,8 @@
 	  	  </ol>
         </div>
       <% end %>
+
+      <%= render :partial => "trees/tree", :locals => { :tree => @latest_version.tree } %>
 
     </div>
   </div>

--- a/app/views/trees/_tree.html.erb
+++ b/app/views/trees/_tree.html.erb
@@ -1,0 +1,9 @@
+<% if tree && tree.tree_data.present? %>
+<div class="depTree runtime">
+  <h5>Dependency Tree</h5>
+  <label><%= check_box_tag "dep_check", "runtime", true %>Only runtime dependencies</label>
+  <ul>
+    <%= render :partial => "trees/tree_node", :locals => { :node => JSON(tree.tree_data) } %>
+  </ul>
+</div>
+<% end %>

--- a/app/views/trees/_tree_node.html.erb
+++ b/app/views/trees/_tree_node.html.erb
@@ -1,0 +1,18 @@
+<li class="<%= node["type"] %>">
+<strong><%= link_to node["name"], "/gems/#{node["name"]}" %> </strong> 
+
+  <% if node["version"] %>
+    <%= link_to node["version"], "/gems/#{node["name"]}/versions/#{node["version"]}" %>
+  <% end %>
+  
+  <% if node["requirement"]  %>
+    (req <%= node["requirement"] %>)
+  <% end %>
+  <% if node["children"] && node["children"].any? %>
+    <ul>
+      <% node["children"].each do |child| %>
+        <%= render :partial => "trees/tree_node", :locals => { :node => child } %>
+      <% end %>
+    </ul>
+  <% end %>
+</li>

--- a/db/migrate/20130904203129_create_trees.rb
+++ b/db/migrate/20130904203129_create_trees.rb
@@ -1,0 +1,16 @@
+class CreateTrees < ActiveRecord::Migration
+  def change
+    create_table :trees do |t|
+      t.integer :version_id
+      t.string :state
+      t.integer :runtime_weight
+      t.integer :development_weight
+      t.text :data
+      t.text :tree_data
+
+      t.timestamps
+    end
+
+    add_index :trees, :version_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130829225823) do
+ActiveRecord::Schema.define(:version => 20130904203129) do
 
   create_table "announcements", :force => true do |t|
     t.text     "body"
@@ -96,6 +96,19 @@ ActiveRecord::Schema.define(:version => 20130829225823) do
 
   add_index "subscriptions", ["rubygem_id"], :name => "index_subscriptions_on_rubygem_id"
   add_index "subscriptions", ["user_id"], :name => "index_subscriptions_on_user_id"
+
+  create_table "trees", :force => true do |t|
+    t.integer  "version_id"
+    t.string   "state"
+    t.integer  "runtime_weight"
+    t.integer  "development_weight"
+    t.text     "data"
+    t.text     "tree_data"
+    t.datetime "created_at",         :null => false
+    t.datetime "updated_at",         :null => false
+  end
+
+  add_index "trees", ["version_id"], :name => "index_trees_on_version_id"
 
   create_table "users", :force => true do |t|
     t.string   "email"

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -2,4 +2,8 @@ $(document).ready(function() {
   $('#version_for_stats').change(function() {
     window.location.href = $(this).val();
   });
+
+  $('#dep_check').change(function(){
+    $(this).parents('.depTree').toggleClass('runtime');
+  });
 });

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -1731,3 +1731,45 @@ h5#downloads {
   font-weight: bold;
   padding-left: 24px;
 }
+
+/* Dependency Tree */
+
+.main .info .depTree ul{
+  padding:0px;
+  margin:0px;
+}
+
+.main .info .depTree ul li{
+  border:1px solid #cbc2ae;
+  margin:0px;
+  padding:4px;
+  margin:4px 0 0 0;
+}
+
+.main .info .depTree h5{
+  margin-bottom:1em;
+}
+
+.main .info .depTree label{
+  font-size:12px;
+}
+
+.main .info .depTree ul li{
+  font-size:12px;
+}
+
+.main .info .depTree ul li:hover{
+  background: rgba(193,184,164,0.2);
+  #background: rgba(52,5,5,0.1);
+  border:1px solid #340505;
+}
+
+.main .info .depTree ul li.development,
+.main .info .depTree ul li.development a{
+  color:#787878;
+}
+
+.main .info .depTree.runtime ul li.development{
+  display:none;
+}
+

--- a/script/capture_specs.rb
+++ b/script/capture_specs.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+# This script is used by the Tree model to capture
+# the dependency tree for a Version.  This script is used to
+# allow Bundler to run outside of the context of the Rails app
+# so that we can get a clean gemset.
+
+require 'rubygems'
+require 'bundler'
+require 'json'
+
+definition = Bundler.definition(true)
+specs = definition.resolve_remotely!
+
+data = []
+
+specs.each do |spec|
+  data << {
+    :name => spec.name,
+    :version => spec.version,
+    :dependencies => spec.dependencies.map do |dep|
+      #spec = dep.to_spec
+      {
+        :name => dep.name,
+        :requirement => dep.requirement,
+        :type => dep.type
+      }
+    end
+  }
+end
+
+File.open('data.json', 'w') {|f| f.write(data.to_json) }
+
+#puts "capture_specs : specs.length = #{specs.length}"

--- a/test/unit/tree_test.rb
+++ b/test/unit/tree_test.rb
@@ -1,0 +1,133 @@
+require 'test_helper'
+
+class TreeTest < ActiveSupport::TestCase
+  
+  setup do
+    @rubygem = create(:rubygem, :name => "phocoder-rb")
+    @version = create(:version, :rubygem => @rubygem, :number => "0.1.7")
+    @tree = Tree.create! :version => @version
+    
+    @data_json = [
+        {"name"=>"i18n",
+        "version"=>"0.6.1",
+        "dependencies"=>
+         [{"name"=>"activesupport",
+           "requirement"=>"~> 3.0.0",
+           "type"=>"development"},
+          {"name"=>"sqlite3", "requirement"=>">= 0", "type"=>"development"},
+          {"name"=>"mocha", "requirement"=>">= 0", "type"=>"development"},
+          {"name"=>"test_declarative",
+           "requirement"=>">= 0",
+           "type"=>"development"}]},
+       {"name"=>"multi_json",
+        "version"=>"1.6.1",
+        "dependencies"=>
+         [{"name"=>"bundler", "requirement"=>"~> 1.0", "type"=>"development"}]},
+       {"name"=>"activesupport",
+        "version"=>"3.2.12",
+        "dependencies"=>
+         [{"name"=>"i18n", "requirement"=>"~> 0.6", "type"=>"runtime"},
+          {"name"=>"multi_json", "requirement"=>"~> 1.0", "type"=>"runtime"}]},
+       {"name"=>"builder", "version"=>"3.1.4", "dependencies"=>[]},
+       {"name"=>"phocoder-rb",
+        "version"=>"0.1.7",
+        "dependencies"=>
+         [{"name"=>"activesupport", "requirement"=>"> 3.0.0", "type"=>"runtime"},
+          {"name"=>"i18n", "requirement"=>">= 0", "type"=>"runtime"},
+          {"name"=>"builder", "requirement"=>">= 0", "type"=>"runtime"}]},
+       {"name"=>"bundler",
+        "version"=>"1.3.0.pre.5",
+        "dependencies"=>
+         [{"name"=>"ronn", "requirement"=>">= 0", "type"=>"development"},
+          {"name"=>"rspec", "requirement"=>"~> 2.11", "type"=>"development"}]}
+      ].to_json
+  end
+
+  context "tmpdir" do
+    should "== /tmp/@tree.id" do
+      assert_equal "/tmp/#{@tree.id}", @tree.tmpdir
+    end
+  end
+
+  context "create_tmpdir" do
+    should "create a directory at /tmp/test_id" do
+      tmpdir = "/tmp/#{@tree.id}"
+      assert !File.exists?(tmpdir)
+      @tree.create_tmpdir
+      assert File.exists?(tmpdir)
+      FileUtils.rm_r(tmpdir)
+    end
+  end
+
+
+  context "gemfile_string" do
+    should "produce a valid string" do
+      assert_equal %[source 'https://rubygems.org'\ngem '#{@version.rubygem.name}', '#{@version.number}'], @tree.gemfile_string
+    end
+  end
+
+  context "gemfile_path" do
+    should "== /tmp/@test.id/Gemfile" do
+      assert_equal "/tmp/#{@tree.id}/Gemfile", @tree.gemfile_path
+    end
+  end
+
+  context "write_gemfile" do
+    should "write a valid Gemfile" do
+      assert !File.exists?(@tree.gemfile_path)
+      @tree.write_gemfile
+      assert File.exists?(@tree.gemfile_path)
+      assert_equal File.open(@tree.gemfile_path).read, @tree.gemfile_string
+      FileUtils.rm_r(@tree.tmpdir)
+    end
+  end
+
+  # NOTE : This test actually shells out and runs 'bundle install'
+  # It will fail if there are network troubles or if rubygems.org is down.
+  # Yes, it's kinda weird...
+  context "prep_data" do
+    should "return true and set the data attribute with some JSON" do
+      success = @tree.prep_data
+      assert success
+
+      data = JSON(@tree.data)
+      assert_equal 10, data.length
+    end
+  end
+
+  context "keyed_specs" do
+    setup do
+      @tree.data = @data_json
+    end
+    should "return a hash" do
+      keyed_specs = @tree.keyed_specs
+      assert_not_nil keyed_specs
+      assert keyed_specs.is_a?(Hash)
+      assert keyed_specs['phocoder-rb'].is_a?(Hash)
+    end
+  end
+
+  context "translate_specs" do
+
+    setup do
+      @tree.data = @data_json
+    end
+
+    should "return the dependency list massaged into a tree" do
+      tree_data = @tree.translate_specs
+      assert_not_nil tree_data
+    end
+
+    should "set the runtime_weight" do
+      @tree.translate_specs
+      assert_equal 4, @tree.runtime_weight
+    end
+
+    should "set the development_weight" do
+      @tree.translate_specs
+      assert_equal 6, @tree.development_weight
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR contains the initial port of the gemlou.pe dependency tree functionality into rubygems.org.  It's meant to be a starting point for discussion of this feature.  Questions/suggestions/criticisms are welcome.
### Background

At RailsConf I gave a lightning talk about my GemLoupe project (https://www.gemlou.pe/), which allows you to see the full dependency tree (not just direct dependencies) of any gem on rubygems.org.  @qrush asked if I'd be interested in porting the dependency tree feature directly into rubygems.org.  (Sorry for the delay, Nick.)
### Approach

To calculate the full dependency tree for a `Version` I'm writing a very simple `Gemfile` containing one gem into a tmp directory then shelling out to a simple script that runs Bundler and resolves the dependencies for that gem.  I had to resort to shelling out to get outside of the Bundler context that is already in place inside the running app.

Part of the delay in submitting this PR is that I had looked into trying to resolve the dep tree entirely within the rubygems.org application (without Bundler, using the DB data), but then realized that I would need to duplicate much of the resolver functionality that is built into Bundler.  I finally decided that it was better to port in the functionality that I already had working in GemLoupe and get some feedback from everyone about the merits of the current approach.  It does introduce a weird circular dependency from rubygems.org -> Bundler -> rubygems.org, but it also means that if the Bundler resolver method changed in the future (however unlikely) the trees calculated for rubygems.org would automatically be up to date.

I'd love to hear any thoughts that anybody has about this approach.
### See it in action

After checking out this branch you can run something like this in a console to prepare the dependency tree for a given version.

``` ruby
version = Version.find(xxx)
version.prep_tree
```

Then when you visit the page for that version you should see something like this:

![Dependency Tree Example](http://production.octolabs.com.s3.amazonaws.com/uploads/10/Screen_Shot_2013-09-05_at_1.39.29_PM.png)
### Issues

Currently I'm storing the dependency tree information as JSON in a `text` column.  Some trees can get very large (Rails for instance), so I'm not sure if this is the best way to go.

I don't have everything wired up to automatically generate a tree when a new version is pushed.  I think it should probably be handled asynchronously in a `DelayedJob`.  Maybe queued up in the `after_write` method of `Pusher`?

The visual style of the dep tree could certainly use some work.  I'm no designer, so I'd love to get someone with a better eye to take a look at that.  My goal was to make it easy to see where the big "heavy" gems are in a tree. 
