### PR TITLE
Comment out Gittip link on gem pages

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -25,7 +25,11 @@
     <div class="meta">
       <div class="admin">
         <%= link_to t('edit'), edit_rubygem_path(@rubygem), :id => "edit" if @rubygem.owned_by?(current_user) %>
+        <!-- 
+          Not ready yet on the Gittip side! :-(
+          https://github.com/gittip/www.gittip.com/issues/1591
         <%= gittip_link(@rubygem) if @rubygem.gittip_enabled? %>
+        -->
         <%= download_link(@latest_version) %>
         <%= documentation_link(@latest_version, @rubygem.linkset) %>
         <%= badge_link(@rubygem) %>


### PR DESCRIPTION
We don't yet have the landing pages on the Gittip side needed to support
the level of indirection to show Gittip accounts associated with a Ruby
gem:

```
https://github.com/gittip/www.gittip.com/issues/1591
```

This comments out the link from gem pages for now. The link from
profile pages on Rubygems to Gittip is fine.
