### PR TITLE
Switch password strategy to BCryptMigrationFromSHA1

### DIFF
--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -2,6 +2,6 @@ unless Rails.env.maintenance?
   Clearance.configure do |config|
     config.mailer_sender = "donotreply@rubygems.org"
     config.secure_cookie = true
-    config.password_strategy = Clearance::PasswordStrategies::SHA1
+    config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
   end
 end


### PR DESCRIPTION
Although there are many ways in which we'd like to be more resilient to a compromise of rubygems.org, this pull request addresses one of the low hanging fruit: we should be using bcrypt instead of SHA1 for hashing passwords. This idea has been considered at least since 589fafc5f99f00e30698f015a8cce5bc35785e02

In case anyone is wondering about whether this will slow down tests, the answer is no: clearance has already thought of that: https://github.com/thoughtbot/clearance/pull/272
