### PR TITLE
Proof of concept implementation of The Update Framework (TUF).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tmp/
 tags
 .idea
 chef
+config/root.txt
+config/keys
+config/tuf

--- a/README.md
+++ b/README.md
@@ -25,6 +25,61 @@ The Ruby community's gem host.
 [code climate]: https://codeclimate.com/github/rubygems/rubygems.org
 [trello board]: https://trello.com/board/rubygems-org/513f9634a7ed906115000755
 
+## TUF
+
+The Update Framework (TUF) is used on top of the Rubygems file structure to
+provide defence against a number of different attacks.
+
+### Development
+
+Bootstrap a TUF environment with default keys.
+
+    export PATH=script/tuf:$PATH
+    tuf-dev-bootstrap config/keys config/tuf
+
+After running the server and `rake jobs:work`, upload a new gem:
+
+    RUBYGEMS_HOST=http://localhost:3000 gem push yourgem-0.0.1.gem
+
+That gem can now be fetched with TUF:
+
+    script/fetch-me-a-gem-with-tuf yourgem
+
+### Production
+
+Production requires more setup because offline keys need to be distributed to
+maintainers, who then need to sign for the initial metadata files.
+
+    # Setting up an initial repository, with offline keys for xavier and tony.
+    export PATH=script/tuf:$PATH
+    export KEYDIR=config/keys
+    export TUFDIR=config/tuf
+    mkdir -p $KEYDIR
+    mkdir -p $TUFDIR
+
+    tuf-generate-key $KEYDIR online # $KEYDIR/online-*.pem
+    tuf-generate-key $KEYDIR xavier # $KEYDIR/xavier-*.pem
+    tuf-generate-key $KEYDIR tony   # $KEYDIR/tony-*.pem
+
+    # Generate initial set of offline documents that need to be # signed.
+    # Need to know all the public keys that will be used to sign documents in
+    # advance. Adding new ones will require re-signing by all keys.
+    tuf-generate-offline-files $TUFDIR \
+      --offline $KEYDIR/xavier-public.pem \
+      --offline $KEYDIR/tony-public.pem \
+      --online $KEYDIR/online-public.pem
+
+    # Each individual signs for the offline files using their private key.
+    # Public key is also required as an identifier.
+    tuf-sign-files $KEYDIR/xavier-{private,public}.pem $TUFDIR/*.txt
+    tuf-sign-files $KEYDIR/tony-{private,public}.pem $TUFDIR/*.txt
+
+    # Publish an empty TUF repository using the already signed offline files,
+    # and an online key to sign new files that need to be generated..
+    tuf-bootstrap $KEYDIR/online-{private,public}.pem $TUFDIR
+
+    rm $TUFDIR/*.txt
+
 ## Contributions
 
 Please see the wiki for the latest [contribution guidelines][].

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -6,20 +6,34 @@ class Indexer
   end
 
   def write_gem(body, spec)
-    gem_file = directory.files.create(
-      :body   => body.string,
-      :key    => "gems/#{spec.original_name}.gem",
-      :public => true
+    gem_file = Tuf::File.from_body(
+      "gems/#{spec.original_name}.gem",
+      body.string
     )
 
     self.class.indexer.abbreviate spec
     self.class.indexer.sanitize spec
 
-    gem_spec = directory.files.create(
-      :body   => Gem.deflate(Marshal.dump(spec)),
-      :key    => "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
-      :public => true
+    gem_spec = Tuf::File.from_body(
+      "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
+      Gem.deflate(Marshal.dump(spec))
     )
+
+    files = [
+      gem_file,
+      gem_spec,
+    ]
+
+    files.each do |file|
+      # These files are stored without their hash in the filename since they
+      # are immutable, so there is no risk of two different versions appearing
+      # in two different snapshots. TUF will still verify the hashes that are
+      # stored in metadata, and legacy clients will be able to find files where
+      # they expect them.
+      file_bucket.create(file.path, file.body)
+    end
+
+    tuf_pending_store.add(files)
   end
 
   def directory
@@ -44,21 +58,67 @@ class Indexer
     final.string
   end
 
-  def upload(key, value)
-    file = directory.files.create(
-      :body   => stringify(value),
-      :key    => key,
-      :public => true
+  def upload(path, value)
+    content = stringify(value)
+    file    = Tuf::File.from_body(path, content)
+
+    # The index files are stored with their hash in the path to support the
+    # consistent snapshots provided by TUF.
+    #
+    # A version without the hash is also stored to support legacy clients.
+    file_bucket.create(file.path_with_hash, file.body)
+    file_bucket.create(file.path, file.body)
+
+    file
+  end
+
+  def tuf_pending_store
+    @tuf_pending_store ||= Tuf::RedisPendingStore.new($redis)
+  end
+
+  def file_bucket
+    @file_bucket ||= PublicFileBucket.new(directory)
+  end
+
+  def tuf_repo
+    @tuf_repo ||= Tuf::OnlineRepository.new(
+      root:   JSON.parse(read_with_error('config/root.txt', "No root.txt available.")),
+      bucket: file_bucket,
+      online_key: Tuf::Key.build('rsa',
+        File.read('config/keys/online-private.pem'),
+        File.read('config/keys/online-public.pem')
+      )
     )
   end
 
+  def read_with_error(path, msg)
+    File.read(path)
+  rescue
+    raise msg
+  end
+
+  # TODO: Integration test for this
   def update_index
-    upload("specs.4.8.gz", specs_index)
+    index_files = []
+    index_files << upload("specs.4.8.gz", specs_index)
     log "Uploaded all specs index"
-    upload("latest_specs.4.8.gz", latest_index)
+    index_files << upload("latest_specs.4.8.gz", latest_index)
     log "Uploaded latest specs index"
-    upload("prerelease_specs.4.8.gz", prerelease_index)
+    index_files << upload("prerelease_specs.4.8.gz", prerelease_index)
     log "Uploaded prerelease specs index"
+
+    index_files.each do |file|
+      tuf_repo.replace_file(file, 'targets/unclaimed', 'targets')
+    end
+
+    # For now assume all files are unclaimed
+    pending_files = tuf_pending_store.pending
+    pending_files.each do |file|
+      puts "Adding file: #{file.path}"
+      tuf_repo.add_file(file, 'targets/unclaimed', 'targets')
+    end
+    tuf_repo.publish!
+    tuf_pending_store.clear(pending_files)
   end
 
   def minimize_specs(data)

--- a/app/middleware/hostess.rb
+++ b/app/middleware/hostess.rb
@@ -12,7 +12,7 @@ class Hostess < Sinatra::Base
 
   def serve
     if self.class.local
-      send_file(Pusher.server_path(request.path_info))
+      send_file Pusher.server_path(request.path_info)
     else
       yield
     end
@@ -33,6 +33,9 @@ class Hostess < Sinatra::Base
   %w[/specs.4.8.gz
      /latest_specs.4.8.gz
      /prerelease_specs.4.8.gz
+     /specs.4.8.*.gz
+     /latest_specs.4.8.*.gz
+     /prerelease_specs.4.8.*.gz
   ].each do |index|
     get index do
       content_type('application/x-gzip')
@@ -77,6 +80,10 @@ class Hostess < Sinatra::Base
     else
       error 404, "This gem does not currently live at RubyGems.org."
     end
+  end
+
+  get "/metadata/*" do
+    serve_via_cf
   end
 
   get "/gems/*.gem" do

--- a/app/models/public_file_bucket.rb
+++ b/app/models/public_file_bucket.rb
@@ -1,0 +1,23 @@
+# Wraps a simple interface around the fog library, so we don't need to directly
+# depend on it everywhere.
+class PublicFileBucket
+  def initialize(fog_directory)
+    @directory = fog_directory
+  end
+
+  def create(path, content)
+    directory.files.create(
+      key:    path,
+      body:   content,
+      public: true
+    )
+  end
+
+  def get(path, opts = {})
+    directory.files.get(path).body
+  end
+
+  private
+
+  attr_reader :directory
+end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -33,12 +33,8 @@ class Pusher
   end
 
   def pull_spec
-    Gem::Package.open body, "r", nil do |pkg|
-      @spec = pkg.metadata
-      return true
-    end
-
-    false
+    @spec = Gem::Package.new(body).spec
+    true
   rescue Psych::WhitelistException => e
     Rails.logger.info "Attempted YAML metadata exploit: #{e}"
     notify("RubyGems.org cannot process this gem.\nThe metadata is invalid.\n#{e}", 422)

--- a/app/models/tuf/file.rb
+++ b/app/models/tuf/file.rb
@@ -1,0 +1,65 @@
+require 'digest/sha2'
+
+module Tuf
+  class File
+    def self.from_body(path, body)
+      new(path, body)
+    end
+
+    def self.from_metadata(path, metadata)
+      FileSpec.new(path, metadata)
+    end
+
+    def initialize(path, body)
+      @path   = path
+      @body   = body
+      @length = body.bytesize
+      @hash   = Digest::SHA256.hexdigest(@body)
+    end
+
+    def to_hash
+      {
+        'hashes' => { 'sha256' => @hash },
+        'length' => @length,
+      }
+    end
+
+    def path_with_hash
+      ext  = ::File.extname(path)
+      dir  = ::File.dirname(path)
+      base = ::File.basename(path, ext)
+
+      ::File.join(dir, base + '.' + hash + ext)
+    end
+
+    attr_reader :path, :body, :length, :hash
+  end
+
+  class FileSpec
+    attr_reader :path, :length, :hash
+
+    def initialize(path, metadata)
+      @path   = path
+      @hash   = metadata.fetch('hashes').fetch('sha256')
+      @length = metadata.fetch('length')
+    end
+
+    # TODO: De-dup with above
+    def path_with_hash
+      ext  = ::File.extname(path)
+      dir  = ::File.dirname(path)
+      base = ::File.basename(path, ext)
+
+      ::File.join(dir, base + '.' + hash + ext)
+    end
+
+    def attach_body!(body)
+      file = File.from_body(path, body)
+
+      raise "Invalid length for #{path}. Expected #{length}, got #{file.length}" unless file.length == length
+      raise "Invalid hash for #{path}" unless file.hash == hash
+
+      file
+    end
+  end
+end

--- a/app/models/tuf/gemcutter.rb
+++ b/app/models/tuf/gemcutter.rb
@@ -1,0 +1,66 @@
+require 'openssl'
+require 'rubygems/tuf'
+
+module Tuf
+
+  # A grab bag of methods used to bootstrap TUF specifically for gemcutter.
+  class Gemcutter
+    def generate_key
+      rsa = OpenSSL::PKey::RSA.new(2048, 65537)
+      Tuf::Key.build('rsa', rsa.to_pem, rsa.public_key.to_pem)
+    end
+
+    def generate_root(online_keys, offline_keys)
+      root = Tuf::Role::Root.empty
+      root.add_roles(
+        'root'      => offline_keys,
+        'targets'   => offline_keys,
+        'release'   => online_keys,
+        'timestamp' => online_keys,
+      )
+
+      Tuf::Signer.wrap(root.to_hash)
+    end
+
+    def generate_targets(online_keys, offline_keys)
+      targets = Tuf::Role::Targets.empty
+      targets.delegate_to('targets/claimed', offline_keys)
+      targets.delegate_to('targets/recently-claimed', online_keys)
+      targets.delegate_to('targets/unclaimed', online_keys)
+
+      Tuf::Signer.wrap(targets.to_hash)
+    end
+
+    def generate_claimed
+      Tuf::Signer.wrap Tuf::Role::Targets.empty
+    end
+
+    def sign_file(key, path)
+      signed = Tuf::Signer.sign(JSON.parse(File.read(path)), key)
+
+      File.write path, Tuf::Serialize.canonical(signed)
+    end
+
+    def bootstrap!(bucket, online_key, signed_files)
+      repo = Tuf::OnlineRepository.new(
+        bucket:     bucket,
+        online_key: online_key,
+        root:       signed_files.fetch('root')
+      )
+      repo.bootstrap!
+
+      unclaimed = Tuf::Role::Targets.empty
+      recent    = Tuf::Role::Targets.empty
+
+      signed_files['targets/recently-claimed'] = Tuf::Signer.sign_unwrapped(unclaimed.to_hash, online_key)
+      signed_files['targets/unclaimed']        = Tuf::Signer.sign_unwrapped(recent.to_hash, online_key)
+
+      repo.add_signed_delegated_role('targets', 'root', signed_files.fetch('targets'))
+      repo.add_signed_delegated_role('targets/claimed', 'targets', signed_files.fetch('targets/claimed'))
+      repo.add_signed_delegated_role('targets/recently-claimed', 'targets', signed_files.fetch('targets/recently-claimed'))
+      repo.add_signed_delegated_role('targets/unclaimed', 'targets', signed_files.fetch('targets/unclaimed'))
+
+      repo.publish!
+    end
+  end
+end

--- a/app/models/tuf/key.rb
+++ b/app/models/tuf/key.rb
@@ -1,0 +1,65 @@
+require 'tuf/serialize'
+require 'digest/sha2'
+
+module Tuf
+
+  # Value object for working with TUF key hashes.
+  class Key
+
+    # Convenience method for programatically building keys.
+    def self.build(type, private, public)
+      new Tuf::Serialize.roundtrip(
+        'keytype' => type,
+        'keyval' => {'private' => private, 'public' => public}
+      )
+    end
+
+    def self.public(type, public)
+      build(type, "", public)
+    end
+
+    def initialize(key)
+      @key     = key
+      @public  = key.fetch('keyval').fetch('public')
+      @private = key.fetch('keyval').fetch('private')
+      @type    = key.fetch('keytype')
+      @id      = Digest::SHA256.hexdigest(Tuf::Serialize.canonical(to_hash))
+    end
+
+    # TODO: Unsupported for public key
+    def sign(content)
+      case type
+      when 'insecure'
+        Digest::MD5.hexdigest(public + content)
+      when 'rsa'
+        rsa_key = OpenSSL::PKey::RSA.new(private)
+        rsa_key.sign(Gem::TUF::DIGEST_ALGORITHM.new, content).unpack("H*")[0]
+      else raise "Unknown key type: #{type}"
+      end
+    end
+
+    def valid_digest?(content, expected_digest)
+      case type
+      when 'insecure'
+        expected_digest == Digest::MD5.hexdigest(public + content)
+      when 'rsa'
+        signature_bytes = [expected_digest].pack("H*")
+        rsa_key = OpenSSL::PKey::RSA.new(public)
+        rsa_key.verify(Gem::TUF::DIGEST_ALGORITHM.new, signature_bytes, content)
+      else raise "Unknown key type: #{type}"
+      end
+    end
+
+    def to_hash
+      {
+        'keytype' => type,
+        'keyval' => {
+          'private' => '', # Never include private key when writing out
+          'public' => public,
+        }
+      }
+    end
+
+    attr_reader :id, :public, :private, :type
+  end
+end

--- a/app/models/tuf/online_repository.rb
+++ b/app/models/tuf/online_repository.rb
@@ -1,0 +1,110 @@
+require 'tuf/repository'
+
+module Tuf
+
+  # An online repository has access to the online private key, enabling it to
+  # make changes to the repository.
+  class OnlineRepository < Repository
+    def initialize(opts)
+      super
+
+      @online_key  = opts.fetch(:online_key)
+    end
+
+    # TODO: Handle heirachical delegations properly
+    # TODO: parent_role is redundant
+    # TODO: Document, DRY up with replace_file
+    def add_file(file, role_name, parent_role)
+      content = release.fetch_role(parent_role, root)
+      parent = Tuf::Role.from_hash(content)
+
+      targets = Tuf::Role::Targets.new(release.fetch_role(role_name, parent))
+      targets.add_file(file)
+
+      bucket.create(file.path, file.body)
+      targets_signed = parent.sign_role(role_name, targets.to_hash, online_key)
+
+      add_signed_delegated_role(role_name, parent_role, targets_signed)
+    end
+
+    # TODO: Handle heirachical delegations properly
+    def replace_file(file, role_name, parent_role)
+      content = release.fetch_role(parent_role, root)
+      parent = Tuf::Role.from_hash(content)
+
+      targets = Tuf::Role::Targets.new(release.fetch_role(role_name, parent))
+      targets.replace_file(file)
+
+      bucket.create(file.path, file.body)
+      targets_signed = parent.sign_role(role_name, targets.to_hash, online_key)
+
+      add_signed_delegated_role(role_name, parent_role, targets_signed)
+    end
+
+    # Creates and publishes an initial empty snapshot from nothing. Should only
+    # be used during new system setup or disaster recovery.
+    def bootstrap!
+      root_file = Tuf::File.new 'metadata/root.txt',
+        Tuf::Serialize.canonical(signed_root)
+
+      targets = Tuf::Role::Targets.empty
+      targets_file = build_role 'targets', targets
+
+      release = Role::Release.empty
+      release.replace(targets_file)
+      release.replace(root_file)
+      release_file = build_role 'release', release
+
+      timestamp = Role::Timestamp.empty
+      timestamp.replace(release_file)
+      timestamp_file = build_role 'timestamp', timestamp
+
+      [root_file, targets_file, release_file].each do |file|
+        bucket.create file.path_with_hash, file.body
+      end
+      bucket.create timestamp_file.path, timestamp_file.body
+    end
+
+    # TODO: Document
+    def add_signed_delegated_role(role, parent_role, signed_document)
+      content = release.fetch_role(parent_role, root)
+      parent  = Tuf::Role.from_hash(content)
+
+      # Verify that the parent has sufficient keys to unwrap the document. If
+      # not, this will raise - the caller needs to write an updated parent
+      # first.
+      parent.unwrap_role(role, signed_document)
+
+      path = 'metadata/' + role + '.txt'
+
+      file = Tuf::File.from_body(path, Tuf::Serialize.canonical(signed_document))
+      release.replace(file)
+      bucket.create(file.path_with_hash, file.body)
+    end
+
+    # Publishes a new consistent snapshot. The only file that is overwritten is
+    # the timestamp, since that is the "root" of the metadata and needs to be
+    # able to be fetched independent of others. All other files are persisted
+    # with their hash added to their filename.
+    def publish!
+      release_file = build_role 'release', release
+
+      timestamp.replace(release_file)
+
+      timestamp_file = build_role 'timestamp', timestamp
+
+      bucket.create(release_file.path_with_hash, release_file.body)
+      bucket.create(timestamp_file.path, timestamp_file.body)
+    end
+
+    private
+
+    attr_accessor :online_key
+
+    def build_role(role, object)
+      release_file = Tuf::File.new 'metadata/' + role + '.txt',
+        Tuf::Serialize.canonical(root.sign_role(role, object.to_hash, online_key))
+    end
+
+  end
+end

--- a/app/models/tuf/redis_pending_store.rb
+++ b/app/models/tuf/redis_pending_store.rb
@@ -1,0 +1,41 @@
+module Tuf
+  # The pending store is a place to keep a record of all files that have yet to
+  # be added to TUF, so that the next re-index will pick them up.
+  #
+  # TODO: Don't use Marshal
+  class RedisPendingStore
+    def initialize(redis, namespace = "rubygems.org:tuf:")
+      @redis     = redis
+      @namespace = namespace
+    end
+
+    def add(files)
+      files.each do |x|
+        redis.lpush(pending_key, Marshal.dump(x))
+      end
+    end
+
+    # After pending files have been successfully processed, they should be
+    # passed back to the clear method.
+    def pending
+      redis.lrange(pending_key, 0, -1).map {|x| Marshal.load(x) }
+    end
+
+    # Clears files after they have been successfully processed. This will be
+    # most efficient if you pass files in the same order that they were
+    # returned from pending.
+    def clear(files)
+      files.each do |x|
+        redis.lrem(pending_key, 0, Marshal.dump(x))
+      end
+    end
+
+    private
+
+    def pending_key
+      namespace + "pending"
+    end
+
+    attr_reader :redis, :namespace
+  end
+end

--- a/app/models/tuf/repository.rb
+++ b/app/models/tuf/repository.rb
@@ -1,0 +1,67 @@
+require 'fileutils'
+
+require 'tuf/role'
+require 'tuf/signer'
+
+module Tuf
+
+  # A read-only view of a TUF repository.
+  class Repository
+    def initialize(opts)
+      @bucket      = opts.fetch(:bucket)
+      @signed_root = opts.fetch(:root)
+      # TODO: Document, actually verify
+      @root   = Tuf::Role::Root.new(Tuf::Signer.unwrap_unsafe(@signed_root))
+    end
+
+    def target(path)
+      metadata = find_metadata path, 'targets', root
+
+      if metadata
+        file = Tuf::File.from_metadata(path, metadata)
+        file.attach_body! bucket.get(path, cache_key: file.path_with_hash)
+      end
+    end
+
+    def role(path)
+      bucket.get('metadata/' + path + '.txt')
+    end
+
+    protected
+
+    def release
+      @release ||= begin
+         file = timestamp.fetch_role('release', root)
+
+         # TODO: Check expiry
+         Role::Release.new(file, @bucket)
+       end
+    end
+
+    def timestamp
+      @timestamp ||= begin
+        signed_file = JSON.parse(bucket.get("metadata/timestamp.txt", cache: false))
+
+        # TODO: Check expiry
+        Role::Timestamp.new(root.unwrap_role('timestamp', signed_file), @bucket)
+      end
+    end
+
+    def find_metadata(path, role, parent)
+      targets = Tuf::Role::Targets.new(release.fetch_role(role, parent))
+
+      if targets.files[path]
+        targets.files[path]
+      else
+        targets.delegated_roles.each do |role|
+          x = find_metadata(path, role.fetch('name'), targets)
+          return x if x
+        end
+        nil
+      end
+    end
+
+    attr_reader :bucket, :root, :signed_root
+
+  end
+end

--- a/app/models/tuf/role.rb
+++ b/app/models/tuf/role.rb
@@ -1,0 +1,20 @@
+require 'pp'
+
+require 'tuf/role/metadata'
+require 'tuf/role/targets'
+require 'tuf/role/root'
+
+module Tuf
+  module Role
+    def from_hash(content)
+      case content['_type']
+      when 'Root'      then Tuf::Role::Root
+      when 'Targets'   then Tuf::Role::Targets
+      when 'Release'   then Tuf::Role::Release
+      when 'Timestamp' then Tuf::Role::Timestamp
+      else raise("Unknown role: #{content.pretty_inspect}")
+      end.new(content)
+    end
+    module_function :from_hash
+  end
+end

--- a/app/models/tuf/role/metadata.rb
+++ b/app/models/tuf/role/metadata.rb
@@ -1,0 +1,66 @@
+require 'json'
+
+require 'tuf/file'
+
+module Tuf
+  module Role
+    class NullBucket
+      def get(*_); raise "Remote operations not available" end
+      def create(*_); raise "Remote operations not available" end
+    end
+
+    class Metadata
+      def self.empty(bucket = NullBucket.new)
+        new({'meta' => {}}, bucket)
+      end
+
+      def initialize(source, bucket)
+        @role_metadata = source['meta']
+        @bucket = bucket
+      end
+
+      def fetch_role(role, parent)
+        path = "metadata/" + role + ".txt"
+
+        metadata = role_metadata.fetch(path) {
+          raise "Could not find #{path} in: #{role_metadata.keys.sort.join("\n")}"
+        }
+
+        filespec = ::Tuf::File.from_metadata(path, role_metadata[path])
+
+        data = bucket.get(filespec.path_with_hash)
+
+        signed_file = filespec.attach_body!(data)
+
+        parent.unwrap_role(role, JSON.parse(signed_file.body))
+      end
+
+      def replace(file)
+        role_metadata[file.path] = file.to_hash
+      end
+
+      attr_reader :role_metadata, :bucket
+    end
+
+    class Timestamp < Metadata
+      def to_hash
+        {
+          '_type'   => "Timestamp",
+          'meta'    => role_metadata,
+          'version' => 2
+        }
+      end
+    end
+
+    class Release < Metadata
+      # TODO: Expires
+      def to_hash
+        {
+          '_type'   => "Release",
+          'meta'    => role_metadata,
+          'version' => 2
+        }
+      end
+    end
+  end
+end

--- a/app/models/tuf/role/root.rb
+++ b/app/models/tuf/role/root.rb
@@ -1,0 +1,85 @@
+require 'tuf/key'
+require 'tuf/signer'
+
+module Tuf
+  module Role
+    # TODO: DRY this up with Targets role
+    class Root
+      def self.empty
+        new({ 'keys' => {}, 'roles' => {}})
+      end
+
+      def initialize(content)
+        @root = content
+      end
+
+      def body
+        @root
+      end
+
+      def unwrap_role(role, content)
+        # TODO: get threshold for role rather than requiring all signatures to be
+        # valid.
+        Tuf::Signer.unwrap(content, self)
+      end
+
+      def sign_role(role, content, *keys)
+        signed = keys.inject(Tuf::Signer.wrap(content)) do |content, key|
+          Tuf::Signer.sign(content, key)
+        end
+
+        # Verify that this role contains sufficent public keys to unwrap what
+        # was just signed.
+        unwrap_role role, signed
+
+        signed
+      end
+
+      def add_roles(roles)
+        roles.each do |name, keys|
+          keys.each do |key|
+            @root['keys'][key.id] ||= key.to_hash
+          end
+
+          @root['roles'][name] = { 'keyids' => keys.map {|x| x.id }}
+        end
+      end
+
+      def to_hash
+        @root.merge('_type' => 'Root')
+      end
+
+      def files
+        @target.fetch('targets')
+      end
+
+      def delegated_roles
+        @root.fetch('roles', [])
+      end
+
+      def fetch(key_id)
+        key(key_id)
+      end
+
+      def path_for(role)
+        role
+      end
+
+      def delegations
+        @root['roles']
+      end
+
+      private
+
+      attr_reader :root
+
+      def key(key_id)
+        keys = root.fetch('keys', {})
+
+        Tuf::Key.new(keys.fetch(key_id) {
+          raise "#{key_id} not found among:\n#{keys.keys.join("\n")}"
+        })
+      end
+    end
+  end
+end

--- a/app/models/tuf/role/targets.rb
+++ b/app/models/tuf/role/targets.rb
@@ -1,0 +1,94 @@
+require 'tuf/key'
+require 'tuf/signer'
+
+module Tuf
+  module Role
+    # TODO: DRY this up with Root role
+    class Targets
+      def self.empty
+        new('delegations' => {}, 'targets' => {})
+      end
+
+      def initialize(content)
+        @target = content
+        @root   = @target.fetch('delegations', {})
+      end
+
+      def sign_role(role, content, *keys)
+        signed = keys.inject(Tuf::Signer.wrap(content)) do |content, key|
+          Tuf::Signer.sign(content, key)
+        end
+
+        # Verify that this role contains sufficent public keys to unwrap what
+        # was just signed.
+        unwrap_role role, signed
+
+        signed
+      end
+
+      def unwrap_role(role, content)
+        # TODO: get threshold for role rather than requiring all signatures to
+        # be valid.
+        Tuf::Signer.unwrap(content, self)
+      end
+
+      def to_hash
+        @target.merge(
+          '_type' => 'Targets'
+        )
+      end
+
+      def add_file(file)
+        raise "File already exists." if @target['targets'][file.path]
+
+        replace_file(file)
+      end
+
+      def replace_file(file)
+        @target['targets'][file.path] = file.to_hash
+      end
+
+      def delegate_to(role_name, keys)
+        @root['keys'] ||= {}
+        keys.each do |key|
+          @root['keys'][key.id] = key.to_hash
+        end
+
+        delegated_roles << {
+          'name' => role_name,
+          'keyids' => keys.map {|x| x.id }
+        }
+      end
+
+      def files
+        @target.fetch('targets')
+      end
+
+      def delegated_roles
+        @root['roles'] ||= []
+      end
+
+      def fetch(key_id)
+        key(key_id)
+      end
+
+      def path_for(role)
+        "targets/#{role}"
+      end
+
+      def delegations
+        @root['roles']
+      end
+
+      private
+
+      attr_reader :root
+
+      def key(key_id)
+        keys = root.fetch('keys', {})
+
+        Tuf::Key.new(keys.fetch(key_id))
+      end
+    end
+  end
+end

--- a/app/models/tuf/serialize.rb
+++ b/app/models/tuf/serialize.rb
@@ -1,0 +1,12 @@
+module Tuf
+  class Serialize
+    def self.canonical(document)
+      # TODO: Use CanonicalJSON
+      JSON.pretty_generate(document)
+    end
+
+    def self.roundtrip(document)
+      JSON.parse(canonical(document))
+    end
+  end
+end

--- a/app/models/tuf/signer.rb
+++ b/app/models/tuf/signer.rb
@@ -1,0 +1,78 @@
+require 'json'
+
+module Tuf
+  class Signer
+    class << self
+      # Return the wrapped document inside a new signing envelope that contains
+      # all signatures from the previous one, plus a new signature from the
+      # given key.
+      #
+      # TODO: handle signing with the same key twice.
+      def sign(wrapped_document, key)
+        unwrapped = wrapped_document.fetch('signed') {
+          raise "The given document is not wrapped in a signing envelope"
+        }
+
+        to_sign = Tuf::Serialize.canonical(unwrapped)
+
+        signed = wrapped_document.dup
+        signed['signatures'] << {
+          'keyid'  => key.id,
+          'method' => key.type,
+          'sig'    => key.sign(to_sign)
+        }
+        signed
+      end
+
+      # Wrap a document in an empty signing envelope. Multiple signatures can
+      # be added to this envelope using the .sign method.
+      #
+      # TODO: Support `as_json` method to avoid calling `to_hash` everywhere.
+      def wrap(to_sign)
+        {
+          'signatures' => [],
+          'signed'     => to_sign,
+        }
+      end
+
+      def sign_unwrapped(to_sign, key)
+        sign(wrap(to_sign), key)
+      end
+
+      # Verify signatures on a document and return the signed portion.
+      #
+      # TODO: Support threshold parameter.
+      def unwrap(signed_document, keystore)
+        verify!(signed_document, keystore)
+        unwrap_unsafe(signed_document)
+      end
+
+      # Unwrap a document without verifying signatures. This should only ever
+      # be used internal to this class, or in a bootstrapping situation (such
+      # as root.txt) where you are going to verify the document later.
+      #
+      # All external uses of this method MUST have explicit documentation
+      # justifying that use.
+      def unwrap_unsafe(signed_document)
+        signed_document.fetch('signed') {
+          raise "The given document is not wrapped in a signing envelope"
+        }
+      end
+
+      private
+
+      def verify!(signed_document, keystore)
+        document = Tuf::Serialize.canonical(unwrap_unsafe(signed_document))
+
+        signed_document.fetch('signatures').each do |sig|
+          key_id = sig.fetch('keyid')
+          method = sig.fetch('method')
+
+          key = keystore.fetch(key_id)
+          key.valid_digest?(document, sig.fetch('sig')) ||
+            raise("Invalid signature for #{key_id}")
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,18 @@
+# TODO: Remove this before merging to master, after rubygems changes have
+# shipped.
+$LOAD_PATH.unshift(File.expand_path('../../../rubygems/lib', __FILE__))
+
+begin
+  require 'openssl'
+  require 'rubygems/tuf'
+rescue LoadError
+  $stderr.puts <<-EOS
+Your version of rubygems is too old, it does not include rubygems/tuf which
+is required for secure operation.
+  EOS
+  exit 1
+end
+
 require File.expand_path('../boot', __FILE__)
 
 require 'rails'

--- a/config/initializers/requires.rb
+++ b/config/initializers/requires.rb
@@ -1,5 +1,8 @@
+# TODO: These requires are only required for tests, and are not present in new
+# versions of rubygems. Need to remove the dependency on them.
 require 'rubygems/format'
 require 'rubygems/indexer'
+
 require 'rdoc/markup'
 require 'rdoc/markup/to_html'
 require 'simple_ssl_requirement'

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -1,4 +1,10 @@
 namespace :gemcutter do
+  namespace :tuf do
+    task generate_metadata: :environment do
+      Indexer.new.perform
+    end
+  end
+
   namespace :index do
     desc "Update the index"
     task :update => :environment do

--- a/script/fetch-me-a-gem-with-tuf
+++ b/script/fetch-me-a-gem-with-tuf
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+
+# TODO: Remove this before merging to master, after rubygems changes have
+# shipped.
+$LOAD_PATH.unshift(File.expand_path('../../../rubygems/lib', __FILE__))
+
+begin
+  require 'openssl'
+  require 'rubygems/tuf'
+rescue LoadError
+  $stderr.puts <<-EOS
+Your version of rubygems is too old, it does not include rubygems/tuf which
+is required for secure operation.
+  EOS
+  exit 1
+end
+
+$LOAD_PATH.unshift 'app/models'
+
+require 'tuf/repository'
+
+require 'pp'
+require 'open-uri'
+require 'json'
+require 'digest/md5'
+require 'digest/sha2'
+require 'zlib'
+
+$host = 'http://localhost:3000'
+$cache_dir = '/tmp'
+
+# Proof-of-concept implementation of remote file fetching with TUF.
+def main
+  last_good_root = from_file($cache_dir + '/root.txt') ||
+                   from_file('config/root.txt') ||
+                   raise("Can't find root.txt")
+
+  repository = Tuf::Repository.new(
+    root:   JSON.parse(last_good_root),
+    bucket: FileCachingBucket.new(HttpBucket.new($host))
+  )
+
+  gem_name = ARGV.shift
+
+  specs = repository.target('latest_specs.4.8.gz')
+  raise "could not find latest_specs.4.8.gz" unless specs
+  specs = unmarshal_gz specs
+  gem = specs.detect {|x| x[0] == gem_name } || raise("Can't find gem #{gem}")
+
+  gem_with_version = "#{gem[0]}-#{gem[1]}"
+  gem_path         = "gems/#{gem_with_version}.gem"
+  gemspec_path     = "quick/Marshal.4.8/#{gem_with_version}.gemspec.rz"
+
+  repository.target(gemspec_path)
+  repository.target(gem_path)
+
+  puts "Downloaded #{gem_path} and #{gemspec_path}"
+end
+
+def from_file(path)
+  if File.exists?(path)
+    File.read(path)
+  end
+end
+
+def unmarshal_gz(content)
+  # ....
+  Marshal.load(Zlib::GzipReader.new(StringIO.new(content.body)).read)
+end
+
+class HttpBucket
+  def initialize(host)
+  end
+
+  def get(path, opts = {})
+    open($host + '/' + path).read
+  end
+
+  def create(*)
+    raise "Not supported, this is a read-only bucket."
+  end
+end
+
+class FileCachingBucket
+  def initialize(bucket, dir = "/tmp/tuf-cache/")
+    @bucket = bucket
+    FileUtils.mkdir_p(dir)
+    @dir = dir
+  end
+
+  def get(path, opts = {})
+    cache_key = opts.fetch(:cache_key, path)
+    full_path = dir + cache_key
+
+    if ::File.exists?(full_path) && opts[:cache] != false
+      puts "cache hit: #{cache_key}"
+      ::File.read(full_path)
+    else
+      puts "cache miss: #{cache_key}"
+      bucket.get(path).tap do |content|
+        FileUtils.mkdir_p(::File.dirname(full_path))
+        ::File.write full_path, content
+      end
+    end
+  end
+
+  private
+
+  attr_reader :dir, :bucket
+end
+
+main

--- a/script/tuf/tuf-bootstrap
+++ b/script/tuf/tuf-bootstrap
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require_relative '../../config/boot'
+require_relative '../../config/environment'
+
+require 'tuf/gemcutter'
+
+private_file = ARGV.shift
+public_file  = ARGV.shift
+indir        = ARGV.shift
+
+# TODO: DRY this up with Indexer
+def fog
+  $fog || Fog::Storage.new(
+    :provider   => 'Local',
+    :local_root => Pusher.server_path
+  )
+end
+
+bucket = PublicFileBucket.new(
+  fog.directories.get($rubygems_config[:s3_bucket]) ||
+  fog.directories.create(key: $rubygems_config[:s3_bucket])
+)
+key = Tuf::Key.build('rsa', File.read(private_file), File.read(public_file))
+
+signed_files = {
+  'root'            => JSON.parse(File.read(indir + '/root.txt')),
+  'targets'         => JSON.parse(File.read(indir + '/targets.txt')),
+  'targets/claimed' => JSON.parse(File.read(indir + '/claimed.txt'))
+}
+
+Tuf::Gemcutter.new.bootstrap!(bucket, key, signed_files)

--- a/script/tuf/tuf-dev-bootstrap
+++ b/script/tuf/tuf-dev-bootstrap
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+KEYDIR=$1
+TUFDIR=$2
+
+mkdir -p $KEYDIR
+mkdir -p $TUFDIR
+
+tuf-generate-key $KEYDIR online
+tuf-generate-key $KEYDIR offline
+
+tuf-generate-offline-files $TUFDIR \
+  --offline $KEYDIR/offline-public.pem \
+  --online  $KEYDIR/online-public.pem
+
+tuf-sign-files $KEYDIR/offline-{private,public}.pem $TUFDIR/*.txt
+
+tuf-bootstrap $KEYDIR/online-{private,public}.pem $TUFDIR
+
+rm $TUFDIR/*.txt

--- a/script/tuf/tuf-generate-key
+++ b/script/tuf/tuf-generate-key
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require_relative '../../config/boot'
+require_relative '../../config/environment'
+
+require 'tuf/gemcutter'
+
+keydir = ARGV.shift
+name   = ARGV.shift
+
+tuf = Tuf::Gemcutter.new
+key = tuf.generate_key
+
+File.write "#{keydir}/#{name}-private.pem", key.private
+File.write "#{keydir}/#{name}-public.pem", key.public

--- a/script/tuf/tuf-generate-offline-files
+++ b/script/tuf/tuf-generate-offline-files
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require_relative '../../config/boot'
+require_relative '../../config/environment'
+
+require 'optparse'
+
+require 'tuf/gemcutter'
+
+options = {
+  offline: [],
+  online:  []
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: generate-offline-files OUTDIR [options]"
+
+  opts.on("--offline PATH", "Include the given offline public key") do |path|
+    options[:offline] << path
+  end
+
+  opts.on("--online PATH", "Include the given online public key") do |path|
+    options[:online] << path
+  end
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+end.parse!
+
+outdir = ARGV.shift
+
+to_rsa = lambda {|path| Tuf::Key.public('rsa', File.read(path)) }
+
+offline_keys = options[:offline].map(&to_rsa)
+online_keys  = options[:online].map(&to_rsa)
+
+tuf = Tuf::Gemcutter.new
+{
+  'root'    => tuf.generate_root(online_keys, offline_keys),
+  'targets' => tuf.generate_targets(online_keys, offline_keys),
+  'claimed' => tuf.generate_claimed
+}.each do |file, content|
+  File.write(outdir + "/#{file}.txt", Tuf::Serialize.canonical(content))
+end

--- a/script/tuf/tuf-sign-files
+++ b/script/tuf/tuf-sign-files
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require_relative '../../config/boot'
+require_relative '../../config/environment'
+
+require 'tuf/gemcutter'
+
+private_file = ARGV.shift
+public_file  = ARGV.shift
+to_sign      = ARGV
+
+key = Tuf::Key.build('rsa', File.read(private_file), File.read(public_file))
+tuf = Tuf::Gemcutter.new
+
+to_sign.each do |path|
+  tuf.sign_file(key, path)
+end

--- a/test/integration/repository_test.rb
+++ b/test/integration/repository_test.rb
@@ -1,0 +1,83 @@
+require 'minitest/unit'
+require 'minitest/autorun'
+
+require 'json'
+
+require 'tuf/online_repository'
+
+class TufRepositoryTest < MiniTest::Unit::TestCase
+  class InMemoryBucket
+    def initialize
+      @paths = {}
+    end
+
+    def get(path, _ = {})
+      @paths[path]
+    end
+
+    def create(path, content)
+      @paths[path] = content
+    end
+
+    attr_reader :paths
+  end
+
+  def test_bootstrapping_a_new_system
+    offline_key = Tuf::Key.build('insecure', '', 'offline')
+    online_key  = Tuf::Key.build('insecure', '', 'insecure')
+
+    root = Tuf::Role::Root.empty
+    root.add_roles(
+      'root'      => [offline_key],
+      'targets'   => [offline_key],
+      'release'   => [online_key],
+      'timestamp' => [online_key],
+    )
+
+    signed_root = Tuf::Signer.sign_unwrapped(root.to_hash, offline_key)
+
+    repo = Tuf::OnlineRepository.new(
+      bucket:     bucket = InMemoryBucket.new,
+      online_key: online_key,
+      root:       signed_root
+    )
+    repo.bootstrap!
+
+    claimed   = Tuf::Role::Targets.empty
+    unclaimed = Tuf::Role::Targets.empty
+    recent    = Tuf::Role::Targets.empty
+
+    targets = Tuf::Role::Targets.empty
+    targets.delegate_to('targets/claimed', [offline_key])
+    targets.delegate_to('targets/recently-claimed', [online_key])
+    targets.delegate_to('targets/unclaimed', [online_key])
+
+    signed_claimed   = Tuf::Signer.sign_unwrapped(claimed.to_hash, offline_key)
+    signed_unclaimed = Tuf::Signer.sign_unwrapped(unclaimed.to_hash, online_key)
+    signed_recent    = Tuf::Signer.sign_unwrapped(recent.to_hash, online_key)
+    signed_targets   = Tuf::Signer.sign_unwrapped(targets.to_hash, offline_key)
+
+    repo.add_signed_delegated_role('targets', 'root', signed_targets)
+    repo.add_signed_delegated_role('targets/claimed', 'targets', signed_claimed)
+    repo.add_signed_delegated_role('targets/recently-claimed', 'targets', signed_recent)
+    repo.add_signed_delegated_role('targets/unclaimed', 'targets', signed_unclaimed)
+
+    repo.publish!
+
+    file = Tuf::File.from_body('gems/mygem-0.0.1.gem', 'gemgemgemgemgem')
+
+    repo.add_file(file, 'targets/unclaimed', 'targets')
+
+
+    assert bucket.paths['metadata/timestamp.txt'], "timestamp is not available"
+
+    assert_equal 'gemgemgemgemgem', bucket.paths['gems/mygem-0.0.1.gem'],     "cannot fetch file without TUF"
+    assert_equal 'gemgemgemgemgem', repo.target('gems/mygem-0.0.1.gem').body, "cannot fetch file with TUF"
+
+#     bucket.paths.each do |path, content|
+#       puts
+#       puts "===== #{path}"
+#       puts content
+#     end
+  end
+end


### PR DESCRIPTION
This allows a gem to be published with TUF metadata, and to be fetched
securely using a custom fetch script.

See the README for details of getting it running. This requires https://github.com/rubygems/rubygems/pull/719 to be checked out alongside this repository.

```
> script/fetch-me-a-gem-with-tuf cane
cache miss: metadata/timestamp.txt
cache miss: metadata/release.0aa4ee2b00d39a4a1db21c0811f8c2c8de406b7cfac362504276f324e485b0b5.txt
cache hit: metadata/targets.2372d612fb24776e928af5af8a0ab924c046cefe265885cc6011b346ba8c3bd3.txt
cache hit: metadata/targets/claimed.f1095e1b16f935dff02f178ded5b0b8e0986cfa89c402ec8d1eb20475abde25d.txt
cache hit: metadata/targets/recently-claimed.3fa663ba393d90c519403eaa97cfa8f2ad5bfb98022fa4426438f2d9526adaee.txt
cache miss: metadata/targets/unclaimed.cabf35a8f5713ed399847c61a2ea9f1beab4fa0667d987ee41b06228114c51e9.txt
cache miss: ./latest_specs.4.8.a1c235ed3d94b6a2897f92c528c38fe14e1594de4f53a6821767c82091c2862d.gz
cache hit: metadata/targets.2372d612fb24776e928af5af8a0ab924c046cefe265885cc6011b346ba8c3bd3.txt
cache hit: metadata/targets/claimed.f1095e1b16f935dff02f178ded5b0b8e0986cfa89c402ec8d1eb20475abde25d.txt
cache hit: metadata/targets/recently-claimed.3fa663ba393d90c519403eaa97cfa8f2ad5bfb98022fa4426438f2d9526adaee.txt
cache hit: metadata/targets/unclaimed.cabf35a8f5713ed399847c61a2ea9f1beab4fa0667d987ee41b06228114c51e9.txt
cache miss: quick/Marshal.4.8/cane-2.6.3.gemspec.807cd0070ffa50f7b4ff8acb7723cce47734796a36a5bebf1208e3a79ad7cbfb.rz
cache hit: metadata/targets.2372d612fb24776e928af5af8a0ab924c046cefe265885cc6011b346ba8c3bd3.txt
cache hit: metadata/targets/claimed.f1095e1b16f935dff02f178ded5b0b8e0986cfa89c402ec8d1eb20475abde25d.txt
cache hit: metadata/targets/recently-claimed.3fa663ba393d90c519403eaa97cfa8f2ad5bfb98022fa4426438f2d9526adaee.txt
cache hit: metadata/targets/unclaimed.cabf35a8f5713ed399847c61a2ea9f1beab4fa0667d987ee41b06228114c51e9.txt
cache miss: gems/cane-2.6.3.0eab3cf91e486649d4b2d39518d15c6bf5f350f9f8201f971b76c2d0327e1f37.gem
Downloaded gems/cane-2.6.3.gem and quick/Marshal.4.8/cane-2.6.3.gemspec.rz
```

Still a lot of work remains. Some of the bigger items:
- Numerous TODOs in code.
- Support thresholds.
- Support timestamps and expiry.
- New endpoint allowing developers to uploaded targets for their gems,
  delegating to them from recently-claimed role.
- Ability for maintainers to easily promote recently-claimed to claimed.
- Move/integrate most of the TUF code to rubygems client, since it is needed to
  fetch gems using the framework.
- Integrate fetching code into actual gem CLI.
- Bundler support.
- Test coverage.
- Update code base to work with latest ruby/rubygems.
- Document emergency procedures, such as re-issuing root.txt.
- High-level documentation tying this implementation to the spec.
- Establish the manual procedure and key distribution for updating the
  claimed role.
- Import process for all existing gems.

@tarcieri @nealharris @jkingdon @justine-square @sandersch (note: this is pretty different from the last code I showed you - pretty sure I've settled down on the architecture now.)

References:
- https://github.com/theupdateframework/pep-on-pypi-with-tuf
- https://updateframework.com/projects/project
- http://mirror1.poly.edu/test-pypi/
