### PR TITLE
Bump to 2.1.11

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ Bundler.require(:default, Rails.env) if defined?(Bundler)
 $rubygems_config = YAML.load_file("config/rubygems.yml")[Rails.env].symbolize_keys
 HOST             = $rubygems_config[:host]
 
-RUBYGEMS_VERSION = "2.1.7"
+RUBYGEMS_VERSION = "2.1.11"
 
 module Gemcutter
   class Application < Rails::Application


### PR DESCRIPTION
The version on the front page hasn’t matched the release version in nearly 3 months, this corrects that.
