### PR TITLE
Keep a consistent sans-serif font

### DIFF
--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -2,7 +2,7 @@ body {
   line-height: 1;
   font-size: .625em;
   background: #340505 url(/images/top.png) repeat-x;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: sans-serif;
 }
 
 ol, ul {
@@ -1146,7 +1146,7 @@ label, .form_links {
   color: #453000;
   border-bottom: 2px solid #fff8e8;
   margin: 5px 0 0 0;
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: sans-serif;
 }
 
 .text_field label,


### PR DESCRIPTION
This pull request is very font-nerdy :books: but here it goes.

One line of CSS specifies that Arial should be used over Helvetica, when possible. The other line of CSS specifies that Helvetica should be used over Arial, when possible. For visual consistency, the two lines should be the same.

And indeed, there is no need to specify either of those options, since `font-family: sans-serif` [already makes that choice for you](http://css-tricks.com/sans-serif), defaulting to Helvetica on Mac (where it's available) and to Arial on Windows.
