### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,7 @@ running:
 **Environment:**
 
 * Use Ruby 1.9.3
+* Use Rubygem 1.8.11
 * Install bundler: `gem install bundler`
 * Install [redis](http://github.com/antirez/redis),
     **version 2.0 or higher**. If you have homebrew,


### PR DESCRIPTION
requires rubygem 1.8.11 to run `rake gemcutter:import:process PATHTO_GEMS/cache`

Added line to note requirement
