### PR TITLE
Update RUBYGEMS_VERSION to 2.2.2.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ Bundler.require(:default, Rails.env) if defined?(Bundler)
 $rubygems_config = YAML.load_file("config/rubygems.yml")[Rails.env].symbolize_keys
 HOST             = $rubygems_config[:host]
 
-RUBYGEMS_VERSION = "2.1.11"
+RUBYGEMS_VERSION = "2.2.2"
 
 module Gemcutter
   class Application < Rails::Application


### PR DESCRIPTION
http://rubygems.org/pages/download still shows 2.1.11 as the latest version.

There's some discussion about integrating this into the rubygems/rubygems release task in issue #629.
