### PR TITLE
Single quotes are clean, easier to read, and using them is preferred

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -231,7 +231,7 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    %{gem "#{rubygem.name}", "~> #{number}"}
+    %{gem '#{rubygem.name}', '~> #{number}'}
   end
 
   def to_gem_version

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -266,7 +266,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "give version with twiddle-wakka for #to_bundler" do
-      assert_equal %{gem "#{@version.rubygem.name}", "~> #{@version.to_s}"}, @version.to_bundler
+      assert_equal %{gem '#{@version.rubygem.name}', '~> #{@version.to_s}'}, @version.to_bundler
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
This PR is to bring the use of single vs. double quotes in Gemfile back for consideration.

What rubygems.org is currently providing as an example for Gemfile inclusion is the style promoted in GitHub's [style guidelines](https://github.com/styleguide/ruby?utm_source=rubyweekly&utm_medium=email) but is inconsistent with its own [Gemfile](https://github.com/rubygems/rubygems.org/blob/d4c645b1837c62b1842b46e5c31e1485738a7ad1/Gemfile) and many of the Gemfiles in rubygems projects. I'll provide some other reasons why this change should be considered, though I know it is currently still a point of contention with many.

According to the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide), although "The second style (always using double-quotes) is arguably a bit more popular in the Ruby community", it says, "The string literals in this guide, however, are aligned with the first style (using single-quotes)."

Both IDea and RubyMine [flag](http://confluence.jetbrains.com/display/RUBYDEV/RubyMine+Inspections) non-interpolated strings that don't contain escape characters and that are in double-quotes.

From a speed-of-syntax-processing standpoint, it may not matter which is used, but this is not a point in favor of use of double-quotes for non-literal strings. Historically in Ruby (going way back), single-quotes have been the form to use for literal strings; they have not been deprecated. Single-quotes are used for a similar purpose in bash, perl, etc., so they should be familiar to many. Use of single-quotes implies that a String is literal; this is almost always the case within a Gemfile, and it certainly is the case here. To use double-quotes would imply that there is a possibility of interpolation or escape characters that does not exist for the example provided.

It is argued that, if you use double quotes, you would not have to go back and change them when you require interpolation or escape characters. This seems to imply that using them is an energy and time-saving technique. But, with commonly-used key layouts, you have to press shift and the quote key to enter a double-quote vs. only the quote key. If you compound that additional time and energy to press the shift key, double-quotes may waste effort. :) But, in all seriousness, there is very little chance in a Gemfile that either interpolation or escape characters would be needed for the gem name or version strings, and certainly not for the examples provided.

Finally, each additional mark caused by double-quotes is [visual noise](http://uxdesign.smashingmagazine.com/2009/10/07/minimizing-complexity-in-user-interfaces/). Using single quotes in the Gemfile will clean up and promote readability.

Thank you for your consideration.
