### PR TITLE
require test gems. without modules not defined.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'factory_girl_rails'
+require 'webmock'
 require 'rr'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
without the require statements, I get these errors, 

``` sh
$ bundle exec rake default                                                                                                                                                                   
rake aborted!
uninitialized constant ActiveSupport::TestCase::FactoryGirl
/Users/weston/git/rubygems.org/test/test_helper.rb:9:in `<class:TestCase>'
/Users/weston/git/rubygems.org/test/test_helper.rb:6:in `<top (required)>'
/Users/weston/git/rubygems.org/test/unit/dependencies_middleware_test.rb:1:in `<top (required)>'
Tasks: TOP => test:run => test:units
(See full trace by running task with --trace)
Run options: --seed 7697
```

``` sh
$ bundle exec rake default                                                                                                                                                                   
rake aborted!
uninitialized constant ActiveSupport::TestCase::WebMock
/Users/weston/git/rubygems.org/test/test_helper.rb:12:in `<class:TestCase>'
/Users/weston/git/rubygems.org/test/test_helper.rb:7:in `<top (required)>'
/Users/weston/git/rubygems.org/test/unit/dependencies_middleware_test.rb:1:in `<top (required)>'
Tasks: TOP => test:run => test:unit
```
