### PR TITLE
remove protected_attributes, and bring in strong_param behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_script:
 git:
   strategy: tarball
 language: ruby
+services:
+  - redis-server
 rvm:
   - 1.9.3
 script: bundle exec rake default


### PR DESCRIPTION
This is the first shot at removing the `protected_attributes` gem and it's functionality, and bringing in the rails 4 `strong_params` behavior. 

Before this is merged, the controller/model created/update actions need further testing to prove `strong_params` properly protects into form inputs.
