### PR TITLE
test against ruby 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.1
 matrix:
   allow_failures:
     - rvm: 2.0.0
+    - rvm: 2.1.1
 script: bundle exec rake default
 services:
   - redis-server


### PR DESCRIPTION
@sferik / @dwradcliffe - opening this when someone, I think @sferik, mentioned wanting to move from 1.9.3-p0 directly to 2.1.1 to leverage 2.1.1 speed improvements. 

Please close it 2.1.1 is not a priority.
