### PR TITLE
move TEST_DIR location within Rails app test folder

### DIFF
--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -7,8 +7,8 @@ end
 
 When /^I push the fixture gem "([^\"]*)" with my API key$/ do |name|
   api_key_header
-  path = Rails.root.join('test', 'gems', name)
-  page.driver.post api_v1_rubygems_path, File.read(path), {"CONTENT_TYPE" => "application/octet-stream"}
+  fixture_gem_path = Rails.root.join("test", "gems", name)
+  page.driver.post api_v1_rubygems_path, File.read(fixture_gem_path), {"CONTENT_TYPE" => "application/octet-stream"}
 end
 
 When /^I GET "(.*?)"$/ do |url|
@@ -42,8 +42,8 @@ end
 
 When /^I push the gem "([^\"]*)" with my API key$/ do |name|
   api_key_header
-  path = File.join(TEST_DIR, name)
-  page.driver.post api_v1_rubygems_path, File.read(path), {"CONTENT_TYPE" => "application/octet-stream"}
+  tmp_gem_path = "#{TEST_DIR}/#{name}"
+  page.driver.post api_v1_rubygems_path, File.read(tmp_gem_path), {"CONTENT_TYPE" => "application/octet-stream"}
 end
 
 When /^I push an invalid .gem file$/ do

--- a/features/support/gemcutter.rb
+++ b/features/support/gemcutter.rb
@@ -4,7 +4,7 @@ WebMock.disable_net_connect!
 Hostess.local = true
 Capybara.app_host = "https://gemcutter.local"
 
-TEST_DIR = File.join('/', 'tmp', 'gemcutter')
+TEST_DIR = Rails.root.join('tmp', 'gemcutter')
 
 World(FactoryGirl::Syntax::Methods)
 
@@ -16,6 +16,7 @@ Before do
 end
 
 After do
+  Dir.chdir(Rails.root)
   FileUtils.rm_rf(TEST_DIR)
   $redis.flushdb
 end


### PR DESCRIPTION
I ran into issues running the test suite both on travis and on my machine, 

https://travis-ci.org/westonplatter/rubygems.org/jobs/22411414

``` sh
/home/travis/.rvm/rubies/ruby-1.9.3-p484/bin/ruby -S bundle exec cucumber  --profile default
You are using Excon 0.25.3. WebMock supports version >= 0.27.5.
Using the default profile...
Feature: API key reset
  In order to protect my account if my API key becomes known
  A user
  Should be able to reset it
  Scenario: User sees existing key on their profile page # features/api_key_reset.feature:6
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
    Given I have signed in with "email@person.com"       # features/step_definitions/clearance/clearance_steps.rb:61
    And I am on my edit profile page                     # features/step_definitions/web_steps.rb:44
    Then I should see my "API key"                       # features/step_definitions/user_steps.rb:10
  Scenario: User resets API key                    # features/api_key_reset.feature:11
No such file or directory - getcwd (Errno::ENOENT)
```

On my local machine, `TEST_DIR = File.join('/', 'tmp', 'gemcutter')` was interpreted as `/private/tmp/gemcutter`, and resulted in cumcumber tests being unable to find built gems.

Changes aslo stem from the opinion that it's best to constrict the test suite to only use folder structures within the Rails app and not create external app folder requirements. 

The `Dir.chdir(Rails.root)` change in `gemcutter.rb` was added since I believe deleting a folder while in it causes issues when you created it (as we do in the before/after callbacks).
