### PR TITLE
Force 1.8.25 rubygems version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - rvm rubygems 1.8.25
+  - gem update --system 1.8.25
 before_script:
   - cp config/database.yml.example config/database.yml
   - bundle exec rake db:create db:migrate db:test:prepare


### PR DESCRIPTION
The rvm command is not working, as we can see this output from travis:
$ rvm rubygems 1.8.25
Installed rubygems 2.2.2 is newer than 1.8.25 provided with installed ruby, skipping installation, use --force to force installation.

We can use the gem --system command to install a older version

review @sferik
