### PR TITLE
Fix clearance test warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,7 +41,7 @@ class ActionController::TestCase
 end
 
 require 'shoulda'
-require 'clearance/testing'
+require 'clearance/test_unit'
 require 'capybara/rails'
 
 def regenerate_index


### PR DESCRIPTION
to fix:

``` ruby
[DEPRECATION] Requiring `clearance/testing` in `spec/spec_helper.rb` (or in `test/test_helper.rb`) is deprecated. Require `clearance/rspec` or `clearance/test_unit` instead.
```

review @sferik
