### PR TITLE
Update rubygems

### DIFF
--- a/config/initializers/requires.rb
+++ b/config/initializers/requires.rb
@@ -1,3 +1,4 @@
+require 'rubygems/package'
 require 'rubygems/indexer'
 require 'rdoc/markup'
 require 'rdoc/markup/to_html'


### PR DESCRIPTION
Update rubygems.org to work with latest rubygems gem.(2.2.2)

Most of the changes were necessary because of this refactor that happened on 2.0:
https://github.com/rubygems/rubygems/commit/f0dcf9f8cfe73d0844d2b3d9500d4dc10d34a761
Basically a `Gem::Package` can only receive a file name, and not a `io` . So I had to copy some internal API in order to make it work...
Not sure if we want to fix rubygems core to support a file.. Maybe not.. let me know if you see any concerns about my approach in here.

review @sferik @drbrain