### PR TITLE
Dont raise if rubygem is nil on dependency

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -59,7 +59,7 @@ class Dependency < ActiveRecord::Base
   end
 
   def name
-    unresolved_name || rubygem.name
+    unresolved_name || rubygem.try(:name)
   end
 
   def payload


### PR DESCRIPTION
[fixes #653]

thats not a fully fix, but at least it should display nil on the view, instead of throw 500 error.

review @dwradcliffe @knappe @sferik
