### PR TITLE
Set Canonical

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
     <link rel="fluid-icon" href="/fluid-icon.png"/>
     <link rel="search" type="application/opensearchdescription+xml" title="<%=t :title %>" href="/opensearch.xml">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <% if content_for?(:canonical) %>
+      <link rel="canonical" href="<%= yield(:canonical) %>" />
+    <% end %>
     <%= stylesheet_link_tag "reset", "960", "screen", :cache => true %>
     <!--[if IE 7]>
       <%= stylesheet_link_tag "ie7" %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -2,6 +2,7 @@
 <% @subtitle = @latest_version.try(:slug) %>
 
 <%= content_for :head, auto_discovery_link_tag(:atom, rubygem_versions_path(@rubygem, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
+<% content_for :canonical, rubygem_path(@rubygem) %>
 
 <% if @rubygem.versions.count.zero? %>
   <p><%= t '.not_hosted_notice' %></p>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :canonical, rubygem_path(@rubygem) %>
+
 <% @title = t('.title', :name => @rubygem.name) %>
 <% if @versions.size.zero? %>
   <p><%= t('.not_hosted_notice') %></p>


### PR DESCRIPTION
Hi,

Is it possible to set canonical for version pages of a rubygem? I think no one needs all the versions of a gem on Google search result.

![screen shot 2014-07-01 at 5 10 58 pm](https://cloud.githubusercontent.com/assets/1162120/3441721/b5c987aa-0108-11e4-8510-b585116c510e.png)
