### PR TITLE
Update location of rubygems.org credentials

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::ApiKeysController < Api::BaseController
 
   def reset
     current_user.reset_api_key!
-    flash[:notice] = "Your API key has been reset. Don't forget to update your .gemrc file!"
+    flash[:notice] = "Your API key has been reset. Don't forget to update your ~/.gem/credentials file!"
     redirect_to edit_profile_path
   end
 end


### PR DESCRIPTION
No longer using .gemrc, so tell them to update their .gem/credentials file instead!

Ref: #694
