### PR TITLE
Update link to creating a gem

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -29,7 +29,7 @@
   <div class="gems">
     <% if @my_gems.empty? %>
       <p>
-        <%= t('.no_owned', :creating_link => link_to(t('.creating_link_text'), page_url("create")),
+        <%= t('.no_owned', :creating_link => link_to(t('.creating_link_text'), "http://guides.rubygems.org/make-your-own-gem/").html_safe,
                            :migrating_link => link_to(t('.migrating_link_text'), page_url("migrate"))).html_safe %>
       </p>
     <% else %>

--- a/app/views/pages/create.html.erb
+++ b/app/views/pages/create.html.erb
@@ -1,3 +1,0 @@
-<% @title = t('.title') %>
-
-<%= link_to t('.notice'), "http://help.rubygems.org/faqs/gemcutter/publishing-your-own-rubygem" %>


### PR DESCRIPTION
These links are pretty out of date. This now links to guides.rubygems.org. This also removes the create page which has an out of date link as well.

Let me know if there's a better way and I can update.
