### PR TITLE
Fix most recent version if there are no release versions

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -83,7 +83,7 @@ class Version < ActiveRecord::Base
   end
 
   def self.most_recent
-    latest.find_by_platform('ruby') || latest.order("number DESC").first || first
+    latest.find_by_platform('ruby') || latest.order("number DESC").first || last
   end
 
   def self.just_updated(limit=5)

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -412,6 +412,20 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context "with only prerelease versions" do
+    setup do
+      @rubygem = create(:rubygem)
+      @one = create(:version, :rubygem => @rubygem, :number => '1.0.0.pre')
+      @two = create(:version, :rubygem => @rubygem, :number => '1.0.1.pre')
+      @three = create(:version, :rubygem => @rubygem, :number => '1.0.2.pre')
+      @rubygem.reload
+    end
+
+    should "show last pushed as latest version" do
+      assert_equal @three, @rubygem.versions.most_recent
+    end
+  end
+
   context "with versions created out of order" do
     setup do
       @gem = create(:rubygem)


### PR DESCRIPTION
If there are no release versions, the site will just pick the first version available. This is likely wrong, as the latest prerelease version should be shown.

Example: https://rubygems.org/gems/judopay
