### PR TITLE
Fix the size of Clippy because it prevents Copy.

### DIFF
--- a/app/views/rubygems/_clippy.html.erb
+++ b/app/views/rubygems/_clippy.html.erb
@@ -9,7 +9,7 @@
   <param name="wmode" value="transparent">
   <embed src="/<%= embed %>.swf"
          width="110"
-         height="32"
+         height="24"
          name="clippy"
          quality="high"
          allowScriptAccess="always"


### PR DESCRIPTION
A commit made in #433 / #440 is broken in recent versions of Chrome which do not like Objects to extend past their bounds, the oversizing of the area causes Chrome to trip out (at least on Linux, I assume on Windows and OS X too) because it extends into the text area and thus prevents any manual copy and paste.  This could also be broken by other changes and might not necessarily be related to Chrome at all.

The size of 24px was manually selected after adjusting the maximum size in inspector until I could copy.
