### PR TITLE
Leverage metadata to populate gems urls

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -76,11 +76,6 @@ module RubygemsHelper
     link_to_page :download, "/downloads/#{version.full_name}.gem"
   end
 
-  def documentation_link(version, linkset)
-    return unless linkset.nil? || linkset.docs.blank?
-    link_to_page :docs, version.documentation_path
-  end
-
   def badge_link(rubygem)
     badge_url = "https://badge.fury.io/rb/#{rubygem.name}/install"
     link_to t(".links.badge"), badge_url, class: "gem__link t-list__item", id: :badge

--- a/app/models/linkset.rb
+++ b/app/models/linkset.rb
@@ -1,18 +1,27 @@
 class Linkset < ActiveRecord::Base
   belongs_to :rubygem
 
-  LINKS = %w(home code docs wiki mail bugs).freeze
+  LINKS = {
+    'home' => 'homepage_uri',
+    'code' => 'source_code_uri',
+    'docs' => 'documentation_uri',
+    'wiki' => 'wiki_uri',
+    'mail' => 'mailing_list_uri',
+    'bugs' => 'bug_tracker_uri'
+  }.freeze
 
-  LINKS.each do |url|
+  LINKS.each do |url, aka|
     validates_formatting_of url.to_sym,
       using: :url,
       allow_nil: true,
       allow_blank: true,
       message: "does not appear to be a valid URL"
+
+    alias_attribute aka.to_sym, url.to_sym
   end
 
   def empty?
-    LINKS.map { |link| attributes[link] }.all?(&:blank?)
+    LINKS.keys.map { |link| attributes[link] }.all?(&:blank?)
   end
 
   def update_attributes_from_gem_specification!(spec)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -158,7 +158,7 @@ class Rubygem < ActiveRecord::Base
       'gem_uri'           => "#{protocol}://#{host_with_port}/gems/#{version.full_name}.gem",
       'homepage_uri'      => version.link_uri(:homepage_uri, linkset),
       'wiki_uri'          => version.link_uri(:wiki_uri, linkset),
-      'documentation_uri' => version.link_uri(:documentation_uri, linkset).presence || version.documentation_path,
+      'documentation_uri' => version.link_uri(:documentation_uri, linkset),
       'mailing_list_uri'  => version.link_uri(:mailing_list_uri, linkset),
       'source_code_uri'   => version.link_uri(:source_code_uri, linkset),
       'bug_tracker_uri'   => version.link_uri(:bug_tracker_uri, linkset),

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -156,12 +156,12 @@ class Rubygem < ActiveRecord::Base
       'sha'               => version.sha256_hex,
       'project_uri'       => "#{protocol}://#{host_with_port}/gems/#{name}",
       'gem_uri'           => "#{protocol}://#{host_with_port}/gems/#{version.full_name}.gem",
-      'homepage_uri'      => linkset.try(:home),
-      'wiki_uri'          => linkset.try(:wiki),
-      'documentation_uri' => linkset.try(:docs).presence || version.documentation_path,
-      'mailing_list_uri'  => linkset.try(:mail),
-      'source_code_uri'   => linkset.try(:code),
-      'bug_tracker_uri'   => linkset.try(:bugs),
+      'homepage_uri'      => version.link_uri(:homepage_uri, linkset),
+      'wiki_uri'          => version.link_uri(:wiki_uri, linkset),
+      'documentation_uri' => version.link_uri(:documentation_uri, linkset).presence || version.documentation_path,
+      'mailing_list_uri'  => version.link_uri(:mailing_list_uri, linkset),
+      'source_code_uri'   => version.link_uri(:source_code_uri, linkset),
+      'bug_tracker_uri'   => version.link_uri(:bug_tracker_uri, linkset),
       'dependencies'      => {
         'development' => deps.select { |r| r.rubygem && 'development' == r.scope },
         'runtime'     => deps.select { |r| r.rubygem && 'runtime' == r.scope }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -350,6 +350,10 @@ class Version < ActiveRecord::Base
     update_column(:required_rubygems_version, required_rubygems_version.to_s)
   end
 
+  def link_uri(name, linkset = nil)
+    metadata[name.to_s].presence || linkset.try(name).presence
+  end
+
   def documentation_path
     "http://www.rubydoc.info/gems/#{rubygem.name}/#{number}"
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -351,7 +351,8 @@ class Version < ActiveRecord::Base
   end
 
   def link_uri(name, linkset = nil)
-    metadata[name.to_s].presence || linkset.try(name).presence
+    metadata[name.to_s].presence || linkset.try(name).presence ||
+      (name.to_s == "documentation_uri" ? documentation_path : nil)
   end
 
   def documentation_path

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -63,7 +63,7 @@
 
     <% if @latest_version.indexed %>
       <% if @rubygem.linkset.present? %>
-        <%- Linkset::LINKS.each do |link| %>
+        <%- Linkset::LINKS.keys.each do |link| %>
           <%= link_to_page link, @rubygem.linkset.public_send(link) %>
         <%- end %>
       <% end %>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -69,7 +69,6 @@
       <%= download_link(@latest_version) %>
     <% end %>
 
-    <%= documentation_link(@latest_version, @rubygem.linkset) %>
     <%= badge_link(@rubygem) %>
     <%= subscribe_link(@rubygem) if @latest_version.indexed %>
     <%= unsubscribe_link(@rubygem) %>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -62,11 +62,9 @@
     <%= link_to t('edit'), edit_rubygem_path(@rubygem), :class => "gem__link t-list__item", :id => "edit" if @rubygem.owned_by?(current_user) %>
 
     <% if @latest_version.indexed %>
-      <% if @rubygem.linkset.present? %>
-        <%- Linkset::LINKS.keys.each do |link| %>
-          <%= link_to_page link, @rubygem.linkset.public_send(link) %>
-        <%- end %>
-      <% end %>
+      <%- Linkset::LINKS.each do |link, attribute| %>
+        <%= link_to_page link, @latest_version.link_uri(attribute, @rubygem.linkset) %>
+      <%- end %>
 
       <%= download_link(@latest_version) %>
     <% end %>

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -56,23 +56,6 @@ class RubygemsHelperTest < ActionView::TestCase
     assert_equal "March 18, 2011", nice_date_for(time)
   end
 
-  should "link to docs if no docs link is set" do
-    version = build(:version)
-    linkset = build(:linkset, docs: nil)
-
-    @virtual_path = "rubygems.show"
-    link = documentation_link(version, linkset)
-    assert link.include?(version.documentation_path)
-  end
-
-  should "not link to docs if docs link is set" do
-    version = build(:version)
-    linkset = build(:linkset)
-
-    link = documentation_link(version, linkset)
-    assert link.blank?
-  end
-
   should "link to the badge" do
     rubygem = create(:rubygem)
     url = "https://badge.fury.io/rb/#{rubygem.name}/install"

--- a/test/unit/linkset_test.rb
+++ b/test/unit/linkset_test.rb
@@ -17,10 +17,20 @@ class LinksetTest < ActiveSupport::TestCase
     end
 
     should "be empty with no links filled out" do
-      Linkset::LINKS.each do |link|
+      Linkset::LINKS.keys.each do |link|
         @linkset.send("#{link}=", nil)
       end
       assert @linkset.empty?
+    end
+
+    should "have api uri getter" do
+      @linkset.docs = "http://example.com/docs"
+      assert_equal "http://example.com/docs", @linkset.documentation_uri
+    end
+
+    should "have api uri setter" do
+      @linkset.documentation_uri = "http://example.com/docs"
+      assert_equal "http://example.com/docs", @linkset.docs
     end
   end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -458,6 +458,44 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal run_dep.name, doc.at_css("dependencies runtime dependency name").content
     end
 
+    context "with metadata" do
+      setup do
+        @rubygem = build(:rubygem)
+        @version = create(:version, rubygem: @rubygem)
+      end
+
+      should "prefer metadata over links in JSON" do
+        @version.update_attributes!(
+          metadata: {
+            "homepage_uri" => "http://example.com/home",
+            "wiki_uri" => "http://example.com/wiki",
+            "documentation_uri" => "http://example.com/docs",
+            "mailing_list_uri" => "http://example.com/mail",
+            "source_code_uri" => "http://example.com/code",
+            "bug_tracker_uri" => "http://example.com/bugs"
+          }
+        )
+
+        hash = MultiJson.load(@rubygem.to_json)
+
+        assert_equal "http://example.com/home", hash["homepage_uri"]
+        assert_equal "http://example.com/wiki", hash["wiki_uri"]
+        assert_equal "http://example.com/docs", hash["documentation_uri"]
+        assert_equal "http://example.com/mail", hash["mailing_list_uri"]
+        assert_equal "http://example.com/code", hash["source_code_uri"]
+        assert_equal "http://example.com/bugs", hash["bug_tracker_uri"]
+      end
+
+      should "return version documentation url if metadata and linkset docs is empty" do
+        @version.update_attributes!(metadata: {})
+        @rubygem.linkset.docs = ""
+        @rubygem.save
+        hash = JSON.load(@rubygem.to_json)
+
+        assert_equal @version.documentation_path, hash["documentation_uri"]
+      end
+    end
+
     context "with a linkset" do
       setup do
         @rubygem = build(:rubygem)


### PR DESCRIPTION
This parses common urls from the `gemspec` metadata. It uses the same keys as the api (found in `gemspec.rb`).

Addresses questions I've seen in mailing list and gh issues.

Addresses issues in #718

Thanks

/cc @qrush @fwolfst

**UPDATE:** reduced heading comment since the original concern was determining the keys to use. (this was resolved by using the ones in `gemspec.rb`
