### PR TITLE
Don't start redirect loop on docs url requests

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -6,10 +6,10 @@ class Redirector
   def call(env)
     request = Rack::Request.new(env)
 
-    if request.host != Gemcutter::HOST && request.path !~ %r{^/api}
+    if request.host != Gemcutter::HOST && request.path !~ %r{^/api} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))
       redirect_to(fake_request.url)
-    elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)}
+    elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)} && request.host !~ /docs/
       redirect_to("http://docs.rubygems.org#{request.path}")
     elsif request.path =~ %r{^/pages/docs$}
       redirect_to("http://guides.rubygems.org")

--- a/test/unit/redirector_test.rb
+++ b/test/unit/redirector_test.rb
@@ -51,6 +51,12 @@ class RedirectorTest < ActiveSupport::TestCase
     end
   end
 
+  should "not redirect docs.rubygems.org to a url that redirects back to docs.rubygems.org" do
+    get '/read/book/2', {}, {"HTTP_HOST" => 'docs.rubygems.org'}
+
+    assert_equal 200, last_response.status
+  end
+
   should "redirect request to docs to guides " do
     get "/pages/docs", {}, {"HTTP_HOST" => Gemcutter::HOST}
 


### PR DESCRIPTION
A redirect loop was occurring for some urls, including, for example, "docs.rubygems.org/read".  This was because urls starting with docs.rubygems.org were always redirected to rubygems.org, and the url "rubygems.org/read" was redirected then redirected back to "docs.rubygems.org/read".  See https://github.com/rubygems/rubygems.org/issues/716