### PR TITLE
Fix user menu links on homepage.

### DIFF
--- a/public/stylesheets/home.css
+++ b/public/stylesheets/home.css
@@ -7,6 +7,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  z-index: -1;
 }
 
 @media (min-width: 1020px) {


### PR DESCRIPTION
### Issue

When viewing the hompage as a signed in user the 'dashboard' and 'sign out' links are not clickable.  I confirmed this behavior is present in the current versions of chrome, firefox, and safari.

![rubygems_org___your_community_gem_host](https://cloud.githubusercontent.com/assets/533751/5101586/438505da-6f70-11e4-8dd3-84b3fb96ae36.png)
### Patch

I was able to get the desired behavior working by adjusting the `z-index` on one of the banner nodes on the home page.

I don't proclaim to be a CSS aficionado so there is likely a better or more correct way to do this.  Also, I was unable to find a way of testing this as the capybara driver used in the cucumber suite (based on my reading of the source) simply grabs the 'href' for a hyperlink when an action like 'click' is invoked on a node so it doesn't really simulate an interaction with the cursor.

At any rate, thanks for taking a look.
