### PR TITLE
Use number_with_delimiter when printing stats

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -4,15 +4,15 @@
 <div class="stats">
   <h2 class="stat" data-icon="⟡">
     Total Gems
-    <span class="stat__count"><%= @number_of_gems %></span>
+    <span class="stat__count"><%= number_with_delimiter @number_of_gems %></span>
   </h2>
   <h2 class="stat" data-icon="☺">
     Total Users
-    <span class="stat__count"><%= @number_of_users %></span>
+    <span class="stat__count"><%= number_with_delimiter @number_of_users %></span>
   </h2>
   <h2 class="stat" data-icon="⌄">
     Total Downloads
-    <span class="stat__count"><%= @number_of_downloads %></span>
+    <span class="stat__count"><%= number_with_delimiter @number_of_downloads %></span>
   </h2>
 </div>
 


### PR DESCRIPTION
This commit improves the view:

![before](https://cloud.githubusercontent.com/assets/10076/5132312/3c32986a-70b0-11e4-88d6-edd72b5ecf78.png)

making it look like:

![after](https://cloud.githubusercontent.com/assets/10076/5132310/3c1df9a0-70b0-11e4-9763-f19b06538534.png)
