### PR TITLE
Rename homepage search selector id attribute

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,8 +4,8 @@
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_url, :id => "main-search", :method => :get do %>
-    <%= search_field_tag :query, params[:query], :placeholder => "Search Gems&hellip;".html_safe, autofocus: current_page?(root_url), :class => "home__search" %>
-    <%= label_tag :query do %>
+    <%= search_field_tag :query, params[:query], :placeholder => "Search Gems&hellip;".html_safe, autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
+    <%= label_tag :home_query do %>
     <span class="t-hidden">Search gems</span>
     <% end %>
     <%= submit_tag '⌕', :id => 'search_submit', :name => nil, :class => "home__search__icon" %>


### PR DESCRIPTION
Fix for https://github.com/rubygems/rubygems.org/issues/784 :santa: 

Renames the homepage search selector id attribute to remove conflict with search input in the layout header.
