### PR TITLE
Dont use match on routes as wont work on rails4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,7 +132,7 @@ Gemcutter::Application.routes.draw do
 
   resource :session, :only => [:create, :destroy]
 
-  match 'sign_out' => 'sessions#destroy', :via => :delete, :as => 'sign_out'
+  delete '/sign_out' => 'sessions#destroy', as: 'custom_sign_out'
 
   resources :passwords, :only => [:new, :create]
 


### PR DESCRIPTION
### Problem

route `match` is not a thing anymore on rails 4+ .
### Solution

This replaces the syntax using a `delete`, however we cannot use `as: 'sign_out'` as on rails 4 you cannot override a route `as` value if that was defined before, which is the case in https://github.com/thoughtbot/clearance/blob/master/config/routes.rb#L20 . So we give it another key, but we as the path(`/sign_out`) is the same as the original, we can still use `sign_out_path` which will generate `/sign_out` and will pass through out custom route.

This is necessary for rails 4, and works on rails 3.2

r. @dwradcliffe @qrush
cc @georgedrummond
