### PR TITLE
Fix with_versions scope

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -16,7 +16,7 @@ class Rubygem < ActiveRecord::Base
   before_destroy :mark_unresolved
 
   def self.with_versions
-    joins(:versions).where(versions: { indexed: true })
+    where("rubygems.id IN (SELECT rubygem_id FROM versions where versions.indexed IS true)")
   end
 
   def self.with_one_version


### PR DESCRIPTION
this revert scope changed on 960794ed6b78674ef85a913fdc358825f809ddae .
The query is not the same, and it is resulting to show duplicates gems in the dashboard.

r. @dwradcliffe 
