### PR TITLE
Remove format.atom check.

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,7 +1,7 @@
 class DashboardsController < ApplicationController
 
-  before_filter :authenticate_with_api_key, :if => lambda { |controller| controller.request.format.atom? }
-  before_filter :redirect_to_root, :unless => :signed_in?
+  before_filter :authenticate_with_api_key, unless: :signed_in?
+  before_filter :redirect_to_root, unless: :signed_in?
 
   def show
     respond_to do |format|


### PR DESCRIPTION
The check was added at
https://github.com/rubygems/rubygems.org/commit/3d0c24e27ada9989a252e998c19d623d1307e1a2#diff-e4663ec6bcde373fc1ee998eb69725b1R3
Commit message says it was added to make clearance happy, however we
dont need that check anymore.

review @dwradcliffe @qrush 

also this was not fully working under rails 4+ , so removing it would make it easier to upgrade.
