### PR TITLE
Use HTTP_ when setting a header to env

### DIFF
--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -52,7 +52,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
     setup do
       @url = "http://example.org"
       @user = create(:user)
-      @request.env["Authorization"] = @user.api_key
+      @request.env["HTTP_AUTHORIZATION"] = @user.api_key
     end
 
     context "with the gemcutter gem" do

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -37,7 +37,7 @@ class DashboardsControllerTest < ActionController::TestCase
         @subscribed_versions.each { |v| create(:subscription, :rubygem => v.rubygem, :user => @user)}
         @unsubscribed_versions = (1..3).map { |n| create(:version, :created_at => n.hours.ago) }
 
-        @request.env["Authorization"] = @user.api_key
+        @request.env["HTTP_AUTHORIZATION"] = @user.api_key
         get :show, :format => "atom"
       end
 


### PR DESCRIPTION
On latest rack versions, you need to setup the headers under env using HTTP_*, this make tests pass under rails 3 and 4
