### PR TITLE
Dont use Rails.env before require rails/all

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,11 +3,8 @@ require File.expand_path('../boot', __FILE__)
 require 'rails'
 require 'action_controller/railtie'
 
-unless Rails.env.maintenance?
-  require 'rails/test_unit/railtie'
-  require 'action_mailer/railtie'
-  require 'active_record/railtie'
-  require 'sprockets/railtie'
+if 'maintenance' != ENV["RAILS_ENV"]
+  require 'rails/all'
 end
 
 if defined?(Bundler)


### PR DESCRIPTION
On rails 4.0+ , when calling `Rails.env` that will be memoized https://github.com/rails/rails/blob/4-0-stable/railties/lib/rails.rb#L56 , so if RAILS_ENV changes after that, for instance for tests https://github.com/rails/rails/commit/3ff263919c67588e4348da30cb92b860fe83cba5 that `@_env` ivar will have the wrong value.

Solution is not use Rails.env before requiring all rails.

(also I am requiring `rails/all` as we require all dependencies from it)

cc @senny
