### PR TITLE
Remove bundler assets group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,11 +34,9 @@ gem 'xml-simple'
 gem 'yajl-ruby', require: 'yajl'
 gem 'autoprefixer-rails'
 
-group :assets do
-  gem 'sass-rails',   '~> 3.2.3'
-  gem 'coffee-rails', '~> 3.2.1'
-  gem 'uglifier', '>= 1.0.3'
-end
+gem 'sass-rails',   '~> 3.2.3'
+gem 'coffee-rails', '~> 3.2.1'
+gem 'uglifier', '>= 1.0.3'
 
 # enable if on heroku, make sure to toss this into an initializer:
 #     Rails.application.config.middleware.use HerokuAssetCacher

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,12 +10,9 @@ unless Rails.env.maintenance?
   require 'sprockets/railtie'
 end
 
-if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
-  # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
-end
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
 
 $rubygems_config = YAML.load_file("config/rubygems.yml")[Rails.env].symbolize_keys
 HOST             = $rubygems_config[:host]


### PR DESCRIPTION
Rails 4+ dont build an app with assets group anymore, we can remove that right now under rails 3.2 too.
