### PR TITLE
s/assert_include/assert_includes to be compatible rails 3 and 4

### DIFF
--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -101,10 +101,10 @@ class PusherTest < ActiveSupport::TestCase
         @cutter = Pusher.new(@user, @gem)
         @cutter.pull_spec
         assert_nil @cutter.spec
-        assert_include @cutter.message, %{RubyGems.org cannot process this gem}
-        assert_include @cutter.message, %{The metadata is invalid}
-        assert_include @cutter.message, %{Forbidden symbol in YAML}
-        assert_include @cutter.message, %{badsymbol}
+        assert_includes @cutter.message, %{RubyGems.org cannot process this gem}
+        assert_includes @cutter.message, %{The metadata is invalid}
+        assert_includes @cutter.message, %{Forbidden symbol in YAML}
+        assert_includes @cutter.message, %{badsymbol}
         assert_equal @cutter.code, 422
       end
     end


### PR DESCRIPTION
`assert_includes` works on 3 and 4.
`assert_include` wont work on Rails 4+.
