### PR TITLE
Change assert on jsonp response so works on rails 4

### DIFF
--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -159,7 +159,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return latest version" do
       get :latest, :id => @rubygem.name, :format => "js", :callback => "blah"
-      assert_equal "blah", @response.body.split("(",2).first
+      assert_match(/blah\(.*\)\Z/, @response.body)
     end
   end
 


### PR DESCRIPTION
On rails 4+, jsonp responses add a /**/ to the begining of the response, this assert_match will match the response body from 3.2 and 4+
