### PR TITLE
No need for strong_params on login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,10 @@ class SessionsController < Clearance::SessionsController
   ssl_required
 
   def create
-    @user = User.authenticate(params_who, params_password)
+    params.require(:session)
+    @user = User.authenticate(
+      params[:session][:who], params[:session][:password]
+    )
 
     sign_in(@user) do |status|
       if status.success?
@@ -26,13 +29,5 @@ class SessionsController < Clearance::SessionsController
 
   def url_after_create
     dashboard_url
-  end
-
-  def params_who
-    params.require(:session).permit(:who)[:who]
-  end
-
-  def params_password
-    params.require(:session).permit(:password)[:password]
   end
 end


### PR DESCRIPTION
when running in development, I get this warnings:

```
Unpermitted parameters: password
Unpermitted parameters: who
```

Not sure why, if the login actually works. Anyhow this is not a hash association so there is no need to use strong parameters here. Replacing this with a raw get to the params, works under rails 3.2 and 4, tested locally in both, and no warning anymore.
