### PR TITLE
Dont use ssl cookies on tests or dev

### DIFF
--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,7 +1,7 @@
 unless Rails.env.maintenance?
   Clearance.configure do |config|
     config.mailer_sender = "donotreply@rubygems.org"
-    config.secure_cookie = true
+    config.secure_cookie = true unless Rails.env.test? || Rails.env.development?
     config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,7 +5,11 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, :key => '_rubygems_session', :secure => true
+options = {key: '_rubygems_session'}
+unless Rails.env.test? || Rails.env.development?
+  options[:secure] = true
+end
+Rails.application.config.session_store :cookie_store, options
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
[related #680] - It doesnt fix the issue in production, as it is a
clearance issue, but it resolves it in development and test.

development/test has no ssl certificate so setting cookies in that scope is pointless and confusing as the cookies will not be persisted.
This change is necessary for rails 4+ , as the capybara tests were failing because the server in there is not https, and it was losing the session, as no cookie set. Not sure why it works under 3.2, it might be some rails bug where they mix secure and unsecure cookies(which was fixed on 4+). Regardless, the right thing to do is not use ssl cookies locally. (see https://github.com/rubygems/rubygems.org/issues/680#issuecomment-64927047)

cc @derekprior @knappe
r. @dwradcliffe 
