### PR TITLE
Remove not allowed chars from name before use as url.

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -181,7 +181,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def to_param
-    name
+    name.gsub(/[^#{Patterns::ALLOWED_CHARACTERS}]/, '')
   end
 
   def with_downloads

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -366,6 +366,21 @@ class RubygemsControllerTest < ActionController::TestCase
     end
   end
 
+  context "On GET to show for a gem with runtime dependencies that have a bad link" do
+    setup do
+      @version = create(:version)
+      @runtime = create(:runtime_dependency, version: @version)
+      @runtime.rubygem.update_column(:name, 'foo>0.1.1')
+      get :show, id: @version.rubygem.to_param
+    end
+
+    should respond_with :success
+    should render_template :show
+    should "show runtime dependencies and development dependencies" do
+      assert page.has_content?(@runtime.rubygem.name)
+    end
+  end
+
   context "On GET to show for nonexistent gem" do
     setup do
       get :show, :id => "blahblah"


### PR DESCRIPTION
Unfortunately, we have some gems that contains some chars that are not resolved as the URL pattern we have on the routes, so we cannot try to create a link out of them. Ideally we should not save those names, as we have a validation on the Rubygem model, however we still have some bad data in the db.

For instance this fix errors like the one is happening on https://rubygems.org/gems/pasaporte , which has a dependency with `camping>=1.5.180` as name.
