### PR TITLE
Fix bad format on gems/ path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints :id => Patterns::ROUTE_PATTERN do
+  scope constraints: {id: Patterns::ROUTE_PATTERN}, defaults: {format: 'html'} do
     resources :rubygems, :path => 'gems', :only => [:show, :edit, :update] do
 
       constraints :rubygem_id => Patterns::ROUTE_PATTERN do

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class GemsTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @rubygem = create(:rubygem, name: "sandworm", number: "1.0.0")
+  end
+
+  test "gem page with a non valid format" do
+    get rubygem_path(@rubygem), nil, {'HTTP_ACCEPT' => 'application/mercurial-0.1'}
+    assert page.has_content? "1.0.0"
+  end
+end


### PR DESCRIPTION
Fix `ActionView::MissingTemplate` when giving a bad `HTTP_ACCEPT` header. on `/gems/:id` path.

### Solution
Add a scope instead of constraint as we can add a default format with it.

r @qrush 