### PR TITLE
Limit route to html

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,23 +90,24 @@ Rails.application.routes.draw do
 
   ################################################################################
   # UI
+  scope constraints: {format: :html}, defaults: {format: 'html'} do
+    resource  :search,    :only => :show
+    resource  :dashboard, :only => :show
+    resources :profiles,  :only => :show
+    resource  :profile,   :only => [:edit, :update]
+    resources :stats,     :only => :index, :constraints => RecoveryMode
 
-  resource  :search,    :only => :show
-  resource  :dashboard, :only => :show
-  resources :profiles,  :only => :show
-  resource  :profile,   :only => [:edit, :update]
-  resources :stats,     :only => :index, :constraints => RecoveryMode
-
-  resources :rubygems, :only => :index, :path => 'gems' do
-    constraints :rubygem_id => Patterns::ROUTE_PATTERN do
-      resource  :subscription, :only => [:create, :destroy]
-      resources :versions,     :only => :index
+    resources :rubygems, :only => :index, :path => 'gems' do
+      constraints :rubygem_id => Patterns::ROUTE_PATTERN do
+        resource  :subscription, :only => [:create, :destroy]
+        resources :versions,     :only => :index
+      end
     end
-  end
 
-  scope constraints: {id: Patterns::ROUTE_PATTERN}, defaults: {format: 'html'} do
-    resources :rubygems, :path => 'gems', :only => [:show, :edit, :update] do
-      resources :versions, only: :show, constraints: {rubygem_id: Patterns::ROUTE_PATTERN}
+    scope constraints: {id: Patterns::ROUTE_PATTERN} do
+      resources :rubygems, :path => 'gems', :only => [:show, :edit, :update] do
+        resources :versions, only: :show, constraints: {rubygem_id: Patterns::ROUTE_PATTERN}
+      end
     end
   end
 

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -27,4 +27,10 @@ class DashboardTest < ActionDispatch::IntegrationTest
     assert page.has_content? "sandworm"
     assert ! page.has_content?("arrakis")
   end
+
+  test "dashboard with a non valid format" do
+    assert_raises(ActionController::RoutingError) do
+      get dashboard_path(format: :json)
+    end
+  end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -6,7 +6,7 @@ class GemsTest < ActionDispatch::IntegrationTest
     @rubygem = create(:rubygem, name: "sandworm", number: "1.0.0")
   end
 
-  test "gem page with a non valid format" do
+  test "gem page with a non valid HTTP_ACCEPT header" do
     get rubygem_path(@rubygem), nil, {'HTTP_ACCEPT' => 'application/mercurial-0.1'}
     assert page.has_content? "1.0.0"
   end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -43,4 +43,10 @@ class SearchTest < SystemTest
     assert ! page.has_content?("2.2.2")
     assert page.has_content?("3.3.3")
   end
+
+  test "search page with a non valid format" do
+    assert_raises(ActionController::RoutingError) do
+      get search_path(format: :json), {query: 'foobar'}
+    end
+  end
 end


### PR DESCRIPTION
Limit UI routes to html format only.
So when doing things like this, it wont return a 500 error

https://rubygems.org/profiles/arthurnn.json
https://rubygems.org/search.json?query=foo

review @sferik @qrush @dwradcliffe 