### PR TITLE
Always redirect to https, not only after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   helper :announcements
   protect_from_forgery :only => [:create, :update, :destroy]
-  ssl_required :if => :ssl_required?
+  ssl_required
 
   before_filter :set_locale
 
@@ -40,10 +40,6 @@ class ApplicationController < ActionController::Base
       request.body.size if request.body.respond_to? :size
       render :text => t(:please_sign_up), :status => 401
     end
-  end
-
-  def ssl_required?
-    cookies[:ssl]
   end
 
   def find_rubygem

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,6 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         Librato.increment 'login.success'
-        cookies[:ssl] = true
         redirect_back_or(url_after_create)
       else
         Librato.increment 'login.failure'
@@ -18,11 +17,6 @@ class SessionsController < Clearance::SessionsController
         render :template => 'sessions/new', :status => :unauthorized
       end
     end
-  end
-
-  def destroy
-    cookies.delete(:ssl)
-    super
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,8 +116,6 @@ Rails.application.routes.draw do
 
   resource :session, :only => [:create, :destroy]
 
-  delete '/sign_out' => 'sessions#destroy', as: 'custom_sign_out'
-
   resources :passwords, :only => [:new, :create]
 
   resources :users do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -11,10 +11,6 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :redirect
       should redirect_to('the dashboard') { dashboard_url }
 
-      should "set the ssl cookie" do
-        assert_not_nil cookies[:ssl]
-      end
-
       should "sign in the user" do
         assert @controller.signed_in?
       end
@@ -30,10 +26,6 @@ class SessionsControllerTest < ActionController::TestCase
       should render_template 'sessions/new'
       should set_the_flash.now[:notice]
 
-      should "not set the ssl cookie" do
-        assert_nil cookies[:ssl]
-      end
-
       should "not sign in the user" do
         assert !@controller.signed_in?
       end
@@ -47,10 +39,6 @@ class SessionsControllerTest < ActionController::TestCase
 
     should respond_with :redirect
     should redirect_to('login page') { sign_in_url }
-
-    should "clear the ssl cookie" do
-      assert_nil cookies[:ssl]
-    end
 
     should "sign out the user" do
       assert !@controller.signed_in?


### PR DESCRIPTION
[fixes #814]

### Problem
In a browser without rubygems cookies, go to http://rubygems.org/sign_in, and login. It will redirect to https://rubygems.org/session.

### Why this is happening?
Because the POST path to login is `/session`, and `ssl_required` required will run after the login.
rubygems.org pages will only start redirecting to https after login. (because will set `cookies[:ssl] = true`), so right after the login it will send to a bad https page.

### Solution
Always redirect to https. So nobody can go to /sign_in on http.

review @qrush @sferik @dwradcliffe 
cc @knappe