### PR TITLE
Remove XML API

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ActivitiesController < Api::BaseController
-  respond_to :json, :xml, :yaml, :on => [:latest, :just_updated]
+  respond_to :json, :yaml, :on => [:latest, :just_updated]
 
   def latest
     @rubygems = Rubygem.latest(50)

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ApiKeysController < Api::BaseController
   before_filter :redirect_to_root, :unless => :signed_in?, :only => [:reset]
-  respond_to :json, :xml, :yaml, :only => :show
+  respond_to :json, :yaml, :only => :show
 
   def show
     authenticate_or_request_with_http_basic do |username, password|
@@ -9,7 +9,6 @@ class Api::V1::ApiKeysController < Api::BaseController
         respond_to do |format|
           format.any(:all) { render :text => current_user.api_key }
           format.json { render :json => {:rubygems_api_key => current_user.api_key} }
-          format.xml  { render :xml  => {:rubygems_api_key => current_user.api_key} }
           format.yaml { render :text => {:rubygems_api_key => current_user.api_key}.to_yaml }
         end
       else

--- a/app/controllers/api/v1/downloads_controller.rb
+++ b/app/controllers/api/v1/downloads_controller.rb
@@ -1,11 +1,10 @@
 class Api::V1::DownloadsController < Api::BaseController
-  respond_to :json, :xml, :yaml
+  respond_to :json, :yaml
 
   def index
     respond_to do |format|
       format.any(:all) { render :text => Download.count }
       format.json { render :json => {:total => Download.count} }
-      format.xml  { render :xml  => {:total => Download.count} }
       format.yaml { render :text => {:total => Download.count}.to_yaml }
     end
   end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::OwnersController < Api::BaseController
   before_filter :verify_authenticated_user, :except => [:show, :gems]
   before_filter :find_rubygem, :except => :gems
   before_filter :verify_gem_ownership, :except => [:show, :gems]
-  respond_to :yaml, :xml, :json, :only => [:show, :gems]
+  respond_to :yaml, :json, :only => [:show, :gems]
 
   def show
     respond_with @rubygem.owners

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::RubygemsController < Api::BaseController
   before_filter :find_rubygem_by_name,      :only => [:yank, :unyank]
   before_filter :validate_gem_and_version,  :only => [:yank, :unyank]
 
-  respond_to :json, :xml, :yaml, :on => [:index, :show, :latest, :just_updated]
+  respond_to :json, :yaml, :on => [:index, :show, :latest, :just_updated]
 
   def index
     @rubygems = current_user.rubygems.with_versions

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::SearchesController < Api::BaseController
 
   skip_before_filter :verify_authenticity_token
-  respond_to :json, :xml, :yaml
+  respond_to :json, :yaml
 
   def show
     return unless has_required_params?(:query)

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::VersionsController < Api::BaseController
-  respond_to :json, :xml, :yaml
+  respond_to :json, :yaml
 
   def show
     find_rubygem

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::WebHooksController < Api::BaseController
   before_filter :authenticate_with_api_key
   before_filter :verify_authenticated_user
   before_filter :find_rubygem_by_name, :except => :index
-  respond_to :json, :xml, :yaml, :only => :index
+  respond_to :json, :yaml, :only => :index
 
   def index
     respond_with current_user.all_hooks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
         get :top, :on => :collection
         get :all, :on => :collection
       end
-      constraints :id => Patterns::ROUTE_PATTERN, :format => /json|xml|yaml/ do
+      constraints id: Patterns::ROUTE_PATTERN, format: /json|yaml/ do
         get 'owners/:handle/gems', to: 'owners#gems', as: 'owners_gems', constraints: {handle: Patterns::ROUTE_PATTERN}, format: true
 
         resources :downloads, only: :show, format: true
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
 
       resources :dependencies, :only => :index
 
-      resources :rubygems, :path => 'gems', :only => [:create, :show, :index], :id => Patterns::LAZY_ROUTE_PATTERN, :format => /json|xml|yaml/ do
+      resources :rubygems, path: 'gems', only: [:create, :show, :index], id: Patterns::LAZY_ROUTE_PATTERN, format: /json|yaml/ do
         member do
           get :reverse_dependencies
         end
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resource :activity, :only => [], :format => /json|xml|yaml/ do
+      resource :activity, only: [], format: /json|yaml/ do
         collection do
           get :latest
           get :just_updated

--- a/test/functional/api/v1/activities_controller_test.rb
+++ b/test/functional/api/v1/activities_controller_test.rb
@@ -42,12 +42,6 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
         get :latest, :format => :yaml
         should_return_latest_gems YAML.load(@response.body)
       end
-
-      should "return correct XML for latest gems" do
-        get :latest, :format => :xml
-        gems = Hash.from_xml(Nokogiri.parse(@response.body).to_xml)['rubygems']
-        should_return_latest_gems(gems)
-      end
     end
 
     context "On GET to just_updated" do
@@ -74,13 +68,6 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
         get :just_updated, :format => :yaml
         should_return_just_updated_gems YAML.load(@response.body)
       end
-
-      should "return correct XML for just_updated gems" do
-        get :just_updated, :format => :xml
-        gems = Hash.from_xml(Nokogiri.parse(@response.body).to_xml)['rubygems']
-        should_return_just_updated_gems(gems)
-      end
     end
-
   end
 end

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -76,10 +76,6 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     should_respond_to(:yaml, :to_sym) do |body|
      YAML.load body
     end
-
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['hash']
-    end
   end
 
   context "on PUT to reset with signed in user" do

--- a/test/functional/api/v1/downloads_controller_test.rb
+++ b/test/functional/api/v1/downloads_controller_test.rb
@@ -24,10 +24,6 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
       MultiJson.load(body)['total']
     end
 
-    should_respond_to(:xml) do |body|
-      Nokogiri.parse(body).root.children[1].children.first.text.to_i
-    end
-
     should_respond_to(:yaml) do |body|
       YAML.load(body)[:total]
     end
@@ -76,10 +72,6 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
 
     should_respond_to(:json) do |body|
       MultiJson.load body
-    end
-
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['hash']
     end
 
     should_respond_to(:yaml, :to_sym) do |body|
@@ -168,10 +160,6 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     should_respond_to(:yaml) do |body|
       YAML.load(body)[:gems]
     end
-
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['hash']['gems']
-    end
   end
 
   context "On GET to all" do
@@ -200,10 +188,5 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     should_respond_to(:yaml) do |body|
       YAML.load(body)[:gems]
     end
-
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['hash']['gems']
-    end
   end
-
 end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -36,10 +36,6 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     end
   end
 
-  should_respond_to :xml do |body|
-    Hash.from_xml(Nokogiri.parse(body).to_xml)['users']
-  end
-
   should_respond_to :json do |body|
     MultiJson.load body
   end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -64,10 +64,6 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       should_respond_to(:yaml) do |body|
        YAML.load body
       end
-
-      should_respond_to(:xml) do |body|
-        Hash.from_xml(Nokogiri.parse(body).to_xml)
-      end
     end
 
     context "On GET to show for a gem that not hosted" do
@@ -151,10 +147,6 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       should_respond_to :yaml do |body|
         YAML.load body
-      end
-
-      should_respond_to :xml do |body|
-        Hash.from_xml(Nokogiri.parse(body).to_xml)['rubygems']
       end
     end
 

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -42,10 +42,6 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
       MultiJson.load body
     end
 
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['rubygems']
-    end
-
     should_respond_to(:yaml) do |body|
       YAML.load body
     end

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -64,10 +64,6 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
       MultiJson.load(body)
     end
 
-    should_respond_to(:xml) do |body|
-      Hash.from_xml(Nokogiri.parse(body).to_xml)['versions']
-    end
-
     should_respond_to(:yaml) do |body|
       YAML.load(body)
     end

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -137,13 +137,6 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
           YAML.load(body)
         end
 
-        should_respond_to(:xml) do |body|
-          children = Nokogiri.parse(body).root.children
-          Hash.from_xml(children[1].to_xml).update(
-            'all gems' => Hash.from_xml(children[3].to_xml).delete('all_gems')
-          )
-        end
-
         context "On DELETE to remove with owned hook for rubygem" do
           setup do
             delete :remove,
@@ -297,4 +290,3 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
     end
   end
 end
-


### PR DESCRIPTION
Since
https://github.com/rubygems/rubygems-infrastructure/blob/f256a4c9910f3b00e2a4473556ddcc6a552d5dc1/cookbooks/rubygems-balancer/files/default/filters.conf#L4
, all xml requests are blocked on ngnix level, and at the moment they
return a 404. (i.e. https://rubygems.org/api/v1/downloads.xml )

This removes all code that handled xml, as we dont serve those anymore.

After we merge this, we will need to update the API docs accordingly. 

review @evanphx @qrush @sferik @dwradcliffe 