### PR TITLE
Fix atom routes for /dashboard and /gems

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,19 +92,19 @@ Rails.application.routes.draw do
   # UI
   scope constraints: {format: :html}, defaults: {format: 'html'} do
     resource  :search,    :only => :show
-    resource  :dashboard, :only => :show
+    resource  :dashboard, :only => :show, constraints: {format: /html|atom/}
     resources :profiles,  :only => :show
     resource  :profile,   :only => [:edit, :update]
     resources :stats,     :only => :index, :constraints => RecoveryMode
 
-    resources :rubygems, :only => :index, :path => 'gems' do
-      constraints :rubygem_id => Patterns::ROUTE_PATTERN do
+    resources :rubygems, only: :index, path: 'gems', constraints: {format: /html|atom/} do
+      scope constraints: {rubygem_id: Patterns::ROUTE_PATTERN, format: :html} do
         resource  :subscription, :only => [:create, :destroy]
         resources :versions,     :only => :index
       end
     end
 
-    scope constraints: {id: Patterns::ROUTE_PATTERN} do
+    scope constraints: {id: Patterns::ROUTE_PATTERN, format: :html} do
       resources :rubygems, :path => 'gems', :only => [:show, :edit, :update] do
         resources :versions, only: :show, constraints: {rubygem_id: Patterns::ROUTE_PATTERN}
       end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -33,4 +33,14 @@ class DashboardTest < ActionDispatch::IntegrationTest
       get dashboard_path(format: :json)
     end
   end
+
+  test "dashboard with atom format" do
+    rubygem = create(:rubygem, name: "sandworm", number: "1.0.0")
+    create(:subscription, rubygem: rubygem, user: @user)
+
+    get dashboard_path(format: :atom)
+    assert_response :success
+    assert_equal :atom, response.content_type.symbol
+    assert page.has_content? "sandworm"
+  end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -10,4 +10,11 @@ class GemsTest < ActionDispatch::IntegrationTest
     get rubygem_path(@rubygem), nil, {'HTTP_ACCEPT' => 'application/mercurial-0.1'}
     assert page.has_content? "1.0.0"
   end
+
+  test "gems page with atom format" do
+    get rubygems_path(format: :atom)
+    assert_response :success
+    assert_equal :atom, response.content_type.symbol
+    assert page.has_content? "sandworm"
+  end
 end


### PR DESCRIPTION
After c939cdf4264614191bf172b4906cd07ae2f18463, all UI resquests start
only responding to html format, however DashboardController and
RubygemsController also need to respond to atom format.
This fix those format on the routes and add integration test for
them. There was functional tests for them, however the functional tests
dont go through the routes, so thats why they were passing.

r @sferik @dwradcliffe @qrush 