### PR TITLE
Fix more routes

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -15,7 +15,9 @@ protected
 
   def render_toggle_or_unacceptable(success)
     if success
-      render :update
+      respond_to do |format|
+        format.js { render :update }
+      end
     else
       render :text => '', :status => :forbidden
     end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -25,7 +25,7 @@ module RubygemsHelper
 
   def subscribe_link(rubygem)
     if signed_in?
-      subscribe = link_to 'Subscribe', rubygem_subscription_path(rubygem),
+      link_to 'Subscribe', rubygem_subscription_path(rubygem),
         :remote => true,
         :method => :post,
         :id     => 'subscribe',

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   config.active_support.deprecation = :stderr
   config.action_mailer.delivery_method = :test
+  require 'clearance_backdoor'
+  config.middleware.use ClearanceBackdoor
 end
 
 ENV['S3_KEY']    = 'this:is:an:ex:parrot'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,17 +97,9 @@ Rails.application.routes.draw do
     resource  :profile,   :only => [:edit, :update]
     resources :stats,     :only => :index, :constraints => RecoveryMode
 
-    resources :rubygems, only: :index, path: 'gems', constraints: {format: /html|atom/} do
-      scope constraints: {rubygem_id: Patterns::ROUTE_PATTERN, format: :html} do
-        resource  :subscription, :only => [:create, :destroy]
-        resources :versions,     :only => :index
-      end
-    end
-
-    scope constraints: {id: Patterns::ROUTE_PATTERN, format: :html} do
-      resources :rubygems, :path => 'gems', :only => [:show, :edit, :update] do
-        resources :versions, only: :show, constraints: {rubygem_id: Patterns::ROUTE_PATTERN}
-      end
+    resources :rubygems, only: [:index, :show, :edit, :update], path: 'gems', constraints: {id: Patterns::ROUTE_PATTERN, format: /html|atom/} do
+      resource  :subscription, only: [:create, :destroy], constraints: {format: :js}, defaults: {format: :js}
+      resources :versions, only: [:show, :index]
     end
   end
 

--- a/lib/clearance_backdoor.rb
+++ b/lib/clearance_backdoor.rb
@@ -1,0 +1,24 @@
+class ClearanceBackdoor
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @env = env
+    sign_in_through_the_back_door
+    @app.call(@env)
+  end
+
+  private
+
+  def sign_in_through_the_back_door
+    if user_id = params['as']
+      user = User.find(user_id)
+      @env[:clearance].sign_in(user)
+    end
+  end
+
+  def params
+    Rack::Utils.parse_query(@env['QUERY_STRING'])
+  end
+end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -17,4 +17,24 @@ class GemsTest < ActionDispatch::IntegrationTest
     assert_equal :atom, response.content_type.symbol
     assert page.has_content? "sandworm"
   end
+
+  test "subscribe to a gem" do
+    get rubygem_path(@rubygem, as: @user.id)
+    assert page.has_css?('a#subscribe')
+
+    post rubygem_subscription_path(@rubygem, as: @user.id), nil, {'HTTP_ACCEPT' => 'application/javascript'}
+
+    assert_match(/\("\.toggler"\)\.toggle\(\)/, @response.body)
+    assert_equal @user.subscribed_gems.first, @rubygem
+  end
+
+  test "unsubscribe to a gem" do
+    create(:subscription, rubygem: @rubygem, user: @user)
+
+    get rubygem_path(@rubygem, as: @user.id)
+    assert page.has_css?('a#unsubscribe')
+
+    delete rubygem_subscription_path(@rubygem, as: @user.id), nil, {'HTTP_ACCEPT' => 'application/javascript'}
+    assert_match(/\("\.toggler"\)\.toggle\(\)/, @response.body)
+  end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -37,4 +37,11 @@ class GemsTest < ActionDispatch::IntegrationTest
     delete rubygem_subscription_path(@rubygem, as: @user.id), nil, {'HTTP_ACCEPT' => 'application/javascript'}
     assert_match(/\("\.toggler"\)\.toggle\(\)/, @response.body)
   end
+
+  test "versions with atom format" do
+    create(:version, rubygem: @rubygem)
+    get rubygem_versions_path(@rubygem, format: :atom)
+    assert_equal :atom, response.content_type.symbol
+    assert page.has_content? "sandworm"
+  end
 end


### PR DESCRIPTION
Commits are split by different tasks I did in this PR..

The main commit is 70f9970 , which fixes 2 issues:
- [#833] Subscribe/Unsubscribe link is not working
- atom version on versions (i.e. https://rubygems.org/gems/rails/versions.atom)

Mainly, again, we didnt catch those because functional tests dont go through the routes, and only integrations tests do. I added regression tests for those 2 errors to make sure they work.

r @qrush @dwradcliffe @sferik 

