### PR TITLE
Fix 400 status when going to /users/new

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,9 @@
 class UsersController < Clearance::UsersController
-
   ssl_required
+
+  def new
+    redirect_to sign_up_path
+  end
 
   def user_params
     params.require(:user).permit(*User::PERMITTED_ATTRS)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,12 +114,12 @@ Rails.application.routes.draw do
   ################################################################################
   # Clearance Overrides
 
-  resource :session, :only => [:create, :destroy]
+  resource :session, only: [:create, :destroy]
 
-  resources :passwords, :only => [:new, :create]
+  resources :passwords, only: [:new, :create]
 
-  resources :users do
-    resource :password, :only => [:create, :edit, :update]
+  resources :users, only: [:new, :create] do
+    resource :password, only: [:create, :edit, :update]
   end
 
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+
+  context "on GET to new" do
+    setup do
+      get :new
+    end
+
+    should redirect_to("sign up page") { sign_up_url }
+  end
+
+  context "on POST to create" do
+    context "when email and password are given" do
+      should "create a user" do
+        post :create, user: {email: 'foo@bar.com', password: 'secret'}
+        assert User.find_by(email: 'foo@bar.com')
+      end
+    end
+
+    context "when missing a parameter" do
+      should "raises parameter missing" do
+        assert_raises(ActionController::ParameterMissing) do
+          post :create
+        end
+      end
+    end
+
+    context "when extra parameters given" do
+      should "create a user if parameters are ok" do
+        post :create, user: {email: 'foo@bar.com', password: 'secret', handle: 'foo'}
+        assert_equal "foo", User.where(email: 'foo@bar.com').pluck(:handle).first
+      end
+
+      should "create a user but dont assign not valid parameters" do
+        post :create, user: {email: 'foo@bar.com', password: 'secret', api_key: 'nonono'}
+        assert_not_equal "nonono", User.where(email: 'foo@bar.com').pluck(:api_key).first
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Problem
Before adding strong_parameters we used to show the sign_up page on
users/new, which is what clearence does, Now that we override
user_params that wont work anymore. see https://github.com/thoughtbot/clearance/blob/master/app/controllers/clearance/users_controller.rb#L6 that they use `user_params` on the new, which is suppose to not receive any parameter.

### Solution
We can redirect /users/new to /sign_up page

