### PR TITLE
Honeybadger config

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,4 +1,5 @@
 Honeybadger.configure do |config|
   config.api_key = ENV['HONEYBADGER_API_KEY']
+  config.unwrap_exceptions = false
   config.ignore << "ActionDispatch::ParamsParser::ParseError"
 end

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,0 +1,4 @@
+Honeybadger.configure do |config|
+  config.api_key = ENV['HONEYBADGER_API_KEY']
+  config.ignore << "ActionDispatch::ParamsParser::ParseError"
+end


### PR DESCRIPTION
Two things in here:

- Ignore `ActionDispatch::ParamsParser::ParseError` errors on honeybadger, as they are handled by rails in a middleware and the return status is not a 500 error.
- Turn-off unwrap exceptions from honeybadger so we can catch high level exceptions, like Rails ones.

[related honeybadger-io/honeybadger-ruby#107]

review @dwradcliffe 
cc @joshuap @starrhorne

(Tested in staging, and it seems to work)