### PR TITLE
Better caching on versions api

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -1,17 +1,15 @@
 class Api::V1::VersionsController < Api::BaseController
   respond_to :json, :yaml
 
+  before_filter :find_rubygem, only: :show
+
   def show
-    find_rubygem
-    return unless @rubygem
+    return unless stale?(@rubygem)
 
     if @rubygem.public_versions.count.nonzero?
-
-      if stale?(@rubygem)
-        respond_with(@rubygem.public_versions, :yamlish => true)
-      end
+      respond_with(@rubygem.public_versions, yamlish: true)
     else
-      render :text => "This rubygem could not be found.", :status => 404
+      render text: "This rubygem could not be found.", status: 404
     end
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,5 +1,5 @@
 class Version < ActiveRecord::Base
-  belongs_to :rubygem
+  belongs_to :rubygem, touch: true
   has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, :dependent => :destroy
 
   before_save      :update_prerelease


### PR DESCRIPTION
This do a few things on the versions API endpoint:
- Return cache headers even on 404
- Improve controller code
- Add more tests to cover cache states
- touch the parent when updating the version so we bust the cache

The only thing I am not 100% sure in here is to return cache headers on 404, but I guess browsers should handle that fine. see http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13

review @qrush @sferik @dwradcliffe 