### PR TITLE
Cleanup rubygems yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,10 +36,6 @@ gem 'sass-rails',   '~> 4.0.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'uglifier', '>= 1.0.3'
 
-# enable if on heroku, make sure to toss this into an initializer:
-#     Rails.application.config.middleware.use HerokuAssetCacher
-#gem 'heroku_asset_cacher', git: "git@github.com/qrush/heroku_asset_cacher"
-
 group :development do
   gem 'capistrano', '~> 2.0'
   gem 'capistrano-notification'

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,6 @@ module Gemcutter
     end
 
     config.plugins = [:dynamic_form]
-    config.plugins << :heroku_asset_cacher if config.rubygems['asset_cacher']
 
     config.autoload_paths << "./app/jobs"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,9 +22,7 @@ module Gemcutter
     config.encoding  = "utf-8"
 
     config.middleware.use "Hostess"
-    if config.rubygems['redirector'] && ENV["LOCAL"].nil?
-      config.middleware.insert_after "Hostess", "Redirector"
-    end
+    config.middleware.use "Redirector"
 
     unless Rails.env.maintenance?
       config.active_record.include_root_in_json = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,6 @@ module Gemcutter
     end
 
     unless Rails.env.maintenance?
-      config.action_mailer.delivery_method      = config.rubygems['delivery_method']
       config.active_record.include_root_in_json = false
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,6 +58,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :sendmail
   config.action_mailer.default_url_options = { host: Gemcutter::HOST, protocol: "https" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/recovery.rb
+++ b/config/environments/recovery.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_dispatch.x_sendfile_header = "X-Sendfile"
     config.active_support.deprecation = :notify
-    config.serve_static_assets = Gemcutter.config['asset_cacher']
+    config.serve_static_assets = true
     config.i18n.fallbacks = true
 
     config.action_dispatch.session = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -58,6 +58,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :sendmail
   config.action_mailer.default_url_options = { host: Gemcutter::HOST, protocol: "https" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -5,7 +5,6 @@ development:
   s3_bucket: ""
   s3_domain: development.s3.rubygems.org
   cf_domain: development.cf.rubygems.org
-  asset_cacher: false
 
 test:
   host: localhost
@@ -14,7 +13,6 @@ test:
   s3_bucket: test.s3.rubygems.org
   s3_domain: test.s3.rubygems.org
   cf_domain: test.cf.rubygems.org
-  asset_cacher: false
 
 staging:
   host: staging.rubygems.org
@@ -23,7 +21,6 @@ staging:
   s3_bucket: staging.s3.rubygems.org
   s3_domain: staging.s3.rubygems.org
   cf_domain: staging.cf.rubygems.org
-  asset_cacher: false
 
 live: &LIVE
   host: rubygems.org
@@ -32,7 +29,6 @@ live: &LIVE
   s3_bucket: production.s3.rubygems.org
   s3_domain: production.s3.rubygems.org
   cf_domain: production.cf.rubygems.org
-  asset_cacher: false
 
 production:
   <<: *LIVE

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -2,7 +2,6 @@ development:
   host: localhost
   local_storage: true
   redirector: false
-  delivery_method: :sendmail
   s3_bucket: ""
   s3_domain: development.s3.rubygems.org
   cf_domain: development.cf.rubygems.org
@@ -12,7 +11,6 @@ test:
   host: localhost
   local_storage: true
   redirector: false
-  delivery_method: :test
   s3_bucket: test.s3.rubygems.org
   s3_domain: test.s3.rubygems.org
   cf_domain: test.cf.rubygems.org
@@ -22,7 +20,6 @@ staging:
   host: staging.rubygems.org
   local_storage: false
   redirector: true
-  delivery_method: :sendmail
   s3_bucket: staging.s3.rubygems.org
   s3_domain: staging.s3.rubygems.org
   cf_domain: staging.cf.rubygems.org
@@ -38,13 +35,10 @@ live: &LIVE
   asset_cacher: false
 
 production:
-  delivery_method: :sendmail
   <<: *LIVE
 
 maintenance:
-  delivery_method: :test
   <<: *LIVE
 
 recovery:
-  delivery_method: :sendmail
   <<: *LIVE

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -1,7 +1,6 @@
 development:
   host: localhost
   local_storage: true
-  redirector: false
   s3_bucket: ""
   s3_domain: development.s3.rubygems.org
   cf_domain: development.cf.rubygems.org
@@ -9,7 +8,6 @@ development:
 test:
   host: localhost
   local_storage: true
-  redirector: false
   s3_bucket: test.s3.rubygems.org
   s3_domain: test.s3.rubygems.org
   cf_domain: test.cf.rubygems.org
@@ -17,7 +15,6 @@ test:
 staging:
   host: staging.rubygems.org
   local_storage: false
-  redirector: true
   s3_bucket: staging.s3.rubygems.org
   s3_domain: staging.s3.rubygems.org
   cf_domain: staging.cf.rubygems.org
@@ -25,7 +22,6 @@ staging:
 live: &LIVE
   host: rubygems.org
   local_storage: false
-  redirector: true
   s3_bucket: production.s3.rubygems.org
   s3_domain: production.s3.rubygems.org
   cf_domain: production.cf.rubygems.org

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,11 @@ class MiniTest::Test
   end
 end
 
+class ActionDispatch::IntegrationTest
+  setup { host! Gemcutter::HOST }
+end
+Capybara.app_host = "http://#{Gemcutter::HOST}"
+
 class SystemTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 end


### PR DESCRIPTION
Clean-up 3 options from rubygems.yml
- `asset_cacher` was almost not used anymore after the rails4 upgrades, only using to enable `heroku_asset_cacher` plugin, which is not included anymore.
- `delivery_method` should be `:sendmail` on production config file, and default on development so it prints the email on console.
- `redirector` should be enable in all environments so we catch potentially problems with that on tests

review @sferik @qrush @dwradcliffe 