### PR TITLE
Dont call select_rows, and use scopes

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -71,15 +71,15 @@ class Version < ActiveRecord::Base
   end
 
   def self.rows_for_index
-    to_rows(:release)
+    joins(:rubygem).indexed.release.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
   end
 
   def self.rows_for_latest_index
-    to_rows(:latest)
+    joins(:rubygem).indexed.latest.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
   end
 
   def self.rows_for_prerelease_index
-    to_rows(:prerelease)
+    joins(:rubygem).indexed.prerelease.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
   end
 
   def self.most_recent
@@ -257,16 +257,6 @@ class Version < ActiveRecord::Base
   end
 
   private
-
-  def self.to_rows(scope)
-    sql = select("rubygems.name, number, platform").
-            indexed.public_send(scope).
-            from("rubygems, versions").
-            where("rubygems.id = versions.rubygem_id").
-            order("rubygems.name asc, position desc").to_sql
-
-    connection.select_rows(sql)
-  end
 
   def platform_and_number_are_unique
     if Version.exists?(:rubygem_id => rubygem_id,


### PR DESCRIPTION
before:
```ruby
irb(main):031:0> Version.rows_for_index
   (0.4ms)  SELECT rubygems.name, number, platform FROM rubygems, versions  WHERE "versions"."indexed" = 't' AND "versions"."prerelease" = 'f' AND (rubygems.id = versions.rubygem_id)  ORDER BY rubygems.name asc, position desc
=> [["blankblank", "0.0.2", "ruby"], ["blankblank", "0.0.3", "ruby"], ["blankblank", "0.0.4", "ruby"], ["blankblank", "0.0.5", "ruby"]]
irb(main):032:0>
```

after:
```ruby
irb(main):029:0> Version.rows_for_index
   (0.4ms)  SELECT rubygems.name, "versions"."number", "versions"."platform" FROM "versions" INNER JOIN "rubygems" ON "rubygems"."id" = "versions"."rubygem_id" WHERE "versions"."indexed" = 't' AND "versions"."prerelease" = 'f'  ORDER BY rubygems.name asc, position desc
=> [["blankblank", "0.0.2", "ruby"], ["blankblank", "0.0.3", "ruby"], ["blankblank", "0.0.4", "ruby"], ["blankblank", "0.0.5", "ruby"]]
```

As far as I can tell the queries are the same. and tests are green.

review @sferik @qrush @dwradcliffe 