### PR TITLE
Remove shoulda-matchers deprecation warning.

### DIFF
--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -74,7 +74,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
         should respond_with :redirect
         should redirect_to('the profile edit page') { edit_profile_path }
-        should set_the_flash.to("Your profile was updated.")
+        should set_flash.to("Your profile was updated.")
 
         should "update handle" do
           assert_equal @handle, User.last.handle
@@ -92,7 +92,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
         should respond_with :redirect
         should redirect_to('the profile edit page') { edit_profile_path }
-        should set_the_flash.to("Your profile was updated.")
+        should set_flash.to("Your profile was updated.")
 
         should "update email toggle" do
           assert_equal @hide_email, User.last.hide_email

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -117,7 +117,7 @@ class RubygemsControllerTest < ActionController::TestCase
       end
       should respond_with :redirect
       should redirect_to('the homepage') { root_url }
-      should set_the_flash.to("You do not have permission to edit this gem.")
+      should set_flash.to("You do not have permission to edit this gem.")
     end
 
     context "On PUT to update for this user's gem that is successful" do
@@ -128,7 +128,7 @@ class RubygemsControllerTest < ActionController::TestCase
       end
       should respond_with :redirect
       should redirect_to('the gem') { rubygem_path(@rubygem) }
-      should set_the_flash.to("Gem links updated.")
+      should set_flash.to("Gem links updated.")
       should "update source code url" do
         assert_equal @url, Rubygem.last.linkset.code
       end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -24,7 +24,7 @@ class SessionsControllerTest < ActionController::TestCase
 
       should respond_with :unauthorized
       should render_template 'sessions/new'
-      should set_the_flash.now[:notice]
+      should set_flash.now[:notice]
 
       should "not sign in the user" do
         assert !@controller.signed_in?


### PR DESCRIPTION
Since version 2.8.0 ```set_the_flash``` is deprecated -[link](https://github.com/thoughtbot/shoulda-matchers/blob/bbd0d5ed25a66e65ae0232e853ed937ed6ecf40e/NEWS.md#deprecations)-.
This pull request changes it to the new syntax and removes the deprecation warning.
