### PR TITLE
Use psych safe load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 sudo: false
 
-bundler_args: --jobs=3 --retry=3 --deployment --local --without development
+bundler_args: --jobs=3 --retry=3 --without development
 
 before_install:
   - sh -c "if [ '$RUBYGEMS_VERSION' != 'latest' ]; then gem update --system $RUBYGEMS_VERSION; fi"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 # ruby '2.0.0'
 
 gem 'rails', '~> 4.1.9'
-
+gem 'psych', '~> 2.0.12'
 gem 'builder'
 gem 'dynamic_form'
 gem 'excon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    psych (2.0.12)
     rack (1.5.2)
     rack-maintenance (2.0.0)
       rack (>= 1.0)
@@ -276,6 +277,7 @@ DEPENDENCIES
   paul_revere
   pg
   pry
+  psych (~> 2.0.12)
   rack
   rack-maintenance
   rack-test

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -53,7 +53,7 @@ class Pusher
 
     raise Gem::Package::FormatError.new('package metadata is missing') unless @spec
     @spec
-  rescue Psych::WhitelistException => e
+  rescue Psych::Exception => e
     Rails.logger.info "Attempted YAML metadata exploit: #{e}"
     notify("RubyGems.org cannot process this gem.\nThe metadata is invalid.\n#{e}", 422)
   rescue Gem::Package::FormatError

--- a/config/initializers/forbidden_yaml.rb
+++ b/config/initializers/forbidden_yaml.rb
@@ -6,79 +6,28 @@ require "rubygems"
 # Assert we're using Psych
 abort "Use Psych for YAML, install libyaml and reinstall ruby" unless YAML == Psych
 
-module Psych
-  class WhitelistException < Exception; end
-  class ForbiddenClassException < WhitelistException; end
-  class ForbiddenSymbolException < WhitelistException; end
-
-  WHITELISTED_CLASSES = %w(
-    Gem::Dependency
-    Gem::Platform
-    Gem::Requirement
-    Gem::Specification
-    Gem::Version
-    Gem::Version::Requirement
-  )
-
-  # These are all unique symbols used across all currently published gems' metadata
-  WHITELISTED_SYMBOLS = %w(
-    development
-    runtime
-  )
-
-  class WhitelistedScalarScanner < ScalarScanner
-    def tokenize string
-      # Protect against scanned scalars which will become symbols
-      if string[/^:./]
-        symbol = string.sub(/^:/, "")
-        symbol = $2 if string =~ /^(["'])(.*)\1/
-
-        raise ForbiddenSymbolException, "Forbidden symbol in YAML: #{symbol}" unless WHITELISTED_SYMBOLS.include? symbol
-      end
-
-      super
-    end
-  end
-
-  module Visitors
-    class WhitelistedToRuby < ToRuby
-      def initialize
-        super
-        @ss = WhitelistedScalarScanner.new
-      end
-
-      def visit_Psych_Nodes_Scalar o
-        # Protect against explicitly tagged ruby classes which take the YAML shortcut, i.e. ActiveRecord::Base
-        if klass = Psych.load_tags[o.tag]
-          raise ForbiddenClassException, "Forbidden class in YAML: #{klassname}" unless WHITELISTED_CLASSES.include? klass.name
-        end
-
-        # Protect against explicitly tagged ruby symbols
-        if o.tag and o.tag[/^!ruby\/sym(bol)?:?(.*)?$/]
-          raise ForbiddenSymbolException, "Forbidden symbol in YAML: #{o.value}" unless WHITELISTED_SYMBOLS.include? o.value
-        end
-
-        super
-      end
-
-    private
-
-      def resolve_class klassname
-        # Protect against all explicit ruby classes, from tags or otherwise
-        raise ForbiddenClassException, "Forbidden class in YAML: #{klassname}" unless WHITELISTED_CLASSES.include? klassname
-
-        super klassname
-      end
-    end
-  end
-end
-
 module Gem
   class Specification
+    WHITELISTED_CLASSES = %w(
+      Symbol
+      Time
+      Date
+      Gem::Dependency
+      Gem::Platform
+      Gem::Requirement
+      Gem::Specification
+      Gem::Version
+      Gem::Version::Requirement
+    )
+
+    WHITELISTED_SYMBOLS = %w(
+      development
+      runtime
+    )
+
     def self.from_yaml input
       input = normalize_yaml_input input
-      nodes = Psych.parse input
-      spec = Psych::Visitors::WhitelistedToRuby.new.accept nodes
+      spec = Psych.safe_load(input, WHITELISTED_CLASSES, WHITELISTED_SYMBOLS)
 
       if spec && spec.class == FalseClass then
         raise Gem::EndOfYAMLException
@@ -88,12 +37,8 @@ module Gem
         raise Gem::Exception, "YAML data doesn't evaluate to gem specification"
       end
 
-      unless (spec.instance_variables.include? '@specification_version' or
-              spec.instance_variables.include? :@specification_version) and
-             spec.instance_variable_get :@specification_version
-        spec.instance_variable_set :@specification_version,
-                                   NONEXISTENT_SPECIFICATION_VERSION
-      end
+      spec.specification_version ||= NONEXISTENT_SPECIFICATION_VERSION
+      spec.reset_nil_attributes_to_default
 
       spec
     end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -103,8 +103,7 @@ class PusherTest < ActiveSupport::TestCase
         assert_nil @cutter.spec
         assert_includes @cutter.message, %{RubyGems.org cannot process this gem}
         assert_includes @cutter.message, %{The metadata is invalid}
-        assert_includes @cutter.message, %{Forbidden symbol in YAML}
-        assert_includes @cutter.message, %{badsymbol}
+        assert_includes @cutter.message, %{Tried to load unspecified class: Symbol}
         assert_equal @cutter.code, 422
       end
     end


### PR DESCRIPTION
### Problem
Our YAML white-list monkey patch wont work on ruby 2.1.5 as that has a new Psych version.

### Solution
Update Psych under 2.0.x so we can easily move to 2.1.x. Also we need to fix the patch to work with new version.

The YAML patch was added by @sj26 on  https://github.com/rubygems/rubygems.org/commit/334bff6beb072f17c252dee97a03b5c7b81aef02
What it does is whitelist the classes and symbols we allow when loading the input yaml.
Turns out, on new versions of Psych, there is a `safe_load` method, which does exactly what we need (https://github.com/tenderlove/psych/commit/2c644e184192975b261a81f486a04defa3172b3f)
This updates psych and use the new `safe_load` passing the 2 whitelists we have.

review @evanphx @qrush @sferik @drbrain @dwradcliffe 
cc @tenderlove

