### PR TITLE
Improve version specification recommendation

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -237,7 +237,16 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    %{gem '#{rubygem.name}', '~> #{number}'}
+    if number[0] == "0"
+      %{gem '#{rubygem.name}', '~> #{number}'}
+    else
+      release = feature_release(number)
+      if release == Gem::Version.new(number)
+        %{gem '#{rubygem.name}', '~> #{release}'}
+      else
+        %{gem '#{rubygem.name}', '~> #{release}', '>= #{number}'}
+      end
+    end
   end
 
   def to_gem_version
@@ -314,5 +323,10 @@ class Version < ActiveRecord::Base
                  :platform, platform)
 
     push
+  end
+
+  def feature_release(number)
+    feature_version = Gem::Version.new(number).segments[0,2].join('.')
+    Gem::Version.new(feature_version)
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -297,8 +297,51 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "#{@version.rubygem.name} (#{@version.to_s})", @version.to_title
     end
 
-    should "give version with twiddle-wakka for #to_bundler" do
-      assert_equal %{gem '#{@version.rubygem.name}', '~> #{@version.to_s}'}, @version.to_bundler
+    context "#to_bundler" do
+      should "give feature release version and bugfix up to current version for patched versions" do
+        patched_version = create(:version, number: "1.0.3")
+        name = patched_version.rubygem.name
+        actual = patched_version.to_bundler
+        expected = %{gem '#{name}', '~> 1.0', '>= 1.0.3'}
+
+        assert_equal expected, actual
+      end
+
+      should "give only feature release version if no bug fix" do
+        no_bugfix = create(:version, number: "1.0")
+        name = no_bugfix.rubygem.name
+        actual = no_bugfix.to_bundler
+        expected = %{gem '#{name}', '~> 1.0'}
+
+        assert_equal expected, actual
+      end
+
+      should "give only feature release version if long version specified with no bugfix" do
+        long_version = create(:version, number: "1.0.0.0")
+        name = long_version.rubygem.name
+        actual = long_version.to_bundler
+        expected = %{gem '#{name}', '~> 1.0'}
+
+        assert_equal expected, actual
+      end
+
+      should "give feature release version up to current version if long version specified with bugfix" do
+        long_version = create(:version, number: "1.0.3.0")
+        name = long_version.rubygem.name
+        actual = long_version.to_bundler
+        expected = %{gem '#{name}', '~> 1.0', '>= 1.0.3.0'}
+
+        assert_equal expected, actual
+      end
+
+      should "give bugfix version if < 1.0.0" do
+        early_version = create(:version, number: "0.1.2")
+        name = early_version.rubygem.name
+        actual = early_version.to_bundler
+        expected = %{gem '#{name}', '~> 0.1.2'}
+
+        assert_equal expected, actual
+      end
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
Previous Gemfile recommendations for rubygem version were too strict.
This recommends the latest feature release version up to the latest version of
the gem.

Fixes #409, replaces #775 