### PR TITLE
Include SHA256 checksum in versions v2

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -1,3 +1,5 @@
+require 'digest/sha2'
+
 class Pusher
   attr_reader :user, :spec, :message, :code, :rubygem, :body, :version, :version_id, :size
   attr_accessor :bundler_api_url
@@ -87,9 +89,12 @@ class Pusher
     # Update the name to reflect a valid case change
     @rubygem.name = name
 
+    sha256 = Digest::SHA2.base64digest(body.string)
+
     @version = @rubygem.versions.new number: spec.version.to_s,
                                      platform: spec.original_platform.to_s,
-                                     size: size
+                                     size: size,
+                                     sha256: sha256
 
     true
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -159,6 +159,7 @@ class Rubygem < ActiveRecord::Base
       'licenses'          => version.licenses,
       'project_uri'       => "http://#{host_with_port}/gems/#{name}",
       'gem_uri'           => "http://#{host_with_port}/gems/#{version.full_name}.gem",
+      'gem_sha256'        => version.sha256,
       'homepage_uri'      => linkset.try(:home),
       'wiki_uri'          => linkset.try(:wiki),
       'documentation_uri' => linkset.try(:docs),

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -274,6 +274,10 @@ class Version < ActiveRecord::Base
     digest.base64digest
   end
 
+  def recalculate_sha256!
+    update_attributes(sha256: recalculate_sha256)
+  end
+
   private
 
   def platform_and_number_are_unique

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,3 +1,5 @@
+require 'digest/sha2'
+
 class Version < ActiveRecord::Base
   belongs_to :rubygem, touch: true
   has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, :dependent => :destroy
@@ -15,6 +17,10 @@ class Version < ActiveRecord::Base
 
   validate :platform_and_number_are_unique, :on => :create
   validate :authors_format, :on => :create
+
+  def self.without_sha256
+    where(sha256: "")
+  end
 
   def self.reverse_dependencies(name)
     joins({ dependencies: :rubygem }).
@@ -71,15 +77,15 @@ class Version < ActiveRecord::Base
   end
 
   def self.rows_for_index
-    joins(:rubygem).indexed.release.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
+    joins(:rubygem).indexed.release.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform, :sha256)
   end
 
   def self.rows_for_latest_index
-    joins(:rubygem).indexed.latest.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
+    joins(:rubygem).indexed.latest.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform, :sha256)
   end
 
   def self.rows_for_prerelease_index
-    joins(:rubygem).indexed.prerelease.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform)
+    joins(:rubygem).indexed.prerelease.order("rubygems.name asc, position desc").pluck('rubygems.name', :number, :platform, :sha256)
   end
 
   def self.most_recent
@@ -254,6 +260,18 @@ class Version < ActiveRecord::Base
 
   def authors_array
     self.authors.split(',').flatten
+  end
+
+  def recalculate_sha256
+    key = "gems/#{full_name}.gem"
+    digest = Digest::SHA2.new
+    dir = Indexer.new.directory
+
+    dir.files.get(key) do |chunk|
+      digest << chunk
+    end
+
+    digest.base64digest
   end
 
   private

--- a/db/migrate/20140809000000_add_sha256_to_versions.rb
+++ b/db/migrate/20140809000000_add_sha256_to_versions.rb
@@ -1,0 +1,5 @@
+class AddSha256ToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :sha256, :string, :null => false
+  end
+end

--- a/db/migrate/20140809000000_add_sha256_to_versions.rb
+++ b/db/migrate/20140809000000_add_sha256_to_versions.rb
@@ -1,5 +1,5 @@
 class AddSha256ToVersions < ActiveRecord::Migration
   def change
-    add_column :versions, :sha256, :string, :null => false
+    add_column :versions, :sha256, :string, :null => true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131110192552) do
+ActiveRecord::Schema.define(version: 20140809000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 20131110192552) do
     t.string   "licenses"
     t.text     "requirements"
     t.string   "ruby_version"
+    t.string   "sha256",                              :null => false
   end
 
   add_index "versions", ["built_at"], name: "index_versions_on_built_at", using: :btree

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -26,6 +26,33 @@ namespace :gemcutter do
     end
   end
 
+  namespace :checksums do
+    desc "Initialize missing checksums."
+    task :init => :environment do
+      versions = Version.without_sha256
+      versions.each do |version|
+        sha256 = version.recalculate_sha256
+        version.sha256 = sha256
+        version.save!
+      end
+    end
+
+    desc "Check existing checksums."
+    task :check => :environment do
+      failed = false
+      versions = Version.all
+      versions.each do |version|
+        actual_sha256 = version.recalculate_sha256
+        if version.sha256 != actual_sha256
+          puts "#{version.full_name}.gem has sha256 '#{actual_sha256}', but '#{version.sha256}' was expected."
+          failed = true
+        end
+      end
+
+      exit 1 if failed
+    end
+  end
+
   namespace :rubygems do
     desc "Update the download counts for all gems."
     task :update_download_counts => :environment do

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -29,19 +29,13 @@ namespace :gemcutter do
   namespace :checksums do
     desc "Initialize missing checksums."
     task :init => :environment do
-      versions = Version.without_sha256
-      versions.each do |version|
-        sha256 = version.recalculate_sha256
-        version.sha256 = sha256
-        version.save!
-      end
+      Version.without_sha256.find_each(&:recalculate_sha256!)
     end
 
     desc "Check existing checksums."
     task :check => :environment do
       failed = false
-      versions = Version.all
-      versions.each do |version|
+      Version.find_each do |version|
         actual_sha256 = version.recalculate_sha256
         if version.sha256 != actual_sha256
           puts "#{version.full_name}.gem has sha256 '#{actual_sha256}', but '#{version.sha256}' was expected."

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -94,6 +94,7 @@ FactoryGirl.define do
     requirements "Opencv"
     rubygem
     size 1024
+    sha256 "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g="
   end
 
   factory :version_history do

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -113,6 +113,7 @@ class DependencyTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture('with_dependencies-0.0.0')
         @rubygem       = Rubygem.new(:name => @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
+        @version.sha256 = "dummy"
 
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -140,6 +140,7 @@ class PusherTest < ActiveSupport::TestCase
         stub(spec).original_platform { "ruby" }
         stub(@cutter).spec { spec }
         stub(@cutter).size { 5 }
+        stub(@cutter).body { StringIO.new("dummy body") }
         @cutter.find
       end
 
@@ -153,6 +154,11 @@ class PusherTest < ActiveSupport::TestCase
 
       should "set gem version size" do
         assert_equal 5, @cutter.version.size
+      end
+
+      should "set sha256" do
+        expectedSha = Digest::SHA2.base64digest(@cutter.body.string)
+        assert_equal expectedSha, @cutter.version.sha256
       end
     end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -557,6 +557,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture('test-0.0.0')
         @rubygem       = Rubygem.new(:name => @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
+        @version.sha256 = "dummy"
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
       end
 
@@ -575,6 +576,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture('with_dependencies-0.0.0')
         @rubygem       = Rubygem.new(:name => @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
+        @version.sha256 = "dummy"
       end
 
       should "save the gem" do
@@ -594,6 +596,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture('with_dependencies-0.0.0')
         @rubygem       = Rubygem.new(:name => @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
+        @version.sha256 = "dummy"
 
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
 
@@ -617,6 +620,7 @@ class RubygemTest < ActiveSupport::TestCase
 
         @rubygem       = Rubygem.new(:name => @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
+        @version.sha256 = "dummy"
       end
 
       should "save the gem" do

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -574,30 +574,30 @@ class VersionTest < ActiveSupport::TestCase
       @first_rubygem  = create(:rubygem, :name => "first")
       @second_rubygem = create(:rubygem, :name => "second")
 
-      @first_version  = create(:version, :rubygem => @first_rubygem,  :number => "0.0.1", :platform => "ruby")
-      @second_version = create(:version, :rubygem => @first_rubygem,  :number => "0.0.2", :platform => "ruby")
-      @other_version  = create(:version, :rubygem => @second_rubygem, :number => "0.0.2", :platform => "java")
-      @pre_version    = create(:version, :rubygem => @second_rubygem, :number => "0.0.2.pre", :platform => "java", :prerelease => true)
+      @first_version  = create(:version, :rubygem => @first_rubygem,  :number => "0.0.1", :platform => "ruby", :sha256 => "SHA_1")
+      @second_version = create(:version, :rubygem => @first_rubygem,  :number => "0.0.2", :platform => "ruby", :sha256 => "SHA_2")
+      @other_version  = create(:version, :rubygem => @second_rubygem, :number => "0.0.2", :platform => "java", :sha256 => "SHA_3")
+      @pre_version    = create(:version, :rubygem => @second_rubygem, :number => "0.0.2.pre", :platform => "java", :prerelease => true, :sha256 => "SHA_4")
     end
 
     should "select all gems" do
       assert_equal [
-        ["first",  "0.0.1", "ruby"],
-        ["first",  "0.0.2", "ruby"],
-        ["second", "0.0.2", "java"]
+        ["first",  "0.0.1", "ruby", "SHA_1"],
+        ["first",  "0.0.2", "ruby", "SHA_2"],
+        ["second", "0.0.2", "java", "SHA_3"]
       ], Version.rows_for_index
     end
 
     should "select only most recent" do
       assert_equal [
-        ["first",  "0.0.2", "ruby"],
-        ["second", "0.0.2", "java"]
+        ["first",  "0.0.2", "ruby", "SHA_2"],
+        ["second", "0.0.2", "java", "SHA_3"]
       ], Version.rows_for_latest_index
     end
 
     should "select only prerelease" do
       assert_equal [
-        ["second", "0.0.2.pre", "java"]
+        ["second", "0.0.2.pre", "java", "SHA_4"]
       ], Version.rows_for_prerelease_index
     end
   end


### PR DESCRIPTION
## Add `Versions#sha256`

This is a rebase of #713 by @cstrahan - rebase was needed after #610.

- The `sha256` is nullable for now.
- First: populate `sha256` via `rake`.
- Later: add a migration to mark `sha256` as `:null => false`.

