### PR TITLE
Fixes the css issue described in #871

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -36,12 +36,9 @@
   .gem__owners img {
     margin-right: 12px;
     margin-bottom: 12px;
-    float: left;
     height: 32px;
     width: 32px;
     border-radius: 16px; }
-  .gem__owners a {
-    position: relative; }
   .gem__owners a:hover:before {
     content: "";
     height: 32px;


### PR DESCRIPTION
This fixes the issue that was described in #871 

Before:
![2015-02-08 14 35 06](https://cloud.githubusercontent.com/assets/66243/6095411/dfac6fd8-af9f-11e4-9e53-f3d08f7c359a.png)

After:
![2015-02-08 14 35 18](https://cloud.githubusercontent.com/assets/66243/6095413/e2107120-af9f-11e4-8fa6-46443b5a0d1b.png)

I currently don't have an easy way to test this on IE. :(
It's working on Firefox 35.0.1, also still works in Chrome.

I don't *think* this will break anything else, but maybe another pair of :eyes: would be good?