### PR TITLE
Fixes layout in navigation bar

### DIFF
--- a/app/assets/stylesheets/modules/header.css
+++ b/app/assets/stylesheets/modules/header.css
@@ -169,10 +169,7 @@
 @media (min-width: 1020px) {
   .desktop__header__nav-link {
     position: relative;
-    z-index: 1; }
-    .desktop__header__nav-link span {
-      margin-top: -4px;
-      top: 4px; } }
+    z-index: 1; } }
 
 #user_gravatar {
   margin-top: -30px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,8 +54,8 @@
           <nav class="header__nav-links">
             <% if signed_in? %>
               <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link mobile__header__nav-link">
-                <span><%= truncate(current_user.name) %></span>
-                <%= gravatar(80, "user_gravatar") %>
+                <%= truncate current_user.name %>
+                <%= gravatar 80, "user_gravatar" %>
               </a>
             <% end %>
 
@@ -70,8 +70,8 @@
 
             <% if signed_in? %>
               <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
-                <span><%= truncate(current_user.name) %></span>
-                <%= gravatar(80, "user_gravatar") %>
+                <%= truncate current_user.name %>
+                <%= gravatar 80, "user_gravatar" %>
               </a>
               <a href="#" class="header__popup-link" data-icon="▼">
                 <span class="t-hidden">More items</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,15 +57,14 @@
                 <span><%= truncate(current_user.name) %></span>
                 <%= gravatar(80, "user_gravatar") %>
               </a>
-              <a href="#" class="header__popup-link" data-icon="▼">
-                <span class="t-hidden">More items</span>
-              </a>
             <% end %>
+
             <%- if request.path_info == '/gems' %>
               <%= link_to "Gems", rubygems_url, class: "header__nav-link is-active" %>
             <%- else %>
               <%= link_to "Gems", rubygems_url, class: "header__nav-link" %>
             <%- end %>
+
             <%= link_to t('.footer.guides'), "http://guides.rubygems.org", class: "header__nav-link" %>
             <%= link_to t('.footer.contribute'), "http://guides.rubygems.org/contributing/", class: "header__nav-link" %>
 
@@ -74,9 +73,12 @@
                 <span><%= truncate(current_user.name) %></span>
                 <%= gravatar(80, "user_gravatar") %>
               </a>
+              <a href="#" class="header__popup-link" data-icon="▼">
+                <span class="t-hidden">More items</span>
+              </a>
               <div class="header__popup__nav-links">
                 <%= link_to t('.header.dashboard'), dashboard_url, class: "header__nav-link" %>
-                <%= link_to t('.header.sign_out'), sign_out_path, :method => :delete, class: "header__nav-link" %>
+                <%= link_to t('.header.sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
               </div>
             <% else %>
               <%= link_to t('.header.sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_in'}" %>


### PR DESCRIPTION
### Description

Fixes layout in navidation bar (referer #797), namely:
- Remove dropdown arrow to right (now this arrow is located beside profile link for mobile version)
- Deleted excess `span` html tags in the profile link (it's need for alignment links in navbar)
- Replaced all hash rockets in file to the new hash style

### Screenshots
#### Before
![screenshot 2015-02-10 10 34 41](https://cloud.githubusercontent.com/assets/1147484/6123364/8650688a-b112-11e4-8a7c-ccf760cf458e.jpg)
![screenshot 2015-02-10 10 35 15](https://cloud.githubusercontent.com/assets/1147484/6123365/8650aa52-b112-11e4-9986-d4696d21cb0f.jpg)

#### After
![screenshot 2015-02-10 10 35 27](https://cloud.githubusercontent.com/assets/1147484/6123366/8651ebe2-b112-11e4-844e-8f04842170d4.jpg)

**P.S.:** Sorry, but i can check this changes only in Chrome, Firefox and Safary on mac (mac os 10.10.2 version)
**P.P.S.:** If you want i can push this PR to stage server :innocent: