### PR TITLE
Add sha 256 checksum to view when available

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -31,6 +31,9 @@
       overflow: auto;
       border-bottom: 1px solid #c1c4ca; } }
 
+.gem__sha {
+  margin-top: 16px; }
+
 .gem__owners {
   margin-top: 16px; }
   .gem__owners img {

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -210,7 +210,8 @@ class Version < ActiveRecord::Base
       'ruby_version'    => ruby_version,
       'prerelease'      => prerelease,
       'licenses'        => licenses,
-      'requirements'    => requirements
+      'requirements'    => requirements,
+      'sha'             => sha256_hex
     }
   end
 
@@ -256,6 +257,10 @@ class Version < ActiveRecord::Base
 
   def authors_array
     self.authors.split(',').flatten
+  end
+
+  def sha256_hex
+    sha256.unpack("m0").first.unpack("H*").first if sha256
   end
 
   def recalculate_sha256

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -67,6 +67,13 @@
               <%= links_to_owners(@rubygem) %>
             </div>
           <% end %>
+
+          <% if @latest_version.sha256.present? %>
+            <h3 class="t-list__heading">Sha 256 checksum:</h3>
+            <div class="gem__sha">
+              <%= @latest_version.sha256_hex %>
+            </div>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -60,6 +60,9 @@ class VersionsControllerTest < ActionController::TestCase
     should "show not hosted notice" do
       assert page.has_content?('This gem is not currently hosted')
     end
+    should "not show checksum" do
+      assert page.has_no_content?('Sha 256 checksum')
+    end
   end
 
   context "On GET to show" do
@@ -84,6 +87,9 @@ class VersionsControllerTest < ActionController::TestCase
       @versions.each do |version|
         assert page.has_content?(version.number)
       end
+    end
+    should "render the checksum version" do
+      assert page.has_content?(@latest_version.sha256_hex)
     end
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -11,7 +11,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       json = @version.as_json
-      assert_equal %w[number built_at summary description authors platform ruby_version prerelease downloads_count licenses requirements].map(&:to_s).sort, json.keys.sort
+      assert_equal %w[number built_at summary description authors platform ruby_version prerelease downloads_count licenses requirements sha].map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
       assert_equal @version.description, json["description"]
@@ -33,7 +33,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
-      assert_equal %w[number built-at summary description authors platform ruby-version prerelease downloads-count licenses requirements].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
+      assert_equal %w[number built-at summary description authors platform ruby-version prerelease downloads-count licenses requirements sha].map(&:to_s).sort, xml.root.children.map{|a| a.name}.reject{|t| t == "text"}.sort
       assert_equal @version.authors, xml.at_css("authors").content
       assert_equal @version.built_at.to_i, xml.at_css("built-at").content.to_time.to_i
       assert_equal @version.description, xml.at_css("description").content
@@ -604,12 +604,20 @@ class VersionTest < ActiveSupport::TestCase
 
   context "checksums" do
     setup do
-      @version = create(:version, :sha256 => "SHA_1")
+      @version = create(:version)
     end
 
     should "be available from the database" do
-      assert_equal "SHA_1", @version.reload.sha256
+      assert_equal "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=", @version.reload.sha256
+    end
+
+    should "convert to hex on sha256_hex" do
+      assert_equal "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78", @version.reload.sha256_hex
+    end
+
+    should "should return nil on sha256_hex when sha not avaible" do
+      version = create(:version, sha256: nil)
+      assert_nil version.sha256_hex
     end
   end
-
 end


### PR DESCRIPTION
We are generating the new sha256 on new pushes, so we can start showing that on #show view and JSON returns.

thoughts @dwradcliffe @indirect @qrush 