### PR TITLE
Manage Zeroclipboard buttons without Flash

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -90,7 +90,6 @@
   display: inline-block;
   overflow: hidden;
   width: 100%;
-  width: calc(100% - 32px);
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -100,14 +99,14 @@
   text-transform: none;
   white-space: nowrap;
   color: #141c22;
-  -moz-appearance: none; }
+  -moz-appearance: none;
+  -webkit-border-radius: 6px;
+  border-radius: 6px;
+  border: none;
+  font-weight: bold; }
+
   .gem__code::-webkit-scrollbar {
     display: none; }
-  @-moz-document url-prefix() {
-    .gem__code {
-      margin-bottom: -18px;
-      padding-bottom: 18px;
-      width: calc(100% - 45px); } }
 
 .gem__code__icon {
   padding-left: 2px;

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -159,7 +159,20 @@
 
 <% content_for :javascript do %>
   <script>
-    var client = new ZeroClipboard( document.getElementById("js-gem__code--gemfile") );
-    var client2 = new ZeroClipboard( document.getElementById("js-gem__code--install") );
+    var gemfileCopyButton = document.getElementById("js-gem__code--gemfile");
+    var installCopyButton = document.getElementById("js-gem__code--install");
+
+    var client   = new ZeroClipboard( gemfileCopyButton );
+    var client2  = new ZeroClipboard( installCopyButton );
+
+    client.on("error", function() {
+      client.destroy();
+      gemfileCopyButton.style.display = "none";
+    });
+
+    client2.on("error", function() {
+      client2.destroy();
+      installCopyButton.style.display = "none";
+    });
   </script>
 <% end %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -114,7 +114,7 @@
         <h2 class="gem__ruby-version__heading t-list__heading">
           <%= t '.bundler_header' %>:
           <div class="gem__code-wrap">
-            <span class="gem__code"><%= @latest_version.to_bundler %></span>
+            <input type="text" class="gem__code" value="<%= @latest_version.to_bundler %>" readonly="readonly">
             <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-text="<%= @latest_version.to_bundler %>">=</span>
             <span class="gem__code__tooltip--copy">Copy to clipboard</span>
             <span class="gem__code__tooltip--copied">Copied!</span>
@@ -123,7 +123,7 @@
         <h2 class="gem__ruby-version__heading t-list__heading">
           <%= t '.install' %>:
           <div class="gem__code-wrap">
-            <span class="gem__code"><%= @latest_version.to_install %></span>
+            <input type="text" class="gem__code" value="<%= @latest_version.to_bundler %>" readonly="readonly">
             <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-text="<%= @latest_version.to_install %>">=</span>
             <span class="gem__code__tooltip--copy">Copy to clipboard</span>
             <span class="gem__code__tooltip--copied">Copied!</span>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -123,7 +123,7 @@
         <h2 class="gem__ruby-version__heading t-list__heading">
           <%= t '.install' %>:
           <div class="gem__code-wrap">
-            <input type="text" class="gem__code" value="<%= @latest_version.to_bundler %>" readonly="readonly">
+            <input type="text" class="gem__code" value="<%= @latest_version.to_install %>" readonly="readonly">
             <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-text="<%= @latest_version.to_install %>">=</span>
             <span class="gem__code__tooltip--copy">Copy to clipboard</span>
             <span class="gem__code__tooltip--copied">Copied!</span>


### PR DESCRIPTION
Currently I use Firefox, but do not have Flash installed.

I always forget and try to click on the `Gemfile` and `Install` copy buttons, and then I realize it won't work for me.

My current solution is to remove them from the textbox when flash is not present. This is what is looks like without them.

![screen shot 2015-02-15 at 23 28 08](https://cloud.githubusercontent.com/assets/564113/6207197/5585a4b6-b56a-11e4-9847-cef9556d9fa8.png)

I still think there still needs some styling work to do, but I wanted to get a feel if this was a plausible solution that people would like.

Thanks!


