### PR TITLE
Fix helper html escaping for rails 4.2

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,8 @@ module ApplicationHelper
   end
 
   def short_info(version)
-    escape_once(truncate(sanitize(version.info).strip, :length => 90)).html_safe
+    info = version.info.truncate(90)
+    escape_once(sanitize(info)).strip.html_safe
   end
 
   def gravatar(size, id = "gravatar", user = current_user)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,8 +16,8 @@ module ApplicationHelper
   end
 
   def short_info(version)
-    info = version.info.truncate(90)
-    escape_once(sanitize(info)).strip.html_safe
+    info = version.info.strip.truncate(90)
+    escape_once(sanitize(info))
   end
 
   def gravatar(size, id = "gravatar", user = current_user)

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -19,7 +19,7 @@ module RubygemsHelper
     if text =~ /^==+ [A-Z]/
       RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new).html_safe
     else
-      content_tag :p, escape_once(sanitize(text)).strip.html_safe, nil, false
+      content_tag :p, escape_once(sanitize(text.strip)), nil, false
     end
   end
 

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -19,7 +19,7 @@ module RubygemsHelper
     if text =~ /^==+ [A-Z]/
       RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new).html_safe
     else
-      content_tag :p, escape_once(sanitize(text).strip.html_safe), nil, false
+      content_tag :p, escape_once(sanitize(text)).strip.html_safe, nil, false
     end
   end
 

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
   should 'sanitize descriptions' do
-    text = '<script>alert("foo");</script> Rails authentication & authorization'
+    text = '<script>alert("foo");</script>Rails authentication & authorization'
     rubygem = create(:rubygem, :name => "SomeGem")
-    version = create(:version, :rubygem => rubygem, :number => "3.0.0", :platform => "ruby", :description => text)
+    create(:version, rubygem: rubygem, number: "3.0.0", platform: "ruby", description: text)
 
     assert_equal 'Rails authentication &amp; authorization', short_info(rubygem.versions.most_recent)
     assert short_info(rubygem.versions.most_recent).html_safe?

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -98,7 +98,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
   context 'simple_markup' do
     should 'sanitize copy' do
-      text = '<script>alert("foo");</script> Rails authentication & authorization'
+      text = '<script>alert("foo");</script>Rails authentication & authorization'
       assert_equal '<p>Rails authentication &amp; authorization</p>', simple_markup(text)
       assert simple_markup(text).html_safe?
     end


### PR DESCRIPTION
On Rails 4.2 `sanitize` and `truncate` will both escape the html, so we
cannot call both methods as that would cause a double escaping.

We can use the String `truncate`, and only call `sanitize`.
We still need the `escape_once` to make this work with rails 4.1 and 4.2.