### PR TITLE
Small fixes on gemcutter test

### DIFF
--- a/test/rake/gemcutter_test.rb
+++ b/test/rake/gemcutter_test.rb
@@ -1,3 +1,4 @@
+require 'rake'
 require "test_helper"
 
 class GemcutterTest < ActiveSupport::TestCase
@@ -13,11 +14,7 @@ class GemcutterTest < ActiveSupport::TestCase
 
   context "rubygems" do
     setup do
-      @rubygems = create_list(:rubygem_with_downloads, 3, downloads: 0)
-    end
-
-    def update_download_counts
-      run_rake_task("rubygems:update_download_counts")
+      @rubygems = create_list(:rubygem, 3, downloads: 0)
     end
 
     should "update download counts for all gems" do
@@ -25,15 +22,11 @@ class GemcutterTest < ActiveSupport::TestCase
         Redis.current.incrby "downloads:rubygem:#{rubygem.name}", download_count
       end
 
-      update_download_counts
+      run_rake_task("rubygems:update_download_counts")
 
       assert_equal 0, @rubygems[0].reload["downloads"]
       assert_equal 1, @rubygems[1].reload["downloads"]
       assert_equal 2, @rubygems[2].reload["downloads"]
-    end
-
-    teardown do
-      @rubygems.each(&:destroy)
     end
   end
 end


### PR DESCRIPTION
- Require rake
- Fix factory to use the right entry: for some reason on rails 4.2, the
  factory `:rubygem_with_downloads` was not working, but the proper way
  to call it is using the main name and pass a `downloads` option.
- Remove teardown method.

All those are necessary for rails 4.2

review @dwradcliffe @sferik 