### PR TITLE
Use rubygem object when find_from_slug! receives it

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -104,7 +104,7 @@ class Version < ActiveRecord::Base
   end
 
   def self.find_from_slug!(rubygem_id, slug)
-    rubygem = Rubygem.find(rubygem_id)
+    rubygem = rubygem_id.is_a?(Rubygem) ? rubygem_id : Rubygem.find(rubygem_id)
     find_by!(full_name: "#{rubygem.name}-#{slug}")
   end
 


### PR DESCRIPTION
`find_from_slug!` method uses `.find`, which needs to receive an `id` and
not a ActiveRecord object. When passing a rubygem object, we can use that instead.

we use that on https://github.com/rubygems/rubygems.org/blob/master/app/controllers/api/v1/rubygems_controller.rb#L69

review @sferik @dwradcliffe 