### PR TITLE
Fix gem__code bottom border

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -90,6 +90,7 @@
 .gem__code {
   padding-right: 10px;
   padding-left: 10px;
+  margin-bottom: 1px;
   display: inline-block;
   overflow: hidden;
   width: 100%;


### PR DESCRIPTION
Fix for the fact that at certain page widths, the botom border on the gem "Install" box disappears.   
Before:
![image](https://cloud.githubusercontent.com/assets/6726985/6223533/352d69c4-b6af-11e4-9df8-ce67653803e4.png)

After:
![image](https://cloud.githubusercontent.com/assets/6726985/6223547/a952c8b2-b6af-11e4-89df-e69287758577.png)
