### PR TITLE
Fix deprecations introduced in Rails 4.2

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/recovery.rb
+++ b/config/environments/recovery.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_dispatch.x_sendfile_header = "X-Sendfile"
     config.active_support.deprecation = :notify
-    config.serve_static_assets = true
+    config.serve_static_files = true
     config.i18n.fallbacks = true
 
     config.action_dispatch.session = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,8 @@ Rails.application.configure do
 
   require 'clearance_backdoor'
   config.middleware.use ClearanceBackdoor
+
+  config.active_support.test_order = :random
 end
 
 ENV['S3_KEY']    = 'this:is:an:ex:parrot'


### PR DESCRIPTION
These deprecations are now fixed:

> DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.

> DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly.
