### PR TITLE
Gem metadata backfill

### DIFF
--- a/lib/metadata_backfill.rb
+++ b/lib/metadata_backfill.rb
@@ -11,7 +11,8 @@ class MetadataBackfill
     file = dir.files.get(key) or return
     pusher = Pusher.new(nil, StringIO.new(file.body))
     pusher.pull_spec
-    version.update_attributes(metadata: pusher.spec.metadata || {})
+    metadata = pusher.spec.metadata
+    version.update(metadata: metadata) if metadata
   end
 
   private

--- a/lib/metadata_backfill.rb
+++ b/lib/metadata_backfill.rb
@@ -1,0 +1,26 @@
+require 'stringio'
+
+class MetadataBackfill
+  attr_reader :version
+
+  def initialize(version)
+    @version = version
+  end
+
+  def backfill
+    file = dir.files.get(key) or return
+    pusher = Pusher.new(nil, StringIO.new(file.body))
+    pusher.pull_spec
+    version.update_attributes(metadata: pusher.spec.metadata || {})
+  end
+
+  private
+
+  def dir
+    Indexer.new.directory
+  end
+
+  def key
+    "gems/#{version.full_name}.gem"
+  end
+end


### PR DESCRIPTION
Continued from #858, this branch adds a new Rake task, `gemcutter:metadata:backfill` for backfillilng old gem versions with metadata. I based it on the Rake task written for the checksum backfill, so it'll be able to run in parallel against multiple shards.

The use of `Pusher` to extract the specification from a gem file is a bit odd, but I didn't find any code that did that anywhere else and thought it best not to go out of scope and factor that code out of `Pusher`, so I just used it here directly. It's migration code anyway, and can be removed when the migration is done.