### PR TITLE
Revert single quotes back to double quotes

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -239,7 +239,7 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    %{gem '#{rubygem.name}', '~> #{number}'}
+    %{gem "#{rubygem.name}", "~> #{number}"}
   end
 
   def to_gem_version

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -300,7 +300,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "give version with twiddle-wakka for #to_bundler" do
-      assert_equal %{gem '#{@version.rubygem.name}', '~> #{@version.to_s}'}, @version.to_bundler
+      assert_equal %{gem "#{@version.rubygem.name}", "~> #{@version.to_s}"}, @version.to_bundler
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
When you look at the [ruby style guide](https://github.com/bbatsov/ruby-style-guide#strings) it says the following:

>  Adopt a consistent string literal quoting style. There are two popular styles in the Ruby community, both of which are considered good - single quotes by default and double quotes by default.

> The second style is arguably a bit more popular in the Ruby community. 

I think it's best to provide the most popular option as copy and paste.