### PR TITLE
Bump to latest rubygems client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - bundle exec rake db:create db:migrate db:test:prepare
 
 env:
-  - RUBYGEMS_VERSION=2.2.2
+  - RUBYGEMS_VERSION=2.4.5
   - RUBYGEMS_VERSION=latest
 
 matrix:


### PR DESCRIPTION
CI is running green on rubygems 2.4.5 for a while now. I think it is safe to upgrade on the servers.

@dwradcliffe can you do that upgrade on the cookbooks when you have a time, and after we it is all deployed we can merge this.