### PR TITLE
add internal background job stats endpoint

### DIFF
--- a/app/controllers/internal/background_job_stats_controller.rb
+++ b/app/controllers/internal/background_job_stats_controller.rb
@@ -1,0 +1,9 @@
+class Internal::BackgroundJobStatsController < ActionController::Metal
+
+  def stats
+    total = Delayed::Job.count
+    failed = Delayed::Job.where.not(failed_at: nil).count
+    self.response_body = "total=#{total} failed=#{failed}"
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,4 +114,11 @@ Rails.application.routes.draw do
     resource :password, only: [:create, :edit, :update]
   end
 
+  ################################################################################
+  # Internal Routes
+
+  namespace :internal do
+    get 'background_job_stats', to: Internal::BackgroundJobStatsController.action(:stats)
+  end
+
 end


### PR DESCRIPTION
We need to track our delayed job queue depth in DataDog. This endpoint will be consumed by a shell script and sent to statsd (and then datadog). Our nginx config will limit this to local only so this won't be publicly exposed.

review: @qrush @arthurnn @skottler 