### PR TITLE
Adds canonical urls for gems and their versions

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -3,7 +3,9 @@
 
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, rubygem_versions_path(@rubygem, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
-  <% unless @rubygem.versions.count.zero? || @latest_version.indexed %>
+  <% if @rubygem.versions.present? && @latest_version.indexed %>
+    <link rel="canonical" href="<%= rubygem_version_url(@rubygem, @latest_version.slug) %>" />
+  <% else %>
     <meta name="robots" content="noindex" />
   <% end %>
 <% end %>

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -44,4 +44,16 @@ class GemsTest < ActionDispatch::IntegrationTest
     assert_equal :atom, response.content_type.symbol
     assert page.has_content? "sandworm"
   end
+
+  test "canonical url for gem points to most recent version" do
+    create(:version, rubygem: @rubygem, number: "1.1.1")
+    get rubygem_path(@rubygem)
+    assert page.has_css? %{link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.1.1"]}, visible: false
+  end
+
+  test "canonical url for an old version" do
+    create(:version, rubygem: @rubygem, number: "1.1.1")
+    get rubygem_version_path(@rubygem, "1.0.0")
+    assert page.has_css? %{link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.0.0"]}, visible: false
+  end
 end


### PR DESCRIPTION
If a version is yanked or a gem has all their versions yanked, we don't display a canonical url.

This resolves #888
