### PR TITLE
Adds the sha to the gem API response

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -157,6 +157,7 @@ class Rubygem < ActiveRecord::Base
       'authors'           => version.authors,
       'info'              => version.info,
       'licenses'          => version.licenses,
+      'sha'               => version.sha256_hex,
       'project_uri'       => "http://#{host_with_port}/gems/#{name}",
       'gem_uri'           => "http://#{host_with_port}/gems/#{version.full_name}.gem",
       'homepage_uri'      => linkset.try(:home),

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -361,6 +361,7 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal @rubygem.versions.most_recent.downloads_count.to_s, doc.at_css("version-downloads").content
       assert_equal @rubygem.versions.most_recent.authors, doc.at_css("authors").content
       assert_equal @rubygem.versions.most_recent.info, doc.at_css("info").content
+      assert_equal @rubygem.versions.most_recent.sha256_hex, doc.at_css("sha").content
       assert_equal "http://#{Gemcutter::HOST}/gems/#{@rubygem.name}", doc.at_css("project-uri").content
       assert_equal "http://#{Gemcutter::HOST}/gems/#{@rubygem.versions.most_recent.full_name}.gem", doc.at_css("gem-uri").content
 


### PR DESCRIPTION
Last month the sha was added to the version api payload, but I think it would be useful for it to be included in the gem api response as well. This resolves in #712.