### PR TITLE
Remove responders gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 4.2.1'
 
 gem 'psych', '~> 2.0.12'
-gem 'responders', '~> 2.0'
 gem 'builder'
 gem 'dynamic_form'
 gem 'excon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,8 +189,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redis (3.2.1)
-    responders (2.0.2)
-      railties (>= 4.2.0.alpha, < 5)
     rest-client (1.7.3)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
@@ -292,7 +290,6 @@ DEPENDENCIES
   rails-erd
   rdoc (~> 3.12.2)
   redis
-  responders (~> 2.0)
   rest-client
   rr
   sass-rails (~> 5.0.0)

--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,14 +1,20 @@
 class Api::V1::ActivitiesController < Api::BaseController
-  respond_to :json, :yaml, :on => [:latest, :just_updated]
 
   def latest
     @rubygems = Rubygem.latest(50)
-    respond_with(@rubygems, :yamlish => true)
+    render_rubygems
   end
 
   def just_updated
     @rubygems = Version.just_updated(50).map(&:rubygem)
-    respond_with(@rubygems, :yamlish => true)
+    render_rubygems
   end
 
+  private
+  def render_rubygems
+    respond_to do |format|
+      format.json { render json: @rubygems }
+      format.yaml { render yaml: @rubygems, yamlish: true }
+    end
+  end
 end

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::ApiKeysController < Api::BaseController
   before_action :redirect_to_root, :unless => :signed_in?, :only => [:reset]
-  respond_to :json, :yaml, :only => :show
 
   def show
     authenticate_or_request_with_http_basic do |username, password|

--- a/app/controllers/api/v1/downloads_controller.rb
+++ b/app/controllers/api/v1/downloads_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::DownloadsController < Api::BaseController
-  respond_to :json, :yaml
-
   def index
     respond_to do |format|
       format.any(:all) { render :text => Download.count }
@@ -12,29 +10,39 @@ class Api::V1::DownloadsController < Api::BaseController
   def show
     full_name = params[:id]
     if rubygem_name = Version.rubygem_name_for(full_name) and rubygem = Rubygem.find_by_name(rubygem_name) and rubygem.public_versions.count.nonzero?
-      respond_with(
-        :total_downloads   => Download.for_rubygem(rubygem_name),
-        :version_downloads => Download.for_version(full_name)
-      )
+      data = {
+        total_downloads: Download.for_rubygem(rubygem_name),
+        version_downloads: Download.for_version(full_name)
+      }
+      respond_with_data(data)
     else
       render :text => "This rubygem could not be found.", :status => :not_found
     end
   end
 
   def top
-    respond_with(
-      :gems => Download.most_downloaded_today(50).map {|version, count|
-        [version.attributes, count]
+    data =
+      { gems: Download.most_downloaded_today(50).map {|version, count|
+          [version.attributes, count]
+        }
       }
-    )
+    respond_with_data(data)
   end
 
   def all
-    respond_with(
-      :gems => Download.most_downloaded_all_time(50).map {|version, count|
+    data = {
+      gems: Download.most_downloaded_all_time(50).map {|version, count|
         [version.attributes, count]
       }
-    )
+    }
+    respond_with_data(data)
   end
 
+  private
+  def respond_with_data(data)
+    respond_to do |format|
+      format.json { render json: data }
+      format.yaml { render yaml: data }
+    end
+  end
 end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -4,10 +4,12 @@ class Api::V1::OwnersController < Api::BaseController
   before_action :verify_authenticated_user, :except => [:show, :gems]
   before_action :find_rubygem, :except => :gems
   before_action :verify_gem_ownership, :except => [:show, :gems]
-  respond_to :yaml, :json, :only => [:show, :gems]
 
   def show
-    respond_with @rubygem.owners
+    respond_to do |format|
+      format.json { render json: @rubygem.owners }
+      format.yaml { render yaml: @rubygem.owners }
+    end
   end
 
   def create
@@ -35,7 +37,10 @@ class Api::V1::OwnersController < Api::BaseController
     user = User.find_by_handle(params[:handle])
     if user
       rubygems = user.rubygems.with_versions
-      respond_with rubygems, :yamlish => true
+      respond_to do |format|
+        format.json { render json: rubygems }
+        format.yaml { render yaml: rubygems, yamlish: true }
+      end
     else
       render :text => "Owner could not be found.", :status => :not_found
     end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -7,16 +7,20 @@ class Api::V1::RubygemsController < Api::BaseController
   before_action :find_rubygem_by_name,      :only => [:yank, :unyank]
   before_action :validate_gem_and_version,  :only => [:yank, :unyank]
 
-  respond_to :json, :yaml, :on => [:index, :show, :latest, :just_updated]
-
   def index
     @rubygems = current_user.rubygems.with_versions
-    respond_with(@rubygems, :yamlish => true)
+    respond_to do |format|
+      format.json { render json: @rubygems }
+      format.yaml { render yaml: @rubygems, yamlish: true }
+    end
   end
 
   def show
     if @rubygem.hosted? and @rubygem.public_versions.indexed.count.nonzero?
-      respond_with(@rubygem, :yamlish => true)
+      respond_to do |format|
+        format.json { render json: @rubygem }
+        format.yaml { render yaml: @rubygem, yamlish: true }
+      end
     else
       render :text => "This gem does not exist.", :status => :not_found
     end
@@ -51,7 +55,10 @@ class Api::V1::RubygemsController < Api::BaseController
   def reverse_dependencies
     rubygems = Rubygem.reverse_dependencies(params[:id])
 
-    respond_with(rubygems.map(&:name), :yamlish => true)
+    respond_to do |format|
+      format.json { render json: rubygems.map(&:name) }
+      format.yaml { render yaml: rubygems.map(&:name), yamlish: true }
+    end
   end
 
   private

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::SearchesController < Api::BaseController
   skip_before_action :verify_authenticity_token
   before_action :set_page, only: :show
-  respond_to :json, :yaml
 
   def show
     @rubygems = Rubygem.search(params.require(:query)).with_versions.paginate(page: @page)
-    respond_with(@rubygems, yamlish: true)
+    respond_to do |format|
+      format.json { render json: @rubygems }
+      format.yaml { render yaml: @rubygems, yamlish: true }
+    end
   end
 end

--- a/app/controllers/api/v1/versions/downloads_controller.rb
+++ b/app/controllers/api/v1/versions/downloads_controller.rb
@@ -1,9 +1,12 @@
 class Api::V1::Versions::DownloadsController < Api::BaseController
-  respond_to :json, :yaml
 
   def index
     if version
-      respond_with Download.counts_by_day_for_version(version)
+      counts = Download.counts_by_day_for_version(version)
+      respond_to do |format|
+        format.json { render json: counts }
+        format.yaml { render yaml: counts }
+      end
     else
       render :text => "This rubygem could not be found.", :status => :not_found
     end
@@ -15,7 +18,11 @@ class Api::V1::Versions::DownloadsController < Api::BaseController
     end
 
     if version
-      respond_with Download.counts_by_day_for_version_in_date_range(version, start, stop)
+      counts = Download.counts_by_day_for_version_in_date_range(version, start, stop)
+      respond_to do |format|
+        format.json { render json: counts }
+        format.yaml { render yaml: counts }
+      end
     else
       render :text => "This rubygem could not be found.", :status => :not_found
     end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -1,13 +1,14 @@
 class Api::V1::VersionsController < Api::BaseController
-  respond_to :json, :yaml
-
   before_action :find_rubygem, only: :show
 
   def show
     return unless stale?(@rubygem)
 
     if @rubygem.public_versions.count.nonzero?
-      respond_with(@rubygem.public_versions, yamlish: true)
+      respond_to do |format|
+        format.json { render json: @rubygem.public_versions }
+        format.yaml { render yaml: @rubygem.public_versions, yamlish: true }
+      end
     else
       render text: "This rubygem could not be found.", status: 404
     end
@@ -26,13 +27,15 @@ class Api::V1::VersionsController < Api::BaseController
       end
     end
 
-    render :json => { "version" => number },
-           :callback => params['callback']
+    render json: { "version" => number }, callback: params['callback']
   end
 
   def reverse_dependencies
     versions = Version.reverse_dependencies(params[:id])
-
-    respond_with(versions.map(&:full_name), :yamlish => true)
+    names = versions.map(&:full_name)
+    respond_to do |format|
+      format.json { render json: names }
+      format.yaml { render yaml: names, yamlish: true }
+    end
   end
 end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -3,10 +3,12 @@ class Api::V1::WebHooksController < Api::BaseController
   before_action :authenticate_with_api_key
   before_action :verify_authenticated_user
   before_action :find_rubygem_by_name, :except => :index
-  respond_to :json, :yaml, :only => :index
 
   def index
-    respond_with current_user.all_hooks
+    respond_to do |format|
+      format.json { render json: current_user.all_hooks }
+      format.yaml { render yaml: current_user.all_hooks }
+    end
   end
 
   def create


### PR DESCRIPTION
We can easily replace ours `respond_with` calls. And honestly I prefer using `respond_to`.
So we can remove the `responders` gem

thoughts? @sferik @qrush @dwradcliffe 