### PR TITLE
Dont run db:migrate on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,6 @@ set :use_sudo, false
 set :group, "deploy"
 set :assets_role, [:app]
 
-after "deploy", "deploy:migrate"
 after "deploy", "deploy:cleanup"
 after "deploy:finalize_update", "deploy:symlink_database_yml", "deploy:symlink_secret_settings"
 
@@ -54,5 +53,4 @@ namespace :deploy do
     sudo "service unicorn restart"
     sudo "service delayed_job restart"
   end
-
 end


### PR DESCRIPTION
I am not a big capistrano specialist. So I am not sure if this is right. But definitely, right now we are running db:migrate too late (after deploy).

@dwradcliffe @indirect 

***EDIT***: The title and code of this PR was changed, read the discussion bellow