### PR TITLE
Move statsd instrumentation code

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -1,24 +1,28 @@
 class Indexer
+  extend StatsD::Instrument
+
   def perform
     log "Updating the index"
     update_index
     log "Finished updating the index"
   end
+  statsd_count_success :perform, 'Indexer.perform.success'
+  statsd_measure :perform, 'Indexer.perform'
 
   def write_gem(body, spec)
-    gem_file = directory.files.create(
-      :body   => body.string,
-      :key    => "gems/#{spec.original_name}.gem",
-      :public => true
+    directory.files.create(
+      body: body.string,
+      key: "gems/#{spec.original_name}.gem",
+      public: true
     )
 
     self.class.indexer.abbreviate spec
     self.class.indexer.sanitize spec
 
-    gem_spec = directory.files.create(
-      :body   => Gem.deflate(Marshal.dump(spec)),
-      :key    => "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
-      :public => true
+    directory.files.create(
+      body: Gem.deflate(Marshal.dump(spec)),
+      key: "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
+      public: true
     )
   end
 

--- a/app/jobs/notifier.rb
+++ b/app/jobs/notifier.rb
@@ -1,6 +1,7 @@
 require 'timeout'
 
 class Notifier < Struct.new(:url, :host_with_port, :rubygem, :version, :api_key)
+  extend StatsD::Instrument
 
   def payload
     rubygem.payload(version, host_with_port).to_json
@@ -24,6 +25,7 @@ class Notifier < Struct.new(:url, :host_with_port, :rubygem, :version, :api_key)
     WebHook.find_by_url(url).try(:increment!, :failure_count)
     false
   end
+  statsd_count_success :perform, 'Webhook.perform.success'
 
   private
 

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,11 +1,4 @@
-Notifier.extend StatsD::Instrument
-Notifier.statsd_count_success :perform, 'Webhook.perform.success'
-
-Indexer.extend StatsD::Instrument
-Indexer.statsd_count_success :perform, 'Indexer.perform.success'
-Indexer.statsd_measure :perform, 'Indexer.perform'
-
-ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*args|
+ActiveSupport::Notifications.subscribe(/process_action.action_controller/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   event.payload[:format] = event.payload[:format] || 'all'
   event.payload[:format] = 'all' if event.payload[:format] == '*/*'
@@ -16,7 +9,7 @@ ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*a
   ActiveSupport::Notifications.instrument :performance, event.payload.merge(measurement: "status.#{status}")
 end
 
-ActiveSupport::Notifications.subscribe /performance/ do |name, start, finish, id, payload|
+ActiveSupport::Notifications.subscribe(/performance/) do |name, start, finish, id, payload|
   method = payload[:statsd_method] || :increment
   measurement = payload[:measurement]
   value = payload[:value]


### PR DESCRIPTION
We dont need to load Notifier and Indexer classes on rails load as we could just extend the statsd module

review @dwradcliffe 