### PR TITLE
Dont require fog at boot time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'psych', '~> 2.0.12'
 gem 'builder'
 gem 'dynamic_form'
 gem 'excon'
-gem 'fog', '= 1.15.0'
+gem 'fog', '= 1.15.0', require: false
 gem 'gchartrb', require: 'google_chart'
 gem 'gravtastic'
 gem 'high_voltage'

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -1,3 +1,5 @@
+require 'fog'
+
 class Indexer
   extend StatsD::Instrument
 
@@ -34,10 +36,7 @@ class Indexer
   private
 
   def fog
-    $fog || Fog::Storage.new(
-      :provider => 'Local',
-      :local_root => Pusher.server_path
-    )
+    $fog || Fog::Storage.new(provider: 'Local', local_root: Pusher.server_path)
   end
 
   def stringify(value)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,3 @@ Rails.application.configure do
 
   config.active_support.test_order = :random
 end
-
-ENV['S3_KEY']    = 'this:is:an:ex:parrot'
-ENV['S3_SECRET'] = 'it:has:ceased:to:be'

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -1,9 +1,6 @@
 if ENV['S3_KEY'] && ENV['S3_SECRET']
-  Fog.mock! if Rails.env.test?
+  require 'fog'
 
-  $fog = Fog::Storage.new(
-    :provider               => 'AWS',
-    :aws_access_key_id      => ENV['S3_KEY'],
-    :aws_secret_access_key  => ENV['S3_SECRET']
+  $fog = Fog::Storage.new(provider: 'AWS', aws_access_key_id: ENV['S3_KEY'], aws_secret_access_key: ENV['S3_SECRET']
   )
 end

--- a/script/add_sizes_to_versions
+++ b/script/add_sizes_to_versions
@@ -2,6 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'production'
 require_relative '../config/environment'
+require 'fog'
 
 def fog
   $fog || Fog::Storage.new(:provider => 'Local',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,10 @@ I18n.enforce_available_locales = false
 # Shim for compatibility with older versions of MiniTest
 MiniTest::Test = MiniTest::Unit::TestCase unless defined?(MiniTest::Test)
 
+require 'fog'
+Fog.mock!
+$fog = Fog::Storage.new(provider: 'AWS', aws_access_key_id: '', aws_secret_access_key: '')
+
 class MiniTest::Test
   include Rack::Test::Methods
   include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
As we use only small part of fog, and not always, I dont see why we need to require it at boot time

@indirect @sferik @dwradcliffe WDYT?

before:
```
[arthurnn@ralph rubygems.org]$ time bundle exec rake environment
Digest::Digest is deprecated; use Digest

real	0m2.957s
user	0m2.361s
sys	0m0.592s
```

after:
```
[arthurnn@ralph rubygems.org]$ time bundle exec rake environment

real	0m2.709s
user	0m2.167s
sys	0m0.530s
```