### PR TITLE
Update clearance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     choice (0.1.7)
-    clearance (1.8.1)
+    clearance (1.9.0)
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -21,9 +21,9 @@ class PasswordResetTest < SystemTest
 
   test "resetting password without handle" do
     forgot_password_with @user.email
-
-    email = ActionMailer::Base.deliveries.last.body.to_s
-    link = email.split("\n").find { |line| line =~ /^http/ }
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = body.split("\n").find { |line| line =~ /^http/ }
+    assert_not_nil link
 
     visit link
     fill_in "Password", with: "secret321"
@@ -42,8 +42,9 @@ class PasswordResetTest < SystemTest
   test "resetting a password with a blank password" do
     forgot_password_with @user.email
 
-    email = ActionMailer::Base.deliveries.last.body.to_s
-    link = email.split("\n").find { |line| line =~ /^http/ }
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = body.split("\n").find { |line| line =~ /^http/ }
+    assert_not_nil link
 
     visit link
     fill_in "Password", with: ""
@@ -68,8 +69,8 @@ class PasswordResetTest < SystemTest
     fill_in "Email address", with: @user.email
     click_button "Reset password"
 
-    email = ActionMailer::Base.deliveries.last.body.to_s
-    link = email.split("\n").find { |line| line =~ /^http/ }
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = body.split("\n").find { |line| line =~ /^http/ }
     visit link
 
     fill_in "Password", with: "secret321"


### PR DESCRIPTION
Had to change the tests too, to not use `body` on the Mail object. This is because now that email sends a html and a text version. see https://github.com/thoughtbot/clearance/commit/3ca7a6b20a73f90b68fbfdb5a794d6caa1d941ef

review @dwradcliffe @qrush @derekprior

[fixes #908]