### PR TITLE
Remove Hostess Sinatra app from production

### DIFF
--- a/app/middleware/hostess.rb
+++ b/app/middleware/hostess.rb
@@ -4,10 +4,8 @@ class Hostess < Sinatra::Base
 
   set :protection, { :except => [:json_csrf] }
 
-  cattr_writer :local
-
-  def self.local
-    @@local ||= false
+  cattr_accessor :local do
+    true
   end
 
   def serve

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,14 +16,9 @@ module Gemcutter
     config.time_zone = "UTC"
     config.encoding  = "utf-8"
 
-    config.middleware.use "Hostess"
     config.middleware.use "Redirector"
 
     config.active_record.include_root_in_json = false
-
-    config.after_initialize do
-      Hostess.local = config.rubygems['local_storage']
-    end
 
     config.plugins = [:dynamic_form]
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.middleware.use "Hostess"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
 
   require 'clearance_backdoor'
   config.middleware.use ClearanceBackdoor
+  config.middleware.use "Hostess"
 
   config.active_support.test_order = :random
 end


### PR DESCRIPTION
As far as we can tell, this routes are done in ngnix. So this
middleware will only be necessary in development.
In this commit I am only moving this out of production so we can make
sure everything still works, and I will follow up in a next commit to
make the Hostess middleware a way simple class.

r @dwradcliffe 
cc @qrush @evanphx 
