### PR TITLE
move delayed_job logs to delayed_job.log

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,5 +1,6 @@
 require 'delayed_job'
 Delayed::Worker.max_attempts = 3
 Delayed::Worker.max_run_time = 5.minutes
+Delayed::Worker.logger = Logger.new(Rails.root.join('log/delayed_job.log'))
 
 PRIORITIES = {push: 1, download: 2, web_hook: 3 }


### PR DESCRIPTION
This moves delayed_job logs to their own file so we can handle them differently.

@arthurnn @evanphx @qrush 