### PR TITLE
Add id and checks handle for user json responses

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
   end
 
   def payload
-    attrs = { "handle" => handle }
+    attrs = { "id" => id, "handle" => handle }
     attrs["email"] = email unless hide_email
     attrs
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -75,20 +75,20 @@ class UserTest < ActiveSupport::TestCase
 
     should "have email and handle on JSON" do
       json = JSON.parse(@user.to_json)
-      hash = {"email" => @user.email, 'handle' => @user.handle}
+      hash = {"id" => @user.id, "email" => @user.email, 'handle' => @user.handle}
       assert_equal hash, json
     end
 
     should "have email and handle on XML" do
       xml = Nokogiri.parse(@user.to_xml)
       assert_equal "user", xml.root.name
-      assert_equal %w[handle email], xml.root.children.select(&:element?).map(&:name)
+      assert_equal %w[id handle email], xml.root.children.select(&:element?).map(&:name)
       assert_equal @user.email, xml.at_css("email").content
     end
 
     should "have email and handle on YAML" do
       yaml = YAML.load(@user.to_yaml)
-      hash = {'email' => @user.email, 'handle' => @user.handle}
+      hash = {'id' => @user.id, 'email' => @user.email, 'handle' => @user.handle}
       assert_equal hash, yaml
     end
 


### PR DESCRIPTION
related with https://github.com/rubygems/rubygems.org/issues/951

With this commit, api returns user's id by default and also return user handle if it is available.

@antlypls @arthurnn What do you guys think about it?