### PR TITLE
add user id test for profiles json responses

### DIFF
--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -6,7 +6,15 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
     sign_in_as(@user)
   end
 
-  context "on GET to show" do
+  context "on GET to show with id" do
+    setup do
+      get :show, id: @user.id, format: :json
+    end
+
+    should respond_with :success
+  end
+
+  context "on GET to show with handle" do
     setup do
       get :show, id: @user.handle, format: :json
     end


### PR DESCRIPTION
Before this we didn't have test for profiles api responses when we provide user id instead of handle. This pr adds necessary test for that.