### PR TITLE
fixed missing documentation uri for api gem responses

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -56,11 +56,7 @@ module RubygemsHelper
   end
 
   def documentation_link(version, linkset)
-    link_to 'Documentation', documentation_path(version), :class => 'gem__link t-list__item', :id => :docs if linkset.nil? || linkset.docs.blank?
-  end
-
-  def documentation_path(version)
-    "http://www.rubydoc.info/gems/#{version.rubygem.name}/#{version.number}"
+    link_to 'Documentation', version.documentation_path, :class => 'gem__link t-list__item', :id => :docs if linkset.nil? || linkset.docs.blank?
   end
 
   def badge_link(rubygem)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -163,7 +163,7 @@ class Rubygem < ActiveRecord::Base
       'gem_uri'           => "http://#{host_with_port}/gems/#{version.full_name}.gem",
       'homepage_uri'      => linkset.try(:home),
       'wiki_uri'          => linkset.try(:wiki),
-      'documentation_uri' => linkset.try(:docs),
+      'documentation_uri' => linkset.try(:docs) || version.documentation_path,
       'mailing_list_uri'  => linkset.try(:mail),
       'source_code_uri'   => linkset.try(:code),
       'bug_tracker_uri'   => linkset.try(:bugs),

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -267,6 +267,10 @@ class Version < ActiveRecord::Base
     update_attributes(sha256: recalculate_sha256)
   end
 
+  def documentation_path
+    "http://www.rubydoc.info/gems/#{rubygem.name}/#{number}"
+  end
+
   private
 
   def platform_and_number_are_unique

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -35,7 +35,7 @@ class RubygemsHelperTest < ActionView::TestCase
     linkset = build(:linkset, :docs => nil)
 
     link = documentation_link(version, linkset)
-    assert link.include?(documentation_path(version))
+    assert link.include?(version.documentation_path)
   end
 
   should "not link to docs if docs link is set" do


### PR DESCRIPTION
It solves the problem about https://github.com/rubygems/rubygems.org/issues/952. I'm not sure we should test the documentation uri explicitly in rubygems api test since existing tests just check the whole response hash without specifying any attribute.

cc // @sferik @qrush 