### PR TITLE
Use select instead of pluck for reverse_dependencies

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -51,7 +51,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.reverse_dependencies(name)
-    where(id: Version.reverse_dependencies(name).pluck(:rubygem_id))
+    where(id: Version.reverse_dependencies(name).select(:rubygem_id))
   end
 
   def self.total_count


### PR DESCRIPTION
This has better performance, since it's creating one SQL request
instead of two with pluck.