### PR TITLE
fixes rubygem blank documentation url

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -163,7 +163,7 @@ class Rubygem < ActiveRecord::Base
       'gem_uri'           => "http://#{host_with_port}/gems/#{version.full_name}.gem",
       'homepage_uri'      => linkset.try(:home),
       'wiki_uri'          => linkset.try(:wiki),
-      'documentation_uri' => linkset.try(:docs) || version.documentation_path,
+      'documentation_uri' => linkset.try(:docs).presence || version.documentation_path,
       'mailing_list_uri'  => linkset.try(:mail),
       'source_code_uri'   => linkset.try(:code),
       'bug_tracker_uri'   => linkset.try(:bugs),

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -374,7 +374,7 @@ class RubygemTest < ActiveSupport::TestCase
     context "with a linkset" do
       setup do
         @rubygem = build(:rubygem)
-        version = create(:version, :rubygem => @rubygem)
+        @version = create(:version, :rubygem => @rubygem)
       end
 
       should "return a bunch of JSON" do
@@ -386,6 +386,14 @@ class RubygemTest < ActiveSupport::TestCase
         assert_equal @rubygem.linkset.mail, hash["mailing_list_uri"]
         assert_equal @rubygem.linkset.code, hash["source_code_uri"]
         assert_equal @rubygem.linkset.bugs, hash["bug_tracker_uri"]
+      end
+
+      should "return version documentation url if linkset docs is empty" do
+        @rubygem.linkset.docs = ""
+        @rubygem.save
+        hash = MultiJson.load(@rubygem.to_json)
+
+        assert_equal @version.documentation_path, hash["documentation_uri"]
       end
 
       should "return a bunch of XML" do

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -374,7 +374,7 @@ class RubygemTest < ActiveSupport::TestCase
     context "with a linkset" do
       setup do
         @rubygem = build(:rubygem)
-        @version = create(:version, :rubygem => @rubygem)
+        @version = create(:version, rubygem: @rubygem)
       end
 
       should "return a bunch of JSON" do
@@ -391,7 +391,7 @@ class RubygemTest < ActiveSupport::TestCase
       should "return version documentation url if linkset docs is empty" do
         @rubygem.linkset.docs = ""
         @rubygem.save
-        hash = MultiJson.load(@rubygem.to_json)
+        hash = JSON.load(@rubygem.to_json)
 
         assert_equal @version.documentation_path, hash["documentation_uri"]
       end


### PR DESCRIPTION
fixes #967

@AaronLasseigne I think it solves your problem cc // @sferik 
