### PR TITLE
Revert "fetch top gems from redis instead of postgres"

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -62,8 +62,8 @@ class Rubygem < ActiveRecord::Base
     with_one_version.order(created_at: :desc).limit(limit)
   end
 
-  def self.downloaded(limit=10)
-    most_downloaded_by_redis(limit) || most_downloaded_by_db(limit) 
+  def self.downloaded(limit=5)
+    with_versions.by_downloads.limit(limit)
   end
 
   def self.letter(letter)
@@ -80,23 +80,6 @@ class Rubygem < ActiveRecord::Base
 
   def self.monthly_short_dates
     monthly_dates.map { |date| date.strftime("%m/%d") }
-  end
-
-  def self.most_downloaded_by_db(limit=10)
-    with_versions.by_downloads.limit(limit)
-  end
-
-  def self.most_downloaded_by_redis(limit=10)
-    counts = {}
-    self.pluck(:name).in_groups_of(100).each do |group|
-      group.each do |name|
-        counts[name] = Download.for_rubygem(name)
-      end
-    end
-    counts = counts.sort_by{|x| -x.last.to_i }.first(limit).collect(&:first)
-    self.where(name: counts).by_downloads
-  rescue
-    nil
   end
 
   def self.versions_key(name)

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -496,7 +496,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     should "only latest downloaded versions" do
-      assert_equal [@thin, @rake, @json, @thor, @rack],        Rubygem.downloaded(5)
+      assert_equal [@thin, @rake, @json, @thor, @rack],        Rubygem.downloaded
       assert_equal [@thin, @rake, @json, @thor, @rack, @dust], Rubygem.downloaded(6)
     end
   end
@@ -681,40 +681,6 @@ class RubygemTest < ActiveSupport::TestCase
     should "give the monthly dates back" do
       Timecop.freeze Time.utc(2010, 11, 01) do
         assert_equal(("01".."30").map { |date| "10/#{date}" }, Rubygem.monthly_short_dates)
-      end
-    end
-
-    context "give most downloaded gems" do
-      setup do
-        @thin = create(:rubygem, :name => 'thin', :downloads => 76)
-        @rake = create(:rubygem, :name => 'rake', :downloads => 45)
-        @json = create(:rubygem, :name => 'json', :downloads => 32)
-        @thor = create(:rubygem, :name => 'thor', :downloads => 20)
-        @rack = create(:rubygem, :name => 'rack', :downloads => 13)
-        @dust = create(:rubygem, :name => 'dust', :downloads => 0)
-        @haml = create(:rubygem, :name => 'haml', :downloads => 0)
-        @chronic = create(:rubygem, :name => 'chronic', :downloads => 0)
-
-        @gems = [@thin, @rake, @json, @thor, @rack, @dust, @haml, @chronic]
-        @gems.each do |g|
-          create(:version, :rubygem => g)
-          g[:downloads].times { Download.incr(g.name, @version.full_name) }
-        end
-      end
-
-      should "by postgres" do
-        assert_equal [@thin, @rake, @json, @thor, @rack], Rubygem.most_downloaded_by_db(5)
-      end
-
-      should "by redis" do
-        assert_equal [@thin, @rake, @json, @thor, @rack], Rubygem.most_downloaded_by_redis(5)
-      end
-
-      should "differentiate if the ranking is not the same for redis and postgres" do
-        version = @thin.versions.last
-        version.indexed = false
-        version.save
-        assert_not_equal Rubygem.most_downloaded_by_db(5), Rubygem.most_downloaded_by_redis(5)
       end
     end
   end


### PR DESCRIPTION
Reverts rubygems/rubygems.org#961

In staging the stats page wouldn't load anymore after this change. I'm guessing there's a sql statement that's not limited properly and it's attempting to load all the data?

Reverting so we don't leave master in a bad state.

@sferik @farukaydin @indirect 