### PR TITLE
add script to update vendor/cache

### DIFF
--- a/bin/update_vendor_cache
+++ b/bin/update_vendor_cache
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+git submodule update -f
+bundle install
+cd vendor/cache
+git checkout master
+git pull origin master
+git add -A
+git commit -m "update gems"
+git push origin master
+cd ../..
+git add vendor/cache


### PR DESCRIPTION
This is a simple script to automate the steps to updating the vendor/cache. It has worked for me the last few times but it would be good if someone else checked it too. Please note that it does push the new commit to https://github.com/rubygems/rubygems.org-vendor but does not commit the submodule bump. This allows you to include it with other changes. (A gem bump could include the Gemfile changes and the submodule bump in one commit.)

closes #965 

r: @arthurnn @sferik 