### PR TITLE
Accepts a specific version to get info from

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,7 +5,7 @@ class Api::BaseController < ApplicationController
 
   def find_rubygem_by_name
     @url      = params[:url]
-    @gem_name = params[:gem_name]
+    @gem_name = params[:gem_name] || params[:rubygem_name]
     @rubygem  = Rubygem.find_by_name(@gem_name)
     if @rubygem.nil? && @gem_name != WebHook::GLOBAL_PATTERN
       render :text   => "This gem could not be found",

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -1,0 +1,17 @@
+class Api::V2::VersionsController < Api::BaseController
+  before_action :find_rubygem_by_name, only: [:show]
+
+  def show
+    return unless stale?(@rubygem)
+
+    version = @rubygem.public_versions.find_by(number: params[:number])
+    if version
+      respond_to do |format|
+        format.json { render json: version }
+        format.yaml { render yaml: version }
+      end
+    else
+      render text: "This version could not be found.", status: 404
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,17 @@ Rails.application.routes.draw do
   root :to => 'home#index'
 
   ################################################################################
-  # API v1
+  # API
 
   namespace :api do
+    namespace :v2 do
+      resources :rubygems, param: :name, only: [] do
+        resources :versions, param: :number, only: :show, constraints: {
+          number: /#{Gem::Version::VERSION_PATTERN}(?=\.json\z)|#{Gem::Version::VERSION_PATTERN}/
+        }
+      end
+    end
+
     namespace :v1 do
       resource :api_key, :only => :show do
         put :reset

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -1,0 +1,151 @@
+require 'test_helper'
+
+class Api::V2::VersionsControllerTest < ActionController::TestCase
+  def get_show(rubygem, version, format = 'json')
+    get :show, rubygem_name: rubygem.name, number: version, format: format
+  end
+
+  def set_cache_header
+    @request.if_modified_since = @response.headers['Last-Modified']
+    @request.if_none_match = @response.etag
+  end
+
+  def self.should_respond_to(format)
+    context "with #{format.to_s.upcase}" do
+      should "have a list of versions for the first gem" do
+        get_show(@rubygem, '2.0.0', format)
+        @response.body
+        assert_response :success
+      end
+    end
+  end
+
+  context "on GET to show" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:version, rubygem: @rubygem, number: '2.0.0')
+      create(:version, rubygem: @rubygem, number: '1.0.0.pre', prerelease: true)
+      create(:version, rubygem: @rubygem, number: '3.0.0', indexed: false)
+
+      @rubygem2 = create(:rubygem)
+      create(:version, rubygem: @rubygem2, number: '3.0.0')
+      create(:version, rubygem: @rubygem2, number: '2.0.0')
+      create(:version, rubygem: @rubygem2, number: '1.0.0')
+    end
+
+    should_respond_to(:json) do |body|
+      MultiJson.load(body)
+    end
+
+    should_respond_to(:yaml) do |body|
+      YAML.load(body)
+    end
+
+    should "return Last-Modified header" do
+      get_show(@rubygem, '2.0.0')
+      assert_equal @response.headers['Last-Modified'], @rubygem.updated_at.httpdate
+    end
+
+    should "return 304 when If-Modified-Since header is satisfied" do
+      get_show(@rubygem, '2.0.0')
+      assert_response :success
+      set_cache_header
+
+      get_show(@rubygem, '2.0.0')
+      assert_response :not_modified
+    end
+
+    should "return 200 when If-Modified-Since header is not satisfied" do
+      get_show(@rubygem, '2.0.0')
+      assert_response :success
+      set_cache_header
+
+      @rubygem.update(updated_at: Time.zone.now + 1)
+      get_show(@rubygem, '2.0.0')
+      assert_response :success
+    end
+
+    should "return 404 if all versions yanked" do
+      get_show(@rubygem, '2.0.0')
+      assert_response :success
+      set_cache_header
+
+      Timecop.travel(Time.zone.now + 1) do
+        @rubygem.public_versions.each { |v| v.update!(indexed: false) }
+      end
+
+      get_show(@rubygem, '2.0.0')
+      assert_response :not_found
+    end
+  end
+
+  context "on GET to show for an unknown gem" do
+    setup do
+      get_show(Rubygem.new(name: "nonexistent_gem"), '1.2.3')
+    end
+
+    should "return a 404" do
+      assert_response :not_found
+    end
+
+    should "say gem could not be found" do
+      assert_equal "This gem could not be found", @response.body
+    end
+  end
+
+  context "on GET to show for a yanked gem" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:version, rubygem: @rubygem, indexed: false, number: '1.0.0')
+      get_show(@rubygem, '2.0.0')
+    end
+
+    should "return a 404" do
+      assert_response :not_found
+    end
+
+    should "say gem could not be found" do
+      assert_equal "This version could not be found.", @response.body
+    end
+
+    should "should cache the 404" do
+      set_cache_header
+
+      get_show(@rubygem, '2.0.0')
+      assert_response :not_modified
+    end
+  end
+
+  context "on GET to show a gem with with lots of versions" do
+    setup do
+      @rubygem = create(:rubygem)
+      12.times do |n|
+        create(:version, rubygem: @rubygem, number: "#{n}.0.0")
+      end
+    end
+
+    should "gives one specific version" do
+      get_show(@rubygem, '4.0.0')
+      assert_kind_of Hash, MultiJson.load(@response.body)
+      assert_equal "4.0.0", MultiJson.load(@response.body)["number"]
+    end
+
+    context "expected attributes by compact index" do
+      setup do
+      end
+    end
+  end
+
+  context "on GET to show for a gem with a license" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:version, rubygem: @rubygem, number: "2.0.0")
+      get_show(@rubygem, '2.0.0')
+      @response = MultiJson.load(@response.body)
+    end
+
+    should("have sha") { assert @response["sha"] }
+    should("have platform") { assert @response["platform"] }
+    should("have ruby_version") { assert @response["ruby_version"] }
+  end
+end

--- a/test/integration/compact_index.rb
+++ b/test/integration/compact_index.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class CompactIndex < ActionDispatch::IntegrationTest
+  def request_endpoint(rubygem, version, format = 'json', http_params = {})
+    get api_v2_rubygem_version_path(rubygem.name, version, format: format), {}, http_params
+  end
+
+  setup do
+    @rubygem = create(:rubygem)
+    create(:version, rubygem: @rubygem, number: '2.0.0')
+  end
+
+  test "return gem version" do
+    request_endpoint(@rubygem, '2.0.0')
+    assert_response :success
+    json_response = MultiJson.load(@response.body)
+    assert_kind_of Hash, json_response
+    assert_equal '2.0.0', json_response["number"]
+  end
+
+  test "has required fields" do
+    request_endpoint(@rubygem, '2.0.0')
+    json_response = MultiJson.load(@response.body)
+    json_response["sha"]
+    json_response["platform"]
+    json_response["ruby_version"]
+  end
+
+  test "version do not exist" do
+    request_endpoint(@rubygem, '1.2.3')
+    assert_response :not_found
+    assert_equal "This version could not be found.", @response.body
+  end
+
+  test "gem do not exist" do
+    request_endpoint(Rubygem.new(name: "nonexistent_gem"), '2.0.0')
+    assert_response :not_found
+    assert_equal "This gem could not be found", @response.body
+  end
+
+  test "second get returns not modified" do
+    request_endpoint(@rubygem, '2.0.0')
+    assert_response :success
+    http_params = {
+      "HTTP_IF_MODIFIED_SINCE" => @response.headers['Last-Modified'],
+      "HTTP_IF_NONE_MATCH" => @response.etag
+    }
+    request_endpoint(@rubygem, '2.0.0', 'json', http_params)
+    assert_response :not_modified
+  end
+end


### PR DESCRIPTION
Currently the API can return all public versions from a given rubygem.
In order to implement the new index for the bundler project, would be
great if we could request the info of a specific version. This patch
does just that.

Previosly you could do:

    wget rubygems.org/api/v1/versions/rails.json

and the result would be an array with all rails versions and information
about each version.

Now you can do the following:

    wget rubygems.org/api/v1/versions/rails/4.2.0.json

To retrieve information only for the 4.2.0 version.