### PR TITLE
486 native extensions

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -206,6 +206,7 @@ class Version < ActiveRecord::Base
       built_at: spec.date,
       required_rubygems_version: spec.required_rubygems_version.to_s,
       required_ruby_version: spec.required_ruby_version.to_s,
+      extensions: !spec.extensions.empty?,
       indexed: true
     )
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -251,6 +251,7 @@ class Version < ActiveRecord::Base
       'platform'         => platform,
       'rubygems_version' => required_rubygems_version,
       'ruby_version'     => required_ruby_version,
+      'extensions'       => extensions,
       'prerelease'       => prerelease,
       'licenses'         => licenses,
       'requirements'     => requirements,

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -135,16 +135,12 @@
         </i>
       </h2>
 
-      <h2 class="gem__ruby-version__heading t-list__heading">
-        <%= t '.native_extensions' %>:
-        <i class="gem__ruby-version">
-          <% if !@latest_version.extensions.nil? %>
-              <%= @latest_version.extensions ? 'Yes' : 'None' %>
-          <% else %>
-              Unknown
-          <% end %>
-        </i>
-      </h2>
+      <% if @latest_version.extensions %>
+        <h2 class="gem__ruby-version__heading t-list__heading">
+          <%= t('.native_extensions') %>:
+          <i class="gem__ruby-version">Yes</i>
+        </h2>
+      <% end %>
 
       <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
       <div class="t-list__items">

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -135,6 +135,17 @@
         </i>
       </h2>
 
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        <%= t 'native_extensions' %>:
+        <i class="gem__ruby-version">
+          <% if !@latest_version.extensions.nil? %>
+              <%= @latest_version.extensions ? 'Yes' : 'None' %>
+          <% else %>
+              Unknown
+          <% end %>
+        </i>
+      </h2>
+
       <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
       <div class="t-list__items">
         <%= link_to t('edit'), edit_rubygem_path(@rubygem), :class => "gem__link t-list__item", :id => "edit" if @rubygem.owned_by?(current_user) %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -136,7 +136,7 @@
       </h2>
 
       <h2 class="gem__ruby-version__heading t-list__heading">
-        <%= t 'native_extensions' %>:
+        <%= t '.native_extensions' %>:
         <i class="gem__ruby-version">
           <% if !@latest_version.extensions.nil? %>
               <%= @latest_version.extensions ? 'Yes' : 'None' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
       yanked_notice: "This gem has been yanked, and it is not available for download directly or for other gems that may have depended on it."
       authors_header: Authors
       downloads_for_this_version: "For this version"
+      native_extensions: Native extensions
       owners_header: Owners
       links:
         header: Links

--- a/db/migrate/20150618183029_add_extensions_to_versions.rb
+++ b/db/migrate/20150618183029_add_extensions_to_versions.rb
@@ -1,5 +1,5 @@
 class AddExtensionsToVersions < ActiveRecord::Migration
   def change
-    add_column :versions, :extensions, :boolean
+    add_column :versions, :extensions, :boolean, default: false
   end
 end

--- a/db/migrate/20150618183029_add_extensions_to_versions.rb
+++ b/db/migrate/20150618183029_add_extensions_to_versions.rb
@@ -1,0 +1,5 @@
+class AddExtensionsToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :extensions, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 20160528065150) do
     t.string   "sha256"
     t.hstore   "metadata",          default: {},   null: false
     t.string   "required_rubygems_version"
-    t.boolean  "extensions"
+    t.boolean  "extensions",        default: false
   end
 
   add_index "versions", ["built_at"], name: "index_versions_on_built_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 20160528065150) do
     t.string   "sha256"
     t.hstore   "metadata",          default: {},   null: false
     t.string   "required_rubygems_version"
+    t.boolean  "extensions"
   end
 
   add_index "versions", ["built_at"], name: "index_versions_on_built_at", using: :btree

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -98,6 +98,7 @@ FactoryGirl.define do
     rubygem
     size 1024
     sha256 "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g="
+    extensions nil
 
     trait :yanked do
       indexed false

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -98,7 +98,8 @@ FactoryGirl.define do
     rubygem
     size 1024
     sha256 "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g="
-    extensions nil
+    extensions false
+  end
 
     trait :yanked do
       indexed false

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -458,19 +458,6 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :not_found
   end
 
-  context "On GET to show for a gem with unknown extensions" do
-    setup do
-      @version = create(:version)
-      get :show, id: @version.rubygem.to_param
-    end
-
-    should respond_with :success
-    should render_template :show
-    should "show unknown for native extensions" do
-      assert page.has_content?('Unknown')
-    end
-  end
-
   context "On GET to show for a gem without extensions" do
     setup do
       @version = create(:version, extensions: false)
@@ -479,8 +466,8 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should render_template :show
-    should "show none for native extensions" do
-      assert page.has_content?('None')
+    should "not render native extensions block" do
+      assert page.has_no_content?('Native extensions')
     end
   end
 
@@ -492,9 +479,9 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should render_template :show
-    should "show yes for native extensions" do
-      assert page.has_content?('Yes')
-    end
+    should "render native extensions block" do
+      assert page.has_content?('Native extensions')
+    end  
   end
 
   context "When not logged in" do

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -458,6 +458,45 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :not_found
   end
 
+  context "On GET to show for a gem with unknown extensions" do
+    setup do
+      @version = create(:version)
+      get :show, id: @version.rubygem.to_param
+    end
+
+    should respond_with :success
+    should render_template :show
+    should "show unknown for native extensions" do
+      assert page.has_content?('Unknown')
+    end
+  end
+
+  context "On GET to show for a gem without extensions" do
+    setup do
+      @version = create(:version, extensions: false)
+      get :show, id: @version.rubygem.to_param
+    end
+
+    should respond_with :success
+    should render_template :show
+    should "show none for native extensions" do
+      assert page.has_content?('None')
+    end
+  end
+
+  context "On GET to show for a gem with extensions" do
+    setup do
+      @version = create(:version, extensions: true)
+      get :show, id: @version.rubygem.to_param
+    end
+
+    should respond_with :success
+    should render_template :show
+    should "show yes for native extensions" do
+      assert page.has_content?('Yes')
+    end
+  end
+
   context "When not logged in" do
     context "On GET to show for a gem" do
       setup do

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -12,7 +12,7 @@ class VersionTest < ActiveSupport::TestCase
     should "only have relevant API fields" do
       json = @version.as_json
       fields = %w(number built_at summary description authors platform
-                  ruby_version rubygems_version prerelease downloads_count licenses
+                  ruby_version rubygems_version extensions prerelease downloads_count licenses
                   requirements sha metadata created_at)
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
@@ -25,6 +25,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.prerelease, json["prerelease"]
       assert_equal @version.required_rubygems_version, json["rubygems_version"]
       assert_equal @version.required_ruby_version, json["ruby_version"]
+      assert_equal @version.extensions, json['extensions']
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
@@ -40,7 +41,7 @@ class VersionTest < ActiveSupport::TestCase
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w(number built-at summary description authors platform
-                  ruby-version rubygems-version prerelease downloads-count licenses
+                  ruby-version rubygems-version extensions prerelease downloads-count licenses
                   requirements sha metadata created-at)
       assert_equal fields.map(&:to_s).sort,
         xml.root.children.map(&:name).reject { |t| t == "text" }.sort
@@ -54,6 +55,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.prerelease.to_s, xml.at_css("prerelease").content
       assert_equal @version.required_rubygems_version, xml.at_css("rubygems-version").content
       assert_equal @version.required_ruby_version, xml.at_css("ruby-version").content
+      assert_equal @version.extensions.to_s, xml.at_css("extensions").content,
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
       assert_equal @version.requirements, xml.at_css("requirements").content


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/issues/486

OK, so how about this approach.
I've added the boolean field *extensions* to Version model, which is nil by default. On gem pull it checks for the spec .extensions attribute, if it's not blank, when we expect this gem have native extensions, so we set *extensions* to true, otherwise false.

On the gem show page (only on it, no index involved) we show beneath the REQUIRED RUBY VERSION: block for native extensions, with possible values: Yes, None, Unknown.
My approach is not to rebuild the existing gems, that's why I sticked with nil instead of false by default. This is because we don't know from start is there extensions for the gem, until it's pushed again.

![screen shot 2015-06-22 at 20 15 30](https://cloud.githubusercontent.com/assets/2951943/8287909/784031b4-191b-11e5-8025-eb958dd90f2b.png)

Maybe I've missed something to test against, if this is true, feel free to point me up on the problem place.