### PR TITLE
Update bundler bundled with to v1.10.4, use same bundler on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ bundler_args: --jobs=3 --retry=3 --without development
 before_install:
   - sh -c "if [ '$RUBYGEMS_VERSION' != 'latest' ]; then gem update --system $RUBYGEMS_VERSION; fi"
   - gem --version
+  - gem install bundler -v 1.10.4
 
 before_script:
   - cp config/database.yml.example config/database.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,4 +292,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.10.3
+   1.10.4


### PR DESCRIPTION
This pull request updates bundled with section in lockfile, also use same version on travis ci.

> v1.10.4 added a workaround: don't add BUNDLED WITH to the lock when Spring runs check over and over (@indirect)
> https://github.com/bundler/bundler/blob/v1.10.4/CHANGELOG.md