### PR TITLE
no need to require minitest unit explicitly

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ require File.expand_path('../../config/environment', __FILE__)
 
 require 'minitest/autorun'
 require 'rails/test_help'
-require 'minitest/unit'
 require 'mocha/mini_test'
 require 'bourne'
 require 'capybara/rails'


### PR DESCRIPTION
minitest/unit isn't needed to use mocha with rails, which explained in [mocha documentation](https://github.com/freerange/mocha)

cc // @sferik @arthurnn 