### PR TITLE
moved most downloaded gems sort by redis functionality to rubygem model

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,7 +3,7 @@ class StatsController < ApplicationController
     @number_of_gems      = Rubygem.total_count
     @number_of_users     = User.count
     @number_of_downloads = Download.count
-    @most_downloaded     = Rubygem.downloaded(10).sort_by { |r| r.downloads }.reverse!
+    @most_downloaded     = Rubygem.downloaded
     @most_downloaded_count = @most_downloaded.first.downloads
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -62,8 +62,8 @@ class Rubygem < ActiveRecord::Base
     with_one_version.order(created_at: :desc).limit(limit)
   end
 
-  def self.downloaded(limit=5)
-    with_versions.by_downloads.limit(limit)
+  def self.downloaded(limit=10)
+    with_versions.by_downloads.limit(limit).sort_by { |r| r.downloads }.reverse!
   end
 
   def self.letter(letter)

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -35,7 +35,7 @@ class StatsControllerTest < ActionController::TestCase
       assert_received(User, :count)
       assert_received(Rubygem, :total_count)
       assert_received(Download, :count)
-      assert_received(Rubygem, :downloaded) { |subject| subject.with(10) }
+      assert_received(Rubygem, :downloaded)
     end
   end
 
@@ -49,7 +49,7 @@ class StatsControllerTest < ActionController::TestCase
       rg3 = create(:rubygem, downloads: 30, number: "1")
       def rg3.downloads; 30; end
 
-      Rubygem.stubs(:downloaded).returns [rg1, rg2, rg3]
+      Rubygem.stubs(:downloaded).returns [rg2, rg3, rg1]
 
       get :index
     end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -471,14 +471,18 @@ class RubygemTest < ActiveSupport::TestCase
     setup do
       @thin = create(:rubygem, :name => 'thin', :created_at => 1.year.ago,  :downloads => 20)
       @rake = create(:rubygem, :name => 'rake', :created_at => 1.month.ago, :downloads => 10)
-      @json = create(:rubygem, :name => 'json', :created_at => 1.week.ago,  :downloads => 5)
+      @json = create(:rubygem, :name => 'json', :created_at => 1.week.ago,  :downloads => 9)
+      @rdoc = create(:rubygem, :name => 'rdoc', :created_at => 2.year.ago,  :downloads => 8)
+      @mail = create(:rubygem, :name => 'mail', :created_at => 2.year.ago,  :downloads => 7)
+      @sass = create(:rubygem, :name => 'sass', :created_at => 2.year.ago,  :downloads => 6)
+      @arel = create(:rubygem, :name => 'arel', :created_at => 2.year.ago,  :downloads => 5)
       @thor = create(:rubygem, :name => 'thor', :created_at => 2.days.ago,  :downloads => 3)
       @rack = create(:rubygem, :name => 'rack', :created_at => 1.day.ago,   :downloads => 2)
       @dust = create(:rubygem, :name => 'dust', :created_at => 3.days.ago,  :downloads => 1)
       @haml = create(:rubygem, :name => 'haml')
       @new = build(:rubygem)
 
-      @gems = [@thin, @rake, @json, @thor, @rack, @dust]
+      @gems = [@thin, @rake, @json, @rdoc, @mail, @sass, @arel, @thor, @rack, @dust]
       @gems.each { |g| create(:version, :rubygem => g) }
     end
 
@@ -495,7 +499,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     should "give a count of only rubygems with versions" do
-      assert_equal 6, Rubygem.total_count
+      assert_equal 10, Rubygem.total_count
     end
 
     should "only return the latest gems with versions" do
@@ -503,9 +507,9 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal [@rack, @thor, @dust, @json, @rake, @thin], Rubygem.latest(6)
     end
 
-    should "only latest downloaded versions" do
-      assert_equal [@thin, @rake, @json, @thor, @rack],        Rubygem.downloaded
-      assert_equal [@thin, @rake, @json, @thor, @rack, @dust], Rubygem.downloaded(6)
+    should "only most downloaded gems" do
+      assert_equal [@thin, @rake, @json, @rdoc, @mail, @sass, @arel, @thor, @rack, @dust], Rubygem.downloaded
+      assert_equal [@thin, @rake, @json, @rdoc, @mail, @sass], Rubygem.downloaded(6)
     end
   end
 


### PR DESCRIPTION
As rubygems.org convention, I think it's better to move redis sort functionality to model for stats page.Also I changed default ```Rubygem.downloaded``` parameter as 10, since stats controller is the only place that we use ```Rubygem.downloaded``` with 10, I guess it should have the same behavior for both usage and test.

cc// @sferik @arthurnn 