### PR TITLE
make home page resilient to redis outage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ rvm:
 services:
   - redis-server
 
-sudo: false
+sudo: true
 
 bundler_args: --jobs=3 --retry=3 --without development
 
 before_install:
   - sh -c "if [ '$RUBYGEMS_VERSION' != 'latest' ]; then gem update --system $RUBYGEMS_VERSION; fi"
   - gem --version
+  - script/install_toxiproxy.sh
 
 before_script:
   - cp config/database.yml.example config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ gem 'sass-rails',   '~> 5.0.0'
 gem 'coffee-rails', '~> 4.1'
 gem 'uglifier', '>= 1.0.3'
 
+group :development, :test do
+  gem 'toxiproxy'
+end
+
 group :development do
   gem 'quiet_assets'
   gem 'rails-erd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.7.4)
+    toxiproxy (0.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -289,6 +290,7 @@ DEPENDENCIES
   shoulda
   statsd-instrument (~> 2.0.6)
   timecop
+  toxiproxy
   uglifier (>= 1.0.3)
   unicorn
   validates_formatting_of

--- a/app/assets/stylesheets/modules/button.css
+++ b/app/assets/stylesheets/modules/button.css
@@ -47,7 +47,11 @@
       margin-left: auto; } }
   @media (min-width: 520px) {
     .home__join {
-      float: right; } }
+      float: right; }
+    .home__join.no-download-count {
+      float: none;
+      margin-right: auto;
+      margin-left: auto; } }
 
 .form__submit {
   margin-top: 42px;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,9 @@
 class HomeController < ApplicationController
   def index
-    @downloads_count = Download.count
+    begin
+      @downloads_count = Download.count
+    rescue Redis::CannotConnectError
+    end
     respond_to do |format|
       format.html
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,6 @@
 class HomeController < ApplicationController
   def index
-    begin
-      @downloads_count = Download.count
-    rescue Redis::CannotConnectError
-    end
+    @downloads_count = Download.count
     respond_to do |format|
       format.html
     end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -15,6 +15,8 @@ class Download
 
   def self.count
     Redis.current.get(COUNT_KEY).to_i
+  rescue Redis::CannotConnectError
+    nil
   end
 
   def self.today(*versions)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -18,7 +18,7 @@
       <span class="home__downloads__desc">downloads &amp; counting</span>
     </h2>
   <% end %>
-  <%= link_to t('.learn.install_rubygems'), page_url("download"), :class => "home__join", "data-icon" => ">" %>
+  <%= link_to t('.learn.install_rubygems'), page_url("download"), :class => "home__join #{@downloads_count.nil? ? 'no-download-count' : ''}", "data-icon" => ">" %>
 </div>
 <div class="home__links">
   <%= link_to t('.footer.status'), "https://status.rubygems.org", class: "home__link", "data-icon" => "⌁" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,10 +12,12 @@
   <% end %>
 </div>
 <div class="home__cta-wrap">
-  <h2 class="home__downloads">
-    <p><%= number_with_delimiter(@downloads_count) %></p>
-    <span class="home__downloads__desc">downloads &amp; counting</span>
-  </h2>
+  <% if @downloads_count %>
+    <h2 class="home__downloads">
+      <p><%= number_with_delimiter(@downloads_count) %></p>
+      <span class="home__downloads__desc">downloads &amp; counting</span>
+    </h2>
+  <% end %>
   <%= link_to t('.learn.install_rubygems'), page_url("download"), :class => "home__join", "data-icon" => ">" %>
 </div>
 <div class="home__links">

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,24 @@
+class Toxiproxy
+  def self.running?
+    TCPSocket.new('127.0.0.1', 8474).close
+    true
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET
+    false
+  end
+end
+
+port = Toxiproxy.running? ? 22220 : 6379
+
+if Rails.env.test? && Toxiproxy.running?
+  Toxiproxy.populate([{
+    name: "redis",
+    listen: "127.0.0.1:#{port}",
+    upstream: "127.0.0.1:6379"
+  }])
+end
+
 if Rails.env.test?
-  Redis.current = Redis.new(db: 1)
+  Redis.current = Redis.new(db: 1, port: port)
 else
   Redis.current = Redis.new(url: ENV['REDISTOGO_URL'])
 end

--- a/script/install_toxiproxy.sh
+++ b/script/install_toxiproxy.sh
@@ -1,0 +1,25 @@
+set -e
+
+if which toxiproxy > /dev/null; then
+  echo "Toxiproxy is already installed."
+  exit 0
+fi
+
+if which apt-get > /dev/null; then
+  echo "Installing toxiproxy-1.1.0.deb"
+  wget -O /tmp/toxiproxy-1.1.0.deb https://github.com/Shopify/toxiproxy/releases/download/v1.1.0/toxiproxy_1.1.0_amd64.deb
+  sudo dpkg -i /tmp/toxiproxy-1.1.0.deb
+  sudo service toxiproxy start
+  exit 0
+fi
+
+if which brew > /dev/null; then
+  echo "Installing toxiproxy from homebrew."
+  brew tap shopify/shopify
+  brew install toxiproxy
+  brew info toxiproxy
+  exit 0
+fi
+
+echo "Sorry, there is no toxiproxy package available for your system. You might need to build it from source."
+exit 1

--- a/script/setup
+++ b/script/setup
@@ -22,6 +22,7 @@ echo "Cleaning out old logs"
 echo "Installing libraries and plugins"
 { gem list -i bundler || gem install bundler
   bundle
+  script/install_toxiproxy.sh
 } >&3 2>&1
 
 # Wipe and load the database unless KEEPDB=1 env var is set.

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -19,6 +19,16 @@ class HomeControllerTest < ActionController::TestCase
     end
   end
 
+  context "with redis down" do
+    should "render home page" do
+      requires_toxiproxy
+      Toxiproxy[:redis].down do
+        get :index
+        assert_response :success
+      end
+    end
+  end
+
   should "on GET to index with non html accept header" do
     assert_raises(ActionController::UnknownFormat) do
       @request.env['HTTP_ACCEPT'] = "image/gif, image/x-bitmap, image/jpeg, image/pjpeg"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,10 @@ class MiniTest::Test
     Capybara::Node::Simple.new(@response.body)
   end
 
+  def requires_toxiproxy
+    skip("Toxiproxy is not running, but was required for this test.") unless Toxiproxy.running?
+  end
+
   def assert_changed(object, attribute, &block)
     original = object.send(attribute)
     yield

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -297,4 +297,13 @@ class DownloadTest < ActiveSupport::TestCase
                  Redis.current.hkeys(Download.history_key(version)).sort
 
   end
+
+  context "with redis down" do
+    should "return nil for count" do
+      requires_toxiproxy
+      Toxiproxy[:redis].down do
+        assert_equal nil, Download.count
+      end
+    end
+  end
 end


### PR DESCRIPTION
The home page should load even if redis is down. The only visible change is that the download count will not show up.

This introduces a new pattern and tooling for developing and testing resiliency: [toxiproxy](https://github.com/Shopify/toxiproxy).

Toxiproxy is a proxy to simulate network and system conditions. We can use in development to experiment with different conditions, and also write tests to ensure the desired outcome for those conditions.

Since this requires an additional installation and running process, the toxiproxy tests are configured to skip if toxiproxy is not available. This will enable contributors to run tests even without toxiproxy. Travis will install and run everything, ensuring that every contribution is fully tested.

r: @Sirupsen @arthurnn @indirect @qrush @evanphx @sferik 