### PR TITLE
Use link_to_directory helper for gems letter directory

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -12,7 +12,9 @@ module RubygemsHelper
   end
 
   def link_to_directory
-    ("A".."Z").map { |letter| link_to(letter, rubygems_path(:letter => letter)) }.join
+    ("A".."Z").map do |letter|
+      link_to(letter, rubygems_path(:letter => letter), :class => "gems__nav-link")
+    end.join("\n").html_safe
   end
 
   def simple_markup(text)

--- a/app/views/rubygems/index.html.erb
+++ b/app/views/rubygems/index.html.erb
@@ -1,9 +1,7 @@
 <% @title = t('.title') %>
 
 <div class="gems__nav-links">
-  <% ("A".."Z").each do |letter| %>
-    <%= link_to(letter, rubygems_path(:letter => letter), :class => "gems__nav-link") %>
-  <% end %>
+  <%= link_to_directory %>
 </div>
 
 <header class="gems__header">

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -8,7 +8,7 @@ class RubygemsHelperTest < ActionView::TestCase
   should "create the directory" do
     directory = link_to_directory
     ("A".."Z").each do |letter|
-      assert_match rubygems_path(:letter => letter), directory
+      assert_match rubygems_path(letter: letter), directory
     end
   end
 


### PR DESCRIPTION
Gems page letter directory is provided by view without using helper. However there is a helper method called link_to_directory which is built for this exact purpose but somehow is not used anymore.
I modified and used link_to_directory method again, with test.

cc // @qrush 