### PR TITLE
Handle invalid locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
+  rescue I18n::InvalidLocale
+    I18n.locale = I18n.default_locale
   end
 
   rescue_from(ActionController::ParameterMissing) do |e|

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -35,4 +35,9 @@ class HomeControllerTest < ActionController::TestCase
       get :index
     end
   end
+
+  should "use default locale on GET using invalid one" do
+    get :index, locale: 'foobar'
+    assert_equal I18n.locale, I18n.default_locale
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,8 +12,6 @@ require 'shoulda'
 
 require 'helpers/gem_helpers'
 
-I18n.enforce_available_locales = false
-
 RubygemFs.mock!
 
 class MiniTest::Test


### PR DESCRIPTION
So it wont 500 when passing a not valid locale as `?locale=foo`

This fix error I just saw on honeybadger.

review @dwradcliffe @sferik 