### PR TITLE
Refactor mocha gem implementation

### DIFF
--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -18,7 +18,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when login and password are incorrect" do
       setup do
-        User.expects(:authenticate).with('login', 'pass').returns nil
+        User.expects(:authenticate).with('login', 'pass')
         post :create, :session => { :who => 'login', :password => 'pass' }
       end
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -45,7 +45,7 @@ class PusherTest < ActiveSupport::TestCase
 
       should "not attempt to authorize if not found" do
         @cutter.stubs(:pull_spec).returns true
-        @cutter.stubs(:find).returns nil
+        @cutter.stubs(:find)
         @cutter.stubs(:authorize).never
         @cutter.stubs(:save).never
 
@@ -63,7 +63,7 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "not be able to pull spec from a bad path" do
-      @cutter.stubs(:body).stubs(:stub!).stubs(:read).returns nil
+      @cutter.stubs(:body).stubs(:stub!).stubs(:read)
       @cutter.pull_spec
       assert_nil @cutter.spec
       assert_match %r{RubyGems\.org cannot process this gem}, @cutter.message

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -37,17 +37,17 @@ class PusherTest < ActiveSupport::TestCase
 
       should "not attempt to find rubygem if spec can't be pulled" do
         @cutter.stubs(:pull_spec).returns false
-        @cutter.stubs(:find).stubs(:never)
-        @cutter.stubs(:authorize).stubs(:never)
-        @cutter.stubs(:save).stubs(:never)
+        @cutter.stubs(:find).never
+        @cutter.stubs(:authorize).never
+        @cutter.stubs(:save).never
         @cutter.process
       end
 
       should "not attempt to authorize if not found" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns nil
-        @cutter.stubs(:authorize).stubs(:never)
-        @cutter.stubs(:save).stubs(:never)
+        @cutter.stubs(:authorize).never
+        @cutter.stubs(:save).never
 
         @cutter.process
       end
@@ -56,7 +56,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns false
-        @cutter.stubs(:save).stubs(:never)
+        @cutter.stubs(:save).never
 
         @cutter.process
       end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -213,7 +213,7 @@ class WebHookTest < ActiveSupport::TestCase
        Net::HTTPBadResponse,
        Net::HTTPHeaderSyntaxError,
        Net::ProtocolError].each_with_index do |exception, index|
-         RestClient.stubs(:post).raises(exception)
+        RestClient.stubs(:post).raises(exception)
 
         @hook.fire('rubygems.org', @rubygem, @version, false)
 


### PR DESCRIPTION
- Use never function instead of stubbing never. Since stubbing never function is allowed any invocation, it doesn't check whether method is called never.
- Remove nil returns from mocha gem stubs and expectations. Because mocha gem stubs return nil by default, it is not needed to keep codebase clean.
- Remove blank space for RestClient stubs

cc: @arthurnn @sferik 