### PR TITLE
refactor Download model highest_count method

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -211,15 +211,6 @@ class Download
     end
   end
 
-  def self.highest_rank(versions)
-    ranks = versions.map { |version| Download.rank(version) }.reject(&:zero?)
-    if ranks.empty?
-      0
-    else
-      ranks.min
-    end
-  end
-
   def self.cleanup_today_keys
     Redis.current.del(*today_keys)
   end

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -41,7 +41,6 @@ nl:
       overview: Statistiekenoverzicht
       for: Statistieken voor %{for}
       total_downloads: ! 'Downloads totaal'
-      highest_rank: hoogste notering vandaag
       daily_downloads: ! '%{count} downloads vandaag'
   time_ago: ! '%{duration} ago'
   download_count: ! '%{count} downloads'

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -64,9 +64,6 @@ class DownloadTest < ActiveSupport::TestCase
     assert_equal 3, Download.rank(@version_1)
 
     assert_equal 3, Download.today([@version_1, @version_2])
-    assert_equal 2, Download.highest_rank([@version_1, @version_2])
-    assert_equal 1, Download.highest_rank([@version_3])
-    assert_equal 1, Download.highest_rank([@version_3, @version_4])
   end
 
   should "find most downloaded all time" do
@@ -225,10 +222,6 @@ class DownloadTest < ActiveSupport::TestCase
 
   should "return zero for rank if no downloads exist" do
     assert_equal 0, Download.rank(build(:version))
-  end
-
-  should "return zero for highest rank the given versions have zero downloads" do
-    assert_equal 0, Download.highest_rank([build(:version), build(:version)])
   end
 
   should "delete all old today keys except the current" do


### PR DESCRIPTION
used ```rank(version)``` instead of ```Download.rank(version)``` and ternary operator for single-line condition

cc: @sferik 