### PR TITLE
Add created_at to Version payload

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -211,6 +211,7 @@ class Version < ActiveRecord::Base
     {
       'authors'         => authors,
       'built_at'        => built_at,
+      'created_at'      => created_at,
       'description'     => description,
       'downloads_count' => downloads_count,
       'metadata'        => metadata,

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -13,7 +13,7 @@ class VersionTest < ActiveSupport::TestCase
       json = @version.as_json
       fields = %w(number built_at summary description authors platform
                   ruby_version prerelease downloads_count licenses requirements
-                  sha metadata)
+                  sha metadata created_at)
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
@@ -27,6 +27,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
+      assert_equal @version.created_at, json["created_at"]
     end
   end
 
@@ -39,7 +40,7 @@ class VersionTest < ActiveSupport::TestCase
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w(number built-at summary description authors platform
                   ruby-version prerelease downloads-count licenses requirements
-                  sha metadata)
+                  sha metadata created-at)
       assert_equal fields.map(&:to_s).sort,
         xml.root.children.map(&:name).reject { |t| t == "text" }.sort
       assert_equal @version.authors, xml.at_css("authors").content
@@ -54,6 +55,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
       assert_equal @version.requirements, xml.at_css("requirements").content
+      assert_equal @version.created_at.to_i, xml.at_css("created-at").content.to_time.to_i
     end
   end
 


### PR DESCRIPTION
Versions currently have a built_at attribute that's provided as a date via the API, this PR adds `created_at` to `Version#payload` so that the time a version was published is also available via the API.

Fixes #949 
