### PR TITLE
Make user handle available for 'gem owner' commands.

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def create
-    if owner = User.find_by_email(params[:email])
+    if owner = User.find_by_name(params[:email])
       @rubygem.ownerships.create(:user => owner)
       render :text => 'Owner added successfully.'
     else
@@ -22,7 +22,7 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def destroy
-    if owner = @rubygem.owners.find_by_email(params[:email])
+    if owner = @rubygem.owners.find_by_name(params[:email])
       if @rubygem.ownerships.find_by_user_id(owner.id).try(:destroy)
         render :text => "Owner removed successfully."
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,10 @@ class User < ActiveRecord::Base
     find_by(id: slug) || find_by!(handle: slug)
   end
 
+  def self.find_by_name(name)
+    find_by(email: name) || find_by(handle: name)
+  end
+
   def name
     handle || email
   end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -74,6 +74,27 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     assert_recognizes(route, :path => '/api/v1/gems/rails/owners.json', :method => :post)
   end
 
+  context "on POST to owner gem" do
+    setup do
+      @rubygem = create(:rubygem)
+      @user = create(:user)
+      @second_user = create(:user)
+      @third_user = create(:user)
+      @rubygem.ownerships.create(user: @user)
+      @request.env["HTTP_AUTHORIZATION"] = @user.api_key
+    end
+
+    should "add other user as gem owner with email" do
+      post :create, rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json
+      assert @rubygem.owners.include?(@second_user)
+    end
+
+    should "add other user as gem owner with handle" do
+      post :create, rubygem_id: @rubygem.to_param, email: @third_user.handle, format: :json
+      assert @rubygem.owners.include?(@third_user)
+    end
+  end
+
   should "route DELETE" do
     route = {:controller => 'api/v1/owners',
              :action     => 'destroy',

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -96,6 +96,11 @@ class UserTest < ActiveSupport::TestCase
       assert_not_nil @user.api_key
     end
 
+    should "give user if specified name is user handle or email" do
+      assert_not_nil User.find_by_name(@user.handle)
+      assert_equal User.find_by_name(@user.handle), User.find_by_name(@user.handle)
+    end
+
     should "give email if handle is not set for name" do
       @user.handle = nil
       assert_nil @user.handle


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems.org/issues/509   :tada: :tada: 

It can be used as:
```
gem owner --add HANDLE GEMNAME
gem owner --remove HANDLE GEMNAME
```

cc: @qrush @dwradcliffe @indirect 