### PR TITLE
Start with a fresh Contributor Covenant

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,15 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -10,6 +10,6 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue, contacting one or more of the project maintainers, or emailing conduct@rubygems.org.
 
 This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Our deployment process is documented on the wiki as well, there's a multi-step
 
 [checklist]: https://github.com/rubygems/rubygems.org/wiki/Deployment
 
+Also please take note of our [Code of Conduct](https://github.com/rubygems/rubygems.org/blob/master/CONDUCT.md).
+
+If you have any trouble or questions getting set up please create an issue on this repository and we'll be happy to help!
+
 ## Organization
 
 RubyGems.org consists of a few major parts:


### PR DESCRIPTION
Opening this up! It's about time. A few notes:

I think we should have more direct, specific contacts for reporting an incident. Opening an issue is good, but not everyone might want to do that. Anyone else willing to be listed as a contact? (Is there any precedent for that? cc @coralineada)

Also: We are working on a set of policies for the rubygems.org service itself based on NPM's. Hoping to have that ready soon.