### PR TITLE
Use the new help@rubygems.org address instead of donotreply

### DIFF
--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,5 +1,5 @@
 Clearance.configure do |config|
-  config.mailer_sender = "donotreply@rubygems.org"
+  config.mailer_sender = "help@rubygems.org"
   config.secure_cookie = true unless Rails.env.test? || Rails.env.development?
   config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
 end


### PR DESCRIPTION
Do we want to configure sending through Mailgun here as well, or wait for that? cc @evanphx @dwradcliffe 