### PR TITLE
Better Rubocop exludes patterns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   Exclude:
-    - db/schema.rb
-    - vendor/**/*
+    - !ruby/regexp /(vendor|bundle|bin|db)\/.*/
   RunRailsCops: true
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,8 +1,21 @@
-if Rails.env.development? || Rails.env.test?
-  require 'rubocop/rake_task'
-
-  desc 'Execute rubocop -DR'
-  RuboCop::RakeTask.new(:rubocop) do |t|
-    t.options = ['-RDS'] # Rails, display cop name and styleguide link
+begin
+  require "rubocop"
+  require "rubocop/rake_task"
+rescue LoadError # rubocop:disable Lint/HandleExceptions
+else
+  Rake::Task[:rubocop].clear if Rake::Task.task_defined?(:rubocop)
+  desc 'Execute rubocop'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.formatters = ['progress']
+    task.options = ['--rails', '--display-cop-names', '--display-style-guide']
+    task.patterns = [
+      'Gemfile',
+      'Rakefile',
+      'lib/**/*.{rb,rake}',
+      'config/**/*.rb',
+      'app/**/*.rb',
+      'test/**/*.rb'
+    ]
+    task.fail_on_error = true
   end
 end


### PR DESCRIPTION
Ref: https://github.com/rubygems/rubygems.org/pull/1019#discussion_r34818587

@qrush 

> I'm not sure if it's worth it to apply rubocop rules to the db directory.

Note, I also excluded `test/` since there were some style issues in there.