### PR TITLE
Introduce SimpleCov (Test Code Coverage)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  Include:
+    - .simplecov
   Exclude:
     - config/initializers/forbidden_yaml.rb
     - !ruby/regexp /(vendor|bundle|bin|db)\/.*/

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,88 @@
+# https://github.com/colszowka/simplecov#using-simplecov-for-centralized-config
+# see https://github.com/colszowka/simplecov/blob/master/lib/simplecov/defaults.rb
+# vim: set ft=ruby
+@minimum_coverage = ENV.fetch('COVERAGE_MINIMUM') { 91.6 }.to_f.round(2)
+# rubocop:disable Style/DoubleNegation
+ENV['FULL_BUILD'] ||= ENV['CI']
+@running_ci       = !!(ENV['FULL_BUILD'] =~ /\Atrue\z/i)
+@generate_report  = @running_ci || !!(ENV['COVERAGE'] =~ /\Atrue\z/i)
+@output = STDERR
+# rubocop:enable Style/DoubleNegation
+
+SimpleCov.pid = $$ # In case there's any forking
+
+SimpleCov.profiles.define 'app' do
+  coverage_dir 'coverage'
+  load_profile 'test_frameworks'
+
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Models', 'app/models'
+  add_group 'Helpers', 'app/helpers'
+  add_group 'Libraries', 'lib'
+  add_group 'Middlewares', 'app/middleware'
+  add_group 'Jobs', 'app/jobs'
+  add_group 'API', 'app/controllers/api'
+
+  add_group 'Long files' do |src_file|
+    src_file.lines.count > 100
+  end
+  class MaxLinesFilter < SimpleCov::Filter
+    def matches?(source_file)
+      source_file.lines.count < filter_argument
+    end
+  end
+  add_group 'Short files', MaxLinesFilter.new(5)
+
+  # Exclude these paths from analysis
+  add_filter '/config/'
+  add_filter '/db/'
+  add_filter 'tasks'
+end
+
+## START TRACKING COVERAGE
+require 'coverage'
+Coverage.start
+
+# rubocop:disable Style/MultilineBlockChain
+AppCoverage = Class.new do
+  def initialize(&block)
+    @block = block
+  end
+
+  def start
+    @block.call
+  end
+end.new do
+  SimpleCov.start 'app'
+  if @generate_report
+    if @running_ci
+      @output.puts '[COVERAGE] Running with SimpleCov Simple Formatter'
+      formatters = [SimpleCov::Formatter::SimpleFormatter]
+    else
+      @output.puts '[COVERAGE] Running with SimpleCov HTML Formatter'
+      formatters = [SimpleCov::Formatter::HTMLFormatter]
+    end
+  else
+    formatters = []
+  end
+  if @running_ci
+    require 'codeclimate-test-reporter'
+    STDERR.puts '[COVERAGE] Running with CodeClimate TestReporter Formatter'
+    formatters << CodeClimate::TestReporter::Formatter
+  end
+  SimpleCov.formatters = formatters
+end
+# rubocop:enable Style/MultilineBlockChain
+SimpleCov.at_exit do
+  @output.puts "*" * 50
+  @output.puts SimpleCov.result.format!
+  percent = Float(SimpleCov.result.covered_percent)
+  if percent < @minimum_coverage
+    @output.puts "Spec coverage was not high enough: "\
+    "#{percent.round(2)} is < #{@minimum_coverage}%\n"
+    exit 1 if @generate_report
+  else
+    @output.puts "Nice job! Spec coverage (#{percent.round(2)}) "\
+    "is still at or above #{@minimum_coverage}%\n"
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ group :test do
   gem 'bourne', require: false
   gem 'shoulda', require: false
   gem 'timecop'
+  gem 'simplecov', '~> 0.10', require: false
+  gem "codeclimate-test-reporter", require: false
 end
 
 group :development, :deploy do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     clearance-deprecated_password_strategies (1.10.1)
       activesupport
       clearance (>= 1.10)
+    codeclimate-test-reporter (0.4.7)
+      simplecov (>= 0.7.1, < 1.0.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -89,6 +91,7 @@ GEM
     delayed_job_active_record (4.0.3)
       activerecord (>= 3.0, < 5.0)
       delayed_job (>= 3.0, < 4.1)
+    docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     dynamic_form (1.1.4)
@@ -213,6 +216,11 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sprockets (3.3.2)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -263,6 +271,7 @@ DEPENDENCIES
   capybara
   clearance
   clearance-deprecated_password_strategies
+  codeclimate-test-reporter
   coffee-rails (~> 4.1)
   daemons
   dalli
@@ -298,6 +307,7 @@ DEPENDENCIES
   rubocop (~> 0.32.1)
   sass-rails (~> 5.0.0)
   shoulda
+  simplecov (~> 0.10)
   statsd-instrument (~> 2.0.6)
   timecop
   toxiproxy (~> 0.1.3)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,7 @@
+begin
+  require 'simplecov'
+rescue LoadError
+end
 require File.expand_path('../config/application', __FILE__)
 Gemcutter::Application.load_tasks
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,10 @@
 ENV["RAILS_ENV"] ||= "test"
+begin
+  require 'simplecov'
+  AppCoverage.start
+rescue LoadError
+  STDERR.puts 'Running without SimpleCov'
+end
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'rails/test_help'


### PR DESCRIPTION
- Configuration is in `.simplecov` for maximum flexibility
  and minimum bugginess. It is loaded by the `require 'simplecov'`
  at the TOP of the `Rakefile` and `test/test_helper.rb`
- Report is in `reports/coverage` since we cache `reports` on TravisCI (well, not really as long as we're using the legacy infrastructure)
- Rails coverage groups manually added to avoid unused 'Mailers'
- API group added to highlight API coverage
- Coverage always runs with Rake/tests
- Test run fails when minimum coverage is not met.
  - Minimum coverage is defined as a float either 
  by COVERAGE_MINIMUM or at the top of the `.simplecov`.
- Test run is only failed when minimum coverage not met AND
  COVERAGE=true || FULL_BUILD=true
- Coverage HTML report only generated when COVERAGE=true || FULL_BUILD=true
- CodeClimate report only configured when FULL_BUILD=true
- HACK: To ensure coverage is started *before* the Rails app is loaded by SimpleCov *only* runs under test, we start the `Coverage` module, but defer starting SimpleCov via a novel `RubyGemsCoverage` class.
  - Specifically, this allows us to run our tests via `Rake`, but not start SimpleCov when running other Rake tasks.
  - Right now, there's no universally reliable way to know in the Rakefile when we're running tests before we've loaded our Rails app.  We could:
      - rely on checking `RAILS_ENV=test`, which is true on Travis
      - check if `Rake.application.top_level_tasks` starts with default or test. But then commands like 'Rake -T' would still show up as a 'default' task.
      - ensure that *no* app code is run between when config/application is required at the top of the Rakefile and when test_helper is loaded, but that is unlikely, or
     - run a specially named rake task when we want to use coverage, such as `rake test` or `rake coverage`, etc.
  - (I usually test with RSpec which makes it easier for me to tell if I'm running tests since I can check if the caller contains `exe/rspec` in it).

*Admins*: To get coverage to CodeClimate, the ENV must have `CODECLIMATE_REPO_TOKEN`