### PR TITLE
add ping endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,10 @@ Metrics/PerceivedComplexity:
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Style/AndOr:
+  Exclude:
+    - app/controllers/internal/ping_controller.rb
+
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 

--- a/app/controllers/internal/ping_controller.rb
+++ b/app/controllers/internal/ping_controller.rb
@@ -1,0 +1,9 @@
+class Internal::PingController < ApplicationController
+  def index
+    ActiveRecord::Base.connection.select_value('SELECT 1') == '1' or \
+      fail StandardError, 'Failed to SELECT 1 from DB server'
+    Redis.current.set('PING', 1) or \
+      fail StandardError, 'Failed to write PING=1 to redis'
+    render text: 'PONG'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,5 +140,6 @@ Rails.application.routes.draw do
 
   namespace :internal do
     get 'background_job_stats', to: Internal::BackgroundJobStatsController.action(:stats)
+    get 'ping' => 'ping#index'
   end
 end

--- a/test/functional/internal/ping_controller_test.rb
+++ b/test/functional/internal/ping_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class Internal::PingControllerTest < ActionController::TestCase
+  context 'on GET to index' do
+    setup do
+      get :index
+    end
+
+    should respond_with :success
+
+    should 'PONG' do
+      assert page.has_content?('PONG')
+    end
+  end
+
+  context 'with redis down' do
+    should 'not PONG' do
+      requires_toxiproxy
+      Toxiproxy[:redis].down do
+        assert_raises Redis::BaseError do
+          get :index
+        end
+      end
+    end
+  end
+
+  context 'with postgres down' do
+    should 'not PONG' do
+      ActiveRecord::Base.connection.stubs(:select_value).returns(nil)
+      assert_raises StandardError do
+        get :index
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a ping endpoint that can be used by internal and external monitoring.

r: @evanphx @qrush @arthurnn 