### PR TITLE
Fastly integration

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -4,6 +4,7 @@ class Indexer
   def perform
     log "Updating the index"
     update_index
+    purge_cdn
     log "Finished updating the index"
   end
   statsd_count_success :perform, 'Indexer.perform.success'
@@ -42,6 +43,13 @@ class Indexer
     log "Uploaded latest specs index"
     upload("prerelease_specs.4.8.gz", prerelease_index)
     log "Uploaded prerelease specs index"
+  end
+
+  def purge_cdn
+    if ENV['FASTLY_SERVICE_ID'] && ENV['FASTLY_API_KEY']
+      Fastly.purge_key('full-index')
+      log 'Purged index urls from fastly'
+    end
   end
 
   def minimize_specs(data)

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -32,7 +32,7 @@ class Indexer
   end
 
   def upload(key, value)
-    RubygemFs.instance.store(key, stringify(value))
+    RubygemFs.instance.store(key, stringify(value), 'surrogate-key' => 'full-index')
   end
 
   def update_index

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -36,5 +36,7 @@ class Deletion < ActiveRecord::Base
   def remove_from_storage
     RubygemFs.instance.remove("gems/#{@version.full_name}.gem")
     RubygemFs.instance.remove("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    Fastly.purge("https://#{ENV['FASTLY_DOMAIN']}/gems/#{@version.full_name}.gem") if ENV['FASTLY_DOMAIN']
+    Fastly.purge("https://#{ENV['FASTLY_DOMAIN']}/quick/Marshal.4.8/#{@version.full_name}.gemspec.rz") if ENV['FASTLY_DOMAIN']
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -30,6 +30,7 @@ class Deletion < ActiveRecord::Base
   def remove_from_index
     @version.update!(indexed: false)
     Redis.current.lrem(Rubygem.versions_key(rubygem_name), 1, @version.full_name)
+    Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
   end
 
   def remove_from_storage

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -13,7 +13,9 @@ class Fastly
                                            url: url,
                                            timeout: 10,
                                            headers: headers)
-    JSON.parse(response)
+    json = JSON.parse(response)
+    Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
+    json
   end
   def self.purge_key(key, soft = false)
     headers = { 'Fastly-Key' => ENV['FASTLY_API_KEY'] }
@@ -23,6 +25,8 @@ class Fastly
                                            url: url,
                                            timeout: 10,
                                            headers: headers)
-    JSON.parse(response)
+    json = JSON.parse(response)
+    Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
+    json
   end
 end

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -1,0 +1,28 @@
+require 'net/http'
+
+class Net::HTTP::Purge < Net::HTTPRequest
+  METHOD = 'PURGE'
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end
+
+class Fastly
+  def self.purge(url, soft = false)
+    headers = soft ? { 'Fastly-Soft-Purge' => 1 } : {}
+    response = RestClient::Request.execute(method: :purge,
+                                           url: url,
+                                           timeout: 10,
+                                           headers: headers)
+    JSON.parse(response)
+  end
+  def self.purge_key(key, soft = false)
+    headers = { 'Fastly-Key' => ENV['FASTLY_API_KEY'] }
+    headers['Fastly-Soft-Purge'] = 1 if soft
+    url = "https://api.fastly.com/service/#{ENV['FASTLY_SERVICE_ID']}/purge/#{key}"
+    response = RestClient::Request.execute(method: :post,
+                                           url: url,
+                                           timeout: 10,
+                                           headers: headers)
+    JSON.parse(response)
+  end
+end

--- a/lib/rubygem_fs.rb
+++ b/lib/rubygem_fs.rb
@@ -31,7 +31,7 @@ module RubygemFs
   end
 
   class Local
-    def store(key, body)
+    def store(key, body, _metadata = {})
       FileUtils.mkdir_p File.dirname("#{base_dir}/#{key}")
       File.open("#{base_dir}/#{key}", 'wb') do |f|
         f.write(body)
@@ -60,8 +60,8 @@ module RubygemFs
       @config = config
     end
 
-    def store(key, body)
-      s3.put_object(key: key, body: body, bucket: bucket, acl: 'public-read')
+    def store(key, body, metadata = {})
+      s3.put_object(key: key, body: body, bucket: bucket, acl: 'public-read', metadata: metadata)
     end
 
     def get(key)


### PR DESCRIPTION
This PR has several changes necessary for using Fastly for the full index, gem files and gemspec files.

* Add a surrogate key header to the index files uploaded to S3.
* Send a purge request to Fastly on every indexer run after the new files have been uploaded, using the surrogate key.
* Run indexer after gem yank. This will fix 404s for gems after the gem has been deleted.
* Send a purge request to Fastly for specific gem/gemspec files after they have been yanked.

r: @evanphx @qrush @drbrain @arthurnn @indirect 