### PR TITLE
Use most recent version instead of latest for api version endpoint

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -16,7 +16,10 @@ class Api::V1::VersionsController < Api::BaseController
 
   def latest
     rubygem = Rubygem.find_by_name(params[:id])
-    version = rubygem.versions.latest.first if rubygem
+    version = nil
+    if rubygem && rubygem.public_versions.indexed.count.nonzero?
+      version = rubygem.versions.most_recent
+    end
     number  = version.number if version
     render json: { "version" => number || "unknown" }, callback: params['callback']
   end

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -211,6 +211,19 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to of latest for a gem with different platform versions" do
+    setup do
+      @rubygem = create(:rubygem)
+      @version_one = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86-linux")
+      @version_two = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "ruby")
+    end
+
+    should "return most recent version" do
+      get :latest, id: @rubygem.name, format: "json"
+      assert_equal "2.0.0", MultiJson.load(@response.body)['version']
+    end
+  end
+
   context "on GET to show for a gem with a license" do
     setup do
       @rubygem = create(:rubygem)


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems.org/issues/987

cc: @sferik @arthurnn 