### PR TITLE
add yaml option to api profiles endpoint

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,7 +1,9 @@
 class Api::V1::ProfilesController < Api::BaseController
   def show
+    @user = User.find_by_slug!(params[:id])
     respond_to do |format|
-      format.json { render json: User.find_by_slug!(params[:id]) }
+      format.json { render json: @user }
+      format.yaml { render yaml: @user }
     end
   end
 end


### PR DESCRIPTION
Like the title says, it adds yaml respond option in addition to json.

cc: @sferik @arthurnn @qrush 