### PR TITLE
add render_as method to api base controller and refactor api controllers

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,4 +10,11 @@ class Api::BaseController < ApplicationController
     return if @rubygem || @gem_name == WebHook::GLOBAL_PATTERN
     render text: "This gem could not be found", status: :not_found
   end
+
+  def render_as value
+    respond_to do |format|
+      format.json { render json: value }
+      format.yaml { render yaml: value }
+    end
+  end
 end

--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,20 +1,11 @@
 class Api::V1::ActivitiesController < Api::BaseController
   def latest
     @rubygems = Rubygem.latest(50)
-    render_rubygems
+    render_as @rubygems
   end
 
   def just_updated
     @rubygems = Version.just_updated(50).map(&:rubygem)
-    render_rubygems
-  end
-
-  private
-
-  def render_rubygems
-    respond_to do |format|
-      format.json { render json: @rubygems }
-      format.yaml { render yaml: @rubygems }
-    end
+    render_as @rubygems
   end
 end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -6,10 +6,7 @@ class Api::V1::OwnersController < Api::BaseController
   before_action :verify_gem_ownership, except: [:show, :gems]
 
   def show
-    respond_to do |format|
-      format.json { render json: @rubygem.owners }
-      format.yaml { render yaml: @rubygem.owners }
-    end
+    render_as @rubygem.owners
   end
 
   def create
@@ -39,10 +36,7 @@ class Api::V1::OwnersController < Api::BaseController
     user = User.find_by_slug!(params[:handle])
     if user
       rubygems = user.rubygems.with_versions
-      respond_to do |format|
-        format.json { render json: rubygems }
-        format.yaml { render yaml: rubygems }
-      end
+      render_as rubygems
     else
       render text: "Owner could not be found.", status: :not_found
     end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,9 +1,6 @@
 class Api::V1::ProfilesController < Api::BaseController
   def show
     @user = User.find_by_slug!(params[:id])
-    respond_to do |format|
-      format.json { render json: @user }
-      format.yaml { render yaml: @user }
-    end
+    render_as @user
   end
 end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -7,18 +7,12 @@ class Api::V1::RubygemsController < Api::BaseController
 
   def index
     @rubygems = current_user.rubygems.with_versions
-    respond_to do |format|
-      format.json { render json: @rubygems }
-      format.yaml { render yaml: @rubygems }
-    end
+    render_as @rubygems
   end
 
   def show
     if @rubygem.hosted? && @rubygem.public_versions.indexed.count.nonzero?
-      respond_to do |format|
-        format.json { render json: @rubygem }
-        format.yaml { render yaml: @rubygem }
-      end
+      render_as @rubygem
     else
       render text: "This gem does not exist.", status: :not_found
     end
@@ -33,9 +27,6 @@ class Api::V1::RubygemsController < Api::BaseController
   def reverse_dependencies
     names = Rubygem.reverse_dependencies(params[:id]).pluck(:name)
 
-    respond_to do |format|
-      format.json { render json: names }
-      format.yaml { render yaml: names }
-    end
+    render_as names
   end
 end

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -4,9 +4,6 @@ class Api::V1::SearchesController < Api::BaseController
 
   def show
     @rubygems = Rubygem.search(params.require(:query)).with_versions.paginate(page: @page)
-    respond_to do |format|
-      format.json { render json: @rubygems }
-      format.yaml { render yaml: @rubygems }
-    end
+    render_as @rubygems
   end
 end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -5,10 +5,7 @@ class Api::V1::VersionsController < Api::BaseController
     return unless stale?(@rubygem)
 
     if @rubygem.public_versions.count.nonzero?
-      respond_to do |format|
-        format.json { render json: @rubygem.public_versions }
-        format.yaml { render yaml: @rubygem.public_versions }
-      end
+      render_as @rubygem.public_versions
     else
       render text: "This rubygem could not be found.", status: 404
     end
@@ -23,9 +20,6 @@ class Api::V1::VersionsController < Api::BaseController
 
   def reverse_dependencies
     names = Version.reverse_dependencies(params[:id]).pluck(:full_name)
-    respond_to do |format|
-      format.json { render json: names }
-      format.yaml { render yaml: names }
-    end
+    render_as names
   end
 end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -5,10 +5,7 @@ class Api::V1::WebHooksController < Api::BaseController
   before_action :find_rubygem_by_name, except: :index
 
   def index
-    respond_to do |format|
-      format.json { render json: current_user.all_hooks }
-      format.yaml { render yaml: current_user.all_hooks }
-    end
+    render_as current_user.all_hooks
   end
 
   def create


### PR DESCRIPTION
Added render_as method to base api controller and used it for api controllers. It eliminates duplication.

cc: @sferik @qrush 