### PR TITLE
strip :// from protocol for passing to Pusher and webhooks

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def create
-    gemcutter = Pusher.new(current_user, request.body, request.protocol, request.host_with_port)
+    gemcutter = Pusher.new(current_user, request.body, request.protocol.gsub('://', ''), request.host_with_port)
     gemcutter.process
     render text: gemcutter.message, status: gemcutter.code
   end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::WebHooksController < Api::BaseController
     webhook = current_user.web_hooks.new(url: @url)
     @rubygem = Rubygem.find_by_name("gemcutter") unless @rubygem
 
-    if webhook.fire(request.protocol, request.host_with_port, @rubygem,
+    if webhook.fire(request.protocol.gsub('://', ''), request.host_with_port, @rubygem,
       @rubygem.versions.most_recent, false)
       render text: webhook.deployed_message(@rubygem)
     else


### PR DESCRIPTION
Fixes bug created in #1026 

In rails, `request.protocol` is the protocol string along with `://`. We were only expecting the protocol string so I'm removing the `://`. This really should have been caught with a test somewhere. :(

This was causing the webhooks to have incorrect and invalid URLs. Most visible example is the twitter feed:

![rubygems rubygems twitter 2015-08-10 13-27-18](https://cloud.githubusercontent.com/assets/118850/9178139/a45c3d9c-3f63-11e5-8a24-963ba6d071df.png)

r: @qrush @reedloden 