### PR TITLE
include only rubygems helper for pages helper test

### DIFF
--- a/test/unit/helpers/pages_helper_test.rb
+++ b/test/unit/helpers/pages_helper_test.rb
@@ -1,10 +1,7 @@
 require 'test_helper'
 
 class PagesHelperTest < ActionView::TestCase
-  include Rails.application.routes.url_helpers
-  include ApplicationHelper
   include RubygemsHelper
-  include ERB::Util
 
   context "downloads" do
     setup do


### PR DESCRIPTION
We don't use other helpers so it's enough to include only rubygems helper.