### PR TITLE
Remove float right for arrow in nav header. Fixes #1044

### DIFF
--- a/app/assets/stylesheets/modules/header.css
+++ b/app/assets/stylesheets/modules/header.css
@@ -231,7 +231,6 @@
     margin-left: 5px;
     position: relative;
     right: 11px;
-    float: right;
     line-height: 70px;
     color: white;
     z-index: 1;


### PR DESCRIPTION
Hey! This fixes the weird behavior in Chrome. (plus I think aligns better vertically to the rest of the menu items).