### PR TITLE
fix overflow-x param on .profile__header__name

### DIFF
--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -124,7 +124,7 @@
     width: 70%; } }
 
 .profile__header__name {
-  overflow-x: scroll; }
+  overflow-x: auto; }
   @media (min-width: 780px) {
     .profile__header__name {
       padding-top: 16px; } }


### PR DESCRIPTION
[Username on profile page](https://rubygems.org/profiles/polamjag) is displayed with strange vertical scroll bar (tested on latest Chrome / Chromium and Firefox on Windows and Linux).

![scr_2015-09-05_17-12-11](https://cloud.githubusercontent.com/assets/685936/9698463/731431ec-53f2-11e5-96ca-2d2aec16532a.png)

after fix, weird scroll bar disappears by default.

![scr_2015-09-05_17-19-27](https://cloud.githubusercontent.com/assets/685936/9698460/4e400e22-53f2-11e5-93c1-97487fa130c6.png)