### PR TITLE
don't need define application config_for anymore

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,9 +8,6 @@ Bundler.require(*Rails.groups)
 
 module Gemcutter
   class Application < Rails::Application
-    def config_for(name, env = Rails.env)
-      YAML.load_file(Rails.root.join("config/#{name}.yml"))[env]
-    end
     config.rubygems = Application.config_for :rubygems
 
     config.time_zone = "UTC"


### PR DESCRIPTION
Rails::Application.config_for comes with rails from now on. See related commit: https://github.com/rails/rails/commit/9629dea4fb15a948ab4394590fdd946bd9dd4f91