### PR TITLE
Use remove instead of gsub

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -184,7 +184,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def to_param
-    name.gsub(/[^#{Patterns::ALLOWED_CHARACTERS}]/, '')
+    name.remove(/[^#{Patterns::ALLOWED_CHARACTERS}]/)
   end
 
   def with_downloads

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -200,7 +200,7 @@ class Version < ActiveRecord::Base
   end
 
   def slug
-    full_name.gsub(/^#{rubygem.name}-/, '')
+    full_name.remove(/^#{rubygem.name}-/)
   end
 
   def downloads_count

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -358,6 +358,11 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal @rubygem.name, @rubygem.to_s
     end
 
+    should "return name as slug with only allowed characters" do
+      @rubygem.name = "rails?!"
+      assert_equal "rails", @rubygem.to_param
+    end
+
     should "return name with downloads for #with_downloads" do
       assert_equal "#{@rubygem.name} (#{@rubygem.downloads})", @rubygem.with_downloads
     end


### PR DESCRIPTION
Activesupport has ```String.remove(pattern)``` as short-hand for ```String#gsub(pattern, '')```
It's not a big deal but I think it's better to use remove to keep codebase more readable.

Version model has related test, so I added the test for only rubygem.