### PR TITLE
Use activesupport helpers instead of Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ group :test do
   gem 'mocha', require: false
   gem 'bourne', require: false
   gem 'shoulda', require: false
-  gem 'timecop'
 end
 
 group :development, :deploy do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    timecop (0.8.0)
     toxiproxy (0.1.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -305,7 +304,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   shoulda
   statsd-instrument (~> 2.0.6)
-  timecop
   toxiproxy (~> 0.1.3)
   uglifier (>= 1.0.3)
   unicorn

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -97,7 +97,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
       assert_response :success
       set_cache_header
 
-      Timecop.travel(Time.zone.now + 1) do
+      travel 1.second do
         @rubygem.public_versions.each { |v| v.update!(indexed: false) }
       end
 

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -42,7 +42,7 @@ class DownloadTest < ActiveSupport::TestCase
     @rubygem_3 = create(:rubygem)
     @version_4 = create(:version, rubygem: @rubygem_3)
 
-    Timecop.freeze(1.day.ago) do
+    travel_to 1.day.ago do
       Download.incr(@rubygem_1.name, @version_1.full_name)
       Download.incr(@rubygem_1.name, @version_2.full_name)
       Download.incr(@rubygem_2.name, @version_3.full_name)
@@ -107,7 +107,7 @@ class DownloadTest < ActiveSupport::TestCase
     @rubygem_3 = create(:rubygem)
     @version_4 = create(:version, rubygem: @rubygem_3)
 
-    Timecop.freeze(1.day.ago) do
+    travel_to 1.day.ago do
       Download.incr(@rubygem_1, @version_1.full_name)
       Download.incr(@rubygem_1, @version_2.full_name)
       Download.incr(@rubygem_2, @version_3.full_name)
@@ -149,7 +149,7 @@ class DownloadTest < ActiveSupport::TestCase
     @rubygem_3 = create(:rubygem)
     @version_4 = create(:version, rubygem: @rubygem_3)
 
-    Timecop.freeze(1.day.ago) do
+    travel_to 1.day.ago do
       create :version_history, version: @version_1, count: 5
       create :version_history, version: @version_2
       create :version_history, version: @version_3
@@ -181,35 +181,36 @@ class DownloadTest < ActiveSupport::TestCase
   end
 
   should "find counts per day for versions in range across month boundary" do
-    Timecop.freeze(Time.zone.parse("2012-10-01")) do
-      @rubygem_1 = create(:rubygem)
-      @version_1 = create(:version, rubygem: @rubygem_1)
+    initial_time = Time.zone.parse("2012-10-01")
+    travel_to initial_time
+    @rubygem_1 = create(:rubygem)
+    @version_1 = create(:version, rubygem: @rubygem_1)
 
-      Timecop.freeze(1.day.ago) do
-        create :version_history, version: @version_1, count: 5
-      end
-
-      Download.incr(@rubygem_1, @version_1.full_name)
-
-      start = 2.days.ago.to_date
-      fin = Time.zone.today
-
-      downloads = ActiveSupport::OrderedHash.new.tap do |d|
-        d[start.to_s] = 0
-        d["#{Time.zone.yesterday}"] = 5
-        d[fin.to_s] = 1
-      end
-
-      assert_equal downloads,
-        Download.counts_by_day_for_version_in_date_range(@version_1, start, fin)
+    travel_to 1.day.ago do
+      create :version_history, version: @version_1, count: 5
     end
+
+    travel_to initial_time
+    Download.incr(@rubygem_1, @version_1.full_name)
+
+    start = 2.days.ago.to_date
+    fin = Time.zone.today
+
+    downloads = ActiveSupport::OrderedHash.new.tap do |d|
+      d[start.to_s] = 0
+      d["#{Time.zone.yesterday}"] = 5
+      d[fin.to_s] = 1
+    end
+
+    assert_equal downloads,
+      Download.counts_by_day_for_version_in_date_range(@version_1, start, fin)
   end
 
   should "find counts per day for versions in range" do
     @rubygem_1 = create(:rubygem)
     @version_1 = create(:version, rubygem: @rubygem_1)
 
-    Timecop.freeze(1.day.ago) do
+    travel_to 1.day.ago do
       create :version_history, version: @version_1, count: 5
     end
 
@@ -248,7 +249,7 @@ class DownloadTest < ActiveSupport::TestCase
     rubygem = create(:rubygem)
     version = create(:version, rubygem: rubygem)
     10.times do |n|
-      Timecop.freeze(n.days.ago) do
+      travel_to n.days.ago do
         3.times { Download.incr(rubygem.name, version.full_name) }
       end
     end
@@ -283,7 +284,7 @@ class DownloadTest < ActiveSupport::TestCase
     version = create(:version, rubygem: rubygem)
 
     10.times do |n|
-      Timecop.freeze(n.days.ago) do
+      travel_to n.days.ago do
         3.times { Download.incr(rubygem.name, version.full_name) }
       end
     end
@@ -299,7 +300,7 @@ class DownloadTest < ActiveSupport::TestCase
     version = create(:version, rubygem: rubygem)
 
     10.times do |n|
-      Timecop.freeze(n.days.ago) do
+      travel_to n.days.ago do
         3.times { Download.incr(rubygem.name, version.full_name) }
       end
     end

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -52,7 +52,7 @@ class RubygemsHelperTest < ActionView::TestCase
   end
 
   should "show a nice formatted date" do
-    Timecop.travel(Time.zone.parse("2011-03-18T00:00:00-00:00")) do
+    travel_to Time.zone.parse("2011-03-18T00:00:00-00:00") do
       assert_equal "March 18, 2011", nice_date_for(Time.zone.now)
     end
   end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -117,7 +117,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     should "can find when the first built date was" do
-      Timecop.travel(Time.zone.now) do
+      travel_to Time.zone.now do
         create(:version, rubygem: @rubygem, number: "3.0.0", built_at: 1.day.ago)
         create(:version, rubygem: @rubygem, number: "2.0.0", built_at: 2.days.ago)
         create(:version, rubygem: @rubygem, number: "1.0.0", built_at: 3.days.ago)
@@ -707,25 +707,25 @@ class RubygemTest < ActiveSupport::TestCase
       @rubygem = create(:rubygem)
       @version = create(:version, rubygem: @rubygem)
 
-      Timecop.freeze Date.parse("2010-10-02") do
+      travel_to Date.parse("2010-10-02") do
         1.times { Download.incr(@rubygem.name, @version.full_name) }
       end
 
-      Timecop.freeze Date.parse("2010-10-03") do
+      travel_to Date.parse("2010-10-03") do
         6.times { Download.incr(@rubygem.name, @version.full_name) }
       end
 
-      Timecop.freeze Date.parse("2010-10-16") do
+      travel_to Date.parse("2010-10-16") do
         4.times { Download.incr(@rubygem.name, @version.full_name) }
       end
 
-      Timecop.freeze Date.parse("2010-11-01") do
+      travel_to Date.parse("2010-11-01") do
         2.times { Download.incr(@rubygem.name, @version.full_name) }
       end
     end
 
     should "give counts from the past 30 days starting with the day before yesterday" do
-      Timecop.freeze Date.parse("2010-11-03") do
+      travel_to Date.parse("2010-11-03") do
         downloads = @rubygem.monthly_downloads
 
         assert_equal 30, downloads.size
@@ -742,7 +742,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     should "give the monthly dates back" do
-      Timecop.freeze Time.utc(2010, 11, 01) do
+      travel_to Time.utc(2010, 11, 01) do
         assert_equal(("01".."30").map { |date| "10/#{date}" }, Rubygem.monthly_short_dates)
       end
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -178,7 +178,7 @@ class UserTest < ActiveSupport::TestCase
       @ownership = create(:ownership, rubygem: @rubygem, user: @user)
       @version   = create(:version, rubygem: @rubygem)
 
-      Timecop.freeze(1.day.ago) do
+      travel_to 1.day.ago do
         Download.incr(@version.rubygem.name, @version.full_name)
       end
       2.times { Download.incr(@version.rubygem.name, @version.full_name) }

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -111,7 +111,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "updated gems" do
     setup do
-      Timecop.freeze Time.zone.today
+      travel_to Time.zone.today
       @existing_gem = create(:rubygem)
       @second = create(:version, rubygem: @existing_gem, created_at: 1.day.ago)
       @fourth = create(:version, rubygem: @existing_gem, created_at: 4.days.ago)
@@ -126,7 +126,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     teardown do
-      Timecop.return
+      travel_back
     end
 
     should "order gems by created at and show only gems that have more than one version" do


### PR DESCRIPTION
Used activesupport ```travel``` and ```travel_to``` helpers instead of Timecop gem helpers. By this way, we decrease one test dependency without losing any functionality, and the change also has small positive impact on speed of tests.