### PR TITLE
Removed launchy gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ group :test do
   gem 'minitest', require: false
   gem 'capybara'
   gem 'factory_girl_rails'
-  gem 'launchy'
   gem 'rack-test', require: 'rack/test'
   gem 'mocha', require: false
   gem 'bourne', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -119,8 +118,6 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     kgio (2.10.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -280,7 +277,6 @@ DEPENDENCIES
   http_accept_language
   jquery-rails
   jruby-openssl
-  launchy
   mail
   minitest
   mocha


### PR DESCRIPTION
We had to use launchy gem for capybara's ```save_and_open_page``` method. We don't need it now since we doesn't use ```save_and_open_page``` anymore.