### PR TITLE
(refs #1052) move gemfile and install areas higher

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -104,25 +104,7 @@
         </div>
       <% end %>
 
-      <h2 class="gem__ruby-version__heading t-list__heading">
-        Required Ruby Version:
-        <i class="gem__ruby-version">
-          <% if @latest_version.ruby_version %>
-            <%= @latest_version.ruby_version %>
-          <% else %>
-            None
-          <% end %>
-        </i>
-      </h2>
-
       <% if @latest_version.indexed %>
-        <h2 class="gem__ruby-version__heading t-list__heading">
-          <%= pluralized_licenses_header @latest_version %>:
-          <span class="gem__ruby-version">
-            <p><%= formatted_licenses @latest_version.licenses %></p>
-          </span>
-        </h2>
-
         <h2 class="gem__ruby-version__heading t-list__heading">
           <%= t '.bundler_header' %>:
           <div class="gem__code-wrap">
@@ -141,7 +123,24 @@
             <span class="gem__code__tooltip--copied">Copied!</span>
           </div>
         </h2>
+        <h2 class="gem__ruby-version__heading t-list__heading">
+          <%= pluralized_licenses_header @latest_version %>:
+          <span class="gem__ruby-version">
+            <p><%= formatted_licenses @latest_version.licenses %></p>
+          </span>
+        </h2>
       <% end %>
+
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        Required Ruby Version:
+        <i class="gem__ruby-version">
+          <% if @latest_version.ruby_version %>
+            <%= @latest_version.ruby_version %>
+          <% else %>
+            None
+          <% end %>
+        </i>
+      </h2>
 
       <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
       <div class="t-list__items">


### PR DESCRIPTION
Hello! 
I found the [discussion](https://github.com/rubygems/rubygems.org/issues/1052) on moving Gemfile and Install areas higher in the right column. So, I tried to do it and now a gem page looks like this:
https://www.dropbox.com/s/tlilnqbbns4wxlk/Screenshot%202015-10-03%2017.09.03.png?dl=0
