### PR TITLE
Add Dependency type to translation

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -72,7 +72,7 @@ nl:
       title: alle gems
       subtitle: die beginnen met %{prefix}
     dependencies:
-      header: afhankelijkheden
+      header: "%{title} afhankelijkheden"
     edit:
       title: Wijzig gem links
       other_fields_notice: Alle andere velden kunnen alleen gewijzigd worden door een nieuwe versie van de gem te publiceren.


### PR DESCRIPTION
Currently there is no difference between Runtime and Dev dependency in the interface in Dutch. Let's place them back.

Screenshot of the problem: 
![image](https://cloud.githubusercontent.com/assets/1362793/10283116/72a8bf9a-6b7e-11e5-9899-4562833b926c.png)
