### PR TITLE
Added a language selector in the footer

### DIFF
--- a/app/assets/stylesheets/modules/footer.css
+++ b/app/assets/stylesheets/modules/footer.css
@@ -37,6 +37,17 @@
     .footer__about {
       min-height: 222px; } }
 
+.footer__language_selector {
+  clear: both;
+  max-width: 940px;
+  margin: 0 auto;
+  text-align: center;
+  color: #6c767e; }
+  .footer__language {
+    width: 100px;
+    display: inline-block;
+  }
+
 .footer__sponsors-wrap {
   margin-top: 60px;
   padding-top: 45px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -184,6 +184,13 @@
           </a>
         </div>
       </div>
+      <div class="footer__language_selector">
+        <% I18n.available_locales.each do |language| %>
+          <div class="footer__language">
+            <%= link_to I18n.t(:locale_name, locale: language), url_for(locale: language), class: "nav--v__link--footer" %>
+          </div>
+        <% end %>
+      </div>
     </footer>
 
     <%= javascript_include_tag "application" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
   sign_in: "Sign in"
   sign_up: "Sign up"
   footer_about: "RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly publish your gems and install them. Use the API to interact and find out more information about available gems. Become a contributor and enhance the site with your own changes."
+  locale_name: "English"
 
   dashboards:
     show:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,6 +2,7 @@ nl:
   update: Wijzig
   sign_in: Inloggen
   sign_up: Inschrijven
+  locale_name: "Nederlands"
   home:
     index:
       share:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -12,6 +12,7 @@ zh-CN:
   sign_in: "登录"
   sign_up: "注册"
   footer_about: "RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。"
+  locale_name: "简体中文"
 
   dashboards:
     show:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -12,6 +12,7 @@ zh-TW:
   sign_in: "登入"
   sign_up: "註冊"
   footer_about: "RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。"
+  locale_name: "正體中文"
 
   dashboards:
     show:


### PR DESCRIPTION
Currently there is no way to know you can select a certain language. This was
not problem prior to f9851e9fde008e5652fa9f73a0535ccf0fedf938. But now Rubygems
will pick the language the browser is in. This can cause some confusion.

Fixes: #1075

**screenshot**
![image](https://cloud.githubusercontent.com/assets/1362793/10333782/7da5f354-6ce6-11e5-8851-34a7f9d63d69.png)

