### PR TITLE
added black text color to body

### DIFF
--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -21,6 +21,7 @@ footer, header, hgroup, menu, nav, section {
 
 body {
   background-color: #e9573f;
+  color: #000000;
   font-family: "aktiv-grotesk-std", sans-serif;
   font-size: 15px; }
 


### PR DESCRIPTION
Issue #969 noted that body font color wasn't being explicitly set, allowing for some funky behavior when users applied custom CSS to the background color. I just set the color in the body.