### PR TITLE
Top ten downloads stats from redis phase 1

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,7 +3,13 @@ class StatsController < ApplicationController
     @number_of_gems      = Rubygem.total_count
     @number_of_users     = User.count
     @number_of_downloads = Download.count
-    @most_downloaded     = Rubygem.downloaded(10).sort_by(&:downloads).reverse!
-    @most_downloaded_count = @most_downloaded.first.downloads
+
+    if Rails.application.config.stats_page_top_10_from_redis
+      @most_downloaded = Rubygem.downloaded(10)
+      _, @most_downloaded_count = @most_downloaded.first
+    else
+      @most_downloaded = Rubygem.downloaded(10).sort_by(&:downloads).reverse!
+      @most_downloaded_count = @most_downloaded.first.downloads
+    end
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -66,7 +66,19 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.downloaded(limit = 5)
+    if Rails.application.config.stats_page_top_10_from_redis
+      most_downloaded_by_redis(limit)
+    else
+      most_downloaded_by_db(limit)
+    end
+  end
+
+  def self.most_downloaded_by_db(limit = 5)
     with_versions.by_downloads.limit(limit)
+  end
+
+  def self.most_downloaded_by_redis(limit = 5)
+    Download.most_downloaded_gems_all_time(limit)
   end
 
   def self.letter(letter)

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -17,13 +17,27 @@
 
 <h2 class="stats__graph__heading">All Time Most Downloaded</h2>
 
-<% @most_downloaded.each do |gem| %>
-  <div class="stats__graph__gem">
-    <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
-    <div class="stats__graph__gem__meter-wrap">
-      <div class="stats__graph__gem__meter" style="width: <%= stats_graph_meter(gem, @most_downloaded_count) %>%">
-        <span class="stats__graph__gem__count"><%= number_to_delimited gem.downloads %></span>
+<% if Rails.application.config.stats_page_top_10_from_redis %>
+  <% @most_downloaded.each do |(gem, downloads)| %>
+    <div class="stats__graph__gem">
+      <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
+      <div class="stats__graph__gem__meter-wrap">
+        <div class="stats__graph__gem__meter" style="width: <%= stats_graph_meter(gem, @most_downloaded_count) %>%">
+          <span class="stats__graph__gem__count"><%= number_to_delimited downloads %></span>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
+
+<% else %>
+  <% @most_downloaded.each do |gem| %>
+    <div class="stats__graph__gem">
+      <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
+      <div class="stats__graph__gem__meter-wrap">
+        <div class="stats__graph__gem__meter" style="width: <%= stats_graph_meter(gem, @most_downloaded_count) %>%">
+          <span class="stats__graph__gem__count"><%= number_to_delimited gem.downloads %></span>
+        </div>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module Gemcutter
     config.plugins = [:dynamic_form]
 
     config.autoload_paths << Rails.root.join('lib')
+
+    config.stats_page_top_10_from_redis = false
   end
 
   def self.config

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -58,4 +58,72 @@ class StatsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "on GET to index from Redis" do
+    setup do
+      Rails.application.config.stubs(:stats_page_top_10_from_redis).returns true
+
+      @number_of_gems      = 1337
+      @number_of_users     = 101
+      @number_of_downloads = 42
+      @most_downloaded     = [[create(:rubygem), @number_of_downloads]]
+
+      Rubygem.stubs(:total_count).returns @number_of_gems
+      Download.stubs(:count).returns @number_of_downloads
+      Rubygem.stubs(:downloaded).returns @most_downloaded
+      User.stubs(:count).returns @number_of_users
+
+      get :index
+    end
+
+    should respond_with :success
+    should render_template :index
+
+    should "display number of gems" do
+      assert page.has_content?("1,337")
+    end
+
+    should "display number of users" do
+      assert page.has_content?("101")
+    end
+
+    should "display number of downloads" do
+      assert page.has_content?("42")
+    end
+
+    should "load up the number of gems, users, and downloads" do
+      assert_received(User, :count)
+      assert_received(Rubygem, :total_count)
+      assert_received(Download, :count)
+      assert_received(Rubygem, :downloaded) { |subject| subject.with(10) }
+    end
+  end
+
+  context "on GET to index with multiple gems" do
+    setup do
+      Rails.application.config.stubs(:stats_page_top_10_from_redis).returns true
+
+      rg1 = create(:rubygem, number: "1")
+      rg2 = create(:rubygem, number: "1")
+      rg3 = create(:rubygem, number: "1")
+      Rubygem.stubs(:downloaded).returns [[rg3, 30], [rg2, 20], [rg1, 10]]
+
+      get :index
+    end
+
+    should "display number of downloads" do
+      assert page.has_content?("30")
+      assert page.has_content?("20")
+      assert page.has_content?("10")
+    end
+
+    should "not have width greater than 100%" do
+      assert_select ".stats__graph__gem__meter" do |element|
+        element.map { |h| h[:style] }.each do |width|
+          width =~ /width\: (\d+[,.]\d+)%/
+          assert Regexp.last_match(1).to_f <= 100, "#{Regexp.last_match(1)} is greater than 100"
+        end
+      end
+    end
+  end
 end

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -96,6 +96,32 @@ class DownloadTest < ActiveSupport::TestCase
     assert_equal 3, Download.rank(@version_1)
   end
 
+  should "find most downloaded gems all time" do
+    @rubygem_1 = create(:rubygem)
+    @version_1 = create(:version, rubygem: @rubygem_1)
+    @version_2 = create(:version, rubygem: @rubygem_1)
+
+    @rubygem_2 = create(:rubygem)
+    @version_3 = create(:version, rubygem: @rubygem_2)
+
+    @rubygem_3 = create(:rubygem)
+    @version_4 = create(:version, rubygem: @rubygem_3)
+
+    Download.incr(@rubygem_1.name, @version_1.full_name)
+    Download.incr(@rubygem_1.name, @version_2.full_name)
+    Download.incr(@rubygem_2.name, @version_3.full_name)
+    Download.incr(@rubygem_1.name, @version_1.full_name)
+    3.times { Download.incr(@rubygem_2.name, @version_3.full_name) }
+    2.times { Download.incr(@rubygem_1.name, @version_2.full_name) }
+    1.times { Download.incr(@rubygem_3.name, @version_4.full_name) }
+
+    assert_equal [[@rubygem_1, 5], [@rubygem_2, 4], [@rubygem_3, 1]],
+      Download.most_downloaded_gems_all_time
+
+    assert_equal [[@rubygem_1, 5], [@rubygem_2, 4]],
+      Download.most_downloaded_gems_all_time(2)
+  end
+
   should "find counts per day for versions" do
     @rubygem_1 = create(:rubygem)
     @version_1 = create(:version, rubygem: @rubygem_1)


### PR DESCRIPTION
Proposing a two phase fix for #947:

Phase 1 (represented by this PR) would provide a new redis sorted set as the source for all download counts by gem name. This zscore for each gem would be initialized/updated along with the original counter key for each download to seed existing counts in the new set. Stats controller behavior remains the same during this phase by default, while a config option is added to allow for testing of the new rendering logic. This approach allows the change to be made without downtime though time (or a rake task I can add if preferred) is needed to seed existing sorted set values. 

Phase 2 (doesn't exist yet) would fix the issue by enabling the new sorted set and rendering logic, removing the old.
