### PR TITLE
add elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 
 services:
   - redis-server
+  - elasticsearch
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'uglifier', '>= 1.0.3'
 gem 'unicorn'
 gem 'validates_formatting_of'
 gem 'will_paginate'
+gem 'elasticsearch-model', '~> 0.1.7'
+gem 'elasticsearch-rails', '~> 0.1.7'
 gem 'xml-simple'
 gem 'yajl-ruby', require: 'yajl'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,19 @@ GEM
     doorkeeper (3.0.1)
       railties (>= 3.2)
     dynamic_form (1.1.4)
+    elasticsearch (1.0.14)
+      elasticsearch-api (= 1.0.14)
+      elasticsearch-transport (= 1.0.14)
+    elasticsearch-api (1.0.14)
+      multi_json
+    elasticsearch-model (0.1.8)
+      activesupport (> 3)
+      elasticsearch (> 0.4)
+      hashie
+    elasticsearch-rails (0.1.8)
+    elasticsearch-transport (1.0.14)
+      faraday
+      multi_json
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -103,10 +116,13 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     gchartrb (0.8)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     gravtastic (3.2.6)
+    hashie (3.4.2)
     high_voltage (2.4.0)
     highline (1.7.8)
     honeybadger (2.1.5)
@@ -134,6 +150,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
@@ -274,6 +291,8 @@ DEPENDENCIES
   delayed_job_active_record
   doorkeeper
   dynamic_form
+  elasticsearch-model (~> 0.1.7)
+  elasticsearch-rails (~> 0.1.7)
   factory_girl_rails
   gchartrb
   gravtastic

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SearchesController < Api::BaseController
   before_action :set_page, only: :show
 
   def show
-    @rubygems = Rubygem.search(params.require(:query)).with_versions.paginate(page: @page)
+    @rubygems = Rubygem.legacy_search(params.require(:query)).with_versions.paginate(page: @page)
     respond_to do |format|
       format.json { render json: @rubygems }
       format.yaml { render yaml: @rubygems }

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,7 +3,12 @@ class SearchesController < ApplicationController
 
   def show
     return unless params[:query] && params[:query].is_a?(String)
-    @gems = Rubygem.search(params[:query]).with_versions.paginate(page: @page)
+    begin
+      @gems = Rubygem.search(params[:query], es: params[:es] == 'true', page: @page)
+    rescue Rubygem::Searchable::SearchDownError
+      @fallback = true
+      @gems = Rubygem.search(params[:query], es: false, page: @page)
+    end
     @exact_match = Rubygem.name_is(params[:query]).with_versions.first
     redirect_to rubygem_path(@exact_match) if @gems == [@exact_match]
   end

--- a/app/models/concerns/rubygem/searchable.rb
+++ b/app/models/concerns/rubygem/searchable.rb
@@ -1,0 +1,99 @@
+module Rubygem::Searchable
+  include Patterns
+  extend ActiveSupport::Concern
+
+  class SearchDownError < StandardError; end
+
+  included do
+    include Elasticsearch::Model
+
+    delegate :index_document, to: :__elasticsearch__
+    delegate :update_document, to: :__elasticsearch__
+    delegate :delete_document, to: :__elasticsearch__
+
+    # These are not used, because we trigger the ES index from the Pusher class
+    # after_commit -> { delay.index_document  }, on: :create
+    # after_commit -> { delay.update_document }, on: :update
+    # after_commit -> { delay.delete_document }, on: :destroy
+
+    def as_indexed_json(_options = {})
+      most_recent_version = versions.most_recent
+      {
+        name: name,
+        indexed: versions.any?(&:indexed?),
+        info: most_recent_version.try(:description) || most_recent_version.try(:summary)
+      }
+    end
+
+    settings number_of_shards: 1,
+             number_of_replicas: 1,
+             analysis: {
+               analyzer: {
+                 rubygem: {
+                   type: 'pattern',
+                   pattern: "[\s#{Regexp.escape(SPECIAL_CHARACTERS)}]+"
+                 }
+               }
+             }
+
+    mapping do
+      indexes :name, analyzer: 'rubygem'
+      indexes :indexed, type: 'boolean'
+      indexes :info, analyzer: 'english'
+    end
+
+    def self.search(query, es: false, page: 1)
+      if es
+        result = elastic_search(query).page(page).records
+        # Now we need to trigger the ES query so we can fallback if it fails
+        # rather than lazy loading from the view
+        result.load
+        result
+      else
+        legacy_search(query).with_versions.paginate(page: page)
+      end
+    rescue Faraday::ConnectionFailed
+      raise SearchDownError
+    end
+
+    def self.elastic_search(query)
+      __elasticsearch__.search(
+        query: {
+          filtered: {
+            query: {
+              multi_match: {
+                query: query,
+                operator: 'and',
+                fields: ['name^3', 'info']
+              }
+            },
+            filter: {
+              bool: {
+                must: {
+                  term: { indexed: true }
+                }
+              }
+            }
+          }
+        },
+        _source: %w(name info)
+      )
+    end
+
+    def self.legacy_search(query)
+      conditions = <<-SQL
+        versions.indexed and
+          (UPPER(name) LIKE UPPER(:query) OR
+           UPPER(TRANSLATE(name,
+                           '#{SPECIAL_CHARACTERS}',
+                           '#{' ' * SPECIAL_CHARACTERS.length}')
+                ) LIKE UPPER(:query))
+      SQL
+
+      where(conditions, query: "%#{query.strip}%")
+        .includes(:versions)
+        .references(:versions)
+        .by_downloads
+    end
+  end
+end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -122,6 +122,7 @@ class Pusher
   def after_write
     @version_id = version.id
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
+    rubygem.delay.index_document
     enqueue_web_hook_jobs
     update_remote_bundler_api
     StatsD.increment 'push.success'

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -1,5 +1,6 @@
 class Rubygem < ActiveRecord::Base
   include Patterns
+  include Rubygem::Searchable
 
   has_many :owners, through: :ownerships, source: :user
   has_many :ownerships, dependent: :destroy
@@ -31,22 +32,6 @@ class Rubygem < ActiveRecord::Base
     return sensitive unless sensitive.empty?
 
     where("UPPER(name) = UPPER(?)", name.strip).limit(1)
-  end
-
-  def self.search(query)
-    conditions = <<-SQL
-      versions.indexed and
-        (UPPER(name) LIKE UPPER(:query) OR
-         UPPER(TRANSLATE(name,
-                         '#{SPECIAL_CHARACTERS}',
-                         '#{' ' * SPECIAL_CHARACTERS.length}')
-              ) LIKE UPPER(:query))
-    SQL
-
-    where(conditions, query: "%#{query.strip}%")
-      .includes(:versions)
-      .references(:versions)
-      .by_downloads
   end
 
   def self.name_starts_with(letter)

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,5 +1,12 @@
 <% @title = "search" %>
 
+<% if @fallback %>
+  <div class="errorExplanation">
+    <h2>Uh oh...</h2>
+    <ul><li>Advanced search is currently unavailable, sorry!</li></ul>
+  </div>
+<% end %>
+
 <% if @gems %>
   <% @subtitle = t('.subtitle', :query => content_tag(:em, h(params[:query]))) %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'elasticsearch/rails/instrumentation'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,23 @@
+if Rails.env.test? || Rails.env.development?
+  port = Toxiproxy.running? ? 22_221 : 9200
+  if Toxiproxy.running?
+    Toxiproxy.populate(
+      [
+        {
+          name: 'elasticsearch',
+          listen: "127.0.0.1:#{port}",
+          upstream: '127.0.0.1:9200'
+        }
+      ]
+    )
+  end
+end
+
+url = ENV['ELASTICSEARCH_URL'] || "http://localhost:#{port}"
+Elasticsearch::Model.client = Elasticsearch::Client.new(host: url)
+
+if Rails.env.development?
+  tracer = ActiveSupport::Logger.new('log/elasticsearch.log')
+  tracer.level = Logger::DEBUG
+  Elasticsearch::Model.client.transport.tracer = tracer
+end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,1 @@
+require 'elasticsearch/rails/tasks/import'

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -68,4 +68,22 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
     should render_template :show
   end
+
+  context "with elasticsearch down" do
+    setup do
+      @sinatra = create(:rubygem, name: "sinatra")
+      @sinatra_redux = create(:rubygem, name: "sinatra-redux")
+      create(:version, rubygem: @sinatra)
+      create(:version, rubygem: @sinatra_redux)
+    end
+    should "fallback to legacy search" do
+      requires_toxiproxy
+      Toxiproxy[:elasticsearch].down do
+        get :show, query: 'sinatra', es: 'true'
+        assert_response :success
+        assert page.has_content?('Advanced search is currently unavailable')
+        assert page.has_content?('Displaying')
+      end
+    end
+  end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -575,34 +575,36 @@ class RubygemTest < ActiveSupport::TestCase
       create(:version, description: 'julius', rubygem: @orange_julius)
     end
 
-    should "find rubygems by name on #search" do
-      assert Rubygem.search('apple').include?(@apple_pie)
-      assert Rubygem.search('orange').include?(@orange_julius)
+    context '#legacy_search' do
+      should "find rubygems by name" do
+        assert Rubygem.legacy_search('apple').include?(@apple_pie)
+        assert Rubygem.legacy_search('orange').include?(@orange_julius)
 
-      assert !Rubygem.search('apple').include?(@orange_julius)
-      assert !Rubygem.search('orange').include?(@apple_pie)
-    end
+        assert !Rubygem.legacy_search('apple').include?(@orange_julius)
+        assert !Rubygem.legacy_search('orange').include?(@apple_pie)
+      end
 
-    should "find rubygems by name with extra spaces on #search" do
-      assert Rubygem.search('apple  ').include?(@apple_pie)
-      assert Rubygem.search('orange   ').include?(@orange_julius)
-      assert_equal Rubygem.search('apple'), Rubygem.search('apple ')
+      should "find rubygems by name with extra spaces" do
+        assert Rubygem.legacy_search('apple  ').include?(@apple_pie)
+        assert Rubygem.legacy_search('orange   ').include?(@orange_julius)
+        assert_equal Rubygem.legacy_search('apple'), Rubygem.legacy_search('apple ')
 
-      assert !Rubygem.search('apple  ').include?(@orange_julius)
-      assert !Rubygem.search('orange   ').include?(@apple_pie)
-    end
+        assert !Rubygem.legacy_search('apple  ').include?(@orange_julius)
+        assert !Rubygem.legacy_search('orange   ').include?(@apple_pie)
+      end
 
-    should "find rubygems case insensitively on #search" do
-      assert Rubygem.search('APPLE').include?(@apple_pie)
-    end
+      should "find rubygems case insensitively" do
+        assert Rubygem.legacy_search('APPLE').include?(@apple_pie)
+      end
 
-    should "find rubygems with missing punctuation on #search" do
-      assert Rubygem.search('apple crisp').include?(@apple_crisp)
-      assert !Rubygem.search('apple crisp').include?(@apple_pie)
-    end
+      should "find rubygems with missing punctuation" do
+        assert Rubygem.legacy_search('apple crisp').include?(@apple_crisp)
+        assert !Rubygem.legacy_search('apple crisp').include?(@apple_pie)
+      end
 
-    should "sort results by number of downloads, descending" do
-      assert_equal [@apple_crisp, @apple_pie], Rubygem.search('apple')
+      should "sort results by number of downloads, descending" do
+        assert_equal [@apple_crisp, @apple_pie], Rubygem.legacy_search('apple')
+      end
     end
 
     should "find exact match by name on #name_is" do


### PR DESCRIPTION
This PR adds basic elasticsearch search functionality to the app. This version is hidden behind a flag so that we can test this before we roll it out everywhere. This will index gems in the background using delayed job. It will search both the gem name and the description shown on the gem page. The search query might need some tweaking and we can definitely do more down the road, but for now this is a good start and it's way better than what we have now.

Fixes: #899

@evanphx @qrush @arthurnn @karmi @andrewhamon @indirect @bai