### PR TITLE
stop testing ruby-head since it never works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 
 rvm:
   - 2.2.3
-  - ruby-head
 
 services:
   - redis-server


### PR DESCRIPTION
Let's speed up and simplify tests by skipping ruby-head. It hasn't worked for a very long time and doesn't seem to be related to any of our code.

@arthurnn @qrush 