### PR TITLE
remove old background job stats controller

### DIFF
--- a/app/controllers/internal/background_job_stats_controller.rb
+++ b/app/controllers/internal/background_job_stats_controller.rb
@@ -1,7 +1,0 @@
-class Internal::BackgroundJobStatsController < ActionController::Metal
-  def stats
-    total = Delayed::Job.count
-    failed = Delayed::Job.where.not(failed_at: nil).count
-    self.response_body = "total=#{total} failed=#{failed}"
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,6 @@ Rails.application.routes.draw do
   # Internal Routes
 
   namespace :internal do
-    get 'background_job_stats', to: Internal::BackgroundJobStatsController.action(:stats)
     get 'ping' => 'ping#index'
   end
 


### PR DESCRIPTION
We don't need this anymore.

@arthurnn @sferik 