### PR TITLE
Remove defunct api/v1/dependencies route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,8 +55,6 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :dependencies, only: :index
-
       resources :rubygems,
         path: 'gems',
         only: [:create, :show, :index],


### PR DESCRIPTION
Api::V1::DependenciesController was removed by 7e4c702b38f50aac32716401434c4864e886fa1f, but it's route was left undeleted. Although the route was removed by 15e23409e86c790ed33fdcb4398409612f7ae2fe, it was then restored by b9407e1bb8a045123e67693a5e5bccbf4e33f948.