### PR TITLE
Translate Chinese footer services

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -56,6 +56,14 @@ zh-CN:
         api: "API"
         guides: "教程"
         contribute: "贡献"
+        supported_by: "支持"
+        hosted_by: "托管"
+        designed_by: "设计"
+        resolved_with: "解析"
+        optimized_by: "优化"
+        tracking_by: "追踪"
+        monitored_by: "监控"
+        gems_served_by: "服务"
 
   pages:
     about:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -56,6 +56,14 @@ zh-TW:
         api: "API"
         guides: "教學文件"
         contribute: "貢獻"
+        supported_by: "支持"
+        hosted_by: "托管"
+        designed_by: "設計"
+        resolved_with: "解析"
+        optimized_by: "優化"
+        tracking_by: "追蹤"
+        monitored_by: "監控"
+        gems_served_by: "服務"
 
   pages:
     about:


### PR DESCRIPTION
This Pull Request translates services listed in footer for Chinese:

`zh-CN`

<img width="1004" alt="screenshot 2015-10-20 23 13 21" src="https://cloud.githubusercontent.com/assets/1000669/10611797/4970baa2-7780-11e5-980e-62c3c68b74b7.png">

`zh-TW`

<img width="1016" alt="screenshot 2015-10-20 23 13 12" src="https://cloud.githubusercontent.com/assets/1000669/10611800/4eb9cd8c-7780-11e5-8586-446422641e56.png">
