### PR TITLE
Consistent API error message when a rubygem cannot be found (anymore)

### DIFF
--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::DeletionsController < Api::BaseController
 
   def validate_gem_and_version
     if !@rubygem.hosted?
-      render text: "This gem does not exist.",
+      render text: t(:this_rubygem_could_not_be_found),
              status: :not_found
     elsif !@rubygem.owned_by?(current_user)
       render text: "You do not have permission to delete this gem.",

--- a/app/controllers/api/v1/downloads_controller.rb
+++ b/app/controllers/api/v1/downloads_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::DownloadsController < Api::BaseController
       }
       respond_with_data(data)
     else
-      render text: "This rubygem could not be found.", status: :not_found
+      render text: t(:this_rubygem_could_not_be_found), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::RubygemsController < Api::BaseController
         format.yaml { render yaml: @rubygem }
       end
     else
-      render text: "This rubygem could not be found.", status: :not_found
+      render text: t(:this_rubygem_could_not_be_found), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::RubygemsController < Api::BaseController
         format.yaml { render yaml: @rubygem }
       end
     else
-      render text: "This gem does not exist.", status: :not_found
+      render text: "This rubygem could not be found.", status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/versions/downloads_controller.rb
+++ b/app/controllers/api/v1/versions/downloads_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Versions::DownloadsController < Api::BaseController
         format.yaml { render yaml: counts }
       end
     else
-      render text: "This rubygem could not be found.", status: :not_found
+      render text: t(:this_rubygem_could_not_be_found), status: :not_found
     end
   end
 
@@ -23,7 +23,7 @@ class Api::V1::Versions::DownloadsController < Api::BaseController
         format.yaml { render yaml: counts }
       end
     else
-      render text: "This rubygem could not be found.", status: :not_found
+      render text: t(:this_rubygem_could_not_be_found), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::VersionsController < Api::BaseController
         format.yaml { render yaml: @rubygem.public_versions }
       end
     else
-      render text: "This rubygem could not be found.", status: 404
+      render text: t(:this_rubygem_could_not_be_found), status: :not_found
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
     return if @rubygem
     respond_to do |format|
       format.any do
-        render text: "This rubygem could not be found.", status: :not_found
+        render text: t(:this_rubygem_could_not_be_found), status: :not_found
       end
       format.html do
         render file: "public/404", status: :not_found, layout: false, formats: [:html]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   sign_up: "Sign up"
   footer_about: "RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly publish your gems and install them. Use the API to interact and find out more information about available gems. Become a contributor and enhance the site with your own changes."
   locale_name: "English"
+  this_rubygem_could_not_be_found: "This rubygem could not be found."
 
   dashboards:
     show:

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -74,8 +74,8 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :not_found
-      should "say not be found" do
-        assert_match(/does not exist/, @response.body)
+      should "say gem could not be found" do
+        assert_equal "This rubygem could not be found.", @response.body
       end
     end
 
@@ -100,8 +100,8 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :not_found
-      should "say the rubygem was not found" do
-        assert_match(/does not exist/, @response.body)
+      should "say gem could not be found" do
+        assert_equal "This rubygem could not be found.", @response.body
       end
     end
   end


### PR DESCRIPTION
This Pull Request changes the error message of `api/v1/rubygems_controller.rb` to provide a consistent error message for https://rubygems.org users.

Why?

When a gem cannot be found, the current codebase has two kinds of error messages:

- `"This rubygem could not be found"`
- `"This gem does not exist."`

Here are the places use `"This rubygem could not be found"` error message before this Pull Request:

- [app/controllers/api/v1/downloads_controller#L21](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/downloads_controller.rb#L21)
- [app/controllers/api/v1/versions/downloads_controller.rb#L10](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/versions/downloads_controller.rb#L10)
- [app/controllers/api/v1/versions/downloads_controller.rb#L26](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/versions/downloads_controller.rb#L26)
- [app/controllers/api/v1/versions_controller.rb#L13](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/versions_controller.rb#L13)
- [app/controllers/api/v1/application_controller.rb#L53](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/application_controller.rb#L53)

And here are the places use `"This gem does not exist."`:

- [app/controllers/api/v1/deletions_controller.rb#L30](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/deletions_controller.rb#L30)
- [app/controllers/api/v1/rubygems_controller.rb#L23](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/rubygems_controller.rb#L23)

I recently met a bug with this error message: `"This gem does not exist."`.

Here is the case:

This gem [rails-assets-angular](https://rubygems.org/gems/rails-assets-angular) used to host on https://rubygems.org but [yanked](https://github.com/rails-assets/rails-assets/issues/220).

I use [GEM METHODS](http://guides.rubygems.org/rubygems-org-api/#gem-methods) endpoint to get information of this gem. So when I hit this endpoint, the code will first execute [this before action](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/application_controller.rb#L48-L59) to [find given ruby gem](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/rubygems_controller.rb#L6), and because it used to host on https://rubygems.org, so no problems.

It then executes [Api::V1::RubygemsController#show line 1](https://github.com/rubygems/rubygems.org/blob/f55fb1/app/controllers/api/v1/rubygems_controller.rb#L17) and it failed the check:

```ruby
if @rubygem.hosted? && @rubygem.public_versions.indexed.count.nonzero?
```

Because it no longer hosted on https://rubygems.org. It then renders `"This gem does not exist."`.

I originally play with the API, when it cannot found a gem, it will return `"This rubygem could not be found"`. I was thinking this is the only kind of error message when a rubygem cannot be found.

So I think we should provide a consistent not found message. Hence this Pull Request.

What do you think? Thanks!