### PR TITLE
Allow fetching only runtime reverse_dependencies from API

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -35,7 +35,15 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def reverse_dependencies
-    names = Rubygem.reverse_dependencies(params[:id]).pluck(:name)
+    names = begin
+      if params[:only] == "development"
+        Rubygem.reverse_development_dependencies(params[:id]).pluck(:name)
+      elsif params[:only] == "runtime"
+        Rubygem.reverse_runtime_dependencies(params[:id]).pluck(:name)
+      else
+        Rubygem.reverse_dependencies(params[:id]).pluck(:name)
+      end
+    end
 
     respond_to do |format|
       format.json { render json: names }

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -42,6 +42,14 @@ class Rubygem < ActiveRecord::Base
     where(id: Version.reverse_dependencies(name).select(:rubygem_id))
   end
 
+  def self.reverse_development_dependencies(name)
+    where(id: Version.reverse_development_dependencies(name).select(:rubygem_id))
+  end
+
+  def self.reverse_runtime_dependencies(name)
+    where(id: Version.reverse_runtime_dependencies(name).select(:rubygem_id))
+  end
+
   def self.total_count
     with_versions.count
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -24,6 +24,18 @@ class Version < ActiveRecord::Base
       .where(rubygems: { name: name })
   end
 
+  def self.reverse_runtime_dependencies(name)
+    joins(dependencies: :rubygem)
+      .merge(Dependency.runtime)
+      .where(rubygems: { name: name })
+  end
+
+  def self.reverse_development_dependencies(name)
+    joins(dependencies: :rubygem)
+      .merge(Dependency.development)
+      .where(rubygems: { name: name })
+  end
+
   def self.owned_by(user)
     where(rubygem_id: user.rubygem_ids)
   end


### PR DESCRIPTION
This adds a new query parameter (`only`) to the Reverse Dependencies API endpoint in order to return exclusively gems that declare the provided gem as a runtime or development dependency.

It's often much more important to know which gems use your gem at runtime than all the gems that use your gem in development. In this case you would pass `?only=runtime`.

Example: 

```CURL
GET /api/v1/gems/[GEM NAME]/reverse_dependencies.json
GET /api/v1/gems/[GEM NAME]/reverse_dependencies.json?only=runtime
GET /api/v1/gems/[GEM NAME]/reverse_dependencies.json?only=development
```

It may make sense to create a whole separate endpoint for this but it seemed simple enough to add a query param for this.

Let me know if this is entirely dumb. /cc @schneems