### PR TITLE
Use factory_girl traits when appropriate

### DIFF
--- a/test/factories.rb
+++ b/test/factories.rb
@@ -19,14 +19,14 @@ FactoryGirl.define do
     rubygem
     version
 
-    factory :development_dependency do
+    trait :runtime do
+    end
+
+    trait :development do
       gem_dependency { Gem::Dependency.new(Rubygem.last.name, "1.0.0", :development) }
     end
 
-    factory :runtime_dependency do
-    end
-
-    factory :unresolved_dependency do
+    trait :unresolved do
       gem_dependency { Gem::Dependency.new("unresolved-gem-nothere", "1.0.0") }
     end
   end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -325,7 +325,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       @version_three.dependencies << create(:dependency,
         version: @version_three,
         rubygem: @dep_rubygem)
-      @version_five.dependencies << create(:development_dependency,
+      @version_five.dependencies << create(:dependency, :development,
         version: @version_five,
         rubygem: @dep_rubygem)
     end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -381,8 +381,8 @@ class RubygemsControllerTest < ActionController::TestCase
     setup do
       @version = create(:version)
 
-      @development = create(:development_dependency, version: @version)
-      @runtime     = create(:runtime_dependency,     version: @version)
+      @development = create(:dependency, :development, version: @version)
+      @runtime     = create(:dependency, :runtime,     version: @version)
 
       get :show, id: @version.rubygem.to_param
     end
@@ -399,7 +399,7 @@ class RubygemsControllerTest < ActionController::TestCase
     setup do
       @version = create(:version)
 
-      @unresolved = create(:unresolved_dependency, version: @version)
+      @unresolved = create(:dependency, :unresolved, version: @version)
 
       get :show, id: @version.rubygem.to_param
     end
@@ -414,7 +414,7 @@ class RubygemsControllerTest < ActionController::TestCase
   context "On GET to show for a gem with runtime dependencies that have a bad link" do
     setup do
       @version = create(:version)
-      @runtime = create(:runtime_dependency, version: @version)
+      @runtime = create(:dependency, :runtime, version: @version)
       @runtime.rubygem.update_column(:name, 'foo>0.1.1')
       get :show, id: @version.rubygem.to_param
     end

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -50,7 +50,7 @@ class DependencyTest < ActiveSupport::TestCase
     end
 
     should "not push development dependency onto the redis list" do
-      @dependency = create(:development_dependency)
+      @dependency = create(:dependency, :development)
 
       assert !Redis.current.exists(Dependency.runtime_key(@dependency.version.full_name))
     end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -370,8 +370,8 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "return a bunch of json" do
       version = create(:version, rubygem: @rubygem)
-      run_dep = create(:runtime_dependency, version: version)
-      dev_dep = create(:development_dependency, version: version)
+      run_dep = create(:dependency, :runtime, version: version)
+      dev_dep = create(:dependency, :development, version: version)
 
       hash = MultiJson.load(@rubygem.to_json)
 
@@ -394,8 +394,8 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "return a bunch of xml" do
       version = create(:version, rubygem: @rubygem)
-      run_dep = create(:runtime_dependency, version: version)
-      dev_dep = create(:development_dependency, version: version)
+      run_dep = create(:dependency, :runtime, version: version)
+      dev_dep = create(:dependency, :development, version: version)
 
       doc = Nokogiri.parse(@rubygem.to_xml)
 


### PR DESCRIPTION
This removes some naming redundancy in tests and allows for more clear factory creation `create(:dependency, :runtime)` doesn't imply that there is a `RuntimeDependency` model like `create(:runtime_dependency)` does.