### PR TITLE
Add unit tests for new reverse deps methods

### DIFF
--- a/test/factories.rb
+++ b/test/factories.rb
@@ -19,14 +19,14 @@ FactoryGirl.define do
     rubygem
     version
 
-    factory :development_dependency do
+    trait :runtime do
+    end
+
+    trait :development do
       gem_dependency { Gem::Dependency.new(Rubygem.last.name, "1.0.0", :development) }
     end
 
-    factory :runtime_dependency do
-    end
-
-    factory :unresolved_dependency do
+    trait :unresolved do
       gem_dependency { Gem::Dependency.new("unresolved-gem-nothere", "1.0.0") }
     end
   end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -325,7 +325,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       @version_three.dependencies << create(:dependency,
         version: @version_three,
         rubygem: @dep_rubygem)
-      @version_five.dependencies << create(:development_dependency,
+      @version_five.dependencies << create(:dependency, :development,
         version: @version_five,
         rubygem: @dep_rubygem)
     end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -381,8 +381,8 @@ class RubygemsControllerTest < ActionController::TestCase
     setup do
       @version = create(:version)
 
-      @development = create(:development_dependency, version: @version)
-      @runtime     = create(:runtime_dependency,     version: @version)
+      @development = create(:dependency, :development, version: @version)
+      @runtime     = create(:dependency, :runtime,     version: @version)
 
       get :show, id: @version.rubygem.to_param
     end
@@ -399,7 +399,7 @@ class RubygemsControllerTest < ActionController::TestCase
     setup do
       @version = create(:version)
 
-      @unresolved = create(:unresolved_dependency, version: @version)
+      @unresolved = create(:dependency, :unresolved, version: @version)
 
       get :show, id: @version.rubygem.to_param
     end
@@ -414,7 +414,7 @@ class RubygemsControllerTest < ActionController::TestCase
   context "On GET to show for a gem with runtime dependencies that have a bad link" do
     setup do
       @version = create(:version)
-      @runtime = create(:runtime_dependency, version: @version)
+      @runtime = create(:dependency, :runtime, version: @version)
       @runtime.rubygem.update_column(:name, 'foo>0.1.1')
       get :show, id: @version.rubygem.to_param
     end

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -50,7 +50,7 @@ class DependencyTest < ActiveSupport::TestCase
     end
 
     should "not push development dependency onto the redis list" do
-      @dependency = create(:development_dependency)
+      @dependency = create(:dependency, :development)
 
       assert !Redis.current.exists(Dependency.runtime_key(@dependency.version.full_name))
     end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -370,8 +370,8 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "return a bunch of json" do
       version = create(:version, rubygem: @rubygem)
-      run_dep = create(:runtime_dependency, version: version)
-      dev_dep = create(:development_dependency, version: version)
+      run_dep = create(:dependency, :runtime, version: version)
+      dev_dep = create(:dependency, :development, version: version)
 
       hash = MultiJson.load(@rubygem.to_json)
 
@@ -394,8 +394,8 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "return a bunch of xml" do
       version = create(:version, rubygem: @rubygem)
-      run_dep = create(:runtime_dependency, version: version)
-      dev_dep = create(:development_dependency, version: version)
+      run_dep = create(:dependency, :runtime, version: version)
+      dev_dep = create(:dependency, :development, version: version)
 
       doc = Nokogiri.parse(@rubygem.to_xml)
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -229,6 +229,62 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
+  context ".reverse_runtime_dependencies" do
+    setup do
+      @dep_rubygem = create(:rubygem)
+      @gem_one = create(:rubygem)
+      @gem_two = create(:rubygem)
+      @version_one  = create(:version, rubygem: @gem_one, number: '0.2')
+      @version_two  = create(:version, rubygem: @gem_two, number: '1.0')
+
+      @version_one.dependencies << create(:dependency,
+        :runtime,
+        version: @version_one,
+        rubygem: @dep_rubygem)
+      @version_two.dependencies << create(:dependency,
+        :development,
+        version: @version_two,
+        rubygem: @dep_rubygem)
+    end
+
+    should "return all runtime depended rubygems" do
+      gem_list = Rubygem.reverse_runtime_dependencies(@dep_rubygem.name)
+
+      assert_equal 1, gem_list.size
+
+      assert gem_list.include?(@gem_one)
+      assert !gem_list.include?(@gem_two)
+    end
+  end
+
+  context ".reverse_development_dependencies" do
+    setup do
+      @dep_rubygem = create(:rubygem)
+      @gem_one = create(:rubygem)
+      @gem_two = create(:rubygem)
+      @version_one  = create(:version, rubygem: @gem_one, number: '0.2')
+      @version_two  = create(:version, rubygem: @gem_two, number: '1.0')
+
+      @version_one.dependencies << create(:dependency,
+        :development,
+        version: @version_one,
+        rubygem: @dep_rubygem)
+      @version_two.dependencies << create(:dependency,
+        :runtime,
+        version: @version_two,
+        rubygem: @dep_rubygem)
+    end
+
+    should "return all development depended rubygems" do
+      gem_list = Rubygem.reverse_development_dependencies(@dep_rubygem.name)
+
+      assert_equal 1, gem_list.size
+
+      assert gem_list.include?(@gem_one)
+      assert !gem_list.include?(@gem_two)
+    end
+  end
+
   context "with a rubygem" do
     setup do
       @rubygem = build(:rubygem, linkset: nil)


### PR DESCRIPTION
I should have included those with #1099 since these methods may be
used elsewhere.

This depends on #1101 being merged first since I changed a few factories.