### PR TITLE
Reduce duplication in reverse deps methods

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -25,15 +25,13 @@ class Version < ActiveRecord::Base
   end
 
   def self.reverse_runtime_dependencies(name)
-    joins(dependencies: :rubygem)
+    reverse_dependencies(name)
       .merge(Dependency.runtime)
-      .where(rubygems: { name: name })
   end
 
   def self.reverse_development_dependencies(name)
-    joins(dependencies: :rubygem)
+    reverse_dependencies(name)
       .merge(Dependency.development)
-      .where(rubygems: { name: name })
   end
 
   def self.owned_by(user)


### PR DESCRIPTION
I don't know how I didn't see these were easily chainable in #1099. This only has a minor impact on the SQL query structure I believe.

Before:

```ruby
Version.reverse_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"rubygems\".\"name\" = 'rack'"

Version.reverse_runtime_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"dependencies\".\"scope\" = 'runtime' AND \"rubygems\".\"name\" = 'rack'"

Version.reverse_development_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"dependencies\".\"scope\" = 'development' AND \"rubygems\".\"name\" = 'rack'"
```

After:

```ruby
Version.reverse_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"rubygems\".\"name\" = 'rack'"

Version.reverse_runtime_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"rubygems\".\"name\" = 'rack' AND \"dependencies\".\"scope\" = 'runtime'"

Version.reverse_development_dependencies("rack").to_sql
=> "SELECT \"versions\".* FROM \"versions\" INNER JOIN \"dependencies\" ON \"dependencies\".\"version_id\" = \"versions\".\"id\" INNER JOIN \"rubygems\" ON \"rubygems\".\"id\" = \"dependencies\".\"rubygem_id\" WHERE \"rubygems\".\"name\" = 'rack' AND \"dependencies\".\"scope\" = 'development'"
```