### PR TITLE
Remove yanked versions from reverse_dependencies

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -21,6 +21,7 @@ class Version < ActiveRecord::Base
 
   def self.reverse_dependencies(name)
     joins(dependencies: :rubygem)
+      .indexed
       .where(rubygems: { name: name })
   end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -96,6 +96,10 @@ FactoryGirl.define do
     rubygem
     size 1024
     sha256 "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g="
+
+    trait :yanked do
+      indexed false
+    end
   end
 
   factory :version_history do

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -199,12 +199,14 @@ class RubygemTest < ActiveSupport::TestCase
       @gem_two = create(:rubygem)
       @gem_three = create(:rubygem)
       @gem_four = create(:rubygem)
+      @gem_five = create(:rubygem)
       @version_one_latest  = create(:version, rubygem: @gem_one, number: '0.2')
       @version_one_earlier = create(:version, rubygem: @gem_one, number: '0.1')
       @version_two_latest  = create(:version, rubygem: @gem_two, number: '1.0')
       @version_two_earlier = create(:version, rubygem: @gem_two, number: '0.5')
       @version_three = create(:version, rubygem: @gem_three, number: '1.7')
       @version_four = create(:version, rubygem: @gem_four, number: '3.9')
+      @version_five = create(:version, :yanked, rubygem: @gem_five, number: '6.66')
 
       @version_one_latest.dependencies << create(:dependency,
         version: @version_one_latest,
@@ -215,9 +217,12 @@ class RubygemTest < ActiveSupport::TestCase
       @version_three.dependencies << create(:dependency,
         version: @version_three,
         rubygem: @dep_rubygem)
+      @version_five.dependencies << create(:dependency,
+        version: @version_five,
+        rubygem: @dep_rubygem)
     end
 
-    should "return all depended rubygems" do
+    should "return all depended rubygems except yanked versions" do
       gem_list = Rubygem.reverse_dependencies(@dep_rubygem.name)
 
       assert_equal 3, gem_list.size
@@ -226,6 +231,7 @@ class RubygemTest < ActiveSupport::TestCase
       assert gem_list.include?(@gem_two)
       assert gem_list.include?(@gem_three)
       assert !gem_list.include?(@gem_four)
+      assert !gem_list.include?(@gem_five)
     end
   end
 


### PR DESCRIPTION
This is something I remember surprising me when reading @schneems' http://www.schneems.com/blogs/2015-09-30-reverse-rubygems/.

Why did he need to rescue while querying the API for gems depending on the gem he was searching for?

I got my answer when I tried to run reverse dependencies for rake and hundreds of exceptions popped up for gems that have been yanked altogether, I'm not sure why.

Skipping yanked versions will probably speed up this endpoint a bunch although it's hard for me to test at this point. I can just log for posterity that before this commit the following requests total response times were as follows:

- https://rubygems.org/api/v1/gems/rake/reverse_dependencies.json => 4.21 s (X-Runtime: 1.649987)
- https://rubygems.org/api/v1/gems/rails/reverse_dependencies.json => 2.82 s (X-Runtime: 0.522366)
- https://rubygems.org/api/v1/gems/bundler/reverse_dependencies.json => 3.89 s (X-Runtime: 1.636216)
- https://rubygems.org/api/v1/gems/rack/reverse_dependencies.json => 1.97 s (X-Runtime: 0.188214)

Please do let me know if I'm completely out of my depths here, since I don't know much more about version yanking as what I could gather from going through the `Version` and `Deletion` code. I still don't understand what causes a gem to be removed from the index entirely but I'm guessing that's when all its versions are yanked? /cc @qrush 