### PR TITLE
Use mask for pinned tabs in safari

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <link rel="apple-touch-icon" href="/touch-icon-iphone.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="/touch-icon-ipad.png" />
     <link rel="apple-touch-icon" sizes="114x114" href="/touch-icon-iphone4.png" />
+    <link rel="mask-icon" href="/rubygems_logo.svg" color="#e9573f">
     <link rel="fluid-icon" href="/fluid-icon.png"/>
     <link rel="search" type="application/opensearchdescription+xml" title="<%=t :title %>" href="/opensearch.xml">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">

--- a/public/rubygems_logo.svg
+++ b/public/rubygems_logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
+<g id="Logo">
+	<polygon fill="#010101" points="68.8,69.9 68.7,69.8 46.5,92 100.4,145.8 122.6,123.7 154.3,92 132.1,69.8 132.1,69.7 68.7,69.7 	
+		"/>
+	<path fill="#010101" d="M100.2,10.6l-78.5,45v90l78.5,45l78.5-45v-90L100.2,10.6z M163.7,137l-63.5,36.6L36.7,137V64l63.5-36.6
+		L163.7,64V137z"/>
+</g>
+</svg>


### PR DESCRIPTION
First contribution to rubygems.org :tada: 

Before:
<img width="262" alt="screen shot 2015-11-14 at 8 34 53 am" src="https://cloud.githubusercontent.com/assets/1209285/11164299/ba5362ee-8ab1-11e5-8386-1a8afb9468c9.png">

After:
<img width="262" alt="screen shot 2015-11-14 at 8 59 37 am" src="https://cloud.githubusercontent.com/assets/1209285/11164300/bd65236e-8ab1-11e5-95e5-b62b9dfc0526.png">

Inactive Side by Side:
<img width="297" alt="screen shot 2015-11-14 at 9 24 37 am" src="https://cloud.githubusercontent.com/assets/1209285/11164301/beeeddf6-8ab1-11e5-9efb-8cbc76bc200d.png">

I was just tired of seeing the "R"... thoughts?  I'm not a designer, so jump in and what not.