### PR TITLE
Add Minitest::Reporters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 
 group :test do
   gem 'minitest', require: false
+  gem 'minitest-reporters', require: false
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    ansi (1.5.0)
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -147,6 +148,11 @@ GEM
     mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.2)
+    minitest-reporters (1.1.5)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
@@ -305,6 +311,7 @@ DEPENDENCIES
   launchy
   mail
   minitest
+  minitest-reporters
   mocha
   multi_json
   newrelic-redis

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'capybara/rails'
 require 'clearance/test_unit'
 require 'shoulda'
 require 'helpers/gem_helpers'
+require 'minitest/reporters'
 
 RubygemFs.mock!
 
@@ -44,3 +45,5 @@ Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
 class SystemTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 end
+
+Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new


### PR DESCRIPTION
Just installing the [minitest-reporters](https://github.com/kern/minitest-reporters) gem in the `:test` environment for better green/red test visibility.