### PR TITLE
add user profile api endpoint for authenticated oauth clients

### DIFF
--- a/app/controllers/api/v1/doorkeeper/profiles_controller.rb
+++ b/app/controllers/api/v1/doorkeeper/profiles_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::Doorkeeper::ProfilesController < Api::BaseController
+  before_action :doorkeeper_authorize!
+
+  def show
+    profile_info = current_user.as_json
+    profile_info['email'] = current_user.email unless profile_info['email']
+
+    render json: profile_info
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,11 @@ Rails.application.routes.draw do
           post :fire
         end
       end
+
+      # Doorkeeper clients
+      scope module: :doorkeeper, constraints: { format: 'json' } do
+        resource :profile, only: :show
+      end
     end
   end
 

--- a/test/functional/api/v1/doorkeeper/profiles_controller_test.rb
+++ b/test/functional/api/v1/doorkeeper/profiles_controller_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class Api::V1::Doorkeeper::ProfilesControllerTest < ActionController::TestCase
+  setup do
+    @user = create(:user)
+    @oauth_token = create(:oauth_access_token, resource_owner_id: @user.id)
+    @request.headers["Authorization"] = "Bearer #{@oauth_token.token}"
+  end
+
+  def response_body
+    JSON.parse @response.body
+  end
+
+  context "with a valid oauth access token" do
+    context "on GET to show" do
+      setup do
+        get :show, format: :json
+      end
+
+      should respond_with :success
+      should "include user :id, :handle, :email and :api_key" do
+        assert response_body.key?('id')
+        assert_equal @user.id, response_body['id']
+        assert response_body.key?('handle')
+        assert_equal @user.handle, response_body['handle']
+        assert response_body.key?('email')
+        assert_equal @user.email, response_body['email']
+      end
+    end
+
+    context "on GET to show when hide email" do
+      setup do
+        @user.update(hide_email: true)
+        get :show, format: :json
+      end
+
+      should respond_with :success
+      should "include the user email" do
+        assert response_body.key?('email')
+        assert_equal @user.email, response_body['email']
+      end
+    end
+  end
+
+  context "with invalid oauth access token" do
+    context "on GET to show" do
+      setup do
+        @request.headers["Authorization"] = "Bearer invalid_access_token"
+        get :show, format: :json
+      end
+
+      should respond_with :unauthorized
+    end
+  end
+end


### PR DESCRIPTION
After a successfully user authentication through an oauth client (like the adoption center) it is necessary to have an endpoint from were the oauth client can get the user profile information (id, handle, email and api_key) by only having the oauth access token provided by rubygems.

Some annotations:
- the email should always be present.
- if the oauth access token is going to be enough to access all the protected parts of the rubygems.org api, then the api_key wouldn't be necessary