### PR TITLE
If there is an exact match when searching, prerender it.

### DIFF
--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -14,6 +14,9 @@
     <header class="gems__header">
       <p class="gems__meter"><%= t '.exact_match' %></p>
     </header>
+    <% content_for :head do %>
+      <link rel="prerender prefetch" href="<%= rubygem_url(@exact_match) %>">
+    <% end %>
     <%= render @exact_match %>
   <% end %>
 


### PR DESCRIPTION
This should make the search experience a little snappier.

This WILL increase load on the servers, because of course not every time we return an exact match will someone click on the first result. This may be a Bad Idea™ for a community-maintained project, but I'll leave that to @dwradcliffe (or other people running the rubygems.org infrastructure). Of course, we can always deploy and rollback.