### PR TITLE
Don't render announcement partial unless necessary

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,7 +97,7 @@
       </div>
     <% end %>
 
-    <%= render partial: "announcements/public_announcement" %>
+    <%= render partial: "announcements/public_announcement" if announcement_visible?(current_announcement) %>
 
     <% if content_for?(:fold) %>
       <div class="fold">


### PR DESCRIPTION
I lifted the guard clause here straight out of the paul_revere gem. 

Unfortunately partials are so slow just the render call and associated lookup costs 10ms locally for me :( 