### PR TITLE
Update outdated references to Gemcutter in English locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,7 @@ en:
         transparent_pages: Create more transparent and accessible project pages
         enable_community: Enable the community to improve and enhance the site
       founding: "The project was started in April 2009 by %{founder}, and has since grown to include the contributions of over %{contributors} and %{downloads}. As of the RubyGems 1.3.6 release, the site has been renamed to %{title} from Gemcutter to solidify the site's central role in the Ruby community."
-      support: "Although Gemcutter is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove Gemcutter as a viable solution that the whole community could rely on."
+      support: "Although RubyGems.org is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove RubyGems as a viable solution that the whole community could rely on."
       technical: "Some insights into the technical aspects of the site: It's 100% Ruby. The main site is a %{rails} application, and the RubyGem serving is done through %{sinatra}. Gems are hosted on %{s3}, and the time between publishing a new gem and having it ready for installation is minimal. For more info, %{source_code}, which is %{license} over at GitHub."
 
   passwords:
@@ -111,7 +111,7 @@ en:
     index:
       title: 'Gems'
     show:
-      not_hosted_notice: This gem is not currently hosted on Gemcutter.
+      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
       install: install
       yanked_notice: "This gem has been yanked, and it is not available for download directly or for other gems that may have depended on it."
       authors_header: Authors
@@ -153,7 +153,7 @@ en:
     index:
       title: "All versions of %{name}"
       versions_since: "%{count} versions since %{since}"
-      not_hosted_notice: This gem is not currently hosted on Gemcutter.
+      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
     version:
       yanked: "yanked"
 

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -373,7 +373,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :success
     should render_template :show
     should "render info about the gem" do
-      assert page.has_content?("This gem is not currently hosted on Gemcutter.")
+      assert page.has_content?("This gem is not currently hosted on RubyGems.org.")
     end
   end
 


### PR DESCRIPTION
There's only one reference left concerning the name change, otherwise I replaced every mention of 
"Gemcutter" with "RubyGems" (not RubyGems.org).

/cc @arthurnn