### PR TITLE
Extract a lot more I18n strings

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -38,11 +38,11 @@ module RubygemsHelper
               else
                 'display:inline-block'
               end
-      link_to 'Subscribe', rubygem_subscription_path(rubygem),
+      link_to t('.links.subscribe'), rubygem_subscription_path(rubygem),
         class: ['toggler', 'gem__link', 't-list__item'], id: 'subscribe',
         method: :post, remote: true, style: style
     else
-      link_to 'Subscribe', sign_in_path,
+      link_to t('.links.subscribe'), sign_in_path,
         class: [:toggler, 'gem__link', 't-list__item'], id: :subscribe
     end
   end
@@ -54,36 +54,36 @@ module RubygemsHelper
             else
               'display:none'
             end
-    link_to 'Unsubscribe', rubygem_subscription_path(rubygem),
+    link_to t('.links.unsubscribe'), rubygem_subscription_path(rubygem),
       class: [:toggler, 'gem__link', 't-list__item'], id: 'unsubscribe',
       method: :delete, remote: true, style: style
   end
 
   def atom_link(rubygem)
-    link_to 'RSS', rubygem_versions_path(rubygem, format: 'atom'),
+    link_to t(".links.rss"), rubygem_versions_path(rubygem, format: 'atom'),
       class: 'gem__link t-list__item', id: :rss
   end
 
   def download_link(version)
-    link_to "Download", "/downloads/#{version.full_name}.gem",
+    link_to t('.links.download'), "/downloads/#{version.full_name}.gem",
       class: 'gem__link t-list__item', id: :download
   end
 
   def documentation_link(version, linkset)
     return unless linkset.nil? || linkset.docs.blank?
-    link_to 'Documentation', version.documentation_path,
+    link_to t('.links.docs'), version.documentation_path,
       class: 'gem__link t-list__item', id: :docs
   end
 
   def badge_link(rubygem)
     badge_url = "https://badge.fury.io/rb/#{rubygem.name}/install"
-    link_to "Badge", badge_url, class: "gem__link t-list__item", id: :badge
+    link_to t(".links.badge"), badge_url, class: "gem__link t-list__item", id: :badge
   end
 
   def report_abuse_link(rubygem)
     encoded_title = URI.encode("Reporting Abuse on #{rubygem.name}")
     report_abuse_url = "http://help.rubygems.org/discussion/new?discussion[private]=1&discussion[title]=" + encoded_title # rubocop:disable Metrics/LineLength
-    link_to 'Report Abuse', report_abuse_url.html_safe, class: 'gem__link t-list__item'
+    link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: 'gem__link t-list__item'
   end
 
   def links_to_owners(rubygem)

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,9 +17,13 @@
       <% end %>
     </div>
     <div class="profile__downloads-wrap">
-      <h4 class="gem__downloads__heading t-text--s">Total Gems</h4>
+      <h4 class="gem__downloads__heading t-text--s">
+        <%= t('stats.index.total_gems') %>
+      </h4>
       <h2 id="profile-gems-count" class="gem__downloads"><%= @user.total_rubygems_count.to_s %></h2>
-      <h4 id="downloads" class="gem__downloads__heading t-text--s">Total Downloads</h4>
+      <h4 id="downloads" class="gem__downloads__heading t-text--s">
+        <%= t('stats.index.total_downloads') %>
+      </h4>
       <h2 id="downloads_count" class="gem__downloads"><%= number_with_delimiter(@user.total_downloads_count) %></h2>
     </div>
   </header>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -8,6 +8,8 @@
   </div>
   <p class="gems__gem__downloads__count">
     <%= download_count rubygem %>
-    <span class="gems__gem__downloads__heading">Downloads</span>
+    <span class="gems__gem__downloads__heading">
+      <%= t('rubygems.index.downloads') %>
+    </span>
   </p>
 <% end %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -76,7 +76,7 @@
           <% end %>
 
           <% if @latest_version.sha256.present? %>
-            <h3 class="t-list__heading">Sha 256 checksum:</h3>
+            <h3 class="t-list__heading"><%= t '.sha_256_checksum' %>:</h3>
             <div class="gem__sha">
               <%= @latest_version.sha256_hex %>
             </div>
@@ -89,7 +89,7 @@
       <% if @latest_version.indexed %>
         <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
           <h2 class="gem__downloads__heading t-text--s">
-            <%= t('stats.show.total_downloads') %>
+            <%= t('stats.index.total_downloads') %>
             <span class="gem__downloads"><%= number_with_delimiter(@rubygem.downloads) %></span>
           </h2>
           <h2 class="gem__downloads__heading t-text--s">
@@ -110,8 +110,8 @@
           <div class="gem__code-wrap">
             <input type="text" class="gem__code" value="<%= @latest_version.to_bundler %>" readonly="readonly">
             <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-text="<%= @latest_version.to_bundler %>">=</span>
-            <span class="gem__code__tooltip--copy">Copy to clipboard</span>
-            <span class="gem__code__tooltip--copied">Copied!</span>
+            <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
+            <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
           </div>
         </h2>
         <h2 class="gem__ruby-version__heading t-list__heading">
@@ -119,8 +119,8 @@
           <div class="gem__code-wrap">
             <input type="text" class="gem__code" value="<%= @latest_version.to_install %>" readonly="readonly">
             <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-text="<%= @latest_version.to_install %>">=</span>
-            <span class="gem__code__tooltip--copy">Copy to clipboard</span>
-            <span class="gem__code__tooltip--copied">Copied!</span>
+            <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
+            <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
           </div>
         </h2>
         <h2 class="gem__ruby-version__heading t-list__heading">
@@ -132,7 +132,7 @@
       <% end %>
 
       <h2 class="gem__ruby-version__heading t-list__heading">
-        Required Ruby Version:
+        <%= t('.required_ruby_version') %>:
         <i class="gem__ruby-version">
           <% if @latest_version.ruby_version %>
             <%= @latest_version.ruby_version %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -2,20 +2,22 @@
 
 <div class="stats">
   <h2 class="stat" data-icon="⟡">
-    Total Gems
+    <%= t('stats.index.total_gems') %>
     <span class="stat__count"><%= number_with_delimiter @number_of_gems %></span>
   </h2>
   <h2 class="stat" data-icon="☺">
-    Total Users
+    <%= t('stats.index.total_users') %>
     <span class="stat__count"><%= number_with_delimiter @number_of_users %></span>
   </h2>
   <h2 class="stat" data-icon="⌄">
-    Total Downloads
+    <%= t('stats.index.total_downloads') %>
     <span class="stat__count"><%= number_with_delimiter @number_of_downloads %></span>
   </h2>
 </div>
 
-<h2 class="stats__graph__heading">All Time Most Downloaded</h2>
+<h2 class="stats__graph__heading">
+  <%= t('stats.index.all_time_most_downloaded') %>
+</h2>
 
 <% @most_downloaded.each do |gem| %>
   <div class="stats__graph__gem">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,7 @@ en:
       other_fields_notice: All other fields can only be edited by pushing an updated version of your gem.
     index:
       title: 'Gems'
+      downloads: Downloads
     show:
       not_hosted_notice: This gem is not currently hosted on Gemcutter.
       install: install
@@ -125,12 +126,22 @@ en:
         wiki: Wiki
         mail: Mailing List
         bugs: Bug Tracker
+        download: Download
+        subscribe: Subscribe
+        unsubscribe: Unsubscribe
+        report_abuse: Report Abuse
+        badge: Badge
+        rss: RSS
       versions_header: Versions
       bundler_header: Gemfile
       show_all_versions: "Show all versions (%{count} total)"
       licenses_header: License
       no_licenses: N/A
       requirements_header: Requirements
+      sha_256_checksum: SHA 256 checksum
+      copy_to_clipboard: Copy to clipboard
+      copied: Copied!
+      required_ruby_version: Required Ruby Version
 
   searches:
     show:
@@ -142,8 +153,11 @@ en:
       forgot_password: "Forgot Password?"
 
   stats:
-    show:
-      total_downloads: "Total downloads"
+    index:
+      total_downloads: Total downloads
+      total_gems: Total gems
+      total_users: Total gems
+      all_time_most_downloaded: All Time Most Downloaded
 
   users:
     new:
@@ -173,3 +187,21 @@ en:
       session:
         who: Email or Handle
         password: Password
+
+  will_paginate:
+    previous_label: "Previous"
+    next_label: "Next"
+    page_gap: "…"
+    page_entries_info:
+      single_page:
+        zero:  "No %{model} found"
+        one:   "Displaying 1 %{model}"
+        other: "Displaying all %{count} %{model}"
+      single_page_html:
+        zero:  "No %{model} found"
+        one:   "Displaying <b>1</b> %{model}"
+        other: "Displaying <b>all&nbsp;%{count}</b> %{model}"
+
+      multi_page: "Displaying %{model} %{from} - %{to} of %{count} in total"
+      multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total"
+

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,6 +110,7 @@ fr:
       other_fields_notice: "Tous les autres champs ne sont modifiables qu'en soumettant une nouvelle version de votre gem."
     index:
       title: "Gems"
+      downloads: Téléchargements
     show:
       not_hosted_notice: "Gem non hébergé sur Rubygems pour le moment."
       install: "installation"
@@ -125,12 +126,22 @@ fr:
         wiki: "Wiki"
         mail: "Liste de diffusion"
         bugs: "Suivi de bugs"
+        download: "Télécharger"
+        subscribe: "Abonnement"
+        unsubscribe: "Désabonement"
+        report_abuse: Signaler un abus
+        badge: Badge
+        rss: RSS
       versions_header: "Versions"
       bundler_header: "Gemfile"
       show_all_versions: "Voir toutes les versions (%{count})"
       licenses_header: "Licence"
       no_licenses: "aucune"
       requirements_header: "Dépendances"
+      sha_256_checksum: Total de contrôle SHA 256
+      copy_to_clipboard: Copier
+      copied: Copié!
+      required_ruby_version: Version de Ruby requise
 
   searches:
     show:
@@ -142,8 +153,11 @@ fr:
       forgot_password: "Mot de passe oublié ?"
 
   stats:
-    show:
-      total_downloads: "Nombre de téléchargements"
+    index:
+      total_downloads: "Total de téléchargements"
+      total_gems: "Total de gems"
+      total_users: "Total d'utilisateurs"
+      all_time_most_downloaded: "Gems les plus téléchargés"
 
   users:
     new:
@@ -173,3 +187,21 @@ fr:
       session:
         who: "Email ou pseudonyme"
         password: "Mot de passe"
+
+  will_paginate:
+      previous_label: "Précédent"
+      next_label: "Suivant"
+      page_gap: "…"
+      page_entries_info:
+        single_page:
+          zero:  "Aucun %{model} trouvé"
+          one:   "1 %{model} affiché"
+          other: "Les %{count} %{model} affichés"
+        single_page_html:
+          zero:  "Aucun %{model} trouvé"
+          one:   "<b>1</b> %{model} affiché"
+          other: "Les <b>%{count}</b> %{model} affichés"
+
+        multi_page: "%{model} de %{from} à %{to} parmis %{count} au total"
+        multi_page_html: "%{model} de <b>%{from}</b> à <b>%{to}</b> parmis <b>%{count}</b> au total"
+

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -142,7 +142,7 @@ pt-BR:
       forgot_password: "Esqueceu sua Senha?"
 
   stats:
-    show:
+    index:
       total_downloads: "Total de downloads"
 
   users:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -144,7 +144,7 @@ zh-CN:
       forgot_password: "忘记了密码？"
 
   stats:
-    show:
+    index:
       total_downloads: "下载总次数"
 
   users:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -143,7 +143,7 @@ zh-TW:
       forgot_password: "忘記密碼？"
 
   stats:
-    show:
+    index:
       total_downloads: "總下載次數"
 
   users:

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -60,6 +60,7 @@ class RubygemsHelperTest < ActionView::TestCase
     version = build(:version)
     linkset = build(:linkset, docs: nil)
 
+    @virtual_path = "rubygems.show"
     link = documentation_link(version, linkset)
     assert link.include?(version.documentation_path)
   end
@@ -75,12 +76,16 @@ class RubygemsHelperTest < ActionView::TestCase
   should "link to the badge" do
     rubygem = create(:rubygem)
     url = "https://badge.fury.io/rb/#{rubygem.name}/install"
+
+    @virtual_path = "rubygems.show"
     assert_match url, badge_link(rubygem)
   end
 
   should "link to report abuse" do
     rubygem = create(:rubygem, name: 'my_gem')
     url = "http://help.rubygems.org/discussion/new?discussion[private]=1&discussion[title]=Reporting%20Abuse%20on%20my_gem" # rubocop:disable Metrics/LineLength
+
+    @virtual_path = "rubygems.show"
     assert_match url, report_abuse_link(rubygem)
   end
 


### PR DESCRIPTION
I've noticed while working on the French version that we were missing
a lot of interface strings, so I decided to look for obvious one to add
in order to make the newly available translated interfaces more
comprehensive.

I don't believe this is comprehensive but it improves the experience with 
a different locale quite a bit. It should also lower the translation percentages 
for locales other than English here but we should be able to improve this thanks 
to: https://www.localeapp.com/projects/8883

/cc @dwradcliffe @arthurnn 