### PR TITLE
N+1 on activities api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
   Max: 42 # TODO: Lower to 15
 
 Metrics/ClassLength:
-  Max: 300 # TODO: Lower to 100
+  Max: 350 # TODO: Lower to 100
   Exclude:
     - test/**/*.rb
 

--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,20 +1,24 @@
 class Api::V1::ActivitiesController < Api::BaseController
   def latest
-    @rubygems = Rubygem.latest(50)
-    render_rubygems
+    versions = Version.new_pushed_versions(50)
+    render_rubygems(versions)
   end
 
   def just_updated
-    @rubygems = Version.just_updated(50).map(&:rubygem)
-    render_rubygems
+    versions = Version.just_updated(50)
+    render_rubygems(versions)
   end
 
   private
 
-  def render_rubygems
+  def render_rubygems(versions)
+    rubygems = versions.includes(:dependencies, rubygem: :linkset).map do |version|
+      version.rubygem.payload(version)
+    end
+
     respond_to do |format|
-      format.json { render json: @rubygems }
-      format.yaml { render yaml: @rubygems }
+      format.json { render json: rubygems }
+      format.yaml { render yaml: rubygems }
     end
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -141,6 +141,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def payload(version = versions.most_recent, protocol = Gemcutter::PROTOCOL, host_with_port = Gemcutter::HOST)
+    deps = version.dependencies.to_a
     {
       'name'              => name,
       'downloads'         => downloads,
@@ -161,8 +162,8 @@ class Rubygem < ActiveRecord::Base
       'source_code_uri'   => linkset.try(:code),
       'bug_tracker_uri'   => linkset.try(:bugs),
       'dependencies'      => {
-        'development' => version.dependencies.development.to_a.reject { |r| r.rubygem.nil? },
-        'runtime'     => version.dependencies.runtime.to_a.reject { |r| r.rubygem.nil? }
+        'development' => deps.select { |r| r.rubygem && 'development' == r.scope },
+        'runtime'     => deps.select { |r| r.rubygem && 'runtime' == r.scope },
       }
     }
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -163,7 +163,7 @@ class Rubygem < ActiveRecord::Base
       'bug_tracker_uri'   => linkset.try(:bugs),
       'dependencies'      => {
         'development' => deps.select { |r| r.rubygem && 'development' == r.scope },
-        'runtime'     => deps.select { |r| r.rubygem && 'runtime' == r.scope },
+        'runtime'     => deps.select { |r| r.rubygem && 'runtime' == r.scope }
       }
     }
   end

--- a/test/functional/api/v1/activities_controller_test.rb
+++ b/test/functional/api/v1/activities_controller_test.rb
@@ -37,45 +37,44 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
     context "On GET to just_updated" do
       setup do
         rails = create(:rubygem, name: 'rails')
-        create(:version, rubygem: rails)
-        create(:version, rubygem: rails)
-        @rails_version = create(:version, rubygem: rails)
-
         sinatra = create(:rubygem, name: 'sinatra')
+        foo = create(:rubygem, name: 'foo')
+        bar = create(:rubygem, name: 'bar')
+
+        create(:version, rubygem: rails)
         create(:version, rubygem: sinatra)
         @sinatra_version = create(:version, rubygem: sinatra)
-
-        foo = create(:rubygem, name: 'foo')
         create(:version, rubygem: foo)
         @foo_version = create(:version, rubygem: foo)
-
+        @rails_version = create(:version, rubygem: rails)
         # wont show this, as it only has one version
-        bar = create(:rubygem, name: 'bar')
         create(:version, rubygem: bar)
       end
 
       should "return correct JSON for just_updated gems" do
         get :just_updated, format: :json
         gems = JSON.load @response.body
-        assert_equal 7, gems.length
-        assert_equal 'foo', gems[0]['name']
-        assert_equal @foo_version.number, gems[0]['version'], 'should have the latest version'
-        assert_equal 'sinatra', gems[2]['name']
-        assert_equal @sinatra_version.number, gems[2]['version'], 'should have the latest version'
-        assert_equal 'rails', gems[6]['name']
-        assert_equal @rails_version.number, gems[6]['version'], 'should have the latest version'
+
+        assert_equal 6, gems.length
+        assert_equal 'rails', gems[0]['name']
+        assert_equal @rails_version.number, gems[0]['version'], 'should have the latest version'
+        assert_equal 'foo', gems[1]['name']
+        assert_equal @foo_version.number, gems[1]['version'], 'should have the latest version'
+        assert_equal 'sinatra', gems[3]['name']
+        assert_equal @sinatra_version.number, gems[3]['version'], 'should have the latest version'
       end
 
       should "return correct YAML for just_updated gems" do
         get :just_updated, format: :yaml
         gems = YAML.load(@response.body)
-        assert_equal 7, gems.length
-        assert_equal 'foo', gems[0]['name']
-        assert_equal @foo_version.number, gems[0]['version'], 'should have the latest version'
-        assert_equal 'sinatra', gems[2]['name']
-        assert_equal @sinatra_version.number, gems[2]['version'], 'should have the latest version'
-        assert_equal 'rails', gems[6]['name']
-        assert_equal @rails_version.number, gems[6]['version'], 'should have the latest version'
+
+        assert_equal 6, gems.length
+        assert_equal 'rails', gems[0]['name']
+        assert_equal @rails_version.number, gems[0]['version'], 'should have the latest version'
+        assert_equal 'foo', gems[1]['name']
+        assert_equal @foo_version.number, gems[1]['version'], 'should have the latest version'
+        assert_equal 'sinatra', gems[3]['name']
+        assert_equal @sinatra_version.number, gems[3]['version'], 'should have the latest version'
       end
     end
   end


### PR DESCRIPTION
`latest` and `just_updated` endpoints need to load information from a few
other tables, which was causing some big N+1 queries on those endpoints.

Also, improve the query for `latest`, as that didnt have a limit on the
inner query, and eliminate the `latest` flag check, as we already check
if thats the only version for that rubygem.

before:
```
Started GET "/api/v1/activity/latest.json" for ::1 at 2015-11-30 14:45:23 -0500
Completed 200 OK in 4233ms (Views: 810.5ms | ActiveRecord: 3416.9ms | Elasticsearch: 0.0ms)
```

after:
```
Started GET "/api/v1/activity/latest.json" for ::1 at 2015-11-30 14:44:15 -0500
Completed 200 OK in 283ms (Views: 19.0ms | ActiveRecord: 15.8ms | Elasticsearch: 0.0ms)
```

review @dwradcliffe 