### PR TITLE
add revision endpoint

### DIFF
--- a/app/controllers/internal/ping_controller.rb
+++ b/app/controllers/internal/ping_controller.rb
@@ -6,4 +6,8 @@ class Internal::PingController < ApplicationController
       fail StandardError, 'Failed to write PING=1 to redis'
     render text: 'PONG'
   end
+
+  def revision
+    render text: AppRevision.version
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
 
   namespace :internal do
     get 'ping' => 'ping#index'
+    get 'revision' => 'ping#revision'
   end
 
   use_doorkeeper scope: 'oauth'

--- a/lib/app_revision.rb
+++ b/lib/app_revision.rb
@@ -1,0 +1,13 @@
+class AppRevision
+  def self.version
+    @version ||= begin
+      revision_file.read
+    rescue Errno::ENOENT
+      `git rev-parse HEAD`
+    end.strip
+  end
+
+  def self.revision_file
+    Rails.root.join('REVISION')
+  end
+end

--- a/test/functional/internal/ping_controller_test.rb
+++ b/test/functional/internal/ping_controller_test.rb
@@ -32,4 +32,34 @@ class Internal::PingControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context 'on GET to revision' do
+    setup do
+      @old_version = AppRevision.instance_variable_get(:@version)
+      AppRevision.instance_variable_set(:@version, nil)
+    end
+
+    teardown do
+      AppRevision.instance_variable_set(:@version, @old_version)
+    end
+
+    should 'return revision from git' do
+      f = mock
+      f.expects(:read).raises(Errno::ENOENT)
+      AppRevision.expects(:revision_file).returns(f)
+      AppRevision.expects("`".to_sym).with('git rev-parse HEAD').returns("SOMESHAFROMGIT\n")
+
+      get :revision
+      assert_response :ok
+      assert_equal 'SOMESHAFROMGIT', @response.body
+    end
+
+    should 'return revision from file' do
+      AppRevision.stubs(revision_file: stub(read: "SOMESHA\n"))
+
+      get :revision
+      assert_response :ok
+      assert_equal 'SOMESHA', @response.body
+    end
+  end
 end


### PR DESCRIPTION
This adds an endpoint so we can verify what revision is running.

r: @arthurnn @ktheory @sferik 