### PR TITLE
don't filter published versions by date

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -140,10 +140,7 @@ class Version < ActiveRecord::Base
   end
 
   def self.published(limit)
-    where("built_at <= ?", Time.zone.now)
-      .indexed
-      .by_built_at
-      .limit(limit)
+    indexed.by_built_at.limit(limit)
   end
 
   def self.find_from_slug!(rubygem_id, slug)

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -22,14 +22,15 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     context "with #{format.to_s.upcase}" do
       should "have a list of versions for the first gem" do
         get_show(@rubygem, format)
-        assert_equal 2, yield(@response.body).size
+        assert_equal 3, yield(@response.body).size
       end
 
       should "be ordered by position with prereleases" do
         get_show(@rubygem, format)
         arr = yield(@response.body)
-        assert_equal "2.0.0", arr.first["number"]
-        assert_equal "1.0.0.pre", arr.second["number"]
+        assert_equal "4.0.0", arr.first["number"]
+        assert_equal "2.0.0", arr.second["number"]
+        assert_equal "1.0.0.pre", arr.third["number"]
       end
 
       should "be ordered by position" do
@@ -53,6 +54,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
       create(:version, rubygem: @rubygem, number: '2.0.0')
       create(:version, rubygem: @rubygem, number: '1.0.0.pre', prerelease: true)
       create(:version, rubygem: @rubygem, number: '3.0.0', indexed: false)
+      create(:version, rubygem: @rubygem, number: '4.0.0', built_at: 2.days.from_now)
 
       @rubygem2 = create(:rubygem)
       create(:version, rubygem: @rubygem2, number: '3.0.0')

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -536,10 +536,10 @@ class VersionTest < ActiveSupport::TestCase
       @fake = create(:version, authors: %w(fake), indexed: false, built_at: 1.minute.ago)
     end
 
-    should "get the latest versions up to today" do
-      assert_equal [@haml, @rack, @thor, @json, @rake].map(&:authors),
+    should "get the latest versions" do
+      assert_equal [@dust, @haml, @rack, @thor, @json].map(&:authors),
         Version.published(5).map(&:authors)
-      assert_equal [@haml, @rack, @thor, @json, @rake, @thin].map(&:authors),
+      assert_equal [@dust, @haml, @rack, @thor, @json, @rake].map(&:authors),
         Version.published(6).map(&:authors)
     end
   end


### PR DESCRIPTION
Allows gem versions with built_at dates in the future to be returned by the API.

Fixes #1164 

review: @qrush @indirect @segiddins 