### PR TITLE
Free up ~30MB of process memory used by mime-types gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+# https://github.com/mime-types/ruby-mime-types/issues/94
+# This can be removed once all gems depend on > 3.0
+gem 'mime-types', '~> 2.6', require: 'mime/types/columnar'
+
 gem 'rails', '~> 4.2.5'
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ DEPENDENCIES
   jruby-openssl
   launchy
   mail
+  mime-types (~> 2.6)
   minitest
   mocha
   multi_json


### PR DESCRIPTION
Thanks to @schneems for the fix and for `derailed`, which provided the benchmark.

Memory usage at boot before:

```
TOP: 76.2617 MiB
```

After:

```
TOP: 46.5625 MiB
```