### PR TITLE
Fix typo in spanish locale of the home page

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -147,7 +147,7 @@ es:
   home:
     index:
       downloads_counting: descargas y contando
-      find_blurb: Encuentra, instala, y publíca RubyGems.
+      find_blurb: Encuentra, instala, y publica RubyGems.
       footer:
         status: Estado
         uptime:


### PR DESCRIPTION
There is a typo in the home page in Spanish: "publíca" doesn't exist. The correct word is "publica".