### PR TITLE
send S3 errors to honeybadger and fix response code

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -32,7 +32,8 @@ class Pusher
     @indexer.write_gem @body, @spec
   rescue StandardError => e
     @version.destroy
-    notify("There was a problem saving your gem: #{e}", 403)
+    Honeybadger.notify(e)
+    notify("There was a problem saving your gem. Please try again.", 500)
   else
     if update
       after_write


### PR DESCRIPTION
- We should report any s3 errors to honeybadger so that we know if something is broken.
- Also, we should not leak S3 errors back to the client.
- 500 seemed like a better error code for a S3 failure.

@evanphx @qrush @arthurnn 