### PR TITLE
Eliminate 3N+1 query on Rubygems#index

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -8,7 +8,7 @@ class RubygemsController < ApplicationController
     respond_to do |format|
       format.html do
         @letter = Rubygem.letterize(params[:letter])
-        @gems   = Rubygem.letter(@letter).by_downloads.paginate(page: @page)
+        @gems   = Rubygem.letter(@letter).includes(:versions).by_downloads.paginate(page: @page)
       end
       format.atom do
         @versions = Version.published(20)

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -102,6 +102,6 @@ module RubygemsHelper
   end
 
   def latest_version_number(rubygem)
-    rubygem.versions.most_recent.try(:number)
+    rubygem.most_recent_version.try(:number)
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -123,6 +123,19 @@ class Rubygem < ActiveRecord::Base
     ownerships.exists?(user_id: user.id)
   end
 
+  def most_recent_version
+    latest = versions.select(&:latest).sort_by(&:number)
+    latest_for_cruby = latest.select { |v| v.platform == "ruby" }
+
+    if latest_for_cruby.any?
+      latest_for_cruby.last
+    elsif latest.any?
+      latest.last
+    else
+      versions.last
+    end
+  end
+
   def to_s
     versions.most_recent.try(:to_title) || name
   end

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -4,7 +4,7 @@
       <%= rubygem.name %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
     </h2>
-    <p class="gems__gem__desc t-text"><%= short_info(rubygem.versions.most_recent) %></p>
+    <p class="gems__gem__desc t-text"><%= short_info(rubygem.most_recent_version) %></p>
   </div>
   <p class="gems__gem__downloads__count">
     <%= download_count rubygem %>

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -33,24 +33,32 @@ class RubygemTest < ActiveSupport::TestCase
       end
     end
 
-    should "reorder versions with platforms properly" do
-      version3_ruby  = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "ruby")
-      version3_mswin = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "mswin")
-      version2_ruby  = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "ruby")
-      version1_linux = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "linux")
+    context "with many versions" do
+      setup do
+        @version3_ruby  = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "ruby")
+        @version3_mswin = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "mswin")
+        @version2_ruby  = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "ruby")
+        @version1_linux = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "linux")
+      end
 
-      @rubygem.reorder_versions
+      should "reorder versions with platforms properly" do
+        @rubygem.reorder_versions
 
-      assert_equal 0, version3_ruby.reload.position
-      assert_equal 0, version3_mswin.reload.position
-      assert_equal 1, version2_ruby.reload.position
-      assert_equal 2, version1_linux.reload.position
+        assert_equal 0, @version3_ruby.reload.position
+        assert_equal 0, @version3_mswin.reload.position
+        assert_equal 1, @version2_ruby.reload.position
+        assert_equal 2, @version1_linux.reload.position
 
-      latest_versions = Version.latest
-      assert latest_versions.include?(version3_ruby)
-      assert latest_versions.include?(version3_mswin)
+        latest_versions = Version.latest
+        assert latest_versions.include?(@version3_ruby)
+        assert latest_versions.include?(@version3_mswin)
 
-      assert_equal version3_ruby, @rubygem.versions.most_recent
+        assert_equal @version3_ruby, @rubygem.versions.most_recent
+      end
+
+      should "return the correct value for most recent version" do
+        assert_equal @version3_ruby, @rubygem.most_recent_version
+      end
     end
 
     should "order latest platform gems with latest uniquely" do


### PR DESCRIPTION
Version#most_recent can trigger up to 3 SQL queries per Rubygem instance in a rendered collection.

Before:
![screen shot 2016-02-05 at 12 14 45 pm](https://cloud.githubusercontent.com/assets/845662/12853448/1a0fbc96-cc02-11e5-8945-45a48a14d438.png)

After:
![screen shot 2016-02-05 at 12 15 37 pm](https://cloud.githubusercontent.com/assets/845662/12853470/3692e320-cc02-11e5-946b-79c582173520.png)

This speeds up the Rubygems#index action for me by ~33% locally, and eliminates dozens of cached and uncached queries. 

Unfortunately, there is an N+1 situation anywhere Version#most_recent is used when iterating over a collection of Rubygems. This happens in a lot of places. I can fix those other places once this fix is approved.