### PR TITLE
Add Brewfile to centralize OS X environment dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,10 @@
+# Brewfile
+# https://robots.thoughtbot.com/brewfile-a-gemfile-but-for-homebrew
+#
+# Usage (assuming Homebrew installed):
+#   brew tap homebrew/bundle
+#   brew bundle
+
+brew "postgres"
+brew "redis"
+brew "elasticsearch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,14 @@ than Rubygems and may suit your organization’s needs better.**
 
 #### Environment (OS X)
 
+##### Short Version
 * Use Ruby 2.2.3
 * Use Rubygems 2.4.5
+* Install Homebrew: http://brew.sh/
+  * Install Brewfile support: `brew tap homebrew/bundle`
+  * Bundle Brewfile: `brew bundle`
+
+##### Long version
 * Install bundler: `gem install bundler`
 * Install Redis (>= 2.0): `brew install redis -H`
   * Setup information: `brew info redis`


### PR DESCRIPTION
Re-do of #1193 due to branch screw-up. 

This is an idea. It's not perfect but I'm working on a talk to show people how to setup RubyGems.org locally and I noticed that almost every single line of the OS X environment setup included a Homebrew installation instruction:

![image](https://cloud.githubusercontent.com/assets/65950/12988901/e1f58fc4-d0d0-11e5-8013-593d5700c7a6.png)

There are more details about Brewfile here: https://robots.thoughtbot.com/brewfile-a-gemfile-but-for-homebrew

It does require people to tap homebrew/bundle before they can run `brew bundle`:

```
brew tap homebrew/bundle
brew bundle
```

I updated the environment setup instruction accordingly:

![image](https://cloud.githubusercontent.com/assets/65950/12989011/4ffd1cee-d0d1-11e5-8bfb-66edda9846b9.png)

**Important note**: I don't know what `brew install redis -H` (the `-H` part) does specifically. This is the achilles heel of this PR since I don't think Brewfile can support it.