### PR TITLE
Remove unrecognized psql options from load-pg-dump

### DIFF
--- a/script/load-pg-dump
+++ b/script/load-pg-dump
@@ -85,13 +85,13 @@ echo "Creating database $pg_database"
 createdb -U $pg_user $pg_database
 
 echo "Adding hstore extension"
-psql -q -b -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+psql -q -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
 
 # Extract the single PostgresSQL.sql.gz file from the tar file, pass it through gunzip
 # and load it as quietly as possible into the database
 echo "Loading the data from $public_tar"
 tar xOf $public_tar public_postgresql/databases/PostgreSQL.sql.gz | \
   gunzip -c | \
-  psql --echo-errors --username $pg_user --dbname $pg_database
+  psql --username $pg_user --dbname $pg_database
 
 echo "Done."


### PR DESCRIPTION
These flags are not recognized as of psql 9.4.5. Not sure which
version they work with but they don't appear to be in 9.5.x either.

/cc @copiousfreetime

See my comments in https://github.com/rubygems/rubygems.org/commit/de646f1e4ed3b6259ce6cca1c9a04903355617d6#commitcomment-16043375 for details.