### PR TITLE
Replace MultiJson with stdlib

### DIFF
--- a/config/initializers/yaml_renderer.rb
+++ b/config/initializers/yaml_renderer.rb
@@ -1,4 +1,4 @@
 ActionController::Renderers.add :yaml do |obj, _|
-  data = MultiJson.load(obj.to_json).to_yaml
+  data = JSON.load(obj.to_json).to_yaml
   send_data data, type: 'text/yaml'
 end

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -41,8 +41,8 @@ task :brakeman do
     Brakeman.load_brakeman_dependency 'multi_json'
     require 'brakeman/report/initializers/multi_json'
     require 'brakeman/differ'
-    previous_results = JSON.load(File.read(previous_report), symbolize_keys: true)[:warnings]
-    new_results = JSON.load(tracker.report.to_json, symbolize_keys: true)[:warnings]
+    previous_results = JSON.load(File.read(previous_report))['warnings']
+    new_results = JSON.load(tracker.report.to_json)['warnings']
     STDERR.puts Brakeman::Differ.new(new_results, previous_results).diff
   end
   if report.all_warnings.any?

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -41,8 +41,8 @@ task :brakeman do
     Brakeman.load_brakeman_dependency 'multi_json'
     require 'brakeman/report/initializers/multi_json'
     require 'brakeman/differ'
-    previous_results = MultiJson.load(File.read(previous_report), symbolize_keys: true)[:warnings]
-    new_results = MultiJson.load(tracker.report.to_json, symbolize_keys: true)[:warnings]
+    previous_results = JSON.load(File.read(previous_report), symbolize_keys: true)[:warnings]
+    new_results = JSON.load(tracker.report.to_json, symbolize_keys: true)[:warnings]
     STDERR.puts Brakeman::Differ.new(new_results, previous_results).diff
   end
   if report.all_warnings.any?

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -70,7 +70,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
   context "on GET to show" do
     should_respond_to(:json) do |body|
-      MultiJson.load body
+      JSON.load body
     end
 
     should_respond_to(:yaml, :to_sym) do |body|

--- a/test/functional/api/v1/downloads_controller_test.rb
+++ b/test/functional/api/v1/downloads_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load(body)['total']
+      JSON.load(body)['total']
     end
 
     should_respond_to(:yaml) do |body|
@@ -70,7 +70,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load body
+      JSON.load body
     end
 
     should_respond_to(:yaml, :to_sym) do |body|
@@ -155,7 +155,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load(body)['gems']
+      JSON.load(body)['gems']
     end
 
     should_respond_to(:yaml) do |body|
@@ -185,7 +185,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load(body)['gems']
+      JSON.load(body)['gems']
     end
 
     should_respond_to(:yaml) do |body|

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -58,7 +58,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "On GET to show" do
       should_respond_to(:json) do |body|
-        MultiJson.load body
+        JSON.load body
       end
 
       should_respond_to(:yaml) do |body|
@@ -163,7 +163,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "On GET to index" do
       should_respond_to :json do |body|
-        MultiJson.load body
+        JSON.load body
       end
 
       should_respond_to :yaml do |body|
@@ -365,7 +365,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     should "return names of reverse dependencies" do
       get :reverse_dependencies, id: @dep_rubygem.to_param, format: "json"
-      gems = MultiJson.load(@response.body)
+      gems = JSON.load(@response.body)
 
       assert_equal 4, gems.size
 
@@ -382,7 +382,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           only: "development",
           format: "json"
 
-        gems = MultiJson.load(@response.body)
+        gems = JSON.load(@response.body)
 
         assert_equal 1, gems.size
 
@@ -397,7 +397,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           only: "runtime",
           format: "json"
 
-        gems = MultiJson.load(@response.body)
+        gems = JSON.load(@response.body)
 
         assert_equal 3, gems.size
 

--- a/test/functional/api/v1/versions/downloads_controller_test.rb
+++ b/test/functional/api/v1/versions/downloads_controller_test.rb
@@ -41,7 +41,7 @@ class Api::V1::Versions::DownloadsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load body
+      JSON.load body
     end
 
     should_respond_to(:yaml) do |body|
@@ -154,7 +154,7 @@ class Api::V1::Versions::DownloadsControllerTest < ActionController::TestCase
       end
 
       should_respond_to(:json) do |body|
-        MultiJson.load body
+        JSON.load body
       end
 
       should_respond_to(:yaml) do |body|

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -63,7 +63,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load(body)
+      JSON.load(body)
     end
 
     should_respond_to(:yaml) do |body|
@@ -155,7 +155,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "give all releases" do
       get_show(@rubygem)
-      assert_equal 12, MultiJson.load(@response.body).size
+      assert_equal 12, JSON.load(@response.body).size
     end
   end
 
@@ -169,7 +169,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return latest version" do
       get_latest @rubygem
-      assert_equal "3.0.0", MultiJson.load(@response.body)['version']
+      assert_equal "3.0.0", JSON.load(@response.body)['version']
     end
   end
 
@@ -197,7 +197,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return latest version" do
       get :latest, id: "blah", format: "json"
-      assert_equal "unknown", MultiJson.load(@response.body)['version']
+      assert_equal "unknown", JSON.load(@response.body)['version']
     end
   end
 
@@ -209,7 +209,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return latest version" do
       get :latest, id: @rubygem.name, format: "json"
-      assert_equal "unknown", MultiJson.load(@response.body)['version']
+      assert_equal "unknown", JSON.load(@response.body)['version']
     end
   end
 
@@ -222,7 +222,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return most recent version" do
       get :latest, id: @rubygem.name, format: "json"
-      assert_equal "2.0.0", MultiJson.load(@response.body)['version']
+      assert_equal "2.0.0", JSON.load(@response.body)['version']
     end
   end
 
@@ -234,7 +234,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return license info" do
       get :show, id: @rubygem.name, format: "json"
-      assert_equal "MIT", MultiJson.load(@response.body).first['licenses']
+      assert_equal "MIT", JSON.load(@response.body).first['licenses']
     end
   end
 
@@ -278,7 +278,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
     should "return names of reverse dependencies" do
       get_reverse_dependencies(@dep_rubygem, format: "json")
-      ret_versions = MultiJson.load(@response.body)
+      ret_versions = JSON.load(@response.body)
 
       assert_equal 3, ret_versions.size
 

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -133,7 +133,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         end
 
         should_respond_to(:json) do |body|
-          MultiJson.load(body)
+          JSON.load(body)
         end
 
         should_respond_to(:yaml) do |body|

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -34,7 +34,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
     end
 
     should_respond_to(:json) do |body|
-      MultiJson.load(body)
+      JSON.load(body)
     end
 
     should_respond_to(:yaml) do |body|
@@ -126,8 +126,8 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
 
     should "gives one specific version" do
       get_show(@rubygem, '4.0.0')
-      assert_kind_of Hash, MultiJson.load(@response.body)
-      assert_equal "4.0.0", MultiJson.load(@response.body)["number"]
+      assert_kind_of Hash, JSON.load(@response.body)
+      assert_equal "4.0.0", JSON.load(@response.body)["number"]
     end
 
     context "expected attributes by compact index" do
@@ -141,7 +141,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       @rubygem = create(:rubygem)
       create(:version, rubygem: @rubygem, number: "2.0.0")
       get_show(@rubygem, '2.0.0')
-      @response = MultiJson.load(@response.body)
+      @response = JSON.load(@response.body)
     end
 
     should("have sha") { assert @response["sha"] }

--- a/test/integration/compact_index.rb
+++ b/test/integration/compact_index.rb
@@ -13,14 +13,14 @@ class CompactIndex < ActionDispatch::IntegrationTest
   test "return gem version" do
     request_endpoint(@rubygem, '2.0.0')
     assert_response :success
-    json_response = MultiJson.load(@response.body)
+    json_response = JSON.load(@response.body)
     assert_kind_of Hash, json_response
     assert_equal '2.0.0', json_response["number"]
   end
 
   test "has required fields" do
     request_endpoint(@rubygem, '2.0.0')
-    json_response = MultiJson.load(@response.body)
+    json_response = JSON.load(@response.body)
     json_response["sha"]
     json_response["platform"]
     json_response["ruby_version"]

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -16,7 +16,7 @@ class DependencyTest < ActiveSupport::TestCase
 
     should "return JSON" do
       @dependency.save
-      json = MultiJson.load(@dependency.to_json)
+      json = JSON.load(@dependency.to_json)
 
       assert_equal %w(name requirements), json.keys.sort
       assert_equal @dependency.rubygem.name, json["name"]

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -122,7 +122,7 @@ class PusherTest < ActiveSupport::TestCase
 
       _, payload = post_data
 
-      params = MultiJson.load payload
+      params = JSON.load payload
 
       assert_equal "test",  params["name"]
       assert_equal "0.0.0", params["version"]

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -396,7 +396,7 @@ class RubygemTest < ActiveSupport::TestCase
       run_dep = create(:dependency, :runtime, version: version)
       dev_dep = create(:dependency, :development, version: version)
 
-      hash = MultiJson.load(@rubygem.to_json)
+      hash = JSON.load(@rubygem.to_json)
 
       assert_equal @rubygem.name, hash["name"]
       assert_equal @rubygem.downloads, hash["downloads"]
@@ -411,8 +411,8 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}/gems/"\
         "#{@rubygem.versions.most_recent.full_name}.gem", hash["gem_uri"]
 
-      assert_equal MultiJson.load(dev_dep.to_json), hash["dependencies"]["development"].first
-      assert_equal MultiJson.load(run_dep.to_json), hash["dependencies"]["runtime"].first
+      assert_equal JSON.load(dev_dep.to_json), hash["dependencies"]["development"].first
+      assert_equal JSON.load(run_dep.to_json), hash["dependencies"]["runtime"].first
     end
 
     should "return a bunch of xml" do
@@ -456,7 +456,7 @@ class RubygemTest < ActiveSupport::TestCase
       end
 
       should "return a bunch of JSON" do
-        hash = MultiJson.load(@rubygem.to_json)
+        hash = JSON.load(@rubygem.to_json)
 
         assert_equal @rubygem.linkset.home, hash["homepage_uri"]
         assert_equal @rubygem.linkset.wiki, hash["wiki_uri"]

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -71,7 +71,7 @@ class WebHookTest < ActiveSupport::TestCase
         {
           'url'           => @url,
           'failure_count' => @webhook.failure_count
-        }, MultiJson.load(@webhook.to_json))
+        }, JSON.load(@webhook.to_json))
     end
 
     should "show limited attributes for to_xml" do
@@ -141,7 +141,7 @@ class WebHookTest < ActiveSupport::TestCase
     end
 
     should "have gem properties encoded in JSON" do
-      payload = MultiJson.load(@job.payload)
+      payload = JSON.load(@job.payload)
       assert_equal "foogem",    payload['name']
       assert_equal "3.2.1",     payload['version']
       assert_equal 'ruby',      payload['platform']
@@ -156,7 +156,7 @@ class WebHookTest < ActiveSupport::TestCase
       new_version = create(:version, number: "2.0.0", rubygem: @rubygem)
       new_hook    = create(:web_hook)
       job         = Notifier.new(new_hook.url, 'http', 'localhost:1234', @rubygem, new_version)
-      payload     = MultiJson.load(job.payload)
+      payload     = JSON.load(job.payload)
 
       assert_equal "foogem", payload['name']
       assert_equal "2.0.0",  payload['version']


### PR DESCRIPTION
multijson is not even a first class dependency in our gemfile,
Right now we can use it, because the ES gems have it as dependency, however I
think we should replace it with standard lib

@sferik @dwradcliffe @qrush thoughts?