### PR TITLE
Restart shoryuken processes on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,9 +25,7 @@ namespace :deploy do
     on roles(:app) do
       execute :sudo, 'service unicorn restart'
       execute :sudo, 'sv -w 30 restart delayed_job'
-      # Running shoryuken is currently disabled
-      # TODO: enable this after deploying the Chef config to provision the shoryuken sv conf
-      # execute :sudo, 'sv -w 30 restart shoryuken'
+      execute :sudo, 'sv -w 30 restart shoryuken'
     end
   end
   after :publishing, :'deploy:restart'


### PR DESCRIPTION
This runs the `shoryuken` process added in #1176.

FYI @dwradcliffe 

## Prerequisites
- [x] Deploy rubygems/rubygems-infrastructure#38 to provision runit config
