### PR TITLE
Add version navigation links

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -162,6 +162,14 @@ class Version < ActiveRecord::Base
 
   delegate :reorder_versions, to: :rubygem
 
+  def previous
+    rubygem.versions.find_by(position: position + 1)
+  end
+
+  def next
+    rubygem.versions.find_by(position: position - 1)
+  end
+
   def push
     Redis.current.lpush(Rubygem.versions_key(rubygem.name), full_name)
   end

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,0 +1,6 @@
+<% if latest_version.previous.present? %>
+  <%= link_to "Previous version", rubygem_version_path(rubygem, latest_version.previous.number) %>
+<% end %>
+<% if latest_version.next.present? %>
+  <%= link_to "Next version", rubygem_version_path(rubygem, latest_version.next.number) %>
+<% end %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -10,6 +10,8 @@
   <% end %>
 <% end %>
 
+<%= render partial: "rubygems/version_navigation", locals: { rubygem: @rubygem, latest_version: @latest_version } %>
+
 <% if @rubygem.versions.count.zero? %>
   <div class="t-body">
     <p><%= t '.not_hosted_notice' %></p>


### PR DESCRIPTION
This is a really basic feature I find myself needing often when looking for
runtime dependency changes in a gem.

![Demo](https://s3.amazonaws.com/f.cl.ly/items/030o0t280F2p3N3T403b/Screen%20Recording%202016-02-19%20at%2012.03%20PM.gif?v=7fc83002)

It adds two simple methods `Version#previous` and `Versions#next` which just use
`self.position - 1` and `self.position + 1`. If adding the links to the UI seems
unnecessary we could even hook up keyboard shortcuts to make this a power-user
feature only but I'll admit I prefer discoverable features.

If this feature makes sense, let me know and I'll add tests. :-)

The demo doesn't show the dependencies below but that's mostly the advantage