### PR TITLE
Updates Spanish translation for "Source code"

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -268,7 +268,7 @@ es:
       links:
         header: Enlaces
         home: Sitio
-        code: Código de fuente
+        code: Código fuente
         docs: Documentación
         wiki: Wiki
         mail: Lista de correo


### PR DESCRIPTION
The previous sentence (Código de fuente) didn't make any sense.