### PR TITLE
SqsWorker: Unescape S3 object key names.

### DIFF
--- a/lib/shoryuken/sqs_worker.rb
+++ b/lib/shoryuken/sqs_worker.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 class SqsWorker
   include Shoryuken::Worker
 
@@ -7,7 +8,7 @@ class SqsWorker
     s3_objects = body['Records'].map do |record|
       [
         record['s3']['bucket']['name'],
-        record['s3']['object']['key']
+        CGI.unescape(record['s3']['object']['key'])
       ]
     end
 


### PR DESCRIPTION
This fixes a bug with improperly encoded S3 paths for fastly logs.

Per [these S3 docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html)

:wave: @dwradcliffe & @arthurnn 