### PR TITLE
Fastly log processing: use an env var feature flag

### DIFF
--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -12,7 +12,8 @@ class FastlyLogProcessor
   def perform
     counts = download_counts
 
-    unless Gemcutter::ENABLE_FASTLY_LOG_PROCESSOR
+    # Temporary feature flag while we roll out fastly log processing
+    if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] != 'true'
       # Just log & exit w/out updating stats
       Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
       return

--- a/config/initializers/download_processor.rb
+++ b/config/initializers/download_processor.rb
@@ -1,4 +1,0 @@
-module Gemcutter
-  # Feature flag for counting downloads through stats-update or FastlyLogProcessor
-  ENABLE_FASTLY_LOG_PROCESSOR = Rails.env.test? || Rails.env.development?
-end

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class FastlyLogProcessorTest < ActiveSupport::TestCase
   setup do
+    # Enable fastly log processing
+    @orig_fastly_log_processor_enabled = ENV['FASTLY_LOG_PROCESSOR_ENABLED']
+    ENV['FASTLY_LOG_PROCESSOR_ENABLED'] = 'true'
+
     @sample_log = Rails.root.join('test/sample_logs/fastly-fake.log').read
 
     @sample_log_counts = {
@@ -21,6 +25,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
   teardown do
     # Remove stubbed response
     Aws.config.delete(:s3)
+    ENV['FASTLY_LOG_PROCESSOR_ENABLED'] = @orig_fastly_log_processor_enabled
   end
 
   context "#s3_body" do


### PR DESCRIPTION
:wave: @dwradcliffe 

This lets us control the rollout of Fastly log processing with env vars in chef.