### PR TITLE
Use Postgresql to push/pop log files to be processed.

### DIFF
--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -13,7 +13,7 @@ class FastlyLogProcessor
   def perform
     StatsD.increment('fastly_log_processor.processed')
 
-    log_ticket = LogTicket.pop(key, bucket)
+    log_ticket = LogTicket.pop(key: key, directory: bucket)
     if log_ticket.nil?
       StatsD.increment('fastly_log_processor.extra')
       return

--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -11,28 +11,26 @@ class FastlyLogProcessor
   end
 
   def perform
-    counts = download_counts
+    StatsD.increment('fastly_log_processor.processed')
+
+    log_ticket = LogTicket.pop(key, bucket)
+    if log_ticket.nil?
+      StatsD.increment('fastly_log_processor.extra')
+      return
+    end
+
+    counts = download_counts(log_ticket)
 
     # Temporary feature flag while we roll out fastly log processing
     if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] != 'true'
       # Just log & exit w/out updating stats
       Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
-      StatsD.increment('fastly_log_processor.processed')
+      StatsD.increment('fastly_log_processor.disabled')
       return
     end
 
-    # Check if this log has already been processed by another job
-    unless Redis.current.setnx(redis_key, 'processing')
-      raise FastlyLogProcessor::AlreadyProcessedError, "Already processed bucket: #{bucket} key: #{key}"
-    end
-
-    # Set a short expiry while updating
-    Redis.current.expire(redis_key, 2.minutes)
-
     Download.bulk_update(munge_for_bulk_update(counts))
-
-    Redis.current.set(redis_key, 'processed')
-    Redis.current.expire(redis_key, 30.days)
+    log_ticket.update(status: "processed")
   end
 
   # Takes an enumerator of log lines and returns a hash of download counts
@@ -41,7 +39,9 @@ class FastlyLogProcessor
   #     'rails-4.0.0' => 25,
   #     'rails-4.2.0' => 50
   #   }
-  def download_counts(enumerator = log_lines)
+  def download_counts(log_ticket)
+    enumerator = log_ticket.filesystem.get(key).each_line
+
     enumerator.each_with_object(Hash.new(0)) do |log_line, accum|
       path, response_code = log_line.split[10, 2]
       # Only count successful downloads
@@ -66,20 +66,5 @@ class FastlyLogProcessor
       # Skip downloads that don't have a version in redis
       name ? [name, path, count] : nil
     end.compact
-  end
-
-  def log_lines
-    s3_body.each_line
-  end
-
-  def s3_body
-    # TODO: Are rubygems' fastly logs gzipped?
-    io = Aws::S3::Object.new(bucket_name: bucket, key: key).get.body
-    io = Zlib::GzipReader.wrap(io) if key.end_with?('.gz')
-    io
-  end
-
-  def redis_key
-    "fastly-log:#{bucket}:#{key}"
   end
 end

--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -23,12 +23,13 @@ class FastlyLogProcessor
 
     # TODO: wrap this in a transation when download update is in the DB
 
+    Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
     # Temporary feature flag while we roll out fastly log processing
     if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] == 'true'
-      Download.bulk_update(munge_for_bulk_update(counts))
+      updates = munge_for_bulk_update(counts)
+      Download.bulk_update(updates)
     else
       # Just log & exit w/out updating stats
-      Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
       StatsD.increment('fastly_log_processor.disabled')
     end
     log_ticket.update(status: "processed")

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -15,11 +15,7 @@ class LogTicket < ActiveRecord::Base
   def filesystem
     @fs ||=
       if s3?
-        RubygemFs::S3.new(access_key_id: ENV['S3_KEY'],
-                          secret_access_key: ENV['S3_SECRET'],
-                          region: Gemcutter.config['s3_region'],
-                          endpoint: "https://#{Gemcutter.config['s3_endpoint']}",
-                          bucket: directory)
+        RubygemFs::S3.new(bucket: directory)
       else
         RubygemFs::Local.new(directory)
       end

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -1,5 +1,5 @@
 class LogTicket < ActiveRecord::Base
-  enum backend: [ :s3, :local ]
+  enum backend: [:s3, :local]
 
   scope :latest_pending, -> { limit(1).lock(true).select("id").where(status: "pending") }
 

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -1,0 +1,27 @@
+class LogTicket < ActiveRecord::Base
+  enum backend: [ :s3, :local ]
+
+  scope :latest_pending, -> { limit(1).lock(true).select("id").where(status: "pending") }
+
+  def self.pop(key = nil, directory = nil)
+    scope = latest_pending
+    scope = scope.where(key: key) if key
+    scope = scope.where(directory: directory) if directory
+    sql = scope.to_sql
+
+    find_by_sql(["UPDATE #{quoted_table_name} SET status = ? WHERE id IN (#{sql}) RETURNING *", 'processing']).first
+  end
+
+  def filesystem
+    @fs ||=
+      if s3?
+        RubygemFs::S3.new(access_key_id: ENV['S3_KEY'],
+                          secret_access_key: ENV['S3_SECRET'],
+                          region: Gemcutter.config['s3_region'],
+                          endpoint: "https://#{Gemcutter.config['s3_endpoint']}",
+                          bucket: directory)
+      else
+        RubygemFs::Local.new(directory)
+      end
+  end
+end

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -3,7 +3,7 @@ class LogTicket < ActiveRecord::Base
 
   scope :pending, -> { limit(1).lock(true).select("id").where(status: "pending").order("id ASC") }
 
-  def self.pop(key = nil, directory = nil)
+  def self.pop(key: nil, directory: nil)
     scope = pending
     scope = scope.where(key: key) if key
     scope = scope.where(directory: directory) if directory

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -1,10 +1,10 @@
 class LogTicket < ActiveRecord::Base
   enum backend: [:s3, :local]
 
-  scope :latest_pending, -> { limit(1).lock(true).select("id").where(status: "pending") }
+  scope :pending, -> { limit(1).lock(true).select("id").where(status: "pending").order("id ASC") }
 
   def self.pop(key = nil, directory = nil)
-    scope = latest_pending
+    scope = pending
     scope = scope.where(key: key) if key
     scope = scope.where(directory: directory) if directory
     sql = scope.to_sql

--- a/db/migrate/20160227194735_create_log_tickets.rb
+++ b/db/migrate/20160227194735_create_log_tickets.rb
@@ -1,0 +1,14 @@
+class CreateLogTickets < ActiveRecord::Migration
+  def change
+    create_table :log_tickets do |t|
+      t.string :key
+      t.string :directory
+      t.integer :backend, default: 0
+      t.string :status
+
+      t.timestamps null: false
+    end
+
+    add_index :log_tickets, [:directory, :key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150709170542) do
+ActiveRecord::Schema.define(version: 20160227194735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,17 @@ ActiveRecord::Schema.define(version: 20150709170542) do
   end
 
   add_index "linksets", ["rubygem_id"], name: "index_linksets_on_rubygem_id", using: :btree
+
+  create_table "log_tickets", force: :cascade do |t|
+    t.string   "key"
+    t.string   "directory"
+    t.integer  "backend",    default: 0
+    t.string   "status"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
+  add_index "log_tickets", ["directory", "key"], name: "index_log_tickets_on_directory_and_key", unique: true, using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false

--- a/lib/rubygem_fs.rb
+++ b/lib/rubygem_fs.rb
@@ -31,6 +31,10 @@ module RubygemFs
   end
 
   class Local
+    def initialize(base_dir = nil)
+      @base_dir = base_dir
+    end
+
     def store(key, body, _metadata = {})
       FileUtils.mkdir_p File.dirname("#{base_dir}/#{key}")
       File.open("#{base_dir}/#{key}", 'wb') do |f|
@@ -51,12 +55,13 @@ module RubygemFs
     end
 
     def base_dir
-      Rails.root.join('server')
+      @base_dir || Rails.root.join('server')
     end
   end
 
   class S3
     def initialize(config)
+      @bucket = config.delete(:bucket)
       @config = config
     end
 
@@ -84,7 +89,7 @@ module RubygemFs
     private
 
     def bucket
-      Gemcutter.config['s3_bucket']
+      @bucket || Gemcutter.config['s3_bucket']
     end
 
     def s3

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -15,6 +15,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
       "json-1.8.2" => 4,
       "no-such-gem-1.2.3" => 1
     }
+    @log_ticket = LogTicket.create!(backend: 's3', directory: 'test-bucket', key: 'fastly-fake.log', status: "pending")
 
     Aws.config[:s3] = {
       stub_responses: { get_object: { body: @sample_log } }
@@ -28,25 +29,9 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
     ENV['FASTLY_LOG_PROCESSOR_ENABLED'] = @orig_fastly_log_processor_enabled
   end
 
-  context "#s3_body" do
-    should "return a readable object " do
-      assert @job.s3_body.respond_to?(:read)
-    end
-  end
-
-  context "#log_lines" do
-    should "return an enumerator" do
-      assert_kind_of Enumerator, @job.log_lines
-    end
-
-    should "have values" do
-      assert @job.log_lines.first
-    end
-  end
-
   context "#download_counts" do
     should "be correct" do
-      assert_equal @sample_log_counts, @job.download_counts
+      assert_equal @sample_log_counts, @job.download_counts(@log_ticket)
     end
   end
 
@@ -79,25 +64,19 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
     context '#perform' do
       should "update download counts" do
         @job.perform
-
         @sample_log_counts
           .reject { |k, _| k == "no-such-gem-1.2.3" }
           .each do |name, expected_count|
-          assert_equal expected_count, Version.find_by_full_name(name).downloads_count
+          assert_equal expected_count, Version.find_by_full_name(name).downloads_count, "invalid value for #{name}"
         end
 
         assert_equal 7, Rubygem.find_by_name('json').downloads
-      end
-
-      should 'set the redis key' do
-        @job.perform
-        assert_equal 'processed', Redis.current.get(@job.redis_key)
-        assert_in_delta Redis.current.ttl(@job.redis_key), 30.days, 10
+        assert_equal "processed", @log_ticket.reload.status
       end
 
       should "fail if already run" do
-        Redis.current.set(@job.redis_key, 'processed')
-        assert_raises(FastlyLogProcessor::AlreadyProcessedError) { @job.perform }
+        @log_ticket.update(status: 'processed')
+        @job.perform
       end
     end
   end

--- a/test/unit/log_ticket_test.rb
+++ b/test/unit/log_ticket_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class LogTicketTest < ActiveSupport::TestCase
+
+  setup do
+    @log_ticket = LogTicket.create!(directory: "test", key: "foo", status: "pending")
+  end
+
+  should "not allow duplicate directory and key" do
+    assert_raise ActiveRecord::RecordNotUnique do
+      LogTicket.create!(directory: "test", key: "foo")
+    end
+  end
+
+  should "allow different keys for the same directory" do
+    LogTicket.create!(directory: "test", key: "bar")
+    LogTicket.create!(directory: "test", key: "baz")
+  end
+
+  context "#pop" do
+    setup do
+      LogTicket.create!(directory: "test/2", key: "bar", status: "pending")
+    end
+
+    context "without any key" do
+      should "pop the first inputed" do
+        ticket = LogTicket.pop
+        assert_equal "foo", ticket.key
+      end
+    end
+
+    context "with a key" do
+      should "pop the key" do
+        ticket = LogTicket.pop(key: "bar")
+        assert_equal "bar", ticket.key
+      end
+    end
+
+    context "with a directory" do
+      should "pop the first entry" do
+        LogTicket.create!(directory: "test/2", key: "boo", status: "pending")
+
+        ticket = LogTicket.pop(directory: "test/2")
+        assert_equal "bar", ticket.key
+      end
+    end
+
+    should "change the status" do
+      ticket = LogTicket.pop
+      assert_equal "processing", ticket.status
+    end
+
+    should "return nil after no more items are in the queue" do
+      2.times { LogTicket.pop }
+      assert_nil LogTicket.pop
+    end
+  end
+
+  context "filesystem" do
+
+    context "local" do
+      setup do
+        @log_ticket.update!(backend: "local")
+      end
+
+      should "return a local fs" do
+        assert_kind_of RubygemFs::Local, @log_ticket.filesystem
+      end
+
+      should "set the right base directory" do
+        assert_equal "test", @log_ticket.filesystem.send(:base_dir)
+      end
+    end
+
+    context "s3" do
+      setup do
+        @log_ticket.update!(backend: "s3")
+      end
+
+      should "return a s3 fs" do
+        assert_kind_of RubygemFs::S3, @log_ticket.filesystem
+      end
+
+      should "set the right bucket" do
+        assert_equal "test", @log_ticket.filesystem.send(:bucket)
+      end
+    end
+  end
+end

--- a/test/unit/log_ticket_test.rb
+++ b/test/unit/log_ticket_test.rb
@@ -66,7 +66,7 @@ class LogTicketTest < ActiveSupport::TestCase
       end
 
       should "set the right base directory" do
-        assert_equal "test", @log_ticket.filesystem.send(:base_dir)
+        assert_equal "test", @log_ticket.filesystem.base_dir
       end
     end
 
@@ -80,7 +80,7 @@ class LogTicketTest < ActiveSupport::TestCase
       end
 
       should "set the right bucket" do
-        assert_equal "test", @log_ticket.filesystem.send(:bucket)
+        assert_equal "test", @log_ticket.filesystem.bucket
       end
     end
   end

--- a/test/unit/log_ticket_test.rb
+++ b/test/unit/log_ticket_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class LogTicketTest < ActiveSupport::TestCase
-
   setup do
     @log_ticket = LogTicket.create!(directory: "test", key: "foo", status: "pending")
   end
@@ -57,7 +56,6 @@ class LogTicketTest < ActiveSupport::TestCase
   end
 
   context "filesystem" do
-
     context "local" do
       setup do
         @log_ticket.update!(backend: "local")

--- a/test/unit/rubygem_fs_test.rb
+++ b/test/unit/rubygem_fs_test.rb
@@ -1,12 +1,29 @@
 require 'test_helper'
 
 class RubygemFsTest < ActiveSupport::TestCase
+  context "s3 filesystem" do
+    should "use default bucket when not passing as an argument" do
+      fs = RubygemFs::S3.new
+      assert_equal "test.s3.rubygems.org", fs.bucket
+    end
+
+    should "use bucket passed" do
+      fs = RubygemFs::S3.new(bucket: "foo.com")
+      assert_equal "foo.com", fs.bucket
+    end
+
+    should "use a custom config when passed" do
+      fs = RubygemFs::S3.new(access_key_id: 'foo', secret_access_key: 'bar')
+      def fs.s3
+        [@config[:access_key_id], @config[:secret_access_key]]
+      end
+      assert_equal ['foo', 'bar'], fs.s3
+    end
+  end
+
   context "local filesystem" do
     setup do
-      @fs = RubygemFs::Local.new
-      def @fs.base_dir
-        @dir ||= Dir.mktmpdir
-      end
+      @fs = RubygemFs::Local.new(Dir.mktmpdir)
     end
 
     context "#get" do

--- a/test/unit/rubygem_fs_test.rb
+++ b/test/unit/rubygem_fs_test.rb
@@ -17,7 +17,7 @@ class RubygemFsTest < ActiveSupport::TestCase
       def fs.s3
         [@config[:access_key_id], @config[:secret_access_key]]
       end
-      assert_equal ['foo', 'bar'], fs.s3
+      assert_equal %w(foo bar), fs.s3
     end
   end
 


### PR DESCRIPTION
### Problem
SQS delivers the messages as at-least-one, so we need to make sure our
job is idempotent. Previous implementation was rely on Redis for that, however
there was a TTL on it, which could cause problems if a message is delivered again
after the TTL.
Besides we would like to remove Redis from our stack, for a few other
reasons.
[related https://github.com/rubygems/rubygems.org/issues/1208]

### Solution

Use Postgresql to guarantee idempontency in our LogProcessor job.
First, we will only queue a LoProcessor job once, to process a specific ticket

### How

Every time we get a SQS message, push an entry to a table(`log_tickets`) as pending and also enqueue a job. That table has a unique constraint on bucket(directory), key, so the database will guarantee the idempontency of this job.
The job will unqueue that ticket and update its status to `processing` in a atomic operation, so even if we had two jobs running at the same time for the bucket/key, that entry would not be processed twice.
After the logger is processed, we update the counters and change the job status to `processed`, ideally, once we move the counters outside Redis, we will be able to do that in a atomic transaction, so they ticket will only be updated if the counters were updated too.

### Other features of this implementation

- I extracted the logic to lookup the log file, so we can process files locally for tests as well as files from s3.
- The LogProcessor job doesn't need to be enqueued with a key/bucket, we can just process the tickets in a FIFO manner. 
- We can change a status of a ticket at any time to re process it.


What is in here:

- [x] Create new schema to store keys and ensure idempontency.
- [x] Allow multiple backends to process the logs, for easy test locally. allow S3 and local.
- [x] Write tests
- [x] Handle failure cases and test them

review @ktheory @dwradcliffe @evanphx @qrush @tarcieri