### PR TITLE
Correct two URLs to use https:// and fix HTML error in stylesheet link href

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -12,7 +12,7 @@ class Redirector
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))
       redirect_to(fake_request.url)
     elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)} && request.host !~ /docs/
-      redirect_to("http://docs.rubygems.org#{request.path}")
+      redirect_to("https://docs.rubygems.org#{request.path}")
     elsif request.path =~ %r{^/pages/docs$}
       redirect_to("http://guides.rubygems.org")
     elsif request.path =~ %r{^/pages/gem_docs$}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
     <%= stylesheet_link_tag("application") %>
-    <link href="http://fonts.gstatic.com" rel="preconnect" crossorigin>
-    <link href='https://fonts.googleapis.com/css?family=Roboto:100&subset=greek,latin,cyrillic,latin-ext' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:100&amp;subset=greek,latin,cyrillic,latin-ext' rel='stylesheet' type='text/css'>
     <%= render "layouts/feeds" %>
     <%= csrf_meta_tag %>
     <%= yield :head %>

--- a/test/unit/redirector_test.rb
+++ b/test/unit/redirector_test.rb
@@ -51,7 +51,7 @@ class RedirectorTest < ActiveSupport::TestCase
       get uri, {}, "HTTP_HOST" => Gemcutter::HOST
 
       assert_equal 301, last_response.status
-      assert_equal "http://docs.rubygems.org#{uri}", last_response.headers["Location"]
+      assert_equal "https://docs.rubygems.org#{uri}", last_response.headers["Location"]
     end
   end
 


### PR DESCRIPTION
Change the `docs.rubygems.org` and `fonts.gstatic.com` usage to use
https://. Also fix a "fragile syntax construct" by correcting `&`
to be `&amp;` in the fonts stylesheet `<link href>`.

(noticed since I was reading @nateberkopec's commits as a follow-up to his
blog post)