### PR TITLE
link to the rubygems gem in the main gem folder

### DIFF
--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -8,7 +8,7 @@
   <div id="formats" class="download__formats">
     <%= link_to "tgz", "https://rubygems.org/rubygems/rubygems-#{version_number}.tgz", class: "download__format" %>
     <%= link_to "zip", "https://rubygems.org/rubygems/rubygems-#{version_number}.zip", class: "download__format" %>
-    <%= link_to "gem", "https://rubygems.org/rubygems/rubygems-update-#{version_number}.gem", class: "download__format" %>
+    <%= link_to "gem", "https://rubygems.org/gems/rubygems-update-#{version_number}.gem", class: "download__format" %>
     <%= link_to "git", "https://github.com/rubygems/rubygems", class: "download__format" %>
   </div>
   <p>


### PR DESCRIPTION
Seems like we've been uploading the `rubygems-update` gem to two places. First the normal gem location an also to the `/rubygems/` folder. Let's just use one location to simplify things.

@drbrain @indirect @segiddins 