### PR TITLE
Resolve to `gem push` with default gem and stdlib gem.

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -98,7 +98,6 @@ module Patterns
     weakref
     webrick
     win32ole
-    xmlrpc
     yaml
     zlib
     ubygems


### PR DESCRIPTION
I'm going to release `xmlrpc` gem from ruby standard library.  xmlrpc is extracted from Ruby 2.4.0 release. see https://bugs.ruby-lang.org/issues/12160

I already prepared gem file and release status.

 * https://github.com/ruby/xmlrpc

Can I push xmlrpc gem into rubygems.org with this pull request? If I need to some action, Please share to me.