### PR TITLE
Use fastly logs to push counts to postgresql

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - !ruby/regexp /(vendor|bundle|bin|db)\/.*/
   DisplayCopNames: true
   DisplayStyleGuide: true
+  TargetRubyVersion: 2.2
 
 Rails:
   Enabled: true

--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -23,11 +23,10 @@ class FastlyLogProcessor
 
     counts = download_counts(log_ticket)
     Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
-    updates = munge_for_bulk_update(counts)
 
     ActiveRecord::Base.connection.transaction do
-      GemDownload.bulk_update(updates)
-      processed_count = updates.sum { |_, _, v| v }
+      GemDownload.bulk_update(counts)
+      processed_count = counts.sum { |_, v| v }
       log_ticket.update(status: "processed", processed_count: processed_count)
     end
   end
@@ -56,17 +55,4 @@ class FastlyLogProcessor
     end
   end
   statsd_count :download_counts, 'fastly_log_processor.download_counts'
-
-  # Takes a hash of download counts and turns it into an array of arrays for
-  # GemDownload.bulk_update. E.g.:
-  #   [
-  #     ['rails', 'rails-4.0.0', 25 ],
-  #     ['rails', 'rails-4.2.0', 50 ]
-  #   ]
-  def munge_for_bulk_update(download_counts)
-    download_counts.map do |path, count|
-      name = Version.rubygem_name_for(path)
-      [name, path, count]
-    end.compact
-  end
 end

--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -22,20 +22,20 @@ class FastlyLogProcessor
     end
 
     counts = download_counts(log_ticket)
-
-    # TODO: wrap this in a transation when download update is in the DB
-
     Delayed::Worker.logger.info "Processed Fastly log counts: #{counts.inspect}"
     updates = munge_for_bulk_update(counts)
-    # Temporary feature flag while we roll out fastly log processing
-    if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] == 'true'
-      Download.bulk_update(updates)
-    else
-      # Just log & exit w/out updating stats
-      StatsD.increment('fastly_log_processor.disabled')
+
+    ActiveRecord::Base.connection.transaction do
+      # Temporary feature flag while we roll out fastly log processing
+      if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] == 'true'
+        GemDownload.bulk_update(updates)
+      else
+        # Just log & exit w/out updating stats
+        StatsD.increment('fastly_log_processor.disabled')
+      end
+      processed_count = updates.sum { |_, _, v| v }
+      log_ticket.update(status: "processed", processed_count: processed_count)
     end
-    processed_count = updates.sum { |_, _, v| v }
-    log_ticket.update(status: "processed", processed_count: processed_count)
   end
   statsd_count_success :perform, 'fastly_log_processor.perform'
 
@@ -64,7 +64,7 @@ class FastlyLogProcessor
   statsd_count :download_counts, 'fastly_log_processor.download_counts'
 
   # Takes a hash of download counts and turns it into an array of arrays for
-  # Download.bulk_update. E.g.:
+  # GemDownload.bulk_update. E.g.:
   #   [
   #     ['rails', 'rails-4.0.0', 25 ],
   #     ['rails', 'rails-4.2.0', 50 ]
@@ -72,8 +72,7 @@ class FastlyLogProcessor
   def munge_for_bulk_update(download_counts)
     download_counts.map do |path, count|
       name = Version.rubygem_name_for(path)
-      # Skip downloads that don't have a version in redis
-      name ? [name, path, count] : nil
+      [name, path, count]
     end.compact
   end
 end

--- a/app/jobs/fastly_log_processor.rb
+++ b/app/jobs/fastly_log_processor.rb
@@ -26,13 +26,7 @@ class FastlyLogProcessor
     updates = munge_for_bulk_update(counts)
 
     ActiveRecord::Base.connection.transaction do
-      # Temporary feature flag while we roll out fastly log processing
-      if ENV['FASTLY_LOG_PROCESSOR_ENABLED'] == 'true'
-        GemDownload.bulk_update(updates)
-      else
-        # Just log & exit w/out updating stats
-        StatsD.increment('fastly_log_processor.disabled')
-      end
+      GemDownload.bulk_update(updates)
       processed_count = updates.sum { |_, _, v| v }
       log_ticket.update(status: "processed", processed_count: processed_count)
     end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -3,7 +3,8 @@ class GemDownload < ActiveRecord::Base
   belongs_to :version
 
   def self.count_for_rubygem(id)
-    if download = GemDownload.find_by(rubygem_id: id, version_id: 0)
+    download = GemDownload.find_by(rubygem_id: id, version_id: 0)
+    if download
       download.count
     else
       0
@@ -11,20 +12,17 @@ class GemDownload < ActiveRecord::Base
   end
 
   def self.total_count
-    if download =  GemDownload.find_by(rubygem_id: 0, version_id: 0)
+    download = GemDownload.find_by(rubygem_id: 0, version_id: 0)
+    if download
       download.count
     else
       0
     end
   end
 
-  def self.increment(count, rubygem_id:, version_id: nil)
+  def self.increment(count, rubygem_id:, version_id: 0)
     scope = GemDownload.where(rubygem_id: rubygem_id).select("id").lock(true)
-    if version_id
-      scope = scope.where(version_id: version_id)
-    else
-      scope = scope.where(version_id: 0)
-    end
+    scope = scope.where(version_id: version_id)
     sql = scope.to_sql
     find_by_sql(["UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *", count]).first
   end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -2,6 +2,17 @@ class GemDownload < ActiveRecord::Base
   belongs_to :rubygem
   belongs_to :version
 
+  def self.count_for_version(id)
+    v = Version.find(id)
+    return 0 unless v
+    download = GemDownload.find_by(rubygem_id: v.rubygem_id, version_id: v.id)
+    if download
+      download.count
+    else
+      0
+    end
+  end
+
   def self.count_for_rubygem(id)
     download = GemDownload.find_by(rubygem_id: id, version_id: 0)
     if download
@@ -20,11 +31,31 @@ class GemDownload < ActiveRecord::Base
     end
   end
 
-  def self.increment(count, rubygem_id:, version_id: 0)
+  def self.update_count_by(count, rubygem_id:, version_id: 0)
     scope = GemDownload.where(rubygem_id: rubygem_id).select("id").lock(true)
     scope = scope.where(version_id: version_id)
     sql = scope.to_sql
-    find_by_sql(["UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *", count]).first
+
+    update = "UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *"
+
+    # TODO: Remove this comments, once we move to GemDownload only.
+#    insert = "INSERT INTO #{quoted_table_name} (rubygem_id, version_id, count) SELECT ?, ?, ?"
+#    find_by_sql(["WITH upsert AS (#{update}) #{insert} WHERE NOT EXISTS (SELECT * FROM upsert)", count, rubygem_id, version_id, count]).first
+    find_by_sql([update, count]).first
+  end
+
+  def self.increment(name, full_name, count: 1)
+    transaction do
+      gem = Rubygem.find_by(name: name)
+      version = Version.find_by(full_name: full_name)
+      return unless gem && version
+      # Total count
+      update_count_by(count, rubygem_id: 0, version_id: 0)
+      # Gem count
+      update_count_by(count, rubygem_id: gem.id, version_id: 0)
+      # Gem version count
+      update_count_by(count, rubygem_id: gem.id, version_id: version.id)
+    end
   end
 
   # Takes an array where members have the form
@@ -33,16 +64,7 @@ class GemDownload < ActiveRecord::Base
   #   ['rake', 'rake-10.4.2', 1]
   def self.bulk_update(ary)
     ary.each do |name, full_name, count|
-      transaction do
-        gem = Rubygem.find_by(name: name)
-        version = Version.find_by(full_name: full_name)
-        # Total count
-        increment(count, rubygem_id: 0, version_id: 0)
-        # Gem count
-        increment(count, rubygem_id: gem.id, version_id: 0) if gem
-        # Gem version count
-        increment(count, rubygem_id: gem.id, version_id: version.id) if version
-      end
+      increment(name, full_name, count: count)
     end
   end
 end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -1,0 +1,50 @@
+class GemDownload < ActiveRecord::Base
+  belongs_to :rubygem
+  belongs_to :version
+
+  def self.count_for_rubygem(id)
+    if download = GemDownload.find_by(rubygem_id: id, version_id: 0)
+      download.count
+    else
+      0
+    end
+  end
+
+  def self.total_count
+    if download =  GemDownload.find_by(rubygem_id: 0, version_id: 0)
+      download.count
+    else
+      0
+    end
+  end
+
+  def self.increment(count, rubygem_id:, version_id: nil)
+    scope = GemDownload.where(rubygem_id: rubygem_id).select("id").lock(true)
+    if version_id
+      scope = scope.where(version_id: version_id)
+    else
+      scope = scope.where(version_id: 0)
+    end
+    sql = scope.to_sql
+    find_by_sql(["UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *", count]).first
+  end
+
+  # Takes an array where members have the form
+  #   [name, full_name, count]
+  # E.g.:
+  #   ['rake', 'rake-10.4.2', 1]
+  def self.bulk_update(ary)
+    ary.each do |name, full_name, count|
+      transaction do
+        gem = Rubygem.find_by(name: name)
+        version = Version.find_by(full_name: full_name)
+        # Total count
+        increment(count, rubygem_id: 0, version_id: 0)
+        # Gem count
+        increment(count, rubygem_id: gem.id, version_id: 0) if gem
+        # Gem version count
+        increment(count, rubygem_id: gem.id, version_id: version.id) if version
+      end
+    end
+  end
+end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -39,8 +39,8 @@ class GemDownload < ActiveRecord::Base
     update = "UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *"
 
     # TODO: Remove this comments, once we move to GemDownload only.
-#    insert = "INSERT INTO #{quoted_table_name} (rubygem_id, version_id, count) SELECT ?, ?, ?"
-#    find_by_sql(["WITH upsert AS (#{update}) #{insert} WHERE NOT EXISTS (SELECT * FROM upsert)", count, rubygem_id, version_id, count]).first
+    # insert = "INSERT INTO #{quoted_table_name} (rubygem_id, version_id, count) SELECT ?, ?, ?"
+    # find_by_sql(["WITH upsert AS (#{update}) #{insert} WHERE NOT EXISTS (SELECT * FROM upsert)", count, rubygem_id, version_id, count]).first
     find_by_sql([update, count]).first
   end
 

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -44,27 +44,26 @@ class GemDownload < ActiveRecord::Base
     find_by_sql([update, count]).first
   end
 
-  def self.increment(name, full_name, count: 1)
+  def self.increment(full_name, count: 1)
     transaction do
-      gem = Rubygem.find_by(name: name)
       version = Version.find_by(full_name: full_name)
-      return unless gem && version
+      return unless version
       # Total count
       update_count_by(count, rubygem_id: 0, version_id: 0)
       # Gem count
-      update_count_by(count, rubygem_id: gem.id, version_id: 0)
+      update_count_by(count, rubygem_id: version.rubygem_id, version_id: 0)
       # Gem version count
-      update_count_by(count, rubygem_id: gem.id, version_id: version.id)
+      update_count_by(count, rubygem_id: version.rubygem_id, version_id: version.id)
     end
   end
 
   # Takes an array where members have the form
-  #   [name, full_name, count]
+  #   [full_name, count]
   # E.g.:
-  #   ['rake', 'rake-10.4.2', 1]
+  #   ['rake-10.4.2', 1]
   def self.bulk_update(ary)
-    ary.each do |name, full_name, count|
-      increment(name, full_name, count: count)
+    ary.each do |full_name, count|
+      increment(full_name, count: count)
     end
   end
 end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -32,7 +32,7 @@ class GemDownload < ActiveRecord::Base
   end
 
   def self.update_count_by(count, rubygem_id:, version_id: 0)
-    scope = GemDownload.where(rubygem_id: rubygem_id).select("id").lock(true)
+    scope = GemDownload.where(rubygem_id: rubygem_id).select("id")
     scope = scope.where(version_id: version_id)
     sql = scope.to_sql
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -22,7 +22,7 @@ class Rubygem < ActiveRecord::Base
   # TODO: Remove this once we move to GemDownload only
   after_create :create_gem_download
   def create_gem_download
-    GemDownload.create!(count: 0, rubygem_id: self.id, version_id: 0)
+    GemDownload.create!(count: 0, rubygem_id: id, version_id: 0)
   end
 
   def self.with_versions

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -19,6 +19,12 @@ class Rubygem < ActiveRecord::Base
   after_create :update_unresolved
   before_destroy :mark_unresolved
 
+  # TODO: Remove this once we move to GemDownload only
+  after_create :create_gem_download
+  def create_gem_download
+    GemDownload.create!(count: 0, rubygem_id: self.id, version_id: 0)
+  end
+
   def self.with_versions
     where("rubygems.id IN (SELECT rubygem_id FROM versions where versions.indexed IS true)")
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -22,7 +22,7 @@ class Version < ActiveRecord::Base
   # TODO: Remove this once we move to GemDownload only
   after_create :create_gem_download
   def create_gem_download
-    GemDownload.create!(count: 0, rubygem_id: self.rubygem_id, version_id: self.id)
+    GemDownload.create!(count: 0, rubygem_id: rubygem_id, version_id: id)
   end
 
   def self.reverse_dependencies(name)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -19,6 +19,12 @@ class Version < ActiveRecord::Base
   validate :authors_format, on: :create
   attribute :authors, Type::Value.new
 
+  # TODO: Remove this once we move to GemDownload only
+  after_create :create_gem_download
+  def create_gem_download
+    GemDownload.create!(count: 0, rubygem_id: self.rubygem_id, version_id: self.id)
+  end
+
   def self.reverse_dependencies(name)
     joins(dependencies: :rubygem)
       .indexed

--- a/db/migrate/20160318213755_create_gem_download.rb
+++ b/db/migrate/20160318213755_create_gem_download.rb
@@ -1,0 +1,10 @@
+class CreateGemDownload < ActiveRecord::Migration
+  def change
+    create_table :gem_downloads do |t|
+      t.integer :rubygem_id, null: false
+      t.integer :version_id
+      t.column :count, :bigint
+    end
+    add_index :gem_downloads, [:rubygem_id, :version_id], unique: true
+  end
+end

--- a/db/migrate/20160318213755_create_gem_download.rb
+++ b/db/migrate/20160318213755_create_gem_download.rb
@@ -2,7 +2,7 @@ class CreateGemDownload < ActiveRecord::Migration
   def change
     create_table :gem_downloads do |t|
       t.integer :rubygem_id, null: false
-      t.integer :version_id
+      t.integer :version_id, null: false
       t.column :count, :bigint
     end
     add_index :gem_downloads, [:rubygem_id, :version_id], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20160318213755) do
 
   create_table "gem_downloads", force: :cascade do |t|
     t.integer "rubygem_id",           null: false
-    t.integer "version_id"
+    t.integer "version_id",           null: false
     t.integer "count",      limit: 8
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160308201614) do
+ActiveRecord::Schema.define(version: 20160318213755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,14 @@ ActiveRecord::Schema.define(version: 20160308201614) do
   add_index "dependencies", ["rubygem_id"], name: "index_dependencies_on_rubygem_id", using: :btree
   add_index "dependencies", ["unresolved_name"], name: "index_dependencies_on_unresolved_name", using: :btree
   add_index "dependencies", ["version_id"], name: "index_dependencies_on_version_id", using: :btree
+
+  create_table "gem_downloads", force: :cascade do |t|
+    t.integer "rubygem_id",           null: false
+    t.integer "version_id"
+    t.integer "count",      limit: 8
+  end
+
+  add_index "gem_downloads", ["rubygem_id", "version_id"], name: "index_gem_downloads_on_rubygem_id_and_version_id", unique: true, using: :btree
 
   create_table "linksets", force: :cascade do |t|
     t.integer  "rubygem_id"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -132,4 +132,9 @@ FactoryGirl.define do
     expires_in 90.days.from_now
     scopes "public"
   end
+
+  factory :gem_download do
+    rubygem_id 0
+    version_id 0
+  end
 end

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -2,10 +2,6 @@ require 'test_helper'
 
 class FastlyLogProcessorTest < ActiveSupport::TestCase
   setup do
-    # Enable fastly log processing
-    @orig_fastly_log_processor_enabled = ENV['FASTLY_LOG_PROCESSOR_ENABLED']
-    ENV['FASTLY_LOG_PROCESSOR_ENABLED'] = 'true'
-
     @sample_log = Rails.root.join('test/sample_logs/fastly-fake.log').read
 
     @sample_log_counts = {
@@ -26,7 +22,6 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
   teardown do
     # Remove stubbed response
     Aws.config.delete(:s3)
-    ENV['FASTLY_LOG_PROCESSOR_ENABLED'] = @orig_fastly_log_processor_enabled
   end
 
   context "#download_counts" do

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -60,13 +60,12 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
 
       GemDownload.create!(rubygem_id: 0, version_id: 0, count: 0)
       @sample_log_counts.each do |k, _|
-        if v = Version.find_by(full_name: k)
-          begin
-            GemDownload.create!(rubygem_id: v.rubygem.id, version_id: 0, count: 0)
-          rescue ActiveRecord::RecordNotUnique
-          end
-          GemDownload.create!(rubygem_id: v.rubygem.id, version_id: v.id, count: 0)
+        v = Version.find_by(full_name: k)
+        next unless v
+        unless GemDownload.exists?(rubygem_id: v.rubygem.id, version_id: 0)
+          GemDownload.create!(rubygem_id: v.rubygem.id, version_id: 0, count: 0)
         end
+        GemDownload.create!(rubygem_id: v.rubygem.id, version_id: v.id, count: 0)
       end
     end
 

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -17,6 +17,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
       stub_responses: { get_object: { body: @sample_log } }
     }
     @job = FastlyLogProcessor.new('test-bucket', 'fastly-fake.log')
+    GemDownload.create!(count: 0, rubygem_id: 0, version_id: 0)
   end
 
   teardown do
@@ -52,16 +53,6 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
       create(:version, rubygem: json, number: '1.8.3', platform: 'java')
       create(:version, rubygem: json, number: '1.8.3')
       create(:version, rubygem: json, number: '1.8.2')
-
-      GemDownload.create!(rubygem_id: 0, version_id: 0, count: 0)
-      @sample_log_counts.each do |k, _|
-        v = Version.find_by(full_name: k)
-        next unless v
-        unless GemDownload.exists?(rubygem_id: v.rubygem.id, version_id: 0)
-          GemDownload.create!(rubygem_id: v.rubygem.id, version_id: 0, count: 0)
-        end
-        GemDownload.create!(rubygem_id: v.rubygem.id, version_id: v.id, count: 0)
-      end
     end
 
     context '#perform' do
@@ -131,7 +122,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
       should "update the total gem count" do
         assert_equal 0, GemDownload.total_count
         @job.perform
-        assert_equal 10, GemDownload.total_count
+        assert_equal 9, GemDownload.total_count
       end
     end
   end

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -41,7 +41,7 @@ class GemDownloadTest < ActiveSupport::TestCase
 
   context "#increment" do
     should "dont increment if entry doesnt exists" do
-      assert_nil GemDownload.increment("rails", "rails-3.2.22")
+      assert_nil GemDownload.increment("rails-3.2.22")
     end
 
     should "load up all downloads with just raw strings and process them" do
@@ -49,7 +49,7 @@ class GemDownloadTest < ActiveSupport::TestCase
       version = create(:version, rubygem: rubygem)
 
       3.times do
-        GemDownload.increment(rubygem.name, version.full_name)
+        GemDownload.increment(version.full_name)
       end
 
       assert_equal 3, GemDownload.count_for_version(version.id)
@@ -61,7 +61,7 @@ class GemDownloadTest < ActiveSupport::TestCase
       version = create(:version)
       rubygem = version.rubygem
 
-      GemDownload.increment(rubygem.name, version.full_name, count: 100)
+      GemDownload.increment(version.full_name, count: 100)
 
       assert_equal 100, GemDownload.count_for_version(version.id)
       assert_equal 100, GemDownload.count_for_rubygem(rubygem.id)
@@ -73,7 +73,7 @@ class GemDownloadTest < ActiveSupport::TestCase
       versions = Array.new(2) { create(:version) }
       gems     = versions.map(&:rubygem)
       counts   = Array.new(2) { rand(100) }
-      data     = gems.map(&:name).zip(versions.map(&:full_name), counts)
+      data     = versions.map.with_index { |v, i| [v.full_name, counts[i]] }
 
       GemDownload.bulk_update(data)
 
@@ -89,7 +89,7 @@ class GemDownloadTest < ActiveSupport::TestCase
     version = create(:version, rubygem: rubygem, platform: "mswin32-60")
     other_platform_version = create(:version, rubygem: rubygem, platform: "mswin32")
 
-    GemDownload.increment(rubygem.name, version.full_name)
+    GemDownload.increment(version.full_name)
 
     assert_equal 1, GemDownload.count_for_version(version.id)
     assert_equal 1, GemDownload.count_for_rubygem(rubygem.id)
@@ -110,12 +110,12 @@ class GemDownloadTest < ActiveSupport::TestCase
     @rubygem_3 = create(:rubygem)
     @version_4 = create(:version, rubygem: @rubygem_3)
 
-    GemDownload.increment(@rubygem_1.name, @version_1.full_name)
-    GemDownload.increment(@rubygem_1.name, @version_2.full_name)
-    GemDownload.increment(@rubygem_2.name, @version_3.full_name)
-    GemDownload.increment(@rubygem_1.name, @version_1.full_name)
-    3.times { GemDownload.increment(@rubygem_2.name, @version_3.full_name) }
-    2.times { GemDownload.increment(@rubygem_1.name, @version_2.full_name) }
+    GemDownload.increment(@version_1.full_name)
+    GemDownload.increment(@version_2.full_name)
+    GemDownload.increment(@version_3.full_name)
+    GemDownload.increment(@version_1.full_name)
+    3.times { GemDownload.increment(@version_3.full_name) }
+    2.times { GemDownload.increment(@version_2.full_name) }
 
     assert_equal [[@version_3, 4], [@version_2, 3], [@version_1, 2]],
       Download.most_downloaded_all_time
@@ -134,8 +134,8 @@ class GemDownloadTest < ActiveSupport::TestCase
     version1 = create(:version, rubygem: rubygem)
     version2 = create(:version, rubygem: rubygem)
 
-    3.times { GemDownload.increment(rubygem.name, version1.full_name) }
-    2.times { GemDownload.increment(rubygem.name, version2.full_name) }
+    3.times { GemDownload.increment(version1.full_name) }
+    2.times { GemDownload.increment(version2.full_name) }
 
     assert_equal 5, GemDownload.count_for_rubygem(rubygem.id)
     assert_equal 3, GemDownload.count_for_version(version1.id)

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -1,0 +1,111 @@
+require 'test_helper'
+
+class GemDownloadTest < ActiveSupport::TestCase
+  setup do
+    GemDownload.create!(count: 0, rubygem_id: 0, version_id: 0)
+  end
+
+  context "#increment" do
+    should "load up all downloads with just raw strings and process them" do
+      rubygem = create(:rubygem, name: "gem123")
+      version = create(:version, rubygem: rubygem)
+
+      3.times do
+        GemDownload.increment(rubygem.name, version.full_name)
+      end
+
+      assert_equal 3, GemDownload.count_for_version(version.id)
+      assert_equal 3, GemDownload.count_for_rubygem(rubygem.id)
+      assert_equal 3, GemDownload.total_count
+    end
+
+    should "take optional count kwarg" do
+      version = create(:version)
+      rubygem = version.rubygem
+
+      GemDownload.increment(rubygem.name, version.full_name, count: 100)
+
+      assert_equal 100, GemDownload.count_for_version(version.id)
+      assert_equal 100, GemDownload.count_for_rubygem(rubygem.id)
+    end
+  end
+
+  context "#bulk_update" do
+    should "write the proper values" do
+      versions = Array.new(2) { create(:version) }
+      gems     = versions.map(&:rubygem)
+      counts   = Array.new(2) { rand(100) }
+      data     = gems.map(&:name).zip(versions.map(&:full_name), counts)
+
+      GemDownload.bulk_update(data)
+
+      2.times.each do |i|
+        assert_equal counts[i], GemDownload.count_for_version(versions[i].id)
+        assert_equal counts[i], GemDownload.count_for_rubygem(gems[i].id)
+      end
+    end
+  end
+
+  should "track platform gem downloads correctly" do
+    rubygem = create(:rubygem)
+    version = create(:version, rubygem: rubygem, platform: "mswin32-60")
+    other_platform_version = create(:version, rubygem: rubygem, platform: "mswin32")
+
+    GemDownload.increment(rubygem.name, version.full_name)
+
+    assert_equal 1, GemDownload.count_for_version(version.id)
+    assert_equal 1, GemDownload.count_for_rubygem(rubygem.id)
+    assert_equal 0, GemDownload.count_for_version(other_platform_version.id)
+
+    assert_equal 1, GemDownload.total_count
+  end
+
+  should "find most downloaded all time" do
+    skip "fixme"
+    @rubygem_1 = create(:rubygem)
+    @version_1 = create(:version, rubygem: @rubygem_1)
+    @version_2 = create(:version, rubygem: @rubygem_1)
+
+    @rubygem_2 = create(:rubygem)
+    @version_3 = create(:version, rubygem: @rubygem_2)
+
+    @rubygem_3 = create(:rubygem)
+    @version_4 = create(:version, rubygem: @rubygem_3)
+
+    GemDownload.increment(@rubygem_1.name, @version_1.full_name)
+    GemDownload.increment(@rubygem_1.name, @version_2.full_name)
+    GemDownload.increment(@rubygem_2.name, @version_3.full_name)
+    GemDownload.increment(@rubygem_1.name, @version_1.full_name)
+    3.times { GemDownload.increment(@rubygem_2.name, @version_3.full_name) }
+    2.times { GemDownload.increment(@rubygem_1.name, @version_2.full_name) }
+
+    assert_equal [[@version_3, 4], [@version_2, 3], [@version_1, 2]],
+      Download.most_downloaded_all_time
+
+    assert_equal [[@version_3, 4], [@version_2, 3]],
+      Download.most_downloaded_all_time(2)
+
+    assert_equal 3, Download.cardinality
+    assert_equal 1, Download.rank(@version_3)
+    assert_equal 2, Download.rank(@version_2)
+    assert_equal 3, Download.rank(@version_1)
+  end
+
+  should "find download count by gems id" do
+    rubygem = create(:rubygem)
+    version1 = create(:version, rubygem: rubygem)
+    version2 = create(:version, rubygem: rubygem)
+
+    3.times { GemDownload.increment(rubygem.name, version1.full_name) }
+    2.times { GemDownload.increment(rubygem.name, version2.full_name) }
+
+    assert_equal 5, GemDownload.count_for_rubygem(rubygem.id)
+    assert_equal 3, GemDownload.count_for_version(version1.id)
+    assert_equal 2, GemDownload.count_for_version(version2.id)
+  end
+
+  should "return zero for rank if no downloads exist" do
+    skip "fixme"
+    assert_equal 0, Download.rank(build(:version))
+  end
+end

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -29,7 +29,7 @@ class GemDownloadTest < ActiveSupport::TestCase
     create(:gem_download, rubygem_id: 1, version_id: 1, count: 0)
 
     25.times do
-      4.times.map do
+      Array.new(4) do
         Thread.new { GemDownload.update_count_by(1, rubygem_id: 1, version_id: 1) }
       end.each(&:join)
     end


### PR DESCRIPTION
The fastly log worker will now push counts to a postgres table instead
of redis.

This will do a UPDATE lock in the GemDownload table to increment the counter atomically. So after we have an entry on that table, the log processor will try to do an upsert on that counter.
Like this, we can rollout Postgres counters, without having to show them or remove the redis ones.

TODOs:

- [x] Unit tests to GemDownload model
- [x] Remove ENV flag, as we wont need it anymore.
- [ ] Create a job to create a `GemDownload` from the current redis counter.

Known problem about this approach:

In the background job, that will create the first entry on `GemDownload` for a gem, that will have to load in memory the current counter from redis and immediately push that value to `GemDownload`. That operation cannot be atomic, as redis and postgres don't share anything. So, for that fraction of seconds we, possibly could lose some counts for that particular gem.
I would say the chances of that happening are pretty small, and thats better than a full downtime tho.

Also, after we have counts been incremented in both, db and redis. We can run some maintenance tasks to make sure the match. and if they don't, how different are them.

review @dwradcliffe 