### PR TITLE
Revert "Improve update operations on gem download increment"

### DIFF
--- a/test/rake/gemcutter_test.rb
+++ b/test/rake/gemcutter_test.rb
@@ -19,7 +19,7 @@ class GemcutterTest < ActiveSupport::TestCase
     end
 
     should "not change already created downloads" do
-      GemDownload.increment(100, version_id: 0, rubygem_id: @versions.first.rubygem_id)
+      GemDownload.increment(@versions.first.full_name, count: 100)
 
       silence_stream(STDOUT) do
         run_rake_task("rubygems:update_download_counts")


### PR DESCRIPTION
Reverts rubygems/rubygems.org#1229

This was much faster but caused deadlocks. Reverting for now.

@arthurnn 