### PR TITLE
Better log aggregation on stats update

### DIFF
--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -54,8 +54,8 @@ class GemDownload < ActiveRecord::Base
 
     ary.each do |full_name, count|
       if updates_by_version.key?(full_name)
-        version, count = updates_by_version[full_name]
-        updates_by_version[full_name] = [version, count + 1]
+        version, old_count = updates_by_version[full_name]
+        updates_by_version[full_name] = [version, old_count + count]
       else
         version = Version.find_by(full_name: full_name)
         updates_by_version[full_name] = [version, count] if version

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -31,7 +31,7 @@ class GemDownload < ActiveRecord::Base
     end
   end
 
-  def self.update_count_by(count, rubygem_id:, version_id: 0)
+  def self.increment(count, rubygem_id:, version_id: 0)
     scope = GemDownload.where(rubygem_id: rubygem_id).select("id")
     scope = scope.where(version_id: version_id)
     sql = scope.to_sql
@@ -44,24 +44,34 @@ class GemDownload < ActiveRecord::Base
     find_by_sql([update, count]).first
   end
 
-  def self.increment(full_name, count: 1)
-    version = Version.find_by(full_name: full_name)
-    return unless version
-    # Total count
-    update_count_by(count, rubygem_id: 0, version_id: 0)
-    # Gem count
-    update_count_by(count, rubygem_id: version.rubygem_id, version_id: 0)
-    # Gem version count
-    update_count_by(count, rubygem_id: version.rubygem_id, version_id: version.id)
-  end
-
   # Takes an array where members have the form
   #   [full_name, count]
   # E.g.:
   #   ['rake-10.4.2', 1]
   def self.bulk_update(ary)
+    arr = []
+
     ary.each do |full_name, count|
-      increment(full_name, count: count)
+      version = Version.find_by(full_name: full_name)
+      next unless version
+
+      # Gem version count
+      increment(count, rubygem_id: version.rubygem_id, version_id: version.id)
+
+      arr << [version, full_name, count]
     end
+
+    grouped_gems = arr.group_by do |version, _, _|
+      version.rubygem_id
+    end
+    grouped_gems.each do |rubygem_id, counts|
+      count = counts.sum { |_, _, c| c }
+      # Gem count
+      increment(count, rubygem_id: rubygem_id, version_id: 0)
+    end
+
+    total_count = arr.sum { |_, _, c| c }
+    # Total count
+    increment(total_count, rubygem_id: 0, version_id: 0)
   end
 end

--- a/test/rake/gemcutter_test.rb
+++ b/test/rake/gemcutter_test.rb
@@ -19,7 +19,7 @@ class GemcutterTest < ActiveSupport::TestCase
     end
 
     should "not change already created downloads" do
-      GemDownload.increment(@versions.first.full_name, count: 100)
+      GemDownload.increment(100, version_id: 0, rubygem_id: @versions.first.rubygem_id)
 
       silence_stream(STDOUT) do
         run_rake_task("rubygems:update_download_counts")

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -95,6 +95,13 @@ class GemDownloadTest < ActiveSupport::TestCase
     assert_equal 1, GemDownload.total_count
   end
 
+  should "track version count" do
+    version = create(:version)
+    counts = Array.new(3) { |n| [version.full_name, n + 1] }
+    GemDownload.bulk_update(counts)
+    assert_equal 6, GemDownload.count_for_version(version.id)
+  end
+
   should "find most downloaded all time" do
     skip "fixme"
     @rubygem_1 = create(:rubygem)

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -5,22 +5,33 @@ class GemDownloadTest < ActiveSupport::TestCase
     create(:gem_download, count: 0)
   end
 
-  context "update_count_by" do
+  context "#increment" do
     should "not update if download doesnt exist" do
-      assert_nil GemDownload.update_count_by(1, rubygem_id: 1)
+      assert_nil GemDownload.increment(1, rubygem_id: 1)
     end
 
     should "not update if download count is nil" do
       GemDownload.create!(rubygem_id: 1, version_id: 0)
-      download = GemDownload.update_count_by(1, rubygem_id: 1)
+      download = GemDownload.increment(1, rubygem_id: 1)
       assert_nil download.count
     end
 
     should "update the count" do
       GemDownload.create!(rubygem_id: 1, version_id: 1, count: 0)
-      GemDownload.update_count_by(1, rubygem_id: 1, version_id: 1)
+      GemDownload.increment(1, rubygem_id: 1, version_id: 1)
 
       assert_equal 1, GemDownload.where(rubygem_id: 1, version_id: 1).first.count
+    end
+
+    should "take optional count warg" do
+      version = create(:version)
+      rubygem = version.rubygem
+
+      GemDownload.increment(100, rubygem_id: version.rubygem_id, version_id: version.id)
+      GemDownload.increment(100, rubygem_id: version.rubygem_id)
+
+      assert_equal 100, GemDownload.count_for_version(version.id)
+      assert_equal 100, GemDownload.count_for_rubygem(rubygem.id)
     end
   end
 
@@ -30,42 +41,13 @@ class GemDownloadTest < ActiveSupport::TestCase
 
     25.times do
       Array.new(4) do
-        Thread.new { GemDownload.update_count_by(1, rubygem_id: 1, version_id: 1) }
+        Thread.new { GemDownload.increment(1, rubygem_id: 1, version_id: 1) }
       end.each(&:join)
     end
 
     assert_equal 100, GemDownload.where(rubygem_id: 1, version_id: 1).first.count
   ensure
     GemDownload.delete_all
-  end
-
-  context "#increment" do
-    should "dont increment if entry doesnt exists" do
-      assert_nil GemDownload.increment("rails-3.2.22")
-    end
-
-    should "load up all downloads with just raw strings and process them" do
-      rubygem = create(:rubygem, name: "gem123")
-      version = create(:version, rubygem: rubygem)
-
-      3.times do
-        GemDownload.increment(version.full_name)
-      end
-
-      assert_equal 3, GemDownload.count_for_version(version.id)
-      assert_equal 3, GemDownload.count_for_rubygem(rubygem.id)
-      assert_equal 3, GemDownload.total_count
-    end
-
-    should "take optional count kwarg" do
-      version = create(:version)
-      rubygem = version.rubygem
-
-      GemDownload.increment(version.full_name, count: 100)
-
-      assert_equal 100, GemDownload.count_for_version(version.id)
-      assert_equal 100, GemDownload.count_for_rubygem(rubygem.id)
-    end
   end
 
   context "#bulk_update" do
@@ -84,12 +66,27 @@ class GemDownloadTest < ActiveSupport::TestCase
     end
   end
 
+  should "not count, wrong named versions" do
+    GemDownload.bulk_update([['foonotexists', 100]])
+    assert_equal 0, GemDownload.total_count
+
+    version = create(:version)
+    GemDownload.bulk_update([['foonotexists', 100], ['dddd', 50], [version.full_name, 2]])
+    assert_equal 2, GemDownload.total_count
+  end
+
+  should "write global downloads count" do
+    counts = Array.new(3) { [create(:version).full_name, 2] }
+    GemDownload.bulk_update(counts)
+    assert_equal 6, GemDownload.total_count
+  end
+
   should "track platform gem downloads correctly" do
     rubygem = create(:rubygem)
     version = create(:version, rubygem: rubygem, platform: "mswin32-60")
     other_platform_version = create(:version, rubygem: rubygem, platform: "mswin32")
 
-    GemDownload.increment(version.full_name)
+    GemDownload.bulk_update([[version.full_name, 1]])
 
     assert_equal 1, GemDownload.count_for_version(version.id)
     assert_equal 1, GemDownload.count_for_rubygem(rubygem.id)
@@ -133,18 +130,11 @@ class GemDownloadTest < ActiveSupport::TestCase
     rubygem = create(:rubygem)
     version1 = create(:version, rubygem: rubygem)
     version2 = create(:version, rubygem: rubygem)
-
-    3.times { GemDownload.increment(version1.full_name) }
-    2.times { GemDownload.increment(version2.full_name) }
+    GemDownload.bulk_update([[version1.full_name, 3], [version2.full_name, 2]])
 
     assert_equal 5, GemDownload.count_for_rubygem(rubygem.id)
     assert_equal 3, GemDownload.count_for_version(version1.id)
     assert_equal 2, GemDownload.count_for_version(version2.id)
-  end
-
-  should "return zero for rank if no downloads exist" do
-    skip "fixme"
-    assert_equal 0, Download.rank(build(:version))
   end
 
   should "not allow the same gemdownload twice" do


### PR DESCRIPTION
Another attempt on #1229.

@dwradcliffe the difference here is on the aggregation mechanism. Now I aggregate the counters in hashes first, and do the updates after. Not sure if this will fix the deadlocks, but we can try. 
Thoughts?