### PR TITLE
Auto populate Dependency.version with inverse_of

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -2,7 +2,7 @@ require 'digest/sha2'
 
 class Version < ActiveRecord::Base
   belongs_to :rubygem, touch: true
-  has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, dependent: :destroy
+  has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, dependent: :destroy, inverse_of: "version"
   has_one :gem_download, proc { |m| where(rubygem_id: m.rubygem_id) }
 
   before_save :update_prerelease


### PR DESCRIPTION
Since `Version#dependencies` has a scope, `Dependency#version` will not
be populated automatically.

adding an `:inverse_of` will do this for us.

---

To be honest, not sure if this needs to be populated. I was checking the associations elsewhere and saw this one as low hanging fruit.
