### PR TITLE
Add recent uploads to stats page

### DIFF
--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -47,7 +47,7 @@
     .stat__count {
       font-size: 24px; } }
 
-.stats__graph__heading {
+.stats__heading {
   margin-bottom: 42px;
   font-weight: 600;
   font-size: 18px;

--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -205,3 +205,32 @@
   @-moz-document url-prefix() {
     .stats__graph__gem__count {
       top: 8px; } }
+
+.stats__table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 30px 15px;
+  border-left: 3%;
+}
+
+.stats__table__row {
+  height: 30px;
+  width: 100%; }
+
+.stats__table__column {
+  /* Size table columns to contents. */
+  width: 1%;
+  white-space: nowrap;
+
+  font-weight: 400;
+  text-align: right;
+  vertical-align: middle; }
+
+  @media (max-width: 709px) {
+    .stats__table__column {
+      font-size: 13px; } }
+  @media (min-width: 710px) {
+    .stats__table__column {
+      font-size: 15px; } }
+
+.stats__table__column a { color: black; }

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -5,5 +5,6 @@ class StatsController < ApplicationController
     @number_of_downloads = GemDownload.total_count
     @most_downloaded     = Rubygem.by_downloads.limit(10).includes(:gem_download).to_a
     @most_downloaded_count = @most_downloaded.first && @most_downloaded.first.gem_download.count
+    @recent_uploads = Version.recent_uploads(10)
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -157,6 +157,13 @@ class Version < ActiveRecord::Base
       .limit(limit)
   end
 
+  def self.recent_uploads(limit)
+    joins(:rubygem)
+      .indexed
+      .by_created_at
+      .limit(limit)
+  end
+
   def self.published(limit)
     indexed.by_built_at.limit(limit)
   end

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -15,17 +15,39 @@
   </h2>
 </div>
 
-<h2 class="stats__graph__heading">
-  <%= t('stats.index.all_time_most_downloaded') %>
-</h2>
+<div class="stats">
+  <h2 class="stats__graph__heading">
+    <%= t('stats.index.all_time_most_downloaded') %>
+  </h2>
 
-<% @most_downloaded.each do |gem| %>
-  <div class="stats__graph__gem">
-    <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
-    <div class="stats__graph__gem__meter-wrap">
-      <div class="stats__graph__gem__meter" style="width: <%= stats_graph_meter(gem, @most_downloaded_count) %>%">
-        <span class="stats__graph__gem__count"><%= number_to_delimited gem.downloads %></span>
+  <% @most_downloaded.each do |gem| %>
+    <div class="stats__graph__gem">
+      <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
+      <div class="stats__graph__gem__meter-wrap">
+        <div class="stats__graph__gem__meter" style="width: <%= stats_graph_meter(gem, @most_downloaded_count) %>%">
+          <span class="stats__graph__gem__count"><%= number_to_delimited gem.downloads %></span>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>
+
+<div class="stats">
+  <h2 class="stats__graph__heading">
+    recent uploads
+  </h2>
+
+    <table class="stats__table">
+      <% @recent_uploads.each do |version| %>
+        <tr class="stats__table__row">
+          <th class="stats__table__column">
+            <%= version.rubygem.name %>
+          </th>
+          <td class="stats__table__column">
+            <%= version.number %>
+          </td>
+          <td></td>
+        </tr>
+      <% end %>
+    </table>
+</div>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -41,10 +41,10 @@
       <% @recent_uploads.each do |version| %>
         <tr class="stats__table__row">
           <th class="stats__table__column">
-            <%= version.rubygem.name %>
+            <%= link_to version.rubygem.name, rubygem_path(version.rubygem) %>
           </th>
           <td class="stats__table__column">
-            <%= version.number %>
+            <%= link_to version.number, rubygem_version_path(version.rubygem, version.slug) %>
           </td>
           <td></td>
         </tr>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -34,7 +34,7 @@
 
 <div class="stats">
   <h2 class="stats__graph__heading">
-    recent uploads
+    <%= t('stats.index.recent_uploads') %>
   </h2>
 
     <table class="stats__table">

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -16,7 +16,7 @@
 </div>
 
 <div class="stats">
-  <h2 class="stats__graph__heading">
+  <h2 class="stats__heading">
     <%= t('stats.index.all_time_most_downloaded') %>
   </h2>
 
@@ -33,7 +33,7 @@
 </div>
 
 <div class="stats">
-  <h2 class="stats__graph__heading">
+  <h2 class="stats__heading">
     <%= t('stats.index.recent_uploads') %>
   </h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
       total_gems: Total gems
       total_users: Total users
       all_time_most_downloaded: All Time Most Downloaded
+      recent_uploads: Recent Uploads
 
   users:
     new:

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -7,7 +7,7 @@ class StatsControllerTest < ActionController::TestCase
       @number_of_users     = 101
       @number_of_downloads = 42
       rails_cinco = create(:rubygem, name: 'rails_cinco', number: 1)
-      @recent_uploads      = [create(:version)]
+      @recent_uploads = [create(:version)]
 
       Rubygem.stubs(:total_count).returns @number_of_gems
       User.stubs(:count).returns @number_of_users

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -7,9 +7,11 @@ class StatsControllerTest < ActionController::TestCase
       @number_of_users     = 101
       @number_of_downloads = 42
       rails_cinco = create(:rubygem, name: 'rails_cinco', number: 1)
+      @recent_uploads      = [create(:version)]
 
       Rubygem.stubs(:total_count).returns @number_of_gems
       User.stubs(:count).returns @number_of_users
+      Version.stubs(:recent_uploads).returns @recent_uploads
 
       create(:gem_download, count: @number_of_downloads)
       rails_cinco.gem_download.update(count: 1)
@@ -39,6 +41,7 @@ class StatsControllerTest < ActionController::TestCase
     should "load up the number of gems, users, and downloads" do
       assert_received(User, :count)
       assert_received(Rubygem, :total_count)
+      assert_received(Version, :recent_uploads) { |subject| subject.with(10) }
     end
   end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -133,6 +133,27 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context "recent uploads" do
+    setup do
+      @gem_1 = create(:rubygem)
+      @second = create(:version, rubygem: @gem_1, created_at: 1.day.ago)
+      @fourth = create(:version, rubygem: @gem_1, created_at: 4.days.ago)
+
+      @gem_2 = create(:rubygem)
+      @first = create(:version, rubygem: @gem_2, created_at: 1.minute.ago)
+      @not_included_fifth = create(:version, rubygem: @gem_2, created_at: 10.days.ago)
+
+      @gem_3 = create(:rubygem)
+      @third = create(:version, rubygem: @gem_3, created_at: 3.days.ago)
+    end
+
+    should "include specified number of versions ordered by created at" do
+      versions = Version.recent_uploads(4)
+      assert_equal 4, versions.size
+      assert_equal [@first, @second, @third, @fourth], versions
+    end
+  end
+
   context "with a rubygem" do
     setup do
       @rubygem = create(:rubygem)


### PR DESCRIPTION
This PR adds a table for the 10 most recently uploaded gem versions to the stats page, as suggested in #1217.

I've tried to keep this in a similar style to the rest of the page but this might be able to be improved. Potentially more information could also be added to this table, e.g. displaying how long ago uploads took place might be useful.

I did encounter one issue just now after rebasing this branch to be up to date with the latest changes - when I visit the stats page after this I get the following error:

```
NoMethodError (undefined method `gem_download' for nil:NilClass):
app/controllers/stats_controller.rb:7:in `index'
```

I think this is because I have no downloads yet in my local database; I then tried to download a gem to see if this would fix this however I get the following error when visiting the download page:

```
ActionController::RoutingError (No route matches [GET] "/gems/rake-11.1.2.gem"):
```

I'm not sure why this route would be failing though.
