### PR TITLE
Add a width to the footer.

### DIFF
--- a/app/assets/stylesheets/modules/footer.css
+++ b/app/assets/stylesheets/modules/footer.css
@@ -6,7 +6,8 @@
   border-top: 1px solid rgba(255, 255, 255, 0.3);
   background-color: #141c22;
   box-shadow: 0 -4px 0 0 #141c22;
-  z-index: 2; }
+  z-index: 2; 
+  width: 100%; }
   @media (min-width: 780px) {
     .footer {
       min-height: 70vh; } }


### PR DESCRIPTION
As it stood with the old CSS if there was no content then the footer
would only fill half the page.  This fixes it so that if whether there
is content or not then the footer will fill the entire width of the
page.  This problem was noticed in Chrome/Firefox on Linux x86-64.