### PR TITLE
Improve performance on gems page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 bundler_args: --jobs=3 --retry=3 --without development
 
 git:
-  submodules: false
+  submodules: true
 
 cache:
   directories:

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -8,7 +8,7 @@ class RubygemsController < ApplicationController
     respond_to do |format|
       format.html do
         @letter = Rubygem.letterize(params[:letter])
-        @gems   = Rubygem.includes(:gem_download).letter(@letter).by_downloads.paginate(page: @page)
+        @gems   = Rubygem.letter(@letter).includes(:gem_download).paginate(page: @page)
       end
       format.atom do
         @versions = Version.published(20)

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -8,7 +8,7 @@ class RubygemsController < ApplicationController
     respond_to do |format|
       format.html do
         @letter = Rubygem.letterize(params[:letter])
-        @gems   = Rubygem.letter(@letter).includes(:gem_download).paginate(page: @page)
+        @gems   = Rubygem.letter(@letter).includes(:latest_version, :gem_download).paginate(page: @page)
       end
       format.atom do
         @versions = Version.published(20)

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -102,6 +102,6 @@ module RubygemsHelper
   end
 
   def latest_version_number(rubygem)
-    rubygem.versions.most_recent.try(:number)
+    (rubygem.latest_version || rubygem.versions.last).try(:number)
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -7,6 +7,7 @@ class Rubygem < ActiveRecord::Base
   has_many :subscribers, through: :subscriptions, source: :user
   has_many :subscriptions, dependent: :destroy
   has_many :versions, dependent: :destroy, validate: false
+  has_one :latest_version, -> { where(latest: true) }, class_name: "Version"
   has_many :web_hooks, dependent: :destroy
   has_one :linkset, dependent: :destroy
   has_one :gem_download, -> { where(version_id: 0) }

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -4,7 +4,7 @@
       <%= rubygem.name %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
     </h2>
-    <p class="gems__gem__desc t-text"><%= short_info(rubygem.versions.most_recent) %></p>
+    <p class="gems__gem__desc t-text"><%= short_info(rubygem.latest_version || rubygem.versions.last) %></p>
   </div>
   <p class="gems__gem__downloads__count">
     <%= download_count rubygem %>


### PR DESCRIPTION
This removes a big JOIN on that [page](https://rubygems.org/gems/), and also a N+1.

- Big JOIN:
`by_downloads` scope joins with the gem_downloads table, to be able to sort rubygems by the number of downloads. That join is slow. I the case of gems table, we dont need to sort by downloads, as we already sort by the name of the gem.

- N+1:
There was a N+1 to get the latest version of each gem. On the grid list, we show the gem latest number and description, that comes from the latest released gem. I created an association so we can eager load that now.

review @dwradcliffe 