### PR TITLE
Use Type API for authors Array->String cast

### DIFF
--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -683,6 +683,14 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  should "validate authors the same twice" do
+    v = Version.new(authors:  %w(arthurnn dwradcliffe), number: 1, platform: 'ruby')
+    assert_equal "arthurnn, dwradcliffe", v.authors
+    assert v.valid?
+    assert_equal "arthurnn, dwradcliffe", v.authors
+    assert v.valid?
+  end
+
   context "checksums" do
     setup do
       @version = create(:version)


### PR DESCRIPTION
With the new Type API, we dont need to cast the value on a callback,
we can cast it right after we receive the value using the attribute API, like that if calling
the callback stack twice, that will be fine.

review @dwradcliffe 
cc @sgrif