### PR TITLE
Return the latest version on search

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -57,7 +57,7 @@ module RubygemSearchable
         result.load
         result
       else
-        legacy_search(query).with_versions.paginate(page: page)
+        legacy_search(query).eager_load(:latest_version, :gem_download).paginate(page: page)
       end
     rescue Faraday::ConnectionFailed
       raise SearchDownError
@@ -110,8 +110,7 @@ module RubygemSearchable
       SQL
 
       where(conditions, query: "%#{query.strip}%")
-        .includes(:versions)
-        .references(:versions)
+        .joins(:versions)
         .by_downloads
     end
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -7,7 +7,7 @@ class Rubygem < ActiveRecord::Base
   has_many :subscribers, through: :subscriptions, source: :user
   has_many :subscriptions, dependent: :destroy
   has_many :versions, dependent: :destroy, validate: false
-  has_one :latest_version, -> { where(latest: true) }, class_name: "Version"
+  has_one :latest_version, -> { where(latest: true).order(created_at: :desc) }, class_name: "Version"
   has_many :web_hooks, dependent: :destroy
   has_one :linkset, dependent: :destroy
   has_one :gem_download, -> { where(version_id: 0) }

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -629,6 +629,14 @@ class RubygemTest < ActiveSupport::TestCase
       should "sort results by number of downloads, descending" do
         assert_equal [@apple_crisp, @apple_pie], Rubygem.legacy_search('apple')
       end
+
+      should "return the latest version among all the platforms" do
+        create(:version, description: 'pie', rubygem: @apple_crisp, platform: "mswin")
+        version = create(:version, description: 'pie', rubygem: @apple_crisp, platform: "ruby")
+
+        gem = Rubygem.legacy_search('apple crisp').first
+        assert_equal version, gem.latest_version
+      end
     end
 
     should "find exact match by name on #name_is" do


### PR DESCRIPTION
On latest_version association, we need to order by the latest created at, otherwise
we can have more than one version maked as latest=true, because we mark those based on
the platforms. Thus the same rubygem has more than one `latest=true` version.
However, the association, should return only the latest version, so we need to order.

[fixes #1249]

review @dwradcliffe @gioele

Tested this locally, and it works.