### PR TITLE
Do not include major release for pre releases

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -285,7 +285,7 @@ class Version < ActiveRecord::Base
   end
 
   def to_bundler
-    if number[0] == "0"
+    if number[0] == "0" || prerelease?
       %(gem '#{rubygem.name}', '~> #{number}')
     else
       release = feature_release(number)

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -363,6 +363,15 @@ class VersionTest < ActiveSupport::TestCase
 
         assert_equal expected, actual
       end
+
+      should "not include major version of gem for pre releases" do
+        prerelease_version = create(:version, number: "4.0.0.pre")
+        name = prerelease_version.rubygem.name
+        actual = prerelease_version.to_bundler
+        expected = %(gem '#{name}', '~> 4.0.0.pre')
+
+        assert_equal expected, actual
+      end
     end
 
     should "give title and platform for #to_title" do


### PR DESCRIPTION
Make sure major releases are not included in the gemfile line when
showing pre releases. e.g. .pre, .rc1, .rc2, .beta

Fixes #1191