### PR TITLE
allow bundler.rubygems.org host

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -6,7 +6,7 @@ class Redirector
   def call(env)
     request = Rack::Request.new(env)
 
-    allowed_hosts = [Gemcutter::HOST, 'index.rubygems.org', 'fastly.rubygems.org']
+    allowed_hosts = [Gemcutter::HOST, 'index.rubygems.org', 'fastly.rubygems.org', 'bundler.rubygems.org']
 
     if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))


### PR DESCRIPTION
This is preparation for infrastructure changes to allow dependency api traffic to reach the application. This is separate from the other PR so I can test infra changes.

FYI @indirect @segiddins @maclover7 