### PR TITLE
Prevent stats page error when no downloads

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -4,6 +4,6 @@ class StatsController < ApplicationController
     @number_of_users     = User.count
     @number_of_downloads = GemDownload.total_count
     @most_downloaded     = Rubygem.by_downloads.limit(10).includes(:gem_download).to_a
-    @most_downloaded_count = @most_downloaded.first.gem_download.count
+    @most_downloaded_count = @most_downloaded.first && @most_downloaded.first.gem_download.count
   end
 end

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -42,6 +42,14 @@ class StatsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to index with no downloads" do
+    setup do
+      get :index
+    end
+
+    should respond_with :success
+  end
+
   context "on GET to index with multiple gems" do
     setup do
       rg1 = create(:rubygem, downloads: 10, number: "1")


### PR DESCRIPTION
This is a fix for an issue mentioned in https://github.com/rubygems/rubygems.org/pull/1238.

If the stats page was visited while there were no downloads in the database, a `NoMethodError` would be thrown due to `@most_downloaded.first` being nil. This commit prevents this by checking it is available before accessing it.

While this issue wouldn't occur in production it could in development after following the standard instructions for setting up a development environment in `CONTRIBUTING.md`.