### PR TITLE
Fix database setup in dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ than Rubygems and may suit your organization’s needs better.**
 
 * Get set up: `./script/setup`
 * Run the database rake tasks if needed:
-    `bundle exec rake db:create:all db:drop:all db:setup db:test:prepare --trace`
+    `bundle exec rake db:reset db:test:prepare --trace`
 
 #### Running tests
 


### PR DESCRIPTION
Log of previous commands:
```
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:create
** Invoke db:drop (first_time)
** Invoke db:load_config 
** Execute db:drop
** Invoke db:setup (first_time)
** Invoke db:schema:load_if_ruby (first_time)
** Invoke db:create 
** Invoke environment (first_time)
** Execute environment
Sync gem should be back to the blacklist of game names by now.
** Execute db:schema:load_if_ruby
** Invoke db:schema:load (first_time)
** Invoke environment 
** Invoke db:load_config 
** Execute db:schema:load
-- enable_extension("plpgsql")
rake aborted!
ActiveRecord::NoDatabaseError: FATAL:  database "gemcutter_development" does not exist
```
`db:setup` was not creating database because it executes `db:create` only if it was invoked for the first time.
Removing `all` will not any affect cause it is development setup instructions.