### PR TITLE
Uncomment assertions and remove deprecated routes test

### DIFF
--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -1,9 +1,6 @@
 require 'test_helper'
 
 class Api::V1::ApiKeysControllerTest < ActionController::TestCase
-  # should_route :get, "/api_key", :action => :show
-  # should_route :put, "/api_key/reset", :action => :reset
-
   should "route new paths to new controller" do
     route = { controller: 'api/v1/api_keys', action: 'show' }
     assert_recognizes(route, '/api/v1/api_key')

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -128,9 +128,8 @@ class SearchesControllerTest < ActionController::TestCase
     should render_template :show
     should "see sinatra on the page in the suggestions" do
       page.assert_text('Maybe you mean')
-      # assert page.find('.search-suggestions').has_content?(@sinatra.name)
-      # assert page.has_content?(@sinatra.name)
-      # assert page.has_selector?("a[href='#{search_path(q: @sinatra.name)}']")
+      assert page.find('.search__suggestions').has_content?(@sinatra.name)
+      assert page.has_selector?("a[href='#{search_path(query: @sinatra.name)}']")
     end
     should "not see sinatra on the page in the results" do
       page.assert_no_selector("a[href='#{rubygem_path(@sinatra)}']")


### PR DESCRIPTION
Removed assertion is covered in first assertion (`assert page.find('.search__suggestions')...`)