### PR TITLE
Add pagination to stats page

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,7 +3,9 @@ class StatsController < ApplicationController
     @number_of_gems      = Rubygem.total_count
     @number_of_users     = User.count
     @number_of_downloads = GemDownload.total_count
-    @most_downloaded     = Rubygem.by_downloads.limit(10).includes(:gem_download).to_a
-    @most_downloaded_count = @most_downloaded.first && @most_downloaded.first.gem_download.count
+    @most_downloaded     = Rubygem.by_downloads
+      .includes(:gem_download)
+      .paginate(page: params[:page], per_page: 10, total_entries: 100)
+    @most_downloaded_count = GemDownload.most_downloaded_gem_count
   end
 end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -33,6 +33,12 @@ class GemDownload < ActiveRecord::Base
     end
   end
 
+  # version_id: 0 stores count for total gem downloads
+  # we need to find the second maximum
+  def self.most_downloaded_gem_count
+    count_by_sql "SELECT MAX(count) FROM gem_downloads WHERE count NOT IN (SELECT MAX(count) FROM gem_downloads)"
+  end
+
   def self.increment(count, rubygem_id:, version_id: 0)
     scope = GemDownload.where(rubygem_id: rubygem_id).select("id")
     scope = scope.where(version_id: version_id)

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -19,6 +19,10 @@
   <%= t('stats.index.all_time_most_downloaded') %>
 </h2>
 
+<header class="gems__header">
+  <p class="gems__meter"><%= page_entries_info @most_downloaded %></p>
+</header>
+
 <% @most_downloaded.each do |gem| %>
   <div class="stats__graph__gem">
     <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem) %></h3>
@@ -29,3 +33,4 @@
     </div>
   </div>
 <% end %>
+<%= will_paginate @most_downloaded %>

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -52,14 +52,13 @@ class StatsControllerTest < ActionController::TestCase
 
   context "on GET to index with multiple gems" do
     setup do
+      create(:gem_download, count: 0)
       rg1 = create(:rubygem, downloads: 10, number: "1")
       rg2 = create(:rubygem, downloads: 20, number: "1")
       rg3 = create(:rubygem, downloads: 30, number: "1")
       n = 10
-      [rg1, rg2, rg3].each do |rg|
-        rg.versions.last.gem_download.update(count: n)
-        n += 10
-      end
+      data = [rg1, rg2, rg3].map { |r| [r.versions.last.full_name, n += 10] }
+      GemDownload.bulk_update(data)
 
       get :index
     end

--- a/test/unit/gem_download_test.rb
+++ b/test/unit/gem_download_test.rb
@@ -5,7 +5,7 @@ class GemDownloadTest < ActiveSupport::TestCase
     create(:gem_download, count: 0)
   end
 
-  context "#increment" do
+  context ".increment" do
     should "not update if download doesnt exist" do
       assert_nil GemDownload.increment(1, rubygem_id: 1)
     end
@@ -50,7 +50,7 @@ class GemDownloadTest < ActiveSupport::TestCase
     GemDownload.delete_all
   end
 
-  context "#bulk_update" do
+  context ".bulk_update" do
     should "write the proper values" do
       versions = Array.new(2) { create(:version) }
       gems     = versions.map(&:rubygem)
@@ -63,6 +63,20 @@ class GemDownloadTest < ActiveSupport::TestCase
         assert_equal counts[i], GemDownload.count_for_version(versions[i].id)
         assert_equal counts[i], GemDownload.count_for_rubygem(gems[i].id)
       end
+    end
+  end
+
+  context ".most_downloaded_gem_count" do
+    setup do
+      versions = Array.new(20) { create(:version) }
+      @counts  = Array.new(20) { rand(100) }
+      data     = versions.map.with_index { |v, i| [v.full_name, @counts[i]] }
+
+      GemDownload.bulk_update(data)
+    end
+
+    should "return count of most downloaded gem" do
+      assert_equal @counts.max, GemDownload.most_downloaded_gem_count
     end
   end
 


### PR DESCRIPTION
#1166 
![screenshot from 2016-05-15 23-21-48](https://cloud.githubusercontent.com/assets/7680662/15275841/21e0855e-1af4-11e6-9b39-626c1492ccc4.png)
![screenshot from 2016-05-15 23-21-53](https://cloud.githubusercontent.com/assets/7680662/15275843/29125dfc-1af4-11e6-81fe-46ddf0cd3c48.png)

Probably graph would taper off much slowly on rg.org because difference between any two consecutive gems should not be very high. 

Also, for anyone interested in just data of top-50 downloaded gems, we have: https://rubygems.org/api/v1/downloads/all.json