### PR TITLE
Remove bundled/default gems from blacklist. 

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -10,7 +10,6 @@ module Patterns
     abbrev
     base64
     benchmark
-    bigdecimal
     cgi
     cgi-session
     cmath
@@ -34,8 +33,6 @@ module Patterns
     find
     forwardable
     getoptlong
-    gserver
-    io-console
     io-nonblock
     io-wait
     ipaddr
@@ -52,7 +49,6 @@ module Patterns
     net-pop
     net-protocol
     net-smtp
-    net-telnet
     nkf
     observer
     open-uri


### PR DESCRIPTION
These gems need to maintain as standalone gem without ruby core library. Owner of these gems are CRuby committer named @nobu , @mrkn , @hsbt

 * io-console: https://github.com/ruby/ruby/tree/trunk/ext/io/console
 * bigdecimal: https://github.com/ruby/bigdecimal
 * net-telnet: https://github.com/ruby/net-telnet
 * gserver: https://github.com/ruby/gserver

It block to bump new version. see https://bugs.ruby-lang.org/issues/12284#note-4 .

ref https://github.com/rubygems/rubygems.org/pull/1221