### PR TITLE
handle no gems param for dependency api

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -25,6 +25,6 @@ class Api::V1::DependenciesController < Api::BaseController
   end
 
   def gem_names
-    @gem_names ||= params[:gems].split(",")
+    @gem_names ||= params[:gems].blank? ? [] : params[:gems].split(",".freeze)
   end
 end

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -3,11 +3,23 @@ require 'test_helper'
 class Api::V1::DependenciesControllerTest < ActionController::TestCase
   ## JSON ENDPOINTS:
   # NO GEMS:
-  context "On GET to index --> with no gems --> JSON" do
+  context "On GET to index --> with empty gems param --> JSON" do
     setup do
-      @rubygem = create(:rubygem, name: "testgem")
-      @version = create(:version, number: "1.0.0", rubygem_id: @rubygem.id)
       get :index, gems: "", format: "json"
+    end
+
+    should "return 200" do
+      assert_response :success
+    end
+
+    should "return an empty body" do
+      assert_empty response.body
+    end
+  end
+
+  context "On GET to index --> with no gems param --> JSON" do
+    setup do
+      get :index, format: "json"
     end
 
     should "return 200" do


### PR DESCRIPTION
If the gems param was not present we were just failing. We should handle this the same as param with empty string.

@segiddins @maclover7 @sonalkr132 @indirect 