### PR TITLE
Return empty array at dependency endpoint if gem is not found

### DIFF
--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -33,7 +33,8 @@ class GemDependent
   private
 
   def fetch_dependency_from_db(gem_name)
-    gem_record = Rubygem.includes(:versions).find_by_name!(gem_name)
+    gem_record = Rubygem.includes(:versions).find_by_name(gem_name)
+    return [] unless gem_record
     gem_record.versions.includes(:dependencies).sort_by(&:number).reverse_each.map do |version|
       version_deps = version.dependencies.select { |d| d.scope == 'runtime' }
 

--- a/test/unit/gem_dependent_test.rb
+++ b/test/unit/gem_dependent_test.rb
@@ -49,4 +49,10 @@ class GemDependentTest < ActiveSupport::TestCase
       )
     end
   end
+
+  context "with gem_names which do not exist" do
+    should "return empty array" do
+      assert_equal [], GemDependent.new(["does_not_exist"]).to_a
+    end
+  end
 end


### PR DESCRIPTION
Yanked(private?) gems don't give `ActiveRecord::RecordNotFound` error: [example gem denpendency link](http://bundler.rubygems.org/api/v1/dependencies.json?gems=loremoooooooooo)