### PR TITLE
Remove rubygems version check from Indexer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ than Rubygems and may suit your organization’s needs better.**
 
 #### Environment (OS X)
 
-* Use Ruby 2.2.4
-* Use Rubygems 2.4.5
+* Use Ruby 2.3.1
+* Use Rubygems 2.6.4
 * Install bundler: `gem install bundler`
 * Install Elastic Search: `brew install elasticsearch`
   * Setup information: `brew info elasticsearch`
@@ -89,9 +89,9 @@ than Rubygems and may suit your organization’s needs better.**
 
 #### Environment (Linux - Debian/Ubuntu)
 
-* Use Ruby 2.2.4 `apt-get install ruby2.2`
+* Use Ruby 2.3.1 `apt-get install ruby2.3`
   * Or install via [alternate methods](https://www.ruby-lang.org/en/downloads/)
-* Use Rubygems 2.4.5
+* Use Rubygems 2.6.4
 * Install bundler: `gem install bundler`
 * Install Elastic Search 1.5.2: <https://www.elastic.co/downloads/past-releases/elasticsearch-1-5-2>
 * Install PostgreSQL: `apt-get install postgresql postgresql-server-dev-all`

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -13,7 +13,8 @@ class Indexer
   def write_gem(body, spec)
     RubygemFs.instance.store("gems/#{spec.original_name}.gem", body.string)
 
-    self.class.sanitize_spec(spec)
+    spec.abbreviate
+    spec.sanitize
 
     RubygemFs.instance.store(
       "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
@@ -80,27 +81,5 @@ class Indexer
 
   def log(message)
     Rails.logger.info "[GEMCUTTER:#{Time.zone.now}] #{message}"
-  end
-
-  # TODO: remove this after we upgrade rubygems client to 2.5.0+
-  if Gem::VERSION < '2.5.0'
-    def self.indexer
-      @indexer ||=
-        begin
-          indexer = Gem::Indexer.new(Rails.root.join("server"), build_legacy: false)
-          def indexer.say(_) end
-          indexer
-        end
-    end
-
-    def self.sanitize_spec(spec)
-      indexer.abbreviate spec
-      indexer.sanitize spec
-    end
-  else # >= 2.5.0
-    def self.sanitize_spec(spec)
-      spec.abbreviate
-      spec.sanitize
-    end
   end
 end


### PR DESCRIPTION
We are using 2.6.4 now.