### PR TITLE
Remove duplicate show all versions link

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -96,11 +96,6 @@
             <%= t('.downloads_for_this_version') %>
             <span class="gem__downloads"><%= number_with_delimiter(@latest_version.downloads_count) %></span>
           </h2>
-          <% if @versions.present? %>
-            <% if show_all_versions_link?(@rubygem) %>
-              <%= link_to t('.show_all_versions', :count => @rubygem.versions.count), rubygem_versions_url(@rubygem), :class => "gem__see-all-versions t-link--gray t-link--has-arrow" %>
-            <% end %>
-          <% end %>
         </div>
       <% end %>
 


### PR DESCRIPTION
I don't think we need *show all versions* link under number of downloads. It is already there at its appropriate place, ie under the versions.
It was introduced in d760ec4737
**Before:**
![screenshot from 2016-05-25 19-56-58](https://cloud.githubusercontent.com/assets/7680662/15543697/8ada907e-22b3-11e6-8ed3-cc94605b9d0b.png)

**After:**
![screenshot from 2016-05-25 19-57-02](https://cloud.githubusercontent.com/assets/7680662/15543728/a664f672-22b3-11e6-8075-0dc859d5607d.png)

I hope this PR makes sense.