### PR TITLE
Rename rubygems_version to required_rubygems_version

### DIFF
--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -44,7 +44,7 @@ class GemDependent
         name:                  gem_name,
         number:                version.number,
         platform:              version.platform,
-        rubygems_version:      version.rubygems_version,
+        rubygems_version:      version.required_rubygems_version,
         ruby_version:          version.ruby_version,
         checksum:              version.sha256,
         created_at:            version.created_at,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -204,7 +204,7 @@ class Version < ActiveRecord::Base
       metadata: spec.metadata || {},
       requirements: spec.requirements,
       built_at: spec.date,
-      rubygems_version: spec.required_rubygems_version.to_s,
+      required_rubygems_version: spec.required_rubygems_version.to_s,
       ruby_version: spec.required_ruby_version.to_s,
       indexed: true
     )
@@ -248,7 +248,7 @@ class Version < ActiveRecord::Base
       'number'           => number,
       'summary'          => summary,
       'platform'         => platform,
-      'rubygems_version' => rubygems_version,
+      'rubygems_version' => required_rubygems_version,
       'ruby_version'     => ruby_version,
       'prerelease'       => prerelease,
       'licenses'         => licenses,
@@ -333,9 +333,9 @@ class Version < ActiveRecord::Base
     update(metadata: metadata || {})
   end
 
-  def assign_rubygems_version!
-    rubygems_version = get_spec_attribute('rubygems_version')
-    update_column(:rubygems_version, rubygems_version || '')
+  def assign_required_rubygems_version!
+    required_rubygems_version = get_spec_attribute('required_rubygems_version')
+    update_column(:required_rubygems_version, required_rubygems_version.to_s)
   end
 
   def documentation_path

--- a/db/migrate/20160527171228_add_required_rubygems_version.rb
+++ b/db/migrate/20160527171228_add_required_rubygems_version.rb
@@ -1,0 +1,6 @@
+class AddRequiredRubygemsVersion < ActiveRecord::Migration
+  def change
+    remove_column :versions, :rubygems_version, :string
+    add_column :versions, :required_rubygems_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160517061033) do
+ActiveRecord::Schema.define(version: 20160527171228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 20160517061033) do
     t.string   "ruby_version"
     t.string   "sha256"
     t.hstore   "metadata",          default: {},   null: false
-    t.string   "rubygems_version"
+    t.string   "required_rubygems_version"
   end
 
   add_index "versions", ["built_at"], name: "index_versions_on_built_at", using: :btree

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -80,18 +80,18 @@ namespace :gemcutter do
     end
   end
 
-  namespace :rubygems_version do
+  namespace :required_rubygems_version do
     desc "Backfill gem versions with rubygems_version."
     task backfill: :environment do
-      without_rubygems_version = Version.where(rubygems_version: nil)
+      without_required_rubygems_version = Version.where(required_rubygems_version: nil)
       mod = ENV['shard']
-      without_rubygems_version = without_rubygems_version.where("id % 4 = ?", mod.to_i) if mod
+      without_required_rubygems_version = without_required_rubygems_version.where("id % 4 = ?", mod.to_i) if mod
 
-      total = without_rubygems_version.count
+      total = without_required_rubygems_version.count
       i = 0
       puts "Total: #{total}"
-      without_rubygems_version.find_each do |version|
-        version.assign_rubygems_version!
+      without_required_rubygems_version.find_each do |version|
+        version.assign_required_rubygems_version!
         i += 1
         print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
       end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -90,7 +90,7 @@ FactoryGirl.define do
     metadata "foo" => "bar"
     number
     platform "ruby"
-    rubygems_version ">= 2.6.3"
+    required_rubygems_version ">= 2.6.3"
     ruby_version ">= 2.0.0"
     licenses "MIT"
     requirements "Opencv"

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -23,7 +23,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.number, json["number"]
       assert_equal @version.platform, json["platform"]
       assert_equal @version.prerelease, json["prerelease"]
-      assert_equal @version.rubygems_version, json["rubygems_version"]
+      assert_equal @version.required_rubygems_version, json["rubygems_version"]
       assert_equal @version.ruby_version, json["ruby_version"]
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
@@ -52,7 +52,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.number, xml.at_css("number").content
       assert_equal @version.platform, xml.at_css("platform").content
       assert_equal @version.prerelease.to_s, xml.at_css("prerelease").content
-      assert_equal @version.rubygems_version, xml.at_css("rubygems-version").content
+      assert_equal @version.required_rubygems_version, xml.at_css("rubygems-version").content
       assert_equal @version.ruby_version, xml.at_css("ruby-version").content
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
@@ -185,14 +185,14 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a rubygems version" do
     setup do
-      @rubygems_version = ">= 2.6.4"
+      @required_rubygems_version = ">= 2.6.4"
       @version = create(:version)
     end
 
     should "have a rubygems version" do
-      @version.update(rubygems_version: @rubygems_version)
+      @version.update(required_rubygems_version: @required_rubygems_version)
       new_version = Version.find(@version.id)
-      assert_equal new_version.rubygems_version, @rubygems_version
+      assert_equal new_version.required_rubygems_version, @required_rubygems_version
     end
   end
 
@@ -202,9 +202,9 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "not have a rubygems version" do
-      @version.update(rubygems_version: nil)
+      @version.update(required_rubygems_version: nil)
       nil_version = Version.find(@version.id)
-      assert_nil nil_version.rubygems_version
+      assert_nil nil_version.required_rubygems_version
     end
   end
 


### PR DESCRIPTION
`assign_rubygems_version!` used to backfill `rubygems_version` is wrong ([link](https://github.com/rubygems/rubygems.org/blob/master/app/models/version.rb#L337)). It should have used `required_rubygems_version`. To avoid any further confusion we are renaming everything to `required_rubygems_version`.
Endpoints/api won't change, they would still showing them as `rubygems_version`.