### PR TITLE
Rename ruby_version to required_ruby_version

### DIFF
--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -45,7 +45,7 @@ class GemDependent
         number:                version.number,
         platform:              version.platform,
         rubygems_version:      version.required_rubygems_version,
-        ruby_version:          version.ruby_version,
+        ruby_version:          version.required_ruby_version,
         checksum:              version.sha256,
         created_at:            version.created_at,
         dependencies:          version_deps.map { |d| [d.name, d.requirements] }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -205,7 +205,7 @@ class Version < ActiveRecord::Base
       requirements: spec.requirements,
       built_at: spec.date,
       required_rubygems_version: spec.required_rubygems_version.to_s,
-      ruby_version: spec.required_ruby_version.to_s,
+      required_ruby_version: spec.required_ruby_version.to_s,
       indexed: true
     )
   end
@@ -249,7 +249,7 @@ class Version < ActiveRecord::Base
       'summary'          => summary,
       'platform'         => platform,
       'rubygems_version' => required_rubygems_version,
-      'ruby_version'     => ruby_version,
+      'ruby_version'     => required_ruby_version,
       'prerelease'       => prerelease,
       'licenses'         => licenses,
       'requirements'     => requirements,

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -127,8 +127,8 @@
       <h2 class="gem__ruby-version__heading t-list__heading">
         <%= t('.required_ruby_version') %>:
         <i class="gem__ruby-version">
-          <% if @latest_version.ruby_version %>
-            <%= @latest_version.ruby_version %>
+          <% if @latest_version.required_ruby_version %>
+            <%= @latest_version.required_ruby_version %>
           <% else %>
             <%= t('none') %>
           <% end %>

--- a/db/migrate/20160527190738_rename_ruby_version.rb
+++ b/db/migrate/20160527190738_rename_ruby_version.rb
@@ -1,0 +1,5 @@
+class RenameRubyVersion < ActiveRecord::Migration
+  def change
+    rename_column :versions, :ruby_version, :required_ruby_version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160527171228) do
+ActiveRecord::Schema.define(version: 20160527190738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 20160527171228) do
     t.integer  "size"
     t.string   "licenses"
     t.text     "requirements"
-    t.string   "ruby_version"
+    t.string   "required_ruby_version"
     t.string   "sha256"
     t.hstore   "metadata",          default: {},   null: false
     t.string   "required_rubygems_version"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -91,7 +91,7 @@ FactoryGirl.define do
     number
     platform "ruby"
     required_rubygems_version ">= 2.6.3"
-    ruby_version ">= 2.0.0"
+    required_ruby_version ">= 2.0.0"
     licenses "MIT"
     requirements "Opencv"
     rubygem

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -24,7 +24,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.platform, json["platform"]
       assert_equal @version.prerelease, json["prerelease"]
       assert_equal @version.required_rubygems_version, json["rubygems_version"]
-      assert_equal @version.ruby_version, json["ruby_version"]
+      assert_equal @version.required_ruby_version, json["ruby_version"]
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
@@ -53,7 +53,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.platform, xml.at_css("platform").content
       assert_equal @version.prerelease.to_s, xml.at_css("prerelease").content
       assert_equal @version.required_rubygems_version, xml.at_css("rubygems-version").content
-      assert_equal @version.ruby_version, xml.at_css("ruby-version").content
+      assert_equal @version.required_ruby_version, xml.at_css("ruby-version").content
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
       assert_equal @version.requirements, xml.at_css("requirements").content
@@ -210,16 +210,16 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a ruby version" do
     setup do
-      @ruby_version = ">= 1.9.3"
+      @required_ruby_version = ">= 1.9.3"
       @version = create(:version)
     end
     subject { @version }
 
     should "have a ruby version" do
-      @version.ruby_version = @ruby_version
+      @version.required_ruby_version = @required_ruby_version
       @version.save!
       new_version = Version.find(@version.id)
-      assert_equal new_version.ruby_version, @ruby_version
+      assert_equal new_version.required_ruby_version, @required_ruby_version
     end
   end
 
@@ -230,10 +230,10 @@ class VersionTest < ActiveSupport::TestCase
     subject { @version }
 
     should "not have a ruby version" do
-      @version.ruby_version = nil
+      @version.required_ruby_version = nil
       @version.save!
       nil_version = Version.find(@version.id)
-      assert_nil nil_version.ruby_version
+      assert_nil nil_version.required_ruby_version
     end
   end
 


### PR DESCRIPTION
So that it better reflects what it has stored.
endpoints/api has not changed. They still use `ruby_version`.