### PR TITLE
Redirect /api_key/reset to the deprecated action

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
     put 'api_key/reset', to: 'api/deprecated#index'
 
     post 'gems'
-    get 'gems/:id'
+    get 'gems/:id.json'
 
     scope path: 'gems/:rubygem_id' do
       put 'migrate'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,10 +100,10 @@ Rails.application.routes.draw do
 
   scope to: 'api/deprecated#index' do
     get 'api_key'
-    put 'api_key/reset'
+    put 'api_key/reset', to: 'api/deprecated#index'
 
     post 'gems'
-    get 'gems/:id.json'
+    get 'gems/:id'
 
     scope path: 'gems/:rubygem_id' do
       put 'migrate'


### PR DESCRIPTION
Why:

* The intented behavior for all API v0 endpoint is to point to
  `api/deprecated#index`, which `/api/reset` was not

This change addresses the need by:

* Specifing the `to` option on the `api_key/reset` endpoint, which in necessary
  in only in this particular case because of something rails call
  ["match shorthand"](https://github.com/rails/rails/blob/v4.2.6/actionpack/lib/action_dispatch/routing/mapper.rb#L1513),
  which because of the format of the route (`something/something_else`) will
  override the `to` coming from the scope, assuming we want `something` as the
  controller's name and `something_else` as the action.

The issue states that `gems/:id.json` should be `gems/:id`, but that just breaks a bunch of tests, which might be right, but I'm not sure, so I didn't change that.

Closes #1267 