### PR TITLE
Convert checksum/sha256 from base64 to hex at dependency endpoint

### DIFF
--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -61,7 +61,7 @@ class GemDependent
         platform:              dep_key.platform,
         rubygems_version:      dep_key.required_rubygems_version,
         ruby_version:          dep_key.required_ruby_version,
-        checksum:              dep_key.sha256,
+        checksum:              Version._sha256_hex(dep_key.sha256),
         created_at:            Time.zone.parse(dep_key.created_at).strftime('%Y-%m-%d %H:%M:%S %z'),
         dependencies:          gem_deps
       }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -315,7 +315,11 @@ class Version < ActiveRecord::Base
   end
 
   def sha256_hex
-    sha256.unpack("m0").first.unpack("H*").first if sha256
+    Version._sha256_hex(sha256) if sha256
+  end
+
+  def self._sha256_hex(raw)
+    raw.unpack("m0").first.unpack("H*").first
   end
 
   def recalculate_sha256

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -50,7 +50,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         'platform'          => 'ruby',
         'rubygems_version'  => '>= 2.6.3',
         'ruby_version'      => '>= 2.0.0',
-        'checksum'          => 'tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=',
+        'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
         'created_at'        => '2016-05-24 00:00:00 +0000',
         'dependencies'      => []
       }]
@@ -82,7 +82,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'platform'          => 'ruby',
           'rubygems_version'  => '>= 2.6.3',
           'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=',
+          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
           'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         },
@@ -93,7 +93,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'platform'          => 'ruby',
           'rubygems_version'  => '>= 2.6.3',
           'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=',
+          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
           'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         },
@@ -104,7 +104,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'platform'          => 'ruby',
           'rubygems_version'  => '>= 2.6.3',
           'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=',
+          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
           'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         }
@@ -172,7 +172,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         platform:          'ruby',
         rubygems_version:  '>= 2.6.3',
         ruby_version:      '>= 2.0.0',
-        checksum:          'tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=',
+        checksum:          'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
         created_at:        "2016-05-24 00:00:00 +0000",
         dependencies:      []
       }]

--- a/test/unit/gem_dependent_test.rb
+++ b/test/unit/gem_dependent_test.rb
@@ -33,7 +33,7 @@ class GemDependentTest < ActiveSupport::TestCase
         platform:            "ruby",
         rubygems_version:    ">= 2.6.3",
         ruby_version:        ">= 2.0.0",
-        checksum:            "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=",
+        checksum:            "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
         created_at:          "2016-05-24 00:00:00 +0000",
         dependencies: []
       }
@@ -102,7 +102,7 @@ class GemDependentTest < ActiveSupport::TestCase
           platform: "ruby",
           rubygems_version:    ">= 2.6.3",
           ruby_version:        ">= 2.0.0",
-          checksum:            "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=",
+          checksum:            "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
           created_at:          "2016-05-24 00:00:00 +0000",
           dependencies: []
         }


### PR DESCRIPTION
Currently bundler-api uses hex version.