### PR TITLE
Add required_rubygems_version to show page

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -135,6 +135,15 @@
         </i>
       </h2>
 
+      <% if @latest_version.required_rubygems_version != '>= 0' %>
+        <h2 class="gem__ruby-version__heading t-list__heading">
+          <%= t('.required_rubygems_version') %>:
+          <i class="gem__ruby-version">
+              <%= @latest_version.required_rubygems_version %>
+          </i>
+        </h2>
+      <% end %>
+
       <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
       <div class="t-list__items">
         <%= link_to t('edit'), edit_rubygem_path(@rubygem), :class => "gem__link t-list__item", :id => "edit" if @rubygem.owned_by?(current_user) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       copy_to_clipboard: Copy to clipboard
       copied: Copied!
       required_ruby_version: Required Ruby Version
+      required_rubygems_version: Required Rubygems Version
 
   searches:
     show:


### PR DESCRIPTION
![screenshot from 2016-06-04 14-24-16](https://cloud.githubusercontent.com/assets/7680662/15798751/5ebca15c-2a61-11e6-94ea-834a483975df.png)

BTW, majority of gems don't specify `required_ruby_version` either. Can we remove that as well instead of displaying `NONE`?
```sql
rubygems=# select count(*) from versions where ruby_version <> '>= 0';
 count 
-------
 57658
(1 row)

rubygems=# select count(*) from versions where ruby_version = '>= 0';
 count  
--------
 250957
(1 row)
```