### PR TITLE
Update ES index on gem yank and bulk download update

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -9,6 +9,7 @@ class Deletion < ActiveRecord::Base
   after_create :remove_from_index
   after_commit :expire_api_memcached
   after_commit :remove_from_storage
+  after_commit :update_search_index
 
   attr_accessor :version
 
@@ -45,5 +46,9 @@ class Deletion < ActiveRecord::Base
     Fastly.purge("gems/#{@version.full_name}.gem")
     Fastly.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
     Fastly.purge_api_cdn(rubygem)
+  end
+
+  def update_search_index
+    @version.rubygem.delay.update_document
   end
 end

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -4,89 +4,121 @@ class GemDownload < ActiveRecord::Base
 
   scope :most_downloaded_gems, -> { where("version_id != 0").includes(:version).order(count: :desc) }
 
-  def self.count_for_version(id)
-    v = Version.find(id)
-    return 0 unless v
-    download = GemDownload.find_by(rubygem_id: v.rubygem_id, version_id: v.id)
-    if download
-      download.count
-    else
-      0
-    end
-  end
-
-  def self.count_for_rubygem(id)
-    download = GemDownload.find_by(rubygem_id: id, version_id: 0)
-    if download
-      download.count
-    else
-      0
-    end
-  end
-
-  def self.total_count
-    download = GemDownload.find_by(rubygem_id: 0, version_id: 0)
-    if download
-      download.count
-    else
-      0
-    end
-  end
-
-  # version_id: 0 stores count for total gem downloads
-  # we need to find the second maximum
-  def self.most_downloaded_gem_count
-    count_by_sql "SELECT MAX(count) FROM gem_downloads WHERE count NOT IN (#{total_count})"
-  end
-
-  def self.increment(count, rubygem_id:, version_id: 0)
-    scope = GemDownload.where(rubygem_id: rubygem_id).select("id")
-    scope = scope.where(version_id: version_id)
-    sql = scope.to_sql
-
-    update = "UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *"
-
-    # TODO: Remove this comments, once we move to GemDownload only.
-    # insert = "INSERT INTO #{quoted_table_name} (rubygem_id, version_id, count) SELECT ?, ?, ?"
-    # find_by_sql(["WITH upsert AS (#{update}) #{insert} WHERE NOT EXISTS (SELECT * FROM upsert)", count, rubygem_id, version_id, count]).first
-    find_by_sql([update, count]).first
-  end
-
-  # Takes an array where members have the form
-  #   [full_name, count]
-  # E.g.:
-  #   ['rake-10.4.2', 1]
-  def self.bulk_update(ary)
-    updates_by_version = {}
-    updates_by_gem = {}
-
-    ary.each do |full_name, count|
-      if updates_by_version.key?(full_name)
-        version, old_count = updates_by_version[full_name]
-        updates_by_version[full_name] = [version, old_count + count]
+  class << self
+    def count_for_version(id)
+      v = Version.find(id)
+      return 0 unless v
+      download = GemDownload.find_by(rubygem_id: v.rubygem_id, version_id: v.id)
+      if download
+        download.count
       else
-        version = Version.find_by(full_name: full_name)
-        updates_by_version[full_name] = [version, count] if version
+        0
       end
     end
 
-    updates_by_version.values.each do |version, version_count|
-      updates_by_gem[version.rubygem_id] ||= 0
-      updates_by_gem[version.rubygem_id] += version_count
+    def count_for_rubygem(id)
+      download = GemDownload.find_by(rubygem_id: id, version_id: 0)
+      if download
+        download.count
+      else
+        0
+      end
     end
 
-    updates_by_version.values.sort_by { |v, _| v.id }.each do |version, count|
-      # Gem version count
-      increment(count, rubygem_id: version.rubygem_id, version_id: version.id)
+    def total_count
+      download = GemDownload.find_by(rubygem_id: 0, version_id: 0)
+      if download
+        download.count
+      else
+        0
+      end
     end
 
-    updates_by_gem.sort_by { |id, _| id }.each do |rubygem_id, count|
-      # Gem count
-      increment(count, rubygem_id: rubygem_id, version_id: 0)
+    # version_id: 0 stores count for total gem downloads
+    # we need to find the second maximum
+    def most_downloaded_gem_count
+      count_by_sql "SELECT MAX(count) FROM gem_downloads WHERE count NOT IN (#{total_count})"
     end
 
-    total_count = updates_by_gem.values.sum
-    # Total count
-    increment(total_count, rubygem_id: 0, version_id: 0)
+    def increment(count, rubygem_id:, version_id: 0)
+      scope = GemDownload.where(rubygem_id: rubygem_id).select("id")
+      scope = scope.where(version_id: version_id)
+      sql = scope.to_sql
+
+      update = "UPDATE #{quoted_table_name} SET count = count + ? WHERE id = (#{sql}) RETURNING *"
+
+      # TODO: Remove this comments, once we move to GemDownload only.
+      # insert = "INSERT INTO #{quoted_table_name} (rubygem_id, version_id, count) SELECT ?, ?, ?"
+      # find_by_sql(["WITH upsert AS (#{update}) #{insert} WHERE NOT EXISTS (SELECT * FROM upsert)", count, rubygem_id, version_id, count]).first
+      find_by_sql([update, count]).first
+    end
+
+    # Takes an array where members have the form
+    #   [full_name, count]
+    # E.g.:
+    #   ['rake-10.4.2', 1]
+    def bulk_update(ary)
+      updates_by_version = {}
+      updates_by_gem = {}
+
+      ary.each do |full_name, count|
+        if updates_by_version.key?(full_name)
+          version, old_count = updates_by_version[full_name]
+          updates_by_version[full_name] = [version, old_count + count]
+        else
+          version = Version.find_by(full_name: full_name)
+          updates_by_version[full_name] = [version, count] if version
+        end
+      end
+
+      return if updates_by_version.empty?
+      updates_by_version.values.each do |version, version_count|
+        updates_by_gem[version.rubygem_id] ||= 0
+        updates_by_gem[version.rubygem_id] += version_count
+      end
+
+      updates_by_version.values.sort_by { |v, _| v.id }.each do |version, count|
+        # Gem version count
+        increment(count, rubygem_id: version.rubygem_id, version_id: version.id)
+      end
+
+      update_gem_downloads(updates_by_gem)
+
+      total_count = updates_by_gem.values.sum
+
+      # Total count
+      increment(total_count, rubygem_id: 0, version_id: 0)
+    end
+
+    private
+
+    # updates the downloads field of rubygem in DB and ES index
+    # input: [rubygem_id, download_count_to_increment]
+    def update_gem_downloads(gem_downloads)
+      bulk_update_query = []
+
+      gem_ids = gem_downloads.map { |id, _| id }
+      downloads = GemDownload.where(rubygem_id: gem_ids).pluck(:count)
+      with_prev_downloads = gem_downloads.zip(downloads).map(&:flatten)
+
+      with_prev_downloads.sort_by { |id, _| id }.each do |rubygem_id, count, prev_downloads|
+        bulk_update_query << update_query(rubygem_id, count + prev_downloads)
+
+        # increment downloads of rubygem in DB
+        increment(count, rubygem_id: rubygem_id, version_id: 0)
+      end
+
+      # update index of rubygems
+      Rubygem.__elasticsearch__.client.bulk body: bulk_update_query
+    rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error => e
+      Rails.logger.debug "ES update for rubygem_ids: #{gem_ids} has failed: #{e.message}"
+    end
+
+    def update_query(id, downloads)
+      { update: { _index: "rubygems-#{Rails.env}",
+                  _type: 'rubygem',
+                  _id: id,
+                  data: { doc: { downloads: downloads } } } }
+    end
   end
 end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -271,9 +271,9 @@ class PusherTest < ActiveSupport::TestCase
 
     context "successfully saving a gemcutter" do
       setup do
-        @rubygem = create(:rubygem)
+        @rubygem = create(:rubygem, name: 'gemsgemsgems')
         @cutter.stubs(:rubygem).returns @rubygem
-        create(:version, rubygem: @rubygem, number: '0.1.1')
+        create(:version, rubygem: @rubygem, number: '0.1.1', summary: 'old summary')
         @cutter.stubs(:version).returns @rubygem.versions[0]
         @rubygem.stubs(:update_attributes_from_gem_specification!)
         Rails.cache.stubs(:delete)
@@ -311,6 +311,51 @@ class PusherTest < ActiveSupport::TestCase
         assert_received(Fastly, :purge) { |path| path.with("info/#{@rubygem.name}") }
         assert_received(Fastly, :purge) { |path| path.with("versions") }
         assert_received(Fastly, :purge) { |path| path.with("names") }
+      end
+
+      should "enque job for updating ES index and spec index" do
+        assert_difference 'Delayed::Job.count', 2 do
+          @cutter.save
+        end
+      end
+
+      should "create rubygem index" do
+        Delayed::Worker.new.work_off
+        response = Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
+                                                        type:  'rubygem',
+                                                        id:    @rubygem.id
+        expected_response = {
+          'name'                  => 'gemsgemsgems',
+          'yanked'                => false,
+          'summary'               => 'old summary',
+          'description'           => 'Some awesome gem',
+          'downloads'             => 0,
+          'latest_version_number' => '0.1.1'
+        }
+
+        assert_equal expected_response, response['_source']
+      end
+    end
+
+    context 'pushing a new version' do
+      setup do
+        @rubygem = create(:rubygem)
+        @cutter.stubs(:rubygem).returns @rubygem
+        create(:version, rubygem: @rubygem, summary: 'old summary')
+        version = create(:version, rubygem: @rubygem, summary: 'new summary')
+        @cutter.stubs(:version).returns version
+        @rubygem.stubs(:update_attributes_from_gem_specification!)
+        @cutter.stubs(:version).returns version
+        Indexer.any_instance.stubs(:write_gem)
+        @cutter.save
+      end
+
+      should "update rubygem index" do
+        Delayed::Worker.new.work_off
+        response = Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
+                                                        type:  'rubygem',
+                                                        id:    @rubygem.id
+        assert_equal 'new summary', response['_source']['summary']
       end
     end
   end


### PR DESCRIPTION
* `class << self` because I needed `private` method in the class. Besides all the methods were class methods anyway.
* `return if updates_by_version.empty?` was added in `bulk_update` because we don't need to process any further if `updates_by_version` array is empty. It was performing unnecessary updated to gem_downloads table and breaking bulk update of ES index.

sources referred for changed:
* https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb

This PR will need `script.engine.groovy.inline.update: on` in `elasticsearch.yml` config file (exists in `/etc/elasticsearch/` for Fedora) in all the nodes of ES. Tests are passing because this setting is [turned on travis by default](https://github.com/travis-ci/travis-ci/issues/2701#issuecomment-57828804). Read why dynamic scripting is disabled by default: 
* https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
* https://www.elastic.co/blog/scripting-security

Gist of links: Enabling dynamic scripting can lead to security concerns. However is is mostly not applicable in our case because our ES update api is not exposed to internet, download count used in script comes from Fastly. 