### PR TITLE
Correct travis cache settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   bundler: true
   directories:
     - reports
+    - vendor/cache
 
 rvm:
   - 2.2.4
@@ -19,10 +20,6 @@ bundler_args: --jobs=3 --retry=3 --without development
 
 git:
   submodules: true
-
-cache:
-  directories:
-    - vendor/cache
 
 before_install:
   - git submodule update --init


### PR DESCRIPTION
Travis was installing gem in every build: [1](https://travis-ci.org/rubygems/rubygems.org/jobs/135080824#L538), [2](https://travis-ci.org/rubygems/rubygems.org/jobs/134809324#L538), [3](https://travis-ci.org/rubygems/rubygems.org/jobs/134728544#L538), [4](https://travis-ci.org/rubygems/rubygems.org/jobs/134348981)

From https://docs.travis-ci.com/user/caching/#Enabling-multiple-caching-features
>
```yml
cache:
- bundler
- pip
```
 This does not work when caching arbitrary directories. If you want to combine that with other caching modes, you will have to use a hash map:
```yml
 cache:
    bundler: true
    directories:
    - vendor/something
    - .autoconf
```