### PR TITLE
Support advanced search with query string syntax

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -69,10 +69,10 @@ module RubygemSearchable
               filtered do
                 # Main query, search in name, summary, description
                 query do
-                  multi_match do
+                  query_string do
                     query q
                     fields ['name^3', 'summary^1', 'description']
-                    operator 'and'
+                    default_operator 'and'
                   end
                 end
 


### PR DESCRIPTION
See complete list of supported syntax and their use:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax

Are we going to leave this here OR we are going to add search-tip for user (see @karmi PR [implementation](https://github.com/rubygems/rubygems.org/pull/455/files#diff-cf625a69da6ea404abe4b4c62202d1d9R1)) OR we are going to have an advanced search page (see github [advanced search page](https://github.com/search/advanced))