### PR TITLE
Disallow letterwise pages of gems

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /downloads/
+Disallow: /gems?letter=*


### PR DESCRIPTION
Pattern source: https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt?hl=en#example-path-matches

We don't have `gems?query=*` url. We do have `/search?utf8=✓&query=*` however that doesn't seem to appear on [sitemap](http://xmlsitemapgenerator.org/free/GetFile.aspx?job=48390b4e-5d82-4df0-b8ec-d3bef2c720ec&type=v&file=Xml).

We also have lot of duplicate pages because of internationalization (`/?locale=fr` etc). It is [suggested to use markup or sitemap.xml](https://support.google.com/webmasters/answer/189077) for that. Do we need that [given](https://support.google.com/webmasters/answer/6144055?hl=en):

> If your website has pages that return different content based on the perceived country or preferred language of the visitor (i.e., you have locale-adaptive pages), Google might not crawl, index, or rank all of your locale-adaptive content. This is because the default IP addresses of the Googlebot crawler appear to be based in the USA. In addition, the crawler sends HTTP requests without setting Accept-Language in the request header.

cc: @drbrain 