### PR TITLE
#1246 Add autocompletion on gem search inputs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Exclude:
     - lib/patterns.rb
+    - app/models/concerns/rubygem_searchable.rb
 
 Metrics/PerceivedComplexity:
   Max: 10 # TODO: Lower to 7

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'elasticsearch-rails', '~> 0.1.7'
 gem 'elasticsearch-dsl', '~> 0.1.2'
 gem 'xml-simple'
 gem 'yajl-ruby', require: 'yajl'
+gem 'twitter-typeahead-rails'
 gem 'compact_index', '~> 0.10.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,10 @@ GEM
     timers (4.1.1)
       hitimes
     toxiproxy (0.1.4)
+    twitter-typeahead-rails (0.11.1)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -342,6 +346,7 @@ DEPENDENCIES
   shoulda
   statsd-instrument (~> 2.0.6)
   toxiproxy (~> 0.1.3)
+  twitter-typeahead-rails
   uglifier (>= 1.0.3)
   unicorn
   validates_formatting_of

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,4 +8,6 @@
 //= require jquery_ujs
 //= require jquery.color
 //= require clipboard
+//= require twitter/typeahead.min
+//= require search_typeahead
 //= require_tree .

--- a/app/assets/javascripts/search_typeahead.js
+++ b/app/assets/javascripts/search_typeahead.js
@@ -1,0 +1,18 @@
+$(function () {
+    var suggester = new Bloodhound({
+        datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        remote: {
+            url: '/search/autocomplete.json?query=%QUERY',
+            wildcard: '%QUERY'
+        }
+    });
+
+    $('#home_query, .header__search').typeahead({
+        minLength: 2,
+        highlight: true
+    }, {
+        name: "home_query",
+        source: suggester
+    });
+});

--- a/app/assets/stylesheets/modules/home.css
+++ b/app/assets/stylesheets/modules/home.css
@@ -49,6 +49,7 @@
   margin-left: auto;
   position: relative;
   width: 90%;
+  margin-top: 30px;
   max-width: 460px; }
   @media (max-width: 519px) {
     .home__cta-wrap {
@@ -65,6 +66,7 @@
   margin-right: auto;
   margin-left: auto;
   position: relative;
+  padding-bottom: 56px;
   width: 90%;
   max-width: 780px; }
   @media (max-width: 519px) {

--- a/app/assets/stylesheets/modules/search.css
+++ b/app/assets/stylesheets/modules/search.css
@@ -96,7 +96,6 @@
   color: #e9573f; }
 
 .home__search {
-  margin-bottom: 45px;
   padding-right: 48px;
   box-shadow: 0 0 0px 5px rgba(20, 28, 34, .1);
   box-sizing: border-box;

--- a/app/assets/stylesheets/typeahead.css
+++ b/app/assets/stylesheets/typeahead.css
@@ -1,0 +1,200 @@
+/*
+ * typehead.js-bootstrap3.less
+ * @version 0.2.3
+ * https://github.com/hyspace/typeahead.js-bootstrap3.less
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+.has-warning .twitter-typeahead .tt-input,
+.has-warning .twitter-typeahead .tt-hint {
+    border-color: #8a6d3b;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-warning .twitter-typeahead .tt-input:focus,
+.has-warning .twitter-typeahead .tt-hint:focus {
+    border-color: #66512c;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+}
+.has-error .twitter-typeahead .tt-input,
+.has-error .twitter-typeahead .tt-hint {
+    border-color: #a94442;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-error .twitter-typeahead .tt-input:focus,
+.has-error .twitter-typeahead .tt-hint:focus {
+    border-color: #843534;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+.has-success .twitter-typeahead .tt-input,
+.has-success .twitter-typeahead .tt-hint {
+    border-color: #3c763d;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-success .twitter-typeahead .tt-input:focus,
+.has-success .twitter-typeahead .tt-hint:focus {
+    border-color: #2b542c;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+}
+.input-group .twitter-typeahead:first-child .tt-input,
+.input-group .twitter-typeahead:first-child .tt-hint {
+    border-bottom-left-radius: 4px;
+    border-top-left-radius: 4px;
+    width: 100%;
+}
+.input-group .twitter-typeahead:last-child .tt-input,
+.input-group .twitter-typeahead:last-child .tt-hint {
+    border-bottom-right-radius: 4px;
+    border-top-right-radius: 4px;
+    width: 100%;
+}
+.input-group.input-group-sm .twitter-typeahead .tt-input,
+.input-group.input-group-sm .twitter-typeahead .tt-hint {
+    height: 30px;
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px;
+}
+select.input-group.input-group-sm .twitter-typeahead .tt-input,
+select.input-group.input-group-sm .twitter-typeahead .tt-hint {
+    height: 30px;
+    line-height: 30px;
+}
+textarea.input-group.input-group-sm .twitter-typeahead .tt-input,
+textarea.input-group.input-group-sm .twitter-typeahead .tt-hint,
+select[multiple].input-group.input-group-sm .twitter-typeahead .tt-input,
+select[multiple].input-group.input-group-sm .twitter-typeahead .tt-hint {
+    height: auto;
+}
+.input-group.input-group-sm .twitter-typeahead:not(:first-child):not(:last-child) .tt-input,
+.input-group.input-group-sm .twitter-typeahead:not(:first-child):not(:last-child) .tt-hint {
+    border-radius: 0;
+}
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-hint {
+    border-bottom-left-radius: 3px;
+    border-top-left-radius: 3px;
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+}
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-hint {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 3px;
+    border-top-right-radius: 3px;
+}
+.input-group.input-group-lg .twitter-typeahead .tt-input,
+.input-group.input-group-lg .twitter-typeahead .tt-hint {
+    height: 46px;
+    padding: 10px 16px;
+    font-size: 18px;
+    line-height: 1.33;
+    border-radius: 6px;
+}
+select.input-group.input-group-lg .twitter-typeahead .tt-input,
+select.input-group.input-group-lg .twitter-typeahead .tt-hint {
+    height: 46px;
+    line-height: 46px;
+}
+textarea.input-group.input-group-lg .twitter-typeahead .tt-input,
+textarea.input-group.input-group-lg .twitter-typeahead .tt-hint,
+select[multiple].input-group.input-group-lg .twitter-typeahead .tt-input,
+select[multiple].input-group.input-group-lg .twitter-typeahead .tt-hint {
+    height: auto;
+}
+.input-group.input-group-lg .twitter-typeahead:not(:first-child):not(:last-child) .tt-input,
+.input-group.input-group-lg .twitter-typeahead:not(:first-child):not(:last-child) .tt-hint {
+    border-radius: 0;
+}
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-hint {
+    border-bottom-left-radius: 6px;
+    border-top-left-radius: 6px;
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+}
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-hint {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 6px;
+    border-top-right-radius: 6px;
+}
+.twitter-typeahead {
+    width: 100%;
+    float: left;
+}
+.input-group .twitter-typeahead {
+    display: table-cell !important;
+}
+.twitter-typeahead .tt-hint {
+    color: #999999;
+}
+.twitter-typeahead .tt-input {
+    z-index: 2;
+}
+.twitter-typeahead .tt-input[disabled],
+.twitter-typeahead .tt-input[readonly],
+fieldset[disabled] .twitter-typeahead .tt-input {
+    cursor: not-allowed;
+    background-color: #eeeeee !important;
+}
+.tt-dropdown-menu,
+.tt-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    min-width: 160px;
+    width: 100%;
+    padding: 5px 0;
+    margin: 2px 0 0;
+    list-style: none;
+    font-size: 14px;
+    background-color: #ffffff;
+    border: 1px solid #cccccc;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    background-clip: padding-box;
+    *border-right-width: 2px;
+    *border-bottom-width: 2px;
+}
+.tt-dropdown-menu .tt-suggestion,
+.tt-menu .tt-suggestion {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857143;
+    color: #333333;
+}
+.tt-dropdown-menu .tt-suggestion.tt-cursor,
+.tt-menu .tt-suggestion.tt-cursor,
+.tt-dropdown-menu .tt-suggestion:hover,
+.tt-menu .tt-suggestion:hover {
+    cursor: pointer;
+    text-decoration: none;
+    outline: 0;
+    background-color: #f5f5f5;
+    color: #262626;
+}
+.tt-dropdown-menu .tt-suggestion.tt-cursor a,
+.tt-menu .tt-suggestion.tt-cursor a,
+.tt-dropdown-menu .tt-suggestion:hover a,
+.tt-menu .tt-suggestion:hover a {
+    color: #262626;
+}
+.tt-dropdown-menu .tt-suggestion p,
+.tt-menu .tt-suggestion p {
+    margin: 0;
+}

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -13,6 +13,12 @@ class SearchesController < ApplicationController
     redirect_to rubygem_path(@exact_match) if @gems == [@exact_match]
   end
 
+  def autocomplete
+    render json: Rubygem.search(params[:query], es: true).map(&:name)
+  rescue RubygemSearchable::SearchDownError
+    render json: []
+  end
+
   private
 
   def es_enabled?

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -26,17 +26,36 @@ module RubygemSearchable
     settings number_of_shards: 1,
              number_of_replicas: 1,
              analysis: {
-               analyzer: {
-                 rubygem: {
+               filter: {
+                 autocomplete_ngram: {
+                   max_gram: 20,
+                   min_gram: 2,
+                   type: 'edge_ngram'
+                 }
+               },
+               tokenizer: {
+                 special_characters: {
                    type: 'pattern',
                    pattern: "[\s#{Regexp.escape(SPECIAL_CHARACTERS)}]+"
+                 }
+               },
+               analyzer: {
+                 autocomplete_index: {
+                   type: 'custom',
+                   tokenizer: 'special_characters',
+                   filter: %w(lowercase autocomplete_ngram)
+                 },
+                 default_analyzer: {
+                   type: 'custom',
+                   tokenizer: 'special_characters',
+                   filter: %w(lowercase)
                  }
                }
              }
 
     mapping do
       indexes :name, type: 'multi_field' do
-        indexes :name, analyzer: 'rubygem'
+        indexes :name, index_analyzer: 'autocomplete_index', search_analyzer: 'default_analyzer'
         indexes :suggest, analyzer: 'simple'
       end
       indexes :yanked, type: 'boolean'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,9 @@ Rails.application.routes.draw do
   ################################################################################
   # UI
   scope constraints: { format: :html }, defaults: { format: 'html' } do
-    resource :search,    only: :show
+    resource :search,    only: :show do
+      get :autocomplete, constraints: { format: 'json' }
+    end
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
     resource :profile, only: [:edit, :update]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,10 @@ class ActiveSupport::TestCase
     Capybara::Node::Simple.new(@response.body)
   end
 
+  def json
+    ActiveSupport::JSON.decode @response.body
+  end
+
   def requires_toxiproxy
     skip("Toxiproxy is not running, but was required for this test.") unless Toxiproxy.running?
   end


### PR DESCRIPTION
Issue: https://github.com/rubygems/rubygems.org/issues/1246

Added autocompletion for the home search bar using Elasticsearch and typeahead.js.

![photo_2016-06-08_12-01-22](https://cloud.githubusercontent.com/assets/2946397/15888767/f0338a62-2d70-11e6-8626-9de057f8413b.jpg)
