### PR TITLE
Run migrations when executing load-pg-dump script

### DIFF
--- a/script/load-pg-dump
+++ b/script/load-pg-dump
@@ -87,6 +87,9 @@ createdb -U $pg_user $pg_database
 echo "Adding hstore extension"
 psql -q -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
 
+echo "Running migrations"
+rake db:migrate
+
 # Extract the single PostgresSQL.sql.gz file from the tar file, pass it through gunzip
 # and load it as quietly as possible into the database
 echo "Loading the data from $public_tar"


### PR DESCRIPTION
Added ```rake db:migrate``` command before loading data step, otherwise it gives pending migrations error.