### PR TITLE
Remove rubygem_version, ruby_version, checksum and created_at from dependency endpoint

### DIFF
--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -35,7 +35,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
   context "On GET to index --> with gems --> JSON" do
     setup do
       rubygem = create(:rubygem, name: "rails")
-      create(:version, number: "1.0.0", created_at: Date.new(2016, 05, 24), rubygem_id: rubygem.id)
+      create(:version, number: "1.0.0", rubygem_id: rubygem.id)
       get :index, gems: "rails", format: "json"
     end
 
@@ -48,10 +48,6 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         'name'              => 'rails',
         'number'            => '1.0.0',
         'platform'          => 'ruby',
-        'rubygems_version'  => '>= 2.6.3',
-        'ruby_version'      => '>= 2.0.0',
-        'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
-        'created_at'        => '2016-05-24 00:00:00 +0000',
         'dependencies'      => []
       }]
 
@@ -64,9 +60,9 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     setup do
       rubygem1 = create(:rubygem, name: "myrails")
       rubygem2 = create(:rubygem, name: "mybundler")
-      create(:version, number: "1.0.0", created_at: Date.new(2016, 05, 24), rubygem_id: rubygem1.id)
-      create(:version, number: "2.0.0", created_at: Date.new(2016, 05, 24), rubygem_id: rubygem2.id)
-      create(:version, number: "3.0.0", created_at: Date.new(2016, 05, 24), rubygem_id: rubygem1.id)
+      create(:version, number: "1.0.0", rubygem_id: rubygem1.id)
+      create(:version, number: "2.0.0", rubygem_id: rubygem2.id)
+      create(:version, number: "3.0.0", rubygem_id: rubygem1.id)
       get :index, gems: "myrails,mybundler", format: "json"
     end
 
@@ -80,10 +76,6 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'name'              => 'myrails',
           'number'            => '1.0.0',
           'platform'          => 'ruby',
-          'rubygems_version'  => '>= 2.6.3',
-          'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
-          'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         },
 
@@ -91,10 +83,6 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'name'              => 'myrails',
           'number'            => '3.0.0',
           'platform'          => 'ruby',
-          'rubygems_version'  => '>= 2.6.3',
-          'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
-          'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         },
 
@@ -102,10 +90,6 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
           'name'              => 'mybundler',
           'number'            => '2.0.0',
           'platform'          => 'ruby',
-          'rubygems_version'  => '>= 2.6.3',
-          'ruby_version'      => '>= 2.0.0',
-          'checksum'          => 'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
-          'created_at'        => '2016-05-24 00:00:00 +0000',
           'dependencies'      => []
         }
       ]
@@ -157,7 +141,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
   context "On GET to index --> with gems --> Marshal" do
     setup do
       rubygem = create(:rubygem, name: "testgem")
-      create(:version, number: "1.0.0", created_at: Date.new(2016, 05, 24), rubygem_id: rubygem.id)
+      create(:version, number: "1.0.0", rubygem_id: rubygem.id)
       get :index, gems: "testgem", format: "marshal"
     end
 
@@ -170,10 +154,6 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         name:              'testgem',
         number:            '1.0.0',
         platform:          'ruby',
-        rubygems_version:  '>= 2.6.3',
-        ruby_version:      '>= 2.0.0',
-        checksum:          'b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78',
-        created_at:        "2016-05-24 00:00:00 +0000",
         dependencies:      []
       }]
 

--- a/test/unit/gem_dependent_test.rb
+++ b/test/unit/gem_dependent_test.rb
@@ -23,7 +23,7 @@ class GemDependentTest < ActiveSupport::TestCase
   context "with gem_names" do
     setup do
       rack2 = create(:rubygem, name: "rack2")
-      create(:version, number: "0.0.1", created_at: Date.new(2016, 05, 24), rubygem: rack2)
+      create(:version, number: "0.0.1", rubygem: rack2)
     end
 
     should "return rack2" do
@@ -31,10 +31,6 @@ class GemDependentTest < ActiveSupport::TestCase
         name:                "rack2",
         number:              "0.0.1",
         platform:            "ruby",
-        rubygems_version:    ">= 2.6.3",
-        ruby_version:        ">= 2.0.0",
-        checksum:            "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
-        created_at:          "2016-05-24 00:00:00 +0000",
         dependencies: []
       }
 
@@ -47,17 +43,19 @@ class GemDependentTest < ActiveSupport::TestCase
     context "multiple versions" do
       setup do
         rack = create(:rubygem, name: "rack")
-        create(:version, number: "0.2.2", created_at: Date.new(2016, 05, 24), rubygem: rack)
-        create(:version, number: "0.1.2", created_at: Date.new(2016, 05, 24), rubygem: rack)
-        create(:version, number: "0.1.2", created_at: Date.new(2016, 05, 24), platform: 'jruby', rubygem: rack)
-        create(:version, number: "0.1.3", created_at: Date.new(2016, 05, 25), rubygem: rack)
+        create(:version, number: "0.2.2", rubygem: rack)
+        create(:version, number: "0.1.2", rubygem: rack)
+        create(:version, number: "0.1.2", platform: 'jruby', rubygem: rack)
+        create(:version, number: "0.1.3", rubygem: rack)
       end
 
-      should "orders versions by created_at, versions and platform" do
-        result = [["0.1.2", "jruby"], ["0.1.2", "ruby"], ["0.2.2", "ruby"], ["0.1.3", "ruby"]]
+      should "return all versions and platform" do
+        result = [["0.1.3", "ruby"], ["0.1.2", "ruby"], ["0.1.2", "jruby"], ["0.2.2", "ruby"]]
 
         deps = GemDependent.new(["rack"]).to_a
-        assert_equal result, deps.map { |x| [x[:number], x[:platform]] }
+        deps.map { |x| [x[:number], x[:platform]] }.each do |dep|
+          assert_includes result, dep
+        end
       end
     end
 
@@ -74,16 +72,15 @@ class GemDependentTest < ActiveSupport::TestCase
         end
       end
 
-      should "return dependencies ordered by name" do
-        result = {
-          name:         'devise',
-          number:       '1.0.0',
-          dependencies: [['bar', '>= 0.0.0'], ['foo', '>= 0.0.0']]
-        }
+      should "return dependencies" do
+        expected_deps = [["foo", ">= 0.0.0"], ["bar", ">= 0.0.0"]]
 
         dep = GemDependent.new(["devise"]).to_a.first
-        result.each_pair do |k, v|
-          assert_equal v, dep[k]
+        assert_equal 'devise', dep[:name]
+        assert_equal '1.0.0', dep[:number]
+
+        expected_deps.each do |expected_dep|
+          assert_includes dep[:dependencies], expected_dep
         end
       end
     end
@@ -91,7 +88,7 @@ class GemDependentTest < ActiveSupport::TestCase
     context "non indexed versions" do
       setup do
         nokogiri = create(:rubygem, name: "nokogiri")
-        create(:version, number: "0.0.1", created_at: Date.new(2016, 05, 24), rubygem: nokogiri)
+        create(:version, number: "0.0.1", rubygem: nokogiri)
         create(:version, number: "0.1.1", rubygem: nokogiri, indexed: false)
       end
 
@@ -100,10 +97,6 @@ class GemDependentTest < ActiveSupport::TestCase
           name: "nokogiri",
           number: "0.0.1",
           platform: "ruby",
-          rubygems_version:    ">= 2.6.3",
-          ruby_version:        ">= 2.0.0",
-          checksum:            "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
-          created_at:          "2016-05-24 00:00:00 +0000",
           dependencies: []
         }
 


### PR DESCRIPTION
Closes: #1308 
This PR also removes the ordering of response, which was introduced
for changes made for compact index on bundler-api: https://github.com/bundler/bundler-api/commit/c3cda80238ba888e1b7b4af772ac3f15664dc1aa

Bundler side of things:
`api/v1/dependencies` is only mentioned at [`dependency_api_uri`](https://github.com/bundler/bundler/blob/8d7b671909d9b75a9e1e64889f6ba45b302e3940/lib/bundler/fetcher/dependency.rb#L74-L78)
^ is called by [`unmarshalled_dep_gems`](https://github.com/bundler/bundler/blob/8d7b671909d9b75a9e1e64889f6ba45b302e3940/lib/bundler/fetcher/dependency.rb#L53-L60)
^ is called by [`dependency_specs`](https://github.com/bundler/bundler/blob/8d7b671909d9b75a9e1e64889f6ba45b302e3940/lib/bundler/fetcher/dependency.rb#L46-L51):
```ruby
def dependency_specs(gem_names)
   Bundler.ui.debug "Query Gemcutter Dependency Endpoint API: #{gem_names.join(",")}"

   gem_list = unmarshalled_dep_gems(gem_names)
   get_formatted_specs_and_deps(gem_list)
end
```

[`get_formatted_specs_and_deps` test](https://github.com/bundler/bundler/blob/9d2676ed2b9a58ff9251ff55210747c5a07ab201/spec/bundler/fetcher/dependency_spec.rb#L231-L250) says that `gem_list` only needs to contain `dependencies, name, number and platform`.