### PR TITLE
Use Timeout.timeout instead of Kernel.timeout

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -110,7 +110,7 @@ class Pusher
     }.to_json
 
     begin
-      timeout(5) do
+      ::Timeout.timeout(5) do
         to.post @bundler_api_url,
           json,
           :timeout        => 5,


### PR DESCRIPTION
Fixes: /home/travis/build/rubygems/rubygems.org/app/models/pusher.rb:113:in `update_remote_bundler_api': Object#timeout is deprecated, use Timeout.timeout instead