### PR TITLE
Use position to return latest version

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -7,7 +7,7 @@ class Rubygem < ActiveRecord::Base
   has_many :subscribers, through: :subscriptions, source: :user
   has_many :subscriptions, dependent: :destroy
   has_many :versions, dependent: :destroy, validate: false
-  has_one :latest_version, -> { where(latest: true) }, class_name: "Version"
+  has_one :latest_version, -> { where(latest: true).order(:position) }, class_name: "Version"
   has_many :web_hooks, dependent: :destroy
   has_one :linkset, dependent: :destroy
   has_one :gem_download, -> { where(version_id: 0) }

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -154,6 +154,14 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal indexed_v1.reload, @rubygem.reload.versions.most_recent
     end
 
+    should "return latest version on the basis of version number" do
+      version = create(:version, rubygem: @rubygem, number: "0.1.1", platform: 'ruby', latest: true)
+      create(:version, rubygem: @rubygem, number: "0.1.2.rc1", platform: 'ruby')
+      create(:version, rubygem: @rubygem, number: "0.1.0", platform: 'jruby', latest: true)
+
+      assert_equal version, @rubygem.latest_version
+    end
+
     context "#public_versions_with_extra_version" do
       setup do
         @first_version = FactoryGirl.create(:version,


### PR DESCRIPTION
closes: #1249
[`reorder_versions` sorts](https://github.com/rubygems/rubygems.org/blob/master/app/models/rubygem.rb#L226) versions on basis of version numbers. `position` is assigned on sorted order of versions, ie newer versions get lower position.

```Ruby
  def reorder_versions
    numbers = reload.versions.sort.reverse.map(&:number).uniq

    versions.each do |version|
      Version.find(version.id).update_column(:position, numbers.index(version.number))
    end
   ...
  end
```
Only released versions are marked `latest` hence versions like `rails 5.0.0.rc1` won't be returned.