### PR TITLE
Correct advanced option passing to restclient

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -98,7 +98,7 @@ class Pusher
     "<Pusher #{attrs.join(' ')}>"
   end
 
-  def update_remote_bundler_api(to = RestClient)
+  def update_remote_bundler_api(to = RestClient::Request)
     return unless @bundler_api_url
 
     json = {
@@ -110,13 +110,12 @@ class Pusher
     }.to_json
 
     begin
-      ::Timeout.timeout(5) do
-        to.post @bundler_api_url,
-          json,
-          :timeout        => 5,
-          :open_timeout   => 5,
-          'Content-Type'  => 'application/json'
-      end
+      to.execute method: :post,
+                 url: @bundler_api_url,
+                 payload: json,
+                 timeout: 5,
+                 open_timeout: 5,
+                 header: { 'Content-Type' => 'application/json' }
     rescue StandardError, Interrupt
       false
     end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -142,10 +142,10 @@ class PusherTest < ActiveSupport::TestCase
       obj = mock
       post_data = nil
 
-      obj.stubs(:post).with { |*value| post_data = value }
+      obj.stubs(:execute).with { |*value| post_data = value }
       @cutter.update_remote_bundler_api obj
 
-      _, payload = post_data
+      payload = post_data.first[:payload]
 
       params = JSON.load payload
 


### PR DESCRIPTION
::Timeout.timeout is not needed because we are using timeout option of restclient.

https://github.com/rest-client/rest-client#passing-advanced-options
says that top level helper methods like RestClient.get(or post) don't
support advanced option like `timeout`.

https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L604
says that 'content-type' should be key of `header` option.