### PR TITLE
Fix breaking builds on travis because of non-pristine DB

### DIFF
--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -61,7 +61,7 @@ class DeletionTest < ActiveSupport::TestCase
 
   teardown do
     # This is necessary due to after_commit not cleaning up for us
-    [Rubygem, Version, User, Deletion].each(&:delete_all)
+    [Rubygem, Version, User, Deletion, Delayed::Job, GemDownload].each(&:delete_all)
   end
 
   private


### PR DESCRIPTION
I had almost forgotten about [this change](https://github.com/rubygems/rubygems.org/pull/1309/files#diff-4d39483d45f7a1d5777776e9c132ab33R78)..