### PR TITLE
Sql query improvements for stats page

### DIFF
--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -36,7 +36,7 @@ class GemDownload < ActiveRecord::Base
   # version_id: 0 stores count for total gem downloads
   # we need to find the second maximum
   def self.most_downloaded_gem_count
-    count_by_sql "SELECT MAX(count) FROM gem_downloads WHERE count NOT IN (SELECT MAX(count) FROM gem_downloads)"
+    count_by_sql "SELECT MAX(count) FROM gem_downloads WHERE count NOT IN (#{total_count})"
   end
 
   def self.increment(count, rubygem_id:, version_id: 0)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -62,7 +62,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def self.total_count
-    with_versions.count
+    count_by_sql "SELECT COUNT(*) from (SELECT DISTINCT rubygem_id FROM versions WHERE indexed = true) AS v"
   end
 
   def self.latest(limit = 5)

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -20,7 +20,7 @@
 </h2>
 
 <header class="gems__header">
-  <p class="gems__meter"><%= page_entries_info @most_downloaded %></p>
+  <p class="gems__meter"><%= page_entries_info @most_downloaded, model: 'gem' %></p>
 </header>
 
 <% @most_downloaded.each do |gem| %>


### PR DESCRIPTION
`most_downloaded_gem_count`:
Selection is cheaper than aggregation. 700ms->350ms

`Rubygem.total_count`:
Aggregation over filter is cheaper than aggregation over filter over selection. Checkout [query plan](https://gist.github.com/sonalkr132/e2fb9591035b4169554a10a02c1f6a15). 1500ms->1100ms

will_paginate was making two extra sql queries because of following [line](https://github.com/mislav/will_paginate/blob/2f0b4694b3cc7ffcb265daad13eb95c972fa0bb1/lib/will_paginate/view_helpers.rb#L107):
`model = collection.first.class unless model or collection.empty?`
900ms->0ms