### PR TITLE
Fix rubocop Metrics/LineLength

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -82,7 +82,8 @@ module RubygemsHelper
 
   def report_abuse_link(rubygem)
     encoded_title = URI.encode("Reporting Abuse on #{rubygem.name}")
-    report_abuse_url = "http://help.rubygems.org/discussion/new?discussion[private]=1&discussion[title]=" + encoded_title # rubocop:disable Metrics/LineLength
+    report_abuse_url = 'http://help.rubygems.org/discussion/new' \
+      "?discussion[private]=1&discussion[title]=" + encoded_title
     link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: 'gem__link t-list__item'
   end
 


### PR DESCRIPTION
This just fix this cop instead of disabling it.
Cheers