### PR TITLE
Assert array elements disregarding order

### DIFF
--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -94,7 +94,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         }
       ]
 
-      assert_equal result, MultiJson.load(response.body)
+      assert_same_elements result, MultiJson.load(response.body)
     end
   end
 


### PR DESCRIPTION
Order was removed in #1318

This test was breaking the sweet sweet [build](https://travis-ci.org/rubygems/rubygems.org/jobs/139684546#L1098).