### PR TITLE
Blacklist jruby gem name

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -37,6 +37,7 @@ module Patterns
     io-wait
     ipaddr
     irb
+    jruby
     logger
     mathn
     matrix


### PR DESCRIPTION
closes: #1337 (Add jruby and rubinius to gem blacklist )

rubinius gem [already exists on rubygems.org](https://rubygems.org/gems/rubinius) and is owned by rubinius maintainer, so probably that doesn't need blacklisting?

cc: @brixen