### PR TITLE
Clarify difference between yanked gems and versions

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -10,9 +10,10 @@
   <% end %>
 <% end %>
 
-<% if @rubygem.versions.count.zero? %>
+<% if @rubygem.public_versions.count.zero? %>
   <div class="t-body">
     <p><%= t '.not_hosted_notice' %></p>
+    <%= unsubscribe_link(@rubygem) %>
   </div>
 <% else %>
   <div class="l-overflow">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
     show:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
       install: install
-      yanked_notice: "This gem has been yanked, and it is not available for download directly or for other gems that may have depended on it."
+      yanked_notice: "This version has been yanked, and it is not available for download directly or for other gems that may have depended on it."
       authors_header: Authors
       downloads_for_this_version: "For this version"
       owners_header: Owners

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -348,7 +348,7 @@ class RubygemsControllerTest < ActionController::TestCase
       should respond_with :success
       should render_template :show
       should "render info about the gem" do
-        assert page.has_content?("This gem has been yanked")
+        assert page.has_content?("This gem is not currently hosted on RubyGems.org")
         assert page.has_no_content?('Versions')
       end
     end

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -26,7 +26,7 @@ class YankTest < SystemTest
       click_link "Show all versions (2 total)"
     end
     click_link "2.2.2"
-    assert page.has_content? "This gem has been yanked"
+    assert page.has_content? "This version has been yanked"
     assert page.has_css? 'meta[name="robots"][content="noindex"]', visible: false
   end
 
@@ -42,7 +42,7 @@ class YankTest < SystemTest
 
     visit rubygem_path(@rubygem)
     assert page.has_content? "sandworm"
-    assert page.has_content? "This gem has been yanked"
+    assert page.has_content? "This gem is not currently hosted on RubyGems.org"
 
     other_user = create(:user)
 


### PR DESCRIPTION
Addresses: #1322

This is not exactly what the issue asked for but hear me out for the sake of not adding another if statement.
Addressing:
> one that no longer is active and has no gem versions for download either (cut_audio).

If no public version exists, page will say:
![screenshot from 2016-06-26 22-40-36](https://cloud.githubusercontent.com/assets/7680662/16363677/a69160ea-3bef-11e6-95c7-eb8e0698988f.png)

Addressing:
> one that is still active (bioroebe)

If user goes to a versions page and the gem has other versions indexed, they will see this:
![screenshot from 2016-06-26 22-40-18](https://cloud.githubusercontent.com/assets/7680662/16363719/ecbd0852-3bf0-11e6-94d5-abacf1b196dc.png)

The user can already see that other versions of the gem exist(which are sorted by position). Do we really need to add another link saying *here is a version you could use*? 

