### PR TITLE
Purge cache when new version is pushed or a version is yanked

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -29,7 +29,9 @@ class Deletion < ActiveRecord::Base
   end
 
   def expire_api_memcached
-    Rails.cache.delete("deps/v1/#{@version.rubygem.name}")
+    ["deps/v1/#{rubygem}", "info/#{rubygem}", "versions", "names"].each do |key|
+      Rails.cache.delete key
+    end
   end
 
   def remove_from_index
@@ -42,5 +44,6 @@ class Deletion < ActiveRecord::Base
     RubygemFs.instance.remove("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
     Fastly.purge("gems/#{@version.full_name}.gem")
     Fastly.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    Fastly.purge_api_cdn(rubygem)
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -40,9 +40,7 @@ class Deletion < ActiveRecord::Base
   def remove_from_storage
     RubygemFs.instance.remove("gems/#{@version.full_name}.gem")
     RubygemFs.instance.remove("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
-    return unless ENV['FASTLY_DOMAIN']
-    domain = "https://#{ENV['FASTLY_DOMAIN']}"
-    Fastly.purge("#{domain}/gems/#{@version.full_name}.gem")
-    Fastly.purge("#{domain}/quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    Fastly.purge("gems/#{@version.full_name}.gem")
+    Fastly.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
   end
 end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,7 +129,7 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     expire_api_memcached
-    purge_api_cdn
+    Fastly.purge_api_cdn(rubygem.name)
     enqueue_web_hook_jobs
     update_remote_bundler_api
     StatsD.increment 'push.success'
@@ -170,11 +170,5 @@ class Pusher
     Rails.cache.delete("info/#{rubygem.name}")
     checksum = Digest::MD5.hexdigest(CompactIndex.info(rubygem.compact_index_info))
     version.update_attribute :info_checksum, checksum
-  end
-
-  def purge_api_cdn
-    Fastly.purge("info/#{rubygem.name}")
-    Fastly.purge("versions")
-    Fastly.purge("names")
   end
 end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,6 +129,7 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     expire_api_memcached
+    purge_api_cdn
     enqueue_web_hook_jobs
     update_remote_bundler_api
     StatsD.increment 'push.success'
@@ -169,5 +170,11 @@ class Pusher
     Rails.cache.delete("info/#{rubygem.name}")
     checksum = Digest::MD5.hexdigest(CompactIndex.info(rubygem.compact_index_info))
     version.update_attribute :info_checksum, checksum
+  end
+
+  def purge_api_cdn
+    Fastly.purge("info/#{rubygem.name}")
+    Fastly.purge("versions")
+    Fastly.purge("names")
   end
 end

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -7,10 +7,13 @@ class Net::HTTP::Purge < Net::HTTPRequest
 end
 
 class Fastly
-  def self.purge(url, soft = false)
+  def self.purge(path, soft = false)
+    return unless ENV['FASTLY_DOMAIN']
+    domain = "https://#{ENV['FASTLY_DOMAIN']}/"
     headers = soft ? { 'Fastly-Soft-Purge' => 1 } : {}
+
     response = RestClient::Request.execute(method: :purge,
-                                           url: url,
+                                           url: domain + path,
                                            timeout: 10,
                                            headers: headers)
     json = JSON.parse(response)

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -33,4 +33,10 @@ class Fastly
     Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
     json
   end
+
+  def self.purge_api_cdn(gem_name)
+    ["info/#{gem_name}", "versions", "names"].each do |path|
+      purge path
+    end
+  end
 end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -277,6 +277,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:version).returns @rubygem.versions[0]
         @rubygem.stubs(:update_attributes_from_gem_specification!)
         Rails.cache.stubs(:delete)
+        Fastly.stubs(:purge)
         Indexer.any_instance.stubs(:write_gem)
         @cutter.save
       end
@@ -304,6 +305,12 @@ class PusherTest < ActiveSupport::TestCase
         assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@rubygem.name}") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("versions") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
+      end
+
+      should "purge cdn cache" do
+        assert_received(Fastly, :purge) { |path| path.with("info/#{@rubygem.name}") }
+        assert_received(Fastly, :purge) { |path| path.with("versions") }
+        assert_received(Fastly, :purge) { |path| path.with("names") }
       end
     end
   end


### PR DESCRIPTION
closes: #1344 

Don't we need to purge memcache and Fastly when a version is yanked?