### PR TITLE
Allow disabling of sign up with env variable

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,11 @@ class UsersController < Clearance::UsersController
     redirect_to sign_up_path
   end
 
+  def disabled_signup
+    flash[:notice] = "Sign up is temporarily disabled."
+    redirect_to root_path
+  end
+
   def user_params
     params.require(:user).permit(*User::PERMITTED_ATTRS)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,7 +83,9 @@
               </div>
             <% else %>
               <%= link_to t('.header.sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_in'}" %>
-              <%= link_to t('.header.sign_up'), sign_up_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_up'}" %>
+              <% if Clearance.configuration.allow_sign_up? %>
+                <%= link_to t('.header.sign_up'), sign_up_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_up'}" %>
+              <% end %>
             <% end %>
           </nav>
         </div>

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,4 +1,5 @@
 Clearance.configure do |config|
+  config.allow_sign_up = ENV['DISABLE_SIGNUP'] ? false : true
   config.mailer_sender = "help@rubygems.org"
   config.secure_cookie = true unless Rails.env.test? || Rails.env.development?
   config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,4 +161,8 @@ Rails.application.routes.draw do
   end
 
   use_doorkeeper scope: 'oauth'
+
+  unless Clearance.configuration.allow_sign_up?
+    get '/sign_up' => 'users#disabled_signup'
+  end
 end

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -44,4 +44,20 @@ class SignUpTest < SystemTest
 
     assert page.has_content? "error prohibited"
   end
+
+  test "sign up when sign up is disabled" do
+    Clearance.configure { |config| config.allow_sign_up = false }
+    Rails.application.reload_routes!
+
+    visit root_path
+    refute page.has_content? "Sign up"
+    visit sign_up_path
+    assert_equal current_path, "/"
+    assert page.has_content? "Sign up is temporarily disabled."
+  end
+
+  teardown do
+    Clearance.configure { |config| config.allow_sign_up = true }
+    Rails.application.reload_routes!
+  end
 end


### PR DESCRIPTION
close: #1345 
Ideally, it should be tested with setting `ENV['DISABLE_SIGNUP']` but I am not sure if it is possible to reload internalizers between test runs.

Following is what user will see if they try to visit: `/sign_up`
![screenshot from 2016-06-28 18-25-53](https://cloud.githubusercontent.com/assets/7680662/16419845/c8366172-3d6c-11e6-9e1d-c2ebd5065efd.png)
If we ever have to do it on production then I suppose finally we will get to use `announcement`.
