### PR TITLE
Replace quiet_assets gem with sprockets-rails 3.1.0 config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'elasticsearch-dsl', '~> 0.1.2'
 gem 'xml-simple'
 gem 'yajl-ruby', require: 'yajl'
 gem 'compact_index', '~> 0.10.0'
+gem 'sprockets-rails', '~> 3.1.0'
 
 group :development, :test do
   gem 'rubocop', require: false
@@ -53,7 +54,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'quiet_assets'
   gem 'rails-erd'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,8 +189,6 @@ GEM
     pkg-config (1.1.7)
     powerpack (0.1.1)
     psych (2.0.17)
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -252,10 +250,10 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sprockets (3.6.0)
+    sprockets (3.6.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.4)
+    sprockets-rails (3.1.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -329,7 +327,6 @@ DEPENDENCIES
   paul_revere (~> 2.0)
   pg
   psych (~> 2.0.12)
-  quiet_assets
   rack
   rack-test
   rails (~> 4.2.6)
@@ -340,6 +337,7 @@ DEPENDENCIES
   rubocop
   shoryuken (~> 2.0.2)
   shoulda
+  sprockets-rails (~> 3.1.0)
   statsd-instrument (~> 2.0.6)
   toxiproxy (~> 0.1.3)
   uglifier (>= 1.0.3)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # Do not log asset requests
+  config.assets.quiet = true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
@sonalkr132 @dwradcliffe 

You can rebase https://github.com/rubygems/rubygems.org/pull/1341 over this to simplify it a bit. Part of the Rails 5 upgrade.

Replaces `quiet_assets` with config in `sprockets-rails`. Bumps the `sprockets-rails` version to `3.1.0` to include the feature. https://github.com/rails/sprockets-rails/pull/355