### PR TITLE
Use created_at date instead of built_at to generate feed

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -153,7 +153,7 @@ class Version < ActiveRecord::Base
   end
 
   def self.published(limit)
-    indexed.by_built_at.limit(limit)
+    indexed.by_created_at.limit(limit)
   end
 
   def self.find_from_slug!(rubygem_id, slug)


### PR DESCRIPTION
closes: #1145
People are using all kinds of date (>Today) in their gem file.
```sql
gemcutter_development=# SELECT  full_name, indexed, built_at FROM versions ORDER BY built_at DESC LIMIT 20;
           full_name           | indexed |      built_at       
-------------------------------+---------+---------------------
 agi-0.0.1                     | t       | 2915-09-06 00:00:00
 gtl-sluggable-0.2.0           | t       | 2103-09-30 00:00:00
 gtl-sluggable-0.3.0           | t       | 2103-09-30 00:00:00
 gtl-sluggable-0.1.0           | t       | 2103-09-30 00:00:00
 gtl-sluggable-0.0.0           | t       | 2103-09-27 00:00:00
 super-app-0.0.1               | t       | 2024-04-04 00:00:00
 mk-0.2.0                      | t       | 2020-12-18 00:00:00
 mk-0.1.0                      | t       | 2020-12-18 00:00:00
 daddys_girl-0.3               | t       | 2020-03-13 00:00:00
 daddys_girl-0.4               | t       | 2020-03-13 00:00:00
 daddys_girl-0.2               | t       | 2020-03-13 00:00:00
 linkedinparser-0.0.10         | t       | 2017-12-07 00:00:00
 linkedinparser-0.0.9          | t       | 2017-12-07 00:00:00
 linkedinparser-0.1.0          | t       | 2017-12-07 00:00:00
 kamelopard-0.0.16             | t       | 2017-05-16 00:00:00
 hoodoo-1.0.3                  | t       | 2016-12-15 00:00:00
 hoodoo-1.0.2                  | t       | 2016-12-15 00:00:00
 hoodoo-1.0.1                  | f       | 2016-12-10 00:00:00
 hoodoo-1.0.0                  | f       | 2016-12-10 00:00:00
 transport-opendata-0.8.2      | t       | 2016-12-03 00:00:00
 bmi-ricardooliva-1.0.0        | t       | 2016-11-17 00:00:00
 performance_promise-1.0.0     | t       | 2016-11-11 00:00:00
```

This only solved the mentioned issue. I suppose least we should do is impose validation on `built_at` unless we want to drop it all together and use `created_at`? It seems to cause other problems #1171 