### PR TITLE
Fix missing variable name

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -17,7 +17,7 @@ class Fastly
                                            timeout: 10,
                                            headers: headers)
     json = JSON.parse(response)
-    Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
+    Rails.logger.debug "Fastly purge url=#{domain + path} status=#{json['status']} id=#{json['id']}"
     json
   end
 


### PR DESCRIPTION
> Error detected in: Rubygems.org (production)
Full report at https://app.honeybadger.io/projects/40972/faults/30326630
NameError: undefined local variable or method `url' for Fastly:Class
Summary
api/v1/rubygems#create

Sorry :sweat: