### PR TITLE
Set cache control header for amazon s3 objects

### DIFF
--- a/lib/rubygem_fs.rb
+++ b/lib/rubygem_fs.rb
@@ -64,7 +64,12 @@ module RubygemFs
     end
 
     def store(key, body, metadata = {})
-      s3.put_object(key: key, body: body, bucket: bucket, acl: 'public-read', metadata: metadata)
+      s3.put_object(key: key,
+                    body: body,
+                    bucket: bucket,
+                    acl: 'public-read',
+                    metadata: metadata,
+                    cache_control: 'max-age=31536000')
     end
 
     def get(key)


### PR DESCRIPTION
close: #1100
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#put_object-instance_method
> :cache_control (String) — Specifies caching behavior along the request/reply chain.