### PR TITLE
Validate rubygem name with case insensitive

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -15,8 +15,9 @@ class Rubygem < ActiveRecord::Base
   validate :ensure_name_format, if: :needs_name_validation?
   validates :name,
     presence: true,
-    uniqueness: true,
-    exclusion: { in: GEM_NAME_BLACKLIST, message: "'%{value}' is a reserved gem name." }
+    uniqueness: { case_sensitive: false },
+    if: :needs_name_validation?
+  validate :blacklist_names_exclusion
 
   after_create :update_unresolved
   before_destroy :mark_unresolved
@@ -309,6 +310,11 @@ class Rubygem < ActiveRecord::Base
 
   def needs_name_validation?
     new_record? || name_changed?
+  end
+
+  def blacklist_names_exclusion
+    return unless GEM_NAME_BLACKLIST.include? name.downcase
+    errors.add :name, "'#{name}' is a reserved gem name."
   end
 
   def update_unresolved

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -14,7 +14,7 @@ class RubygemTest < ActiveSupport::TestCase
     should have_many(:versions).dependent(:destroy)
     should have_many(:web_hooks).dependent(:destroy)
     should have_one(:linkset).dependent(:destroy)
-    should validate_uniqueness_of :name
+    should validate_uniqueness_of(:name).case_insensitive
     should allow_value("rails").for(:name)
     should allow_value("awesome42").for(:name)
     should allow_value("factory_girl").for(:name)
@@ -22,6 +22,7 @@ class RubygemTest < ActiveSupport::TestCase
     should allow_value("perftools.rb").for(:name)
     should_not allow_value("\342\230\203").for(:name)
     should_not allow_value("2.2").for(:name)
+    should_not allow_value("Ruby").for(:name)
 
     context "that has an invalid name already persisted" do
       setup do


### PR DESCRIPTION
We validate `versions.full_name` with `case_sensitive: false`, we should do the same with `rubygems.name`.Additionally, some OS X have case insensitive file systems.