### PR TITLE
Rescue ActiveRecord::RecordNotFound with 404

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
   def set_locale
     I18n.locale = user_locale
 
@@ -68,5 +70,14 @@ class ApplicationController < ActionController::Base
 
   def http_head_locale
     http_accept_language.language_region_compatible_from(I18n.available_locales)
+  end
+
+  def render_404
+    respond_to do |format|
+      format.html { render file: "public/404", status: :not_found, layout: false }
+      format.json { render json: { error: t(:not_found) }, status: :not_found }
+      format.yaml { render yaml: { error: t(:not_found) }, status: :not_found }
+      format.any(:all) { render text: t(:not_found), status: :not_found }
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
   footer_about: "RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly publish your gems and install them. Use the API to interact and find out more information about available gems. Become a contributor and enhance the site with your own changes."
   locale_name: "English"
   this_rubygem_could_not_be_found: "This rubygem could not be found."
+  not_found: "Not Found"
   none: None
 
   dashboards:

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -2,10 +2,9 @@ require 'test_helper'
 
 class ProfilesControllerTest < ActionController::TestCase
   context "for a user that doesn't exist" do
-    should "throw a not found" do
-      assert_raise ActiveRecord::RecordNotFound do
-        get :show, id: "unknown"
-      end
+    should "render not found page" do
+      get :show, id: "unknown"
+      assert_response :not_found
     end
   end
 


### PR DESCRIPTION
Any reason why should this raise an error? As of now, error rate on rubygems.org is 3.96% because of this. Besides, it [ends up in 404](https://rubygems.org/profiles/does_not_exist) anyway.