### PR TITLE
Add security page link to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -146,6 +146,7 @@
             <%- end %>
             <%= link_to t('.footer.help'), t(:help_url), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.api'), "http://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.security'), page_url("security"), class: "nav--v__link--footer" %>
           </div>
           <div class="l-colspan--l colspan--l--has-border">
             <p class="footer__about"><%= raw t('footer_about') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
         about: "About"
         help: "Help"
         api: "API"
+        security: "Security"
         guides: "Guides"
         contribute: "Contribute"
         supported_by: "Supported by"


### PR DESCRIPTION
![screenshot from 2016-07-04 23-03-29](https://cloud.githubusercontent.com/assets/7680662/16567385/cf84fc8a-423b-11e6-9f75-fcb014853593.png)

We can totally move `code` and `data` links to `about` page if this feels crowed.