### PR TITLE
Remove undefined var response from ordered_names

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -262,13 +262,12 @@ class Rubygem < ActiveRecord::Base
     names = Rails.cache.read('names')
     if names
       StatsD.increment "compact_index.memcached.names.hit"
-      response
     else
       StatsD.increment "compact_index.memcached.names.miss"
       names = order("name").pluck("name")
       Rails.cache.write('names', names)
-      names
     end
+    names
   end
 
   def self.compact_index_versions(date)


### PR DESCRIPTION
Solves:
> Occurred: NameError (#30372507)
Full report at https://app.honeybadger.io/projects/40972/faults/30372507
NameError: undefined local variable or method `response' for #<Class:0x000000060b6bb0>
Summary
api/compact_index#names
URL: https://rubygems.org/names
