### PR TITLE
On gem yank reserve namespace for 100 days if gem is older than a month

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -177,7 +177,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def pushable?
-    new_record? || versions.indexed.count.zero?
+    new_record? || (versions.indexed.none? && not_protected?)
   end
 
   def create_ownership(user)
@@ -296,6 +296,12 @@ class Rubygem < ActiveRecord::Base
   end
 
   private
+
+  # a gem namespace is not protected if it is
+  # updated(yanked) in more than 100 days or it is created in last 30 days
+  def not_protected?
+    updated_at < 100.days.ago || created_at > 30.days.ago
+  end
 
   def ensure_name_format
     if name.class != String

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -12,7 +12,11 @@
 
 <% if @rubygem.public_versions.count.zero? %>
   <div class="t-body">
-    <p><%= t '.not_hosted_notice' %></p>
+    <% if @rubygem.pushable? %>
+      <p><%= t '.not_hosted_notice' %></p>
+    <% else %>
+      <p><%= t('.reserved_namespace', contact: link_to('Contact', 'http://help.rubygems.org/')).html_safe %></p>
+    <% end %>
     <%= unsubscribe_link(@rubygem) %>
   </div>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
       downloads: Downloads
     show:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
+      reserved_namespace: This namespace is reserved by rubygems.org. %{contact} rubygems team if you would like to take over this namespace.
       install: install
       yanked_notice: "This version has been yanked, and it is not available for download directly or for other gems that may have depended on it."
       authors_header: Authors

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -573,8 +573,20 @@ class RubygemTest < ActiveSupport::TestCase
       assert @new.pushable?
     end
 
-    should "be pushable if gem has no versions" do
-      assert @haml.pushable?
+    context "gem has no versions" do
+      should "be pushable if gem is less than one month old" do
+        assert @haml.pushable?
+      end
+
+      should "be pushable if gem was yanked more than 100 days ago" do
+        @haml.update_attributes(created_at: 101.days.ago, updated_at: 101.days.ago)
+        assert @haml.pushable?
+      end
+
+      should "not be pushable if gem is older than a month and yanked less than 100 days ago" do
+        @haml.update_attributes(created_at: 99.days.ago, updated_at: 99.days.ago)
+        refute @haml.pushable?
+      end
     end
 
     should "not be pushable if it has versions" do


### PR DESCRIPTION
Addresses: #1226 

Approach taken [from](https://github.com/rubygems/rubygems.org/issues/1226#issuecomment-200831744):
> When a gem author yanks all versions of a gem, one of three things will happen:
i. If the gem is less than a month old, we will open the namespace and allow anyone to claim the gem name. (This is what happens for all gems now.)
ii. If the gem is more than a month old, we will lock the namespace and prevent anyone from pushing any versions for 100 days. We will display a message on the website informing users that this gem name might be available, but they will need to contact support for assistance. We can then verify on a case by case basis.
iii. After 100 days, this namespace will become available. This should be enough time for the community to realize something has happened and we can step in and fix it. Or it is not a problem and someone else can have the gem name.

Reserved gem page:
![screenshot from 2016-07-07 20-18-09](https://cloud.githubusercontent.com/assets/7680662/16657425/1c5b0310-4480-11e6-8744-b1807fb9d0eb.png)
