### PR TITLE
Allow Twitter username length upto 20 characters

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
     message: "can only contain letters, numbers, and underscores"
   }, allow_nil: true
 
-  validates :twitter_username, length: { within: 0..15 }, allow_nil: true
+  validates :twitter_username, length: { within: 0..20 }, allow_nil: true
 
   def self.authenticate(who, password)
     user = find_by(email: who.downcase) || find_by(handle: who)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -54,6 +54,8 @@ class UserTest < ActiveSupport::TestCase
       should_not allow_value("@user").for(:twitter_username)
       should_not allow_value("user 1").for(:twitter_username)
       should_not allow_value("user-1").for(:twitter_username)
+      should allow_value("01234567890123456789").for(:twitter_username)
+      should_not allow_value("012345678901234567890").for(:twitter_username)
     end
   end
 


### PR DESCRIPTION
Twitter had been limited username length as 20 characters in their early days.
Some early-adopter Twitter users have usernames longer than 15 chars.
I updated Twitter username validation so that they can register their Twitter usernames on rubygems.org.

Thanks!