### PR TITLE
Remove tk entry from blacklist

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -86,7 +86,6 @@ module Patterns
     thwait
     time
     timeout
-    tk
     tmpdir
     tsort
     un


### PR DESCRIPTION
We will extract tk from stdlib at Ruby 2.4

 * https://github.com/ruby/tk
 * https://bugs.ruby-lang.org/issues/8539

Related issue: https://github.com/rubygems/rubygems.org/pull/1273