### PR TITLE
Delay purge requests to fastly

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -43,9 +43,9 @@ class Deletion < ActiveRecord::Base
   def remove_from_storage
     RubygemFs.instance.remove("gems/#{@version.full_name}.gem")
     RubygemFs.instance.remove("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
-    Fastly.purge("gems/#{@version.full_name}.gem")
-    Fastly.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
-    Fastly.purge_api_cdn(rubygem)
+    Fastly.delay.purge("gems/#{@version.full_name}.gem")
+    Fastly.delay.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    Fastly.delay.purge_api_cdn(rubygem)
   end
 
   def update_search_index

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,7 +129,7 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     expire_api_memcached
-    Fastly.purge_api_cdn(rubygem.name)
+    Fastly.delay.purge_api_cdn(rubygem.name)
     enqueue_web_hook_jobs
     update_remote_bundler_api
     StatsD.increment 'push.success'

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -225,7 +225,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
         @request.env["RAW_POST_DATA"] = gem_file("test-1.0.0.gem").read
-        assert_difference 'Delayed::Job.count', 2 do
+        assert_difference 'Delayed::Job.count', 3 do
           post :create
         end
       end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -308,13 +308,14 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "purge cdn cache" do
+        Delayed::Worker.new.work_off
         assert_received(Fastly, :purge) { |path| path.with("info/#{@rubygem.name}") }
         assert_received(Fastly, :purge) { |path| path.with("versions") }
         assert_received(Fastly, :purge) { |path| path.with("names") }
       end
 
-      should "enque job for updating ES index and spec index" do
-        assert_difference 'Delayed::Job.count', 2 do
+      should "enque job for updating ES index, spec index and purging cdn" do
+        assert_difference 'Delayed::Job.count', 3 do
           @cutter.save
         end
       end


### PR DESCRIPTION
Fastly failures should not fail `gem push` or `gem yank`.