### PR TITLE
Force locale to match test expectations

### DIFF
--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -8,6 +8,7 @@ class RubygemsHelperTest < ActionView::TestCase
   context "licenses header" do
     setup do
       @version = build(:version)
+      I18n.locale = :en
     end
     should "singular if version has one license" do
       @version.stubs(:licenses).returns(["MIT"])


### PR DESCRIPTION
One of my commits failed on Travis because the RubygemsHelper tests were expecting responses in English, but the responses were being provided in German. Hopefully this will ensure that stray VM locale settings will not cause the tests to fail.