### PR TITLE
Add version param to /api/v1/gems/:gem

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def show
-    if @rubygem.hosted? && @rubygem.public_versions.indexed.count.nonzero?
+    if @rubygem.hosted? && @rubygem.public_versions.indexed.count.nonzero? &&
+        rubygem_by_version(params[:version])
       respond_to do |format|
         format.json { render json: @rubygem }
         format.yaml { render yaml: @rubygem }
@@ -59,6 +60,12 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   private
+
+  def rubygem_by_version(ver_slug)
+    return @rubygem if ver_slug.blank?
+    version = Version.find_from_slug!(@rubygem, ver_slug)
+    @rubygem = @rubygem.payload(version)
+  end
 
   def cors_set_access_control_headers
     headers['Access-Control-Allow-Origin'] = '*'

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -362,6 +362,25 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to show with a version" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:version, rubygem: @rubygem, number: '0.1')
+      create(:version, rubygem: @rubygem, number: @ver = '0.2')
+      create(:version, rubygem: @rubygem, number: '0.3')
+      get :show, id: @rubygem.to_param, version: @ver, format: "json"
+      @json = JSON.parse(@response.body)
+    end
+    should respond_with :success
+    should "return the correct rubygem" do
+      assert_not_nil @json
+      assert_equal @ver, @json["version"]
+      assert_not_nil @json["dependencies"]
+      assert_equal [], @json["dependencies"]["development"]
+      assert_equal [], @json["dependencies"]["runtime"]
+    end
+  end
+
   context "on GET to reverse_dependencies" do
     setup do
       @dep_rubygem = create(:rubygem)


### PR DESCRIPTION
Other people have requested this feature, so here it is.

`GET /api/v1/gems/:gem(.json|.yaml)?version=:version`
There are other efforts on v2 which haven't been built and it's an ugly, thick controller hack, but it also works with minimal intrusiveness.

`GET /api/v2/.../:gem/:version(.json|.yaml)` would be nicer but that's above my current bandwidth and seems a waste if/when v2 picks up.
