### PR TITLE
Force locale to match expectations in helper tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require 'helpers/gem_helpers'
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true
+I18n.locale = :en
 
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
Supersedes: #1389

> One of my commits failed on Travis because the RubygemsHelper tests were expecting responses in English, but the responses were being provided in German. Hopefully this will ensure that stray VM locale settings will not cause the tests to fail.