### PR TITLE
Version navigation

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -198,3 +198,32 @@
   color: #a6aab2;
   cursor: help;
 }
+
+.gem__navigation {
+  display: inline-block;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.gem__navigation a {
+  color: #9da2ab;
+  transition-duration: 0.25s;
+  transition-property: color;
+  outline: none;
+}
+
+.gem__navigation a:hover, .gem__navigation a:focus, .gem__navigation a:active {
+  color: #141c22;
+}
+
+.gem__previous__version.disabled:hover, .gem__next__version.disabled:hover {
+    color: #9da2ab;
+}
+
+.gem__next__version {
+  float: right;
+}
+
+.gem__previous__version {
+  float: left;
+}

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -171,6 +171,14 @@ class Version < ActiveRecord::Base
 
   delegate :reorder_versions, to: :rubygem
 
+  def previous
+    rubygem.versions.find_by(position: position + 1)
+  end
+
+  def next
+    rubygem.versions.find_by(position: position - 1)
+  end
+
   def yanked?
     !indexed
   end

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,6 +1,13 @@
-<% if latest_version.previous.present? %>
-  <%= link_to "Previous version", rubygem_version_path(rubygem, latest_version.previous.number) %>
-<% end %>
-<% if latest_version.next.present? %>
-  <%= link_to "Next version", rubygem_version_path(rubygem, latest_version.next.number) %>
-<% end %>
+<div class="gem__navigation">
+  <% if latest_version.previous.present? %>
+    <%= link_to "Previous version", rubygem_version_path(rubygem, latest_version.previous.number), class: "gem__previous__version"  %>
+  <% else %>
+    <a href="#" class ="gem__previous__version disabled">Previous version</a>
+  <% end %>
+
+  <% if latest_version.next.present? %>
+    <%= link_to "Next version", rubygem_version_path(rubygem, latest_version.next.number), class: "gem__next__version" %>
+  <% else %>
+    <a href="#" class ="gem__next__version disabled">Next version</a>
+  <% end %>
+</div>

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,0 +1,6 @@
+<% if latest_version.previous.present? %>
+  <%= link_to "Previous version", rubygem_version_path(rubygem, latest_version.previous.number) %>
+<% end %>
+<% if latest_version.next.present? %>
+  <%= link_to "Next version", rubygem_version_path(rubygem, latest_version.next.number) %>
+<% end %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -22,6 +22,7 @@
 <% else %>
   <div class="l-overflow">
     <div class="l-colspan--l colspan--l--has-border">
+      <%= render partial: "rubygems/version_navigation", locals: { rubygem: @rubygem, latest_version: @latest_version } %>
       <% if @latest_version.indexed %>
         <div class="gem__intro">
           <div id="markup" class="gem__desc">

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -62,3 +62,18 @@ class GemsTest < ActionDispatch::IntegrationTest
     assert page.has_css?(css, visible: false)
   end
 end
+
+class GemsSystemTest < SystemTest
+  setup do
+    @rubygem = create(:rubygem, name: "sandworm", number: "1.0.0")
+    create(:version, rubygem: @rubygem, number: "1.1.1")
+  end
+
+  test "version navigation" do
+    visit rubygem_version_path(@rubygem, "1.0.0")
+    click_link "Next version"
+    assert_equal page.current_path, rubygem_version_path(@rubygem, "1.1.1")
+    click_link "Previous version"
+    assert_equal page.current_path, rubygem_version_path(@rubygem, "1.0.0")
+  end
+end


### PR DESCRIPTION
Supersedes: #1200

> This is a really basic feature I find myself needing often when looking for
runtime dependency changes in a gem.
It adds two simple methods Version#previous and Versions#next which just use
self.position - 1 and self.position + 1. If adding the links to the UI seems
unnecessary we could even hook up keyboard shortcuts to make this a power-user
feature only but I'll admit I prefer discoverable features.

![screenshot from 2016-08-27 16-43-59](https://cloud.githubusercontent.com/assets/7680662/18027169/22423c22-6c7a-11e6-9ac1-5e7b516f3a12.png)


