### PR TITLE
Prevent yanking of popular gem versions with downloads greater than 15000

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -4,6 +4,7 @@ class Deletion < ActiveRecord::Base
   validates :user, :rubygem, :number, presence: true
   validates :version, presence: true
   validate :version_is_indexed
+  validate :version_downloads
 
   before_validation :record_metadata
   after_create :remove_from_index
@@ -14,6 +15,10 @@ class Deletion < ActiveRecord::Base
   attr_accessor :version
 
   private
+
+  def version_downloads
+    errors.add(:base, "Gem versions cannot be yanked after they have been downloaded over 15,000 times") unless @version.gem_download.count < 15_000
+  end
 
   def version_is_indexed
     errors.add(:number, "is already deleted") unless @version.indexed?

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -15,6 +15,22 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         RubygemFs.instance.store("gems/#{@v1.full_name}.gem", "")
       end
 
+      context "ON DELETE for a gem with greater than 15000 downloads" do
+        setup do
+          @v1.gem_download.count = 15_000
+          @v1.gem_download.save
+          delete :create, gem_name: @rubygem.to_param, version: @v1.number
+        end
+        should respond_with :unprocessable_entity
+        should "not modify any versions" do
+          assert_equal 1, @rubygem.versions.count
+          assert_equal 1, @rubygem.versions.indexed.count
+        end
+        should "not record the deletion" do
+          assert_equal 0, @user.deletions.count
+        end
+      end
+
       context "ON DELETE to create for existing gem version" do
         setup do
           delete :create, gem_name: @rubygem.to_param, version: @v1.number


### PR DESCRIPTION
Refers to issue #1226 .

> Gem yanks will only be allowed if the version has less than 15,000 downloads. This will allow relatively unused gems to be yanked freely, while popular gems will have a shorter period of time to realize they have a legit reason to yank.

This PR contains the following changes:
- Render error message from validations present in deletion model.
- Gem version can now only be yanked if the downloads for that version is less than 15,000
