### PR TITLE
Move locale intialization to setup

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,11 +11,12 @@ require 'helpers/gem_helpers'
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true
-I18n.locale = :en
 
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
   include GemHelpers
+
+  setup { I18n.locale = :en }
 
   def page
     Capybara::Node::Simple.new(@response.body)


### PR DESCRIPTION
Related: #1393
I have confirmed that `I18n.locale` gets correctly set in integration test as well.

```Ruby
class ActiveSupport::TestCase
  setup { I18n.locale = :fr }
  ...
end

class AuthenticationTest < ActionDispatch::IntegrationTest
  setup do
   ...
   puts I18n.locale
  end

$ rake test TEST=test/integration/authentication_test.rb

fr
.fr
.fr
.fr
.fr
.fr
.
```

