### PR TITLE
Script to release namespace by setting rubygem.updated_at to 101 days ago

### DIFF
--- a/script/release_reserved_namespace
+++ b/script/release_reserved_namespace
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+rubygem_name = *ARGV
+
+abort "Usage: script/release_reserved_namespace [GEM_NAME]" if rubygem_name.nil?
+
+ENV['RAILS_ENV'] ||= 'production'
+require_relative '../config/environment'
+
+rubygem = Rubygem.find_by_name!(rubygem_name)
+rubygem.update_attribute(:updated_at, 101.days.ago)
+
+puts "#{rubygem_name} was released."


### PR DESCRIPTION
The reserved namespace would change from:
> This namespace is reserved by rubygems.org. Contact rubygems team if you would like to take over this namespace.

to
> This gem is not currently hosted on RubyGems.org.

and the namespace will be open `gem push` by **anyone**

Any user requesting the namespace should know that this won't be a brand new namespace. They will have to release versions other than previously used by the gem. For example, in case of [conversation](conversation), any claimer should release version `> 0.2.4`.