### PR TITLE
Throttle login attacks with rack_attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'xml-simple'
 gem 'yajl-ruby', require: 'yajl'
 gem 'compact_index', '~> 0.11.0'
 gem 'sprockets-rails', '~> 3.1.0'
+gem 'rack-attack'
 
 group :development, :test do
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     powerpack (0.1.1)
     psych (2.0.17)
     rack (1.6.4)
+    rack-attack (5.0.1)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -326,6 +328,7 @@ DEPENDENCIES
   pg
   psych (~> 2.0.12)
   rack
+  rack-attack
   rack-test
   rails (~> 4.2.7)
   rails-erd

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module Gemcutter
     config.i18n.fallbacks = true
 
     config.middleware.use "Redirector" unless Rails.env.development?
+    config.middleware.use Rack::Attack
 
     config.active_record.include_root_in_json = false
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,74 @@
+class Rack::Attack
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blacklisting and
+  # whitelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  # throttle('req/ip', :limit => 300, :period => 5.minutes) do |req|
+  #   req.ip # unless req.path.start_with?('/assets')
+  # end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
+    req.ip if req.path == '/session' && req.post?
+  end
+
+  # Throttle POST requests to /login by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  throttle("logins/handler", limit: 5, period: 20.seconds) do |req|
+    if req.path == '/session' && req.post?
+      # return the handler if present, nil otherwise
+      req.params['session']['who'].presence
+    end
+  end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_response = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,32 +1,4 @@
 class Rack::Attack
-  ### Configure Cache ###
-
-  # If you don't want to use Rails.cache (Rack::Attack's default), then
-  # configure it here.
-  #
-  # Note: The store is only used for throttling (not blacklisting and
-  # whitelisting). It must implement .increment and .write like
-  # ActiveSupport::Cache::Store
-
-  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
-
-  ### Throttle Spammy Clients ###
-
-  # If any single client IP is making tons of requests, then they're
-  # probably malicious or a poorly-configured scraper. Either way, they
-  # don't deserve to hog all of the app server's CPU. Cut them off!
-  #
-  # Note: If you're serving assets through rack, those requests may be
-  # counted by rack-attack and this throttle may be activated too
-  # quickly. If so, enable the condition to exclude them from tracking.
-
-  # Throttle all requests by IP (60rpm)
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-  # throttle('req/ip', :limit => 300, :period => 5.minutes) do |req|
-  #   req.ip # unless req.path.start_with?('/assets')
-  # end
-
   ### Prevent Brute-Force Login Attacks ###
 
   # The most common brute-force login attack is a brute-force password
@@ -39,8 +11,15 @@ class Rack::Attack
   # Throttle POST requests to /login by IP address
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
-  throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
-    req.ip if req.path == '/session' && req.post?
+  protected_paths = [
+    "/users", # sign up
+    "/session", # sign in
+    "/passwords" # forgot password
+  ]
+  paths_regex = Regexp.union(protected_paths.map { |path| /\A#{Regexp.escape(path)}\z/ })
+
+  throttle('clearance/ip', limit: 100, period: 10.minutes) do |req|
+    req.ip if req.path =~ paths_regex && req.post?
   end
 
   # Throttle POST requests to /login by email param
@@ -51,8 +30,8 @@ class Rack::Attack
   # throttle logins for another user and force their login requests to be
   # denied, but that's not very common and shouldn't happen to you. (Knock
   # on wood!)
-  throttle("logins/handler", limit: 5, period: 20.seconds) do |req|
-    if req.path == '/session' && req.post?
+  throttle("logins/handler", limit: 100, period: 10.minutes) do |req|
+    if req.path == "/session" && req.post?
       # return the handler if present, nil otherwise
       req.params['session']['who'].presence
     end
@@ -66,9 +45,24 @@ class Rack::Attack
   # If you want to return 503 so that the attacker might be fooled into
   # believing that they've successfully broken your app (or you just want to
   # customize the response), then uncomment these lines.
-  # self.throttled_response = lambda do |env|
-  #  [ 503,  # status
-  #    {},   # headers
-  #    ['']] # body
+  # self.throttled_response = lambda do |_env|
+  #   [503, {}, ['Service Temporarily Unavailable']]
   # end
+
+  ### Logging ###
+
+  ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, payload|
+    if payload.env['rack.attack.match_type'] == :throttle
+      data = {
+        status: 'throttled',
+        ip: payload.ip.to_s,
+        method: payload.env["REQUEST_METHOD"],
+        path: payload.env["REQUEST_PATH"],
+        matched: payload.env["rack.attack.matched"],
+        discriminator: payload.env["rack.attack.match_discriminator"],
+        match_data: payload.env["rack.attack.match_data"]
+      }
+      Rails.logger.info data
+    end
+  end
 end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+## SLOW TESTS ##
+class RackAttackTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, email: "nick@example.com", password: "secret123")
+    @limit = 100
+  end
+
+  context 'requests is lower than limit' do
+    should 'allow sign in' do
+      10.times do
+        post_via_redirect '/session', session: { who: @user.email, password: @user.password }
+        assert_equal @response.status, 200
+      end
+    end
+
+    should 'allow sign up' do
+      10.times do
+        user = build(:user)
+        post_via_redirect '/users', user: { email: user.email, password: user.password }
+        assert_equal @response.status, 200
+      end
+    end
+
+    should 'allow forgot password' do
+      10.times do
+        post '/passwords', password: { email: @user.email }
+        assert_equal @response.status, 200
+      end
+    end
+  end
+
+  context 'requests is higher than limit' do
+    should 'throttle sign in' do
+      (@limit + 1).times do |i|
+        post_via_redirect '/session', session: { who: @user.email, password: @user.password }
+        assert_equal @response.status, 429 if i > @limit
+      end
+    end
+
+    should 'throttle sign up' do
+      (@limit + 1).times do |i|
+        user = build(:user)
+        post_via_redirect '/users', user: { email: user.email, password: user.password }
+        assert_equal @response.status, 429 if i > @limit
+      end
+    end
+
+    should 'throttle forgot password' do
+      (@limit + 1).times do |i|
+        post '/passwords', password: { email: @user.email }
+        assert_equal @response.status, 429 if i > @limit
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,10 @@ class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
   include GemHelpers
 
-  setup { I18n.locale = :en }
+  setup do
+    I18n.locale = :en
+    Rails.cache.clear
+  end
 
   def page
     Capybara::Node::Simple.new(@response.body)


### PR DESCRIPTION
[Example configration](https://github.com/kickstarter/rack-attack/wiki/Example-Configuration)

This PR limits sign in, sign up and forgot password requests to 5 reqs/20sec. It also throttles reverse brute force attack by limiting incorrect login attempts to a given account.

Other possible routes to limit:
```Ruby
POST	/users/:user_id/password(.:format)	passwords#create
POST	/oauth/authorize(.:format)	doorkeeper/authorizations#create
POST	/oauth/token(.:format)	doorkeeper/tokens#create
POST	/oauth/revoke(.:format)	doorkeeper/tokens#revoke
POST	/oauth/applications(.:format)	doorkeeper/applications#create
```
I will add tests after we have an agreement on rate limits :smile_cat: 

cc: @ktheory