### PR TITLE
Don't log Elasticsearch::Transport::Transport::Errors::BadRequest exceptions

### DIFF
--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -47,7 +47,7 @@
     margin-top: 18px; }
   .errorExplanation ul li, .errorExplanation p {
     font-weight: 300;
-    font-size: 18px;
+    font-size: 16px;
     line-height: 1.66; }
   .errorExplanation ul li {
     padding-left: 23px;

--- a/app/controllers/reverse_dependencies_controller.rb
+++ b/app/controllers/reverse_dependencies_controller.rb
@@ -9,7 +9,7 @@ class ReverseDependenciesController < ApplicationController
       .by_downloads
       .includes(:latest_version, :gem_download)
     if params[:rdeps_query] && params[:rdeps_query].is_a?(String)
-      @reverse_dependencies = @reverse_dependencies.search(params[:rdeps_query])
+      _, @reverse_dependencies = @reverse_dependencies.search(params[:rdeps_query])
     end
     @reverse_dependencies = @reverse_dependencies.paginate(page: @page)
   end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,12 +3,7 @@ class SearchesController < ApplicationController
 
   def show
     return unless params[:query] && params[:query].is_a?(String)
-    begin
-      @gems = Rubygem.search(params[:query], es: es_enabled?, page: @page)
-    rescue RubygemSearchable::SearchDownError
-      @fallback = true
-      @gems = Rubygem.search(params[:query], es: false, page: @page)
-    end
+    @error_msg, @gems = Rubygem.search(params[:query], es: es_enabled?, page: @page)
     @exact_match = Rubygem.name_is(params[:query]).with_versions.first
     redirect_to rubygem_path(@exact_match) if @exact_match && @gems.size == 1
   end

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,9 +1,8 @@
 <% @title = "search" %>
 
-<% if @fallback %>
+<% if @error_msg %>
   <div class="errorExplanation">
-    <h2>Uh oh...</h2>
-    <ul><li>Advanced search is currently unavailable, sorry!</li></ul>
+    <p><%= @error_msg %></p>
   </div>
 <% end %>
 

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -153,7 +153,7 @@ class SearchesControllerTest < ActionController::TestCase
         @request.cookies['new_search'] = 'true'
         get :show, query: 'sinatra'
         assert_response :success
-        assert page.has_content?('Advanced search is currently unavailable')
+        assert page.has_content?('Advanced search is currently unavailable. Falling back to legacy search.')
         assert page.has_content?('Displaying')
       end
     end


### PR DESCRIPTION
The exception occurs when an invalid format for advanced query is submitted. Ex: updated:[2016-08-10 TO } We don't need to log what is expected.

SearchDownError was removed because exception should not be used for control flow(ie use legacy search if elasticsearch raised exception).
https://www.sitepoint.com/ruby-error-handling-beyond-basics/

![screenshot from 2016-09-09 23-52-55](https://cloud.githubusercontent.com/assets/7680662/18398535/de99a91c-76ea-11e6-89bc-eb61c865d378.png)
