### PR TITLE
Add recent uploads page

### DIFF
--- a/app/assets/stylesheets/modules/recent.css
+++ b/app/assets/stylesheets/modules/recent.css
@@ -1,0 +1,38 @@
+.recent {
+  margin-top: -15px;
+  overflow: auto;
+  border-bottom: 1px solid #c1c4ca; }
+  @media (max-width: 709px) {
+    .stats {
+      margin-bottom: 24px;
+      padding-bottom: 12px; } }
+  @media (min-width: 710px) {
+    .stats {
+      margin-bottom: 60px;
+      padding-bottom: 10px; } }
+
+.recent__table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 30px 15px;
+  border-left: 3%; }
+
+.recent__table__row {
+  height: 30px;
+  width: 100%; }
+
+.recent__table__column {
+  /* Size table columns to contents. */
+  width: 1%;
+  white-space: nowrap;
+
+  font-weight: 400;
+  text-align: left;
+  vertical-align: middle; }
+
+  @media (max-width: 709px) {
+    .recent__table__column {
+      font-size: 13px; } }
+  @media (min-width: 710px) {
+    .recent__table__column {
+      font-size: 15px; } }

--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -47,6 +47,17 @@
     .stat__count {
       font-size: 24px; } }
 
+.stats__link {
+  margin-top: 81px;
+}
+
+.stats__link a {
+  font-weight: 600;
+  font-size: 20px;
+  color: #000000; }
+
+.stats__link a:focus, .stats__link a:hover { color: #e9573f; }
+
 .stats__graph__heading {
   margin-bottom: 42px;
   font-weight: 600;

--- a/app/controllers/recent_uploads_controller.rb
+++ b/app/controllers/recent_uploads_controller.rb
@@ -1,0 +1,5 @@
+class RecentUploadsController < ApplicationController
+  def index
+    @recent_uploads = Version.recent_uploads(25)
+  end
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -152,6 +152,13 @@ class Version < ActiveRecord::Base
       .limit(limit)
   end
 
+  def self.recent_uploads(limit)
+    joins(:rubygem)
+      .indexed
+      .by_created_at
+      .limit(limit)
+  end
+
   def self.published(limit)
     indexed.by_created_at.limit(limit)
   end

--- a/app/views/recent_uploads/index.html.erb
+++ b/app/views/recent_uploads/index.html.erb
@@ -1,0 +1,19 @@
+<% @title = "Recent Uploads" %>
+
+<div class="recent">
+    <table class="recent__table">
+      <% @recent_uploads.each do |version| %>
+        <tr class="recent__table__row">
+          <th class="recent__table__column">
+            <%= link_to version.rubygem.name, rubygem_path(version.rubygem), class: 'gems__gem__name' %>
+          </th>
+          <td class="recent__table__column">
+            <%= link_to version.number, rubygem_version_path(version.rubygem, version.slug), class: 'gems__gem__version' %>
+          </td>
+          <td class="recent__table__column">
+            <span class="gem__version__date"><%= nice_date_for(version.rubygem.created_at) %></span>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+</div>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -33,4 +33,9 @@
     </div>
   </div>
 <% end %>
+
+<p class="stats__link">
+  <%= link_to t('stats.index.recent_uploads'), recent_uploads_path %>
+</p>
+
 <%= will_paginate @most_downloaded %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
       total_gems: Total gems
       total_users: Total users
       all_time_most_downloaded: All Time Most Downloaded
+      recent_uploads: Recent Uploads
 
   users:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
     resources :profiles, only: :show
     resource :profile, only: [:edit, :update]
     resources :stats, only: :index
+    resources :recent_uploads, only: :index
 
     resources :rubygems,
       only: [:index, :show, :edit, :update],

--- a/test/functional/recent_uploads_controller_test.rb
+++ b/test/functional/recent_uploads_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class RecentUploadsControllerTest < ActionController::TestCase
+  context "on GET to index" do
+    setup do
+      @recent_uploads = [create(:version)]
+
+      Version.stubs(:recent_uploads).returns @recent_uploads
+
+      get :index
+    end
+
+    should "display 25 recently uploaded gems" do
+      assert_received(Version, :recent_uploads) { |subject| subject.with(25) }
+    end
+  end
+
+  context "on GET to index with no data" do
+    setup do
+      get :index
+    end
+
+    should respond_with :success
+  end
+end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -136,6 +136,27 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context "recent uploads" do
+    setup do
+      @gem_1 = create(:rubygem)
+      @second = create(:version, rubygem: @gem_1, created_at: 1.day.ago)
+      @fourth = create(:version, rubygem: @gem_1, created_at: 4.days.ago)
+
+      @gem_2 = create(:rubygem)
+      @first = create(:version, rubygem: @gem_2, created_at: 1.minute.ago)
+      @not_included_fifth = create(:version, rubygem: @gem_2, created_at: 10.days.ago)
+
+      @gem_3 = create(:rubygem)
+      @third = create(:version, rubygem: @gem_3, created_at: 3.days.ago)
+    end
+
+    should "include specified number of versions ordered by created at" do
+      versions = Version.recent_uploads(4)
+      assert_equal 4, versions.size
+      assert_equal [@first, @second, @third, @fourth], versions
+    end
+  end
+
   context "with a rubygem" do
     setup do
       @rubygem = create(:rubygem)


### PR DESCRIPTION
This PR adds a recent uploads page as suggested in #1217.

Continuing from #1238 by adding a new page instead of displaying the recent uploads in the stats page.

Recent Page Screenshot
<img width="1280" alt="screen shot 2016-09-11 at 1 04 57 pm" src="https://cloud.githubusercontent.com/assets/7445868/18416482/fc1651f2-7848-11e6-9852-d824547241d3.png">

Link from the Stats page
<img width="988" alt="screen shot 2016-09-10 at 4 19 01 am" src="https://cloud.githubusercontent.com/assets/7445868/18401559/a5618c6e-770d-11e6-8682-7dc69aa0be7b.png">
