### PR TITLE
Use set_page instead of params[:page] in stats controller

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,11 +1,13 @@
 class StatsController < ApplicationController
+  before_action :set_page, only: :index
+
   def index
     @number_of_gems      = Rubygem.total_count
     @number_of_users     = User.count
     @number_of_downloads = GemDownload.total_count
     @most_downloaded     = Rubygem.by_downloads
       .includes(:gem_download)
-      .paginate(page: params[:page], per_page: 10, total_entries: 100)
+      .paginate(page: @page, per_page: 10, total_entries: 100)
     @most_downloaded_count = GemDownload.most_downloaded_gem_count
   end
 end

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class StatsTest < SystemTest
+  test "page params is not integer" do
+    visit '/stats?page="3\">XSS"'
+    assert page.has_content? "Stats"
+  end
+end


### PR DESCRIPTION
https://app.honeybadger.io/projects/40972/faults/30742663#notice-summary
> ArgumentError: invalid value for Integer(): "3\">XSS"
stats_controller.rb  8  index(...)
[PROJECT_ROOT]/app/controllers/stats_controller.rb:8:in `index'

Times: 1,423

https://app.honeybadger.io/projects/40972/faults/31022066#notice-summary
> RangeError: invalid page: -1
stats_controller.rb  8  index(...)
[PROJECT_ROOT]/app/controllers/stats_controller.rb:8:in `index'

[Failing test](https://travis-ci.org/sonalkr132/rubygems.org/jobs/158955609#L1106) without this patch.

EDIT:
Corrected HB link and quoted backtrace.
Added another HB link.