### PR TITLE
Add owner to reserved namespace and yanked version page

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -24,6 +24,11 @@ class RubygemsController < ApplicationController
     else
       @latest_version = @rubygem.versions.most_recent
       @versions       = @rubygem.public_versions(5)
+      if @rubygem.public_versions.any?
+        render 'show'
+      else
+        render 'show_yanked'
+      end
     end
   end
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -263,6 +263,12 @@ class Rubygem < ActiveRecord::Base
     versions.by_earliest_built_at.limit(1).last.built_at
   end
 
+  # returns days left before the reserved namespace will be released
+  # 100 + 1 days are added so that last_protected_day / 1.day = 1
+  def protected_days
+    (updated_at + 101.days - Time.zone.now).to_i / 1.day
+  end
+
   private
 
   # a gem namespace is not protected if it is

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -1,0 +1,24 @@
+<div class="gem__members">
+  <% if latest_version.authors.present? %>
+    <h3 class="t-list__heading"><%= t '.authors_header' %>:</h3>
+    <ul class="t-list__items">
+      <li class="t-list__item">
+        <p><%= latest_version.authors %></p>
+      </li>
+    </ul>
+  <% end %>
+
+  <% if rubygem.owners.present? %>
+    <h3 class="t-list__heading"><%= t '.owners_header' %>:</h3>
+    <div class="gem__owners">
+      <%= links_to_owners(rubygem) %>
+    </div>
+  <% end %>
+
+  <% if latest_version.sha256.present? %>
+    <h3 class="t-list__heading"><%= t '.sha_256_checksum' %>:</h3>
+    <div class="gem__sha">
+      <%= latest_version.sha256_hex %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -10,168 +10,132 @@
   <% end %>
 <% end %>
 
-<% if @rubygem.public_versions.count.zero? %>
-  <div class="t-body">
-    <% if @rubygem.pushable? %>
-      <p><%= t '.not_hosted_notice' %></p>
-    <% else %>
-      <p><%= t('.reserved_namespace', count: @rubygem.protected_days).html_safe %></p>
-    <% end %>
-    <%= unsubscribe_link(@rubygem) %>
-  </div>
-<% else %>
-  <div class="l-overflow">
-    <div class="l-colspan--l colspan--l--has-border">
-      <% if @latest_version.indexed %>
-        <div class="gem__intro">
-          <div id="markup" class="gem__desc">
-            <%= simple_markup(@latest_version.info) %>
-          </div>
+
+<div class="l-overflow">
+  <div class="l-colspan--l colspan--l--has-border">
+    <% if @latest_version.indexed %>
+      <div class="gem__intro">
+        <div id="markup" class="gem__desc">
+          <%= simple_markup(@latest_version.info) %>
         </div>
-      <% else %>
-        <div class="t-body">
-          <p><%=t '.yanked_notice' %></p>
-        </div>
-      <% end %>
-
-      <% if @versions.present? %>
-        <div class="l-half--l">
-          <div class="versions">
-            <h3 class="t-list__heading"><%= t '.versions_header' %>:</h3>
-            <ol class="gem__versions t-list__items">
-              <%= render @versions %>
-            </ol>
-            <% if show_all_versions_link?(@rubygem) %>
-              <%= link_to t('.show_all_versions', :count => @rubygem.versions.count), rubygem_versions_url(@rubygem), :class => "gem__see-all-versions t-link--gray t-link--has-arrow" %>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-
-      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime, :dependencies_count => @latest_version.runtime_dependencies_count } %>
-      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development, :dependencies_count => @latest_version.development_dependencies_count } %>
-
-      <% if @latest_version.requirements.present? %>
-        <div class="l-half--l">
-          <h3 class="t-list__heading"><%= t '.requirements_header' %>:</h3>
-          <div class="t-list__items">
-            <% Array(@latest_version.requirements).each do |requirement| %>
-              <p><%= requirement %></p>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="gem__members">
-        <% if @latest_version.indexed %>
-          <% if @latest_version.authors.present? %>
-            <h3 class="t-list__heading"><%= t '.authors_header' %>:</h3>
-            <ul class="t-list__items">
-              <li class="t-list__item">
-                <p><%= @latest_version.authors %></p>
-              </li>
-            </ul>
-          <% end %>
-
-          <% if @rubygem.owners.present? %>
-            <h3 class="t-list__heading"><%= t '.owners_header' %>:</h3>
-            <div class="gem__owners">
-              <%= links_to_owners(@rubygem) %>
-            </div>
-          <% end %>
-
-          <% if @latest_version.sha256.present? %>
-            <h3 class="t-list__heading"><%= t '.sha_256_checksum' %>:</h3>
-            <div class="gem__sha">
-              <%= @latest_version.sha256_hex %>
-            </div>
-          <% end %>
-        <% end %>
-
-        <%= render partial: "rubygems/version_navigation", locals: { rubygem: @rubygem, latest_version: @latest_version } %>
       </div>
-    </div>
+    <% else %>
+      <div class="t-body">
+        <p><%=t '.yanked_notice' %></p>
+      </div>
+    <% end %>
 
-    <div class="gem__aside l-col--r--pad">
-      <% if @latest_version.indexed %>
-        <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
-          <h2 class="gem__downloads__heading t-text--s">
-            <%= t('stats.index.total_downloads') %>
-            <span class="gem__downloads"><%= number_with_delimiter(@rubygem.downloads) %></span>
-          </h2>
-          <h2 class="gem__downloads__heading t-text--s">
-            <%= t('.downloads_for_this_version') %>
-            <span class="gem__downloads"><%= number_with_delimiter(@latest_version.downloads_count) %></span>
-          </h2>
-        </div>
-      <% end %>
-
-      <% if @latest_version.indexed %>
-        <h2 class="gem__ruby-version__heading t-list__heading">
-          <%= t '.bundler_header' %>:
-          <div class="gem__code-wrap">
-            <input type="text" class="gem__code" id="gemfile_text" value="<%= @latest_version.to_bundler %>" readonly="readonly">
-            <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-target="#gemfile_text">=</span>
-            <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
-            <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
-          </div>
-        </h2>
-        <h2 class="gem__ruby-version__heading t-list__heading">
-          <%= t '.install' %>:
-          <div class="gem__code-wrap">
-            <input type="text" class="gem__code" id="install_text" value="<%= @latest_version.to_install %>" readonly="readonly">
-            <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-target="#install_text">=</span>
-          </div>
-        </h2>
-        <h2 class="gem__ruby-version__heading t-list__heading">
-          <%= pluralized_licenses_header @latest_version %>:
-          <span class="gem__ruby-version">
-            <p><%= formatted_licenses @latest_version.licenses %></p>
-          </span>
-        </h2>
-      <% end %>
-
-      <h2 class="gem__ruby-version__heading t-list__heading">
-        <%= t('.required_ruby_version') %>:
-        <i class="gem__ruby-version">
-          <% if @latest_version.required_ruby_version %>
-            <%= @latest_version.required_ruby_version %>
-          <% else %>
-            <%= t('none') %>
+    <% if @versions.present? %>
+      <div class="l-half--l">
+        <div class="versions">
+          <h3 class="t-list__heading"><%= t '.versions_header' %>:</h3>
+          <ol class="gem__versions t-list__items">
+            <%= render @versions %>
+          </ol>
+          <% if show_all_versions_link?(@rubygem) %>
+            <%= link_to t('.show_all_versions', :count => @rubygem.versions.count), rubygem_versions_url(@rubygem), :class => "gem__see-all-versions t-link--gray t-link--has-arrow" %>
           <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime, :dependencies_count => @latest_version.runtime_dependencies_count } %>
+    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development, :dependencies_count => @latest_version.development_dependencies_count } %>
+
+    <% if @latest_version.requirements.present? %>
+      <div class="l-half--l">
+        <h3 class="t-list__heading"><%= t '.requirements_header' %>:</h3>
+        <div class="t-list__items">
+          <% Array(@latest_version.requirements).each do |requirement| %>
+            <p><%= requirement %></p>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render partial: "rubygems/gem_members", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
+    <%= render partial: "rubygems/version_navigation", locals: { rubygem: @rubygem, latest_version: @latest_version } %>
+  </div>
+
+  <div class="gem__aside l-col--r--pad">
+    <% if @latest_version.indexed %>
+      <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
+        <h2 class="gem__downloads__heading t-text--s">
+          <%= t('stats.index.total_downloads') %>
+          <span class="gem__downloads"><%= number_with_delimiter(@rubygem.downloads) %></span>
+        </h2>
+        <h2 class="gem__downloads__heading t-text--s">
+          <%= t('.downloads_for_this_version') %>
+          <span class="gem__downloads"><%= number_with_delimiter(@latest_version.downloads_count) %></span>
+        </h2>
+      </div>
+    <% end %>
+
+    <% if @latest_version.indexed %>
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        <%= t '.bundler_header' %>:
+        <div class="gem__code-wrap">
+          <input type="text" class="gem__code" id="gemfile_text" value="<%= @latest_version.to_bundler %>" readonly="readonly">
+          <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-target="#gemfile_text">=</span>
+          <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
+          <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
+        </div>
+      </h2>
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        <%= t '.install' %>:
+        <div class="gem__code-wrap">
+          <input type="text" class="gem__code" id="install_text" value="<%= @latest_version.to_install %>" readonly="readonly">
+          <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-target="#install_text">=</span>
+        </div>
+      </h2>
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        <%= pluralized_licenses_header @latest_version %>:
+        <span class="gem__ruby-version">
+          <p><%= formatted_licenses @latest_version.licenses %></p>
+        </span>
+      </h2>
+    <% end %>
+
+    <h2 class="gem__ruby-version__heading t-list__heading">
+      <%= t('.required_ruby_version') %>:
+      <i class="gem__ruby-version">
+        <% if @latest_version.required_ruby_version %>
+          <%= @latest_version.required_ruby_version %>
+        <% else %>
+          <%= t('none') %>
+        <% end %>
+      </i>
+    </h2>
+
+    <% if @latest_version.required_rubygems_version != '>= 0' %>
+      <h2 class="gem__ruby-version__heading t-list__heading">
+        <%= t('.required_rubygems_version') %>:
+        <i class="gem__ruby-version">
+            <%= @latest_version.required_rubygems_version %>
         </i>
       </h2>
+    <% end %>
 
-      <% if @latest_version.required_rubygems_version != '>= 0' %>
-        <h2 class="gem__ruby-version__heading t-list__heading">
-          <%= t('.required_rubygems_version') %>:
-          <i class="gem__ruby-version">
-              <%= @latest_version.required_rubygems_version %>
-          </i>
-        </h2>
-      <% end %>
+    <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
+    <div class="t-list__items">
+      <%= link_to t('edit'), edit_rubygem_path(@rubygem), :class => "gem__link t-list__item", :id => "edit" if @rubygem.owned_by?(current_user) %>
 
-      <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
-      <div class="t-list__items">
-        <%= link_to t('edit'), edit_rubygem_path(@rubygem), :class => "gem__link t-list__item", :id => "edit" if @rubygem.owned_by?(current_user) %>
-
-        <% if @latest_version.indexed %>
-          <% if @rubygem.linkset.present? %>
-            <%- Linkset::LINKS.each do |link| %>
-              <%= link_to_page t("rubygems.show.links.#{link}"), @rubygem.linkset.public_send(link) %>
-            <%- end %>
-          <% end %>
-
-          <%= download_link(@latest_version) %>
+      <% if @latest_version.indexed %>
+        <% if @rubygem.linkset.present? %>
+          <%- Linkset::LINKS.each do |link| %>
+            <%= link_to_page t("rubygems.show.links.#{link}"), @rubygem.linkset.public_send(link) %>
+          <%- end %>
         <% end %>
 
-        <%= documentation_link(@latest_version, @rubygem.linkset) %>
-        <%= badge_link(@rubygem) %>
-        <%= subscribe_link(@rubygem) if @latest_version.indexed %>
-        <%= unsubscribe_link(@rubygem) %>
-        <%= atom_link(@rubygem) %>
-        <%= report_abuse_link(@rubygem) %>
-      </div>
+        <%= download_link(@latest_version) %>
+      <% end %>
+
+      <%= documentation_link(@latest_version, @rubygem.linkset) %>
+      <%= badge_link(@rubygem) %>
+      <%= subscribe_link(@rubygem) if @latest_version.indexed %>
+      <%= unsubscribe_link(@rubygem) %>
+      <%= atom_link(@rubygem) %>
+      <%= report_abuse_link(@rubygem) %>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -15,7 +15,7 @@
     <% if @rubygem.pushable? %>
       <p><%= t '.not_hosted_notice' %></p>
     <% else %>
-      <p><%= t('.reserved_namespace', contact: link_to('Contact', 'http://help.rubygems.org/')).html_safe %></p>
+      <p><%= t('.reserved_namespace', count: @rubygem.protected_days).html_safe %></p>
     <% end %>
     <%= unsubscribe_link(@rubygem) %>
   </div>

--- a/app/views/rubygems/show_yanked.html.erb
+++ b/app/views/rubygems/show_yanked.html.erb
@@ -1,0 +1,22 @@
+<% @title = @rubygem.name %>
+
+<% content_for :head do %>
+  <meta name="robots" content="noindex" />
+<% end %>
+
+<div class="l-overflow">
+  <div class="l-colspan--l">
+    <div id="markup" class="gem__desc">
+      <% if @rubygem.pushable? %>
+        <%= t '.not_hosted_notice' %>
+      <% else %>
+        <%= t('.reserved_namespace', count: @rubygem.protected_days).html_safe %>
+      <% end %>
+      <%= unsubscribe_link(@rubygem) %>
+    </div>
+
+    <% unless @rubygem.pushable? %>
+      <%= render partial: "rubygems/gem_members", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,18 +122,21 @@ en:
     index:
       title: 'Gems'
       downloads: Downloads
-    show:
+    gem_members:
+      authors_header: Authors
+      owners_header: Owners
+      sha_256_checksum: SHA 256 checksum      
+    show_yanked:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
       reserved_namespace:
         one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
              If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
         other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
                If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+    show:
       install: install
       yanked_notice: "This version has been yanked, and it is not available for download directly or for other gems that may have depended on it."
-      authors_header: Authors
       downloads_for_this_version: "For this version"
-      owners_header: Owners
       links:
         header: Links
         home: Homepage
@@ -154,7 +157,6 @@ en:
       licenses_header: License
       no_licenses: N/A
       requirements_header: Requirements
-      sha_256_checksum: SHA 256 checksum
       copy_to_clipboard: Copy to clipboard
       copied: Copied!
       required_ruby_version: Required Ruby Version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,11 @@ en:
       downloads: Downloads
     show:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
-      reserved_namespace: This namespace is reserved by rubygems.org. %{contact} rubygems team if you would like to take over this namespace.
+      reserved_namespace:
+        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
+             If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
+               If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
       install: install
       yanked_notice: "This version has been yanked, and it is not available for download directly or for other gems that may have depended on it."
       authors_header: Authors

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -771,4 +771,15 @@ class RubygemTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#protected_days" do
+    setup do
+      @rubygem = create(:rubygem)
+      @rubygem.update_attribute(:updated_at, 99.days.ago)
+    end
+
+    should "return number of days left till the gem namespace is protected" do
+      assert_equal 1, @rubygem.protected_days
+    end
+  end
 end


### PR DESCRIPTION
Related: #1413 
This PR provides alternate implementation(and more) to #1419.

Previous gem owner of yanked gem can `gem push ..`, `gem owner ..` etc to reserved namespace. Reserved namespace page should better reflect that. This PR improves the message shown.
It also adds `owners` section to reserved namespace and yanked version (provided other indexed versions of the gem exist).
**Reserved namespace:**
![screenshot from 2016-09-11 18-17-15](https://cloud.githubusercontent.com/assets/7680662/18417789/5280f5e8-7857-11e6-9272-58503c20e7b6.png)

**Yanked version page:**
![screenshot from 2016-09-11 19-30-57](https://cloud.githubusercontent.com/assets/7680662/18417768/a95603e6-7856-11e6-8fbb-40b8aa5ec972.png)
