### PR TITLE
Change gem on dashboard from gemcutter to rake

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -12,7 +12,7 @@
     <div class="push--bottom">
       <% if @latest_updates.empty? %>
         <div class="t-body push--s">
-          <i class="t-text"><%= t('.no_subscriptions', :gem_link => link_to(t('.gem_link_text'), rubygem_path("gemcutter"))).html_safe %></i>
+          <i class="t-text"><%= t('.no_subscriptions', :gem_link => link_to(t('.gem_link_text'), rubygem_path("rake"))).html_safe %></i>
         </div>
       <% else %>
         <ol>


### PR DESCRIPTION
gemcutter is no longer maintained and doesn't have support for latest ruby. Dashboard should take users to more active gem.