### PR TITLE
On denied push, say how to be added

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -22,7 +22,7 @@ class Pusher
   def authorize
     rubygem.pushable? ||
       rubygem.owned_by?(user) ||
-      notify("You do not have permission to push to this gem.", 403)
+      notify("You do not have permission to push to this gem. Ask an owner to add you with: gem owner #{rubygem.name} --add #{user.email}", 403)
   end
 
   def validate

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -290,7 +290,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         assert_equal 1, @rubygem.ownerships.size
         assert_equal @other_user, @rubygem.ownerships.first.user
         assert_equal 1, @rubygem.versions.size
-        assert_equal "You do not have permission to push to this gem.", @response.body
+        assert_includes @response.body, "You do not have permission to push to this gem."
       end
     end
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PusherTest < ActiveSupport::TestCase
   context "creating a new gemcutter" do
     setup do
-      @user = create(:user)
+      @user = create(:user, email: "user@example.com")
       @gem = gem_file
       @cutter = Pusher.new(@user, @gem)
     end
@@ -242,7 +242,7 @@ class PusherTest < ActiveSupport::TestCase
 
       context "with a existing rubygem" do
         setup do
-          @rubygem = create(:rubygem)
+          @rubygem = create(:rubygem, name: "the_gem_name")
           @cutter.stubs(:rubygem).returns @rubygem
         end
 
@@ -258,7 +258,8 @@ class PusherTest < ActiveSupport::TestCase
         should "be false if not owned by user and an indexed version exists" do
           create(:version, rubygem: @rubygem, number: '0.1.1')
           refute @cutter.authorize
-          assert_equal "You do not have permission to push to this gem.", @cutter.message
+          assert_equal "You do not have permission to push to this gem. Ask an owner to add you with: gem owner the_gem_name --add user@example.com",
+            @cutter.message
           assert_equal 403, @cutter.code
         end
 


### PR DESCRIPTION
Every now and then at work, someone notices they're not allowed to push to a gem someone else on the team created, and we always have to Google how to fix that.

I thought it might be convenient if the error message could simply tell you.

I intend this more as a way of starting the conversation than as something I expect to be merged as-is.

Do you think this is a good feature at all?

If so, is rubygems.org the right place or should the client handle this? Perhaps we don't want the server to assume that you use the CLI client in its messages.

Judging by the code, it could be the case that you *are* the owner but the gem is not pushable for some other reason. Then this message would be misleading. I didn't want to spend a lot of time getting every detail right before I checked whether there's a chance of this being accepted, but I'm happy to look at that later.