### PR TITLE
Send confirmation mail to validate email used in sign up and email update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - !ruby/regexp /(vendor|bundle|bin|db)\/.*/
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Rails:
   Enabled: true

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,0 +1,8 @@
+class EmailConfirmationsController < ApplicationController
+  def update
+    user = User.find_by!(confirmation_token: params[:token])
+    user.confirm_email
+    sign_in user
+    redirect_to root_path, notice: t("flashes.confirmed_email")
+  end
+end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -4,7 +4,20 @@ class EmailConfirmationsController < ApplicationController
   def update
     @user.confirm_email
     sign_in @user
-    redirect_to root_path, notice: t('mailer.confirmed_email')
+    redirect_to root_path, notice: t('.confirmed_email')
+  end
+
+  def new
+  end
+
+  # used to resend confirmation mail for email validation
+  def create
+    user = User.find_by_email(params[:email_confirmation][:email])
+    if user
+      user.set_confirmation_token
+      Mailer.delay.email_confirmation(user) if user.save
+    end
+    redirect_to root_path, notice: t('.promise_resend')
   end
 
   def validate_confirmation_token

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -3,6 +3,6 @@ class EmailConfirmationsController < ApplicationController
     user = User.find_by!(confirmation_token: params[:token])
     user.confirm_email
     sign_in user
-    redirect_to root_path, notice: t("flashes.confirmed_email")
+    redirect_to root_path, notice: t('mailer.confirmed_email')
   end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -10,6 +10,6 @@ class EmailConfirmationsController < ApplicationController
   def validate_confirmation_token
     @user = User.find_by_confirmation_token(params[:token])
     return if @user&.valid_confirmation_token?
-    render text: t(:please_sign_up), status: 401
+    redirect_to root_path, alert: t('failure_when_forbidden')
   end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -2,7 +2,7 @@ class EmailConfirmationsController < ApplicationController
   before_action :validate_confirmation_token, only: :update
 
   def update
-    @user.confirm_email
+    @user.confirm_email!
     sign_in @user
     redirect_to root_path, notice: t('.confirmed_email')
   end
@@ -19,6 +19,8 @@ class EmailConfirmationsController < ApplicationController
     end
     redirect_to root_path, notice: t('.promise_resend')
   end
+
+  private
 
   def validate_confirmation_token
     @user = User.find_by_confirmation_token(params[:token])

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,8 +1,15 @@
 class EmailConfirmationsController < ApplicationController
+  before_action :validate_confirmation_token, only: :update
+
   def update
-    user = User.find_by!(confirmation_token: params[:token])
-    user.confirm_email
-    sign_in user
+    @user.confirm_email
+    sign_in @user
     redirect_to root_path, notice: t('mailer.confirmed_email')
+  end
+
+  def validate_confirmation_token
+    @user = User.find_by_confirmation_token(params[:token])
+    return if @user&.valid_confirmation_token?
+    render text: t(:please_sign_up), status: 401
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,8 +16,9 @@ class ProfilesController < ApplicationController
   def update
     @user = current_user.clone
     if @user.update_attributes(params_user)
-      if @user.email_reset
+      if @user.unconfirmed?
         sign_out
+        Mailer.delay.email_reset(self)
         flash[:notice] = "You will receive an email within the next few " \
                          "minutes. It contains instructions for reconfirming " \
                          "your account with your new email address."

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -17,8 +17,8 @@ class ProfilesController < ApplicationController
     @user = current_user.clone
     if @user.update_attributes(params_user)
       if @user.unconfirmed?
+        Mailer.delay.email_reset(current_user)
         sign_out
-        Mailer.delay.email_reset(self)
         flash[:notice] = "You will receive an email within the next few " \
                          "minutes. It contains instructions for reconfirming " \
                          "your account with your new email address."

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,9 +12,10 @@ class UsersController < Clearance::UsersController
     @user = user_from_params
     if @user.save
       Mailer.delay.email_confirmation(@user)
+      flash[:notice] = t('.email_sent')
       redirect_back_or url_after_create
     else
-      render template: "users/new"
+      render template: 'users/new'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,16 @@ class UsersController < Clearance::UsersController
     redirect_to root_path
   end
 
+  def create
+    @user = user_from_params
+    if @user.save
+      Mailer.delay.email_confirmation(@user)
+      redirect_back_or url_after_create
+    else
+      render template: "users/new"
+    end
+  end
+
   def user_params
     params.require(:user).permit(*User::PERMITTED_ATTRS)
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -3,12 +3,11 @@ class Mailer < ActionMailer::Base
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   def email_reset(user)
-    @user = user
+    @user = User.find_by_id(user['id'])
     mail from: Clearance.configuration.mailer_sender,
-         to: user.email,
-         subject: I18n.t(:confirmation,
-           scope: [:clearance, :models, :clearance_mailer],
-           default: "Email address confirmation")
+         to: @user.email,
+         subject: I18n.t('mailer.confirmation_subject',
+           default: 'Please confirm your email address with rubygems.org')
   end
 
   def email_confirmation(user)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -3,7 +3,7 @@ class Mailer < ActionMailer::Base
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   def email_reset(user)
-    @user = User.find_by_id(user['id'])
+    @user = User.find(user['id'])
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t('mailer.confirmation_subject',
@@ -11,7 +11,7 @@ class Mailer < ActionMailer::Base
   end
 
   def email_confirmation(user)
-    @user = User.find_by_id(user['id'])
+    @user = User.find(user['id'])
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t('mailer.confirmation_subject',

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -7,7 +7,7 @@ class Mailer < ActionMailer::Base
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t('mailer.confirmation_subject',
-           default: 'Please confirm your email address with rubygems.org')
+           default: 'Please confirm your email address with RubyGems.org')
   end
 
   def email_confirmation(user)
@@ -15,6 +15,6 @@ class Mailer < ActionMailer::Base
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t('mailer.confirmation_subject',
-           default: 'Please confirm your email address with rubygems.org')
+           default: 'Please confirm your email address with RubyGems.org')
   end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -15,6 +15,7 @@ class Mailer < ActionMailer::Base
     @user = User.find_by_id(user['id'])
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
-         subject: "Please confirm your email address with rubygems.org"
+         subject: I18n.t('mailer.confirmation_subject',
+           default: 'Please confirm your email address with rubygems.org')
   end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -10,4 +10,11 @@ class Mailer < ActionMailer::Base
            scope: [:clearance, :models, :clearance_mailer],
            default: "Email address confirmation")
   end
+
+  def email_confirmation(user)
+    @user = User.find_by_id(user['id'])
+    mail from: Clearance.configuration.mailer_sender,
+         to: @user.email,
+         subject: "Please confirm your email address with rubygems.org"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
   has_many :web_hooks
 
   before_validation :regenerate_token, if: :email_changed?, on: :update
-  before_create :generate_api_key
+  before_create :generate_api_key, :generate_confirmation_token
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {
@@ -119,5 +119,9 @@ class User < ActiveRecord::Base
 
   def total_rubygems_count
     rubygems.with_versions.count
+  end
+
+  def confirm_email
+    self.email_confirmed = true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
   has_many :web_hooks
 
   before_validation :regenerate_token, if: :email_changed?, on: :update
-  before_create :generate_api_key, :generate_confirmation_token
+  before_create :generate_api_key, :set_confirmation_token
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {
@@ -123,5 +123,16 @@ class User < ActiveRecord::Base
 
   def confirm_email
     self.email_confirmed = true
+    save
+  end
+
+  # confirmation token expires after 15 minutes
+  def valid_confirmation_token?
+    token_expires_at > Time.zone.now
+  end
+
+  def set_confirmation_token
+    self.confirmation_token = Clearance::Token.new
+    self.token_expires_at = Time.zone.now + 15.minutes
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ActiveRecord::Base
     rubygems.with_versions.count
   end
 
-  def confirm_email
+  def confirm_email!
     self.email_confirmed = true
     save
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
   has_many :web_hooks
 
   before_validation :unconfirm_email, if: :email_changed?, on: :update
-  before_create :generate_api_key, :set_confirmation_token
+  before_create :generate_api_key, :regenerate_confirmation_token
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {
@@ -103,7 +103,7 @@ class User < ActiveRecord::Base
 
   def unconfirm_email
     self.email_confirmed = false
-    set_confirmation_token
+    regenerate_confirmation_token
   end
 
   def generate_api_key
@@ -123,8 +123,7 @@ class User < ActiveRecord::Base
   end
 
   def confirm_email!
-    self.email_confirmed = true
-    save
+    update(email_confirmed: true)
   end
 
   # confirmation token expires after 15 minutes
@@ -132,7 +131,7 @@ class User < ActiveRecord::Base
     token_expires_at > Time.zone.now
   end
 
-  def set_confirmation_token
+  def regenerate_confirmation_token
     self.confirmation_token = Clearance::Token.new
     self.token_expires_at = Time.zone.now + 15.minutes
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ActiveRecord::Base
   has_many :subscriptions
   has_many :web_hooks
 
-  before_validation :regenerate_token, if: :email_changed?, on: :update
+  before_validation :unconfirm_email, if: :email_changed?, on: :update
   before_create :generate_api_key, :set_confirmation_token
 
   validates :handle, uniqueness: true, allow_nil: true
@@ -101,8 +101,9 @@ class User < ActiveRecord::Base
     coder.map = payload
   end
 
-  def regenerate_token
-    generate_confirmation_token
+  def unconfirm_email
+    self.email_confirmed = false
+    set_confirmation_token
   end
 
   def generate_api_key
@@ -134,5 +135,9 @@ class User < ActiveRecord::Base
   def set_confirmation_token
     self.confirmation_token = Clearance::Token.new
     self.token_expires_at = Time.zone.now + 15.minutes
+  end
+
+  def unconfirmed?
+    !email_confirmed
   end
 end

--- a/app/views/email_confirmations/new.html.erb
+++ b/app/views/email_confirmations/new.html.erb
@@ -4,12 +4,12 @@
   <p><%= t '.will_email_notice' %></p>
 </div>
 
-<%= form_for :email_confirmation, :url => email_confirmations_path do |form| %>
+<%= form_for :email_confirmation, url: email_confirmations_path do |form| %>
   <div class="text_field">
-    <%= form.label :email, t('activerecord.attributes.user.email'), :class => 'form__label' %>
-    <%= form.email_field :email, :size => '25', :class => 'form__input' %>
+    <%= form.label :email, t('activerecord.attributes.user.email'), class: 'form__label' %>
+    <%= form.email_field :email, size: '25', class: 'form__input' %>
   </div>
   <div class="submit_field">
-    <%= form.submit t('.submit'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
+    <%= form.submit t('.submit'), data: {disable_with: t('form_disable_with')}, class: 'form__submit' %>
   </div>
 <% end %>

--- a/app/views/email_confirmations/new.html.erb
+++ b/app/views/email_confirmations/new.html.erb
@@ -1,0 +1,15 @@
+<% @title = t('.title') %>
+
+<div class="t-body">
+  <p><%= t '.will_email_notice' %></p>
+</div>
+
+<%= form_for :email_confirmation, :url => email_confirmations_path do |form| %>
+  <div class="text_field">
+    <%= form.label :email, t('activerecord.attributes.user.email'), :class => 'form__label' %>
+    <%= form.email_field :email, :size => '25', :class => 'form__input' %>
+  </div>
+  <div class="submit_field">
+    <%= form.submit t('.submit'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
+  </div>
+<% end %>

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -1,0 +1,6 @@
+<p> Hi <%= @user.handle %> </p>
+<p>
+  Welcome to rubygems.org! Click the link below to verify your email.
+  <%= link_to "Confirm email address",
+    confirm_email_path(@user, token: @user.confirmation_token.html_safe) %>
+</p>

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -3,5 +3,5 @@
   <%= t('.welcome_message') %>
   <br />
   <%= link_to t('.confirmation_link'),
-    confirm_email_path(@user, token: @user.confirmation_token.html_safe) %>
+    confirm_email_url(@user, token: @user.confirmation_token.html_safe) %>
 </p>

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -3,5 +3,5 @@
   <%= t('.welcome_message') %>
   <br />
   <%= link_to t('.confirmation_link'),
-    confirm_email_url(@user, token: @user.confirmation_token.html_safe) %>
+    update_email_confirmations_url(@user, token: @user.confirmation_token.html_safe) %>
 </p>

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -1,6 +1,7 @@
 <p> Hi <%= @user.handle %> </p>
 <p>
-  Welcome to rubygems.org! Click the link below to verify your email.
-  <%= link_to "Confirm email address",
+  <%= t('.welcome_message') %>
+  <br />
+  <%= link_to t('.confirmation_link'),
     confirm_email_path(@user, token: @user.confirmation_token.html_safe) %>
 </p>

--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -1,0 +1,7 @@
+<p> Hi <%= @user.handle %> </p>
+<p>
+  <%= t('.visit_link_instructions') %>
+  <br />
+  <%= link_to t('.confirmation_link'),
+    update_email_confirmations_url(@user, token: @user.confirmation_token.html_safe) %>
+</p>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,10 @@
 <% @title = t('sign_in') %>
 
-<div class="form_links sign_in_links t-body">
-  <p><%= link_to t('.forgot_password'), new_password_url %></p>
+<div class="t-body">
+  <p>
+    <%= link_to t('.forgot_password'), new_password_url, class: 't-list__item' %>
+    <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: 't-list__item' %>
+  </p>
 </div>
 
 <%= form_for :session, :url => session_path do |form| %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: Gemcutter::HOST,
                                                protocol: Gemcutter::PROTOCOL }
+  config.action_mailer.preview_path = "#{Rails.root}/lib"
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -3,4 +3,5 @@ Clearance.configure do |config|
   config.mailer_sender = "RubyGems.org <no-reply@mailer.rubygems.org>"
   config.secure_cookie = true unless Rails.env.test? || Rails.env.development?
   config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
+  config.sign_in_guards = [ConfirmedUserGuard]
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,13 +229,13 @@ en:
       multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total"
 
   mailer:
-    confirmation_subject: Please confirm your email address with rubygems.org
+    confirmation_subject: Please confirm your email address with RubyGems.org
     confirm_your_email: Please confirm your email address with the link sent to you email.
     email_confirmation:
-      welcome_message: Welcome to rubygems.org! Click the link below to verify your email.
+      welcome_message: Welcome to RubyGems.org! Click the link below to verify your email.
       confirmation_link: Confirm email address
     email_reset:
-      visit_link_instructions: You changed your email address on rubygems.org. Please visit the following url to re-activate your account.
+      visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
 
   email_confirmations:
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,10 +230,12 @@ en:
 
   mailer:
     confirmation_subject: Please confirm your email address with rubygems.org
-    confirm_your_email: Please confirm your email.
+    confirm_your_email: Please confirm your email address with the link sent to you email.
     email_confirmation:
       welcome_message: Welcome to rubygems.org! Click the link below to verify your email.
       confirmation_link: Confirm email address
+    email_reset:
+      visit_link_instructions: You changed your email address on rubygems.org. Please visit the following url to re-activate your account.
 
   email_confirmations:
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,8 @@ en:
 
   sessions:
     new:
-      forgot_password: "Forgot Password?"
+      forgot_password: "Forgot password?"
+      resend_confirmation: Didn't receive confirmation mail?
 
   stats:
     index:
@@ -229,8 +230,17 @@ en:
 
   mailer:
     confirmation_subject: Please confirm your email address with rubygems.org
-    confirmed_email: Your email address have been verified
     confirm_your_email: Please confirm your email.
     email_confirmation:
       welcome_message: Welcome to rubygems.org! Click the link below to verify your email.
       confirmation_link: Confirm email address
+
+  email_confirmations:
+    update:
+      confirmed_email: Your email address have been verified.
+    new:
+      title: Resend confirmation email
+      will_email_notice: We will email you confirmation link to activate your account.
+      submit: Resend Confirmation
+    create:
+      promise_resend: We will email you confirmation link to activate your account if one exists.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,8 @@ en:
   users:
     new:
       have_account: "Already have an account?"
+    create:
+      email_sent: A confirmation mail has been sent to your email address.
 
   versions:
     index:
@@ -223,3 +225,11 @@ en:
 
       multi_page: "Displaying %{model} %{from} - %{to} of %{count} in total"
       multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total"
+
+  mailer:
+    confirmation_subject: Please confirm your email address with rubygems.org
+    confirmed_email: Your email address have been verified
+    confirm_your_email: Please confirm your email.
+    email_confirmation:
+      welcome_message: Welcome to rubygems.org! Click the link below to verify your email.
+      confirmation_link: Confirm email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
   locale_name: "English"
   this_rubygem_could_not_be_found: "This rubygem could not be found."
   not_found: "Not Found"
+  failure_when_forbidden: Please double check the URL or try submitting it again.
   none: None
 
   dashboards:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
   ################################################################################
   # Clearance Overrides
 
+  get "/confirm_email/:token" => "email_confirmations#update", as: "confirm_email"
   resource :session, only: [:create, :destroy]
 
   resources :passwords, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,9 +143,12 @@ Rails.application.routes.draw do
   end
 
   ################################################################################
-  # Clearance Overrides
+  # Clearance Overrides and Additions
 
-  get "/confirm_email/:token" => "email_confirmations#update", as: "confirm_email"
+  resource :email_confirmations, only: [:new, :create] do
+    get 'confirm/:token', to: 'email_confirmations#update', as: :update
+  end
+
   resource :session, only: [:create, :destroy]
 
   resources :passwords, only: [:new, :create]

--- a/lib/confirmed_user_guard.rb
+++ b/lib/confirmed_user_guard.rb
@@ -1,0 +1,13 @@
+class ConfirmedUserGuard < Clearance::SignInGuard
+  def call
+    if user_confirmed?
+      next_guard
+    else
+      failure I18n.t("flashes.confirm_your_email")
+    end
+  end
+
+  def user_confirmed?
+    signed_in? && current_user.email_confirmed
+  end
+end

--- a/lib/confirmed_user_guard.rb
+++ b/lib/confirmed_user_guard.rb
@@ -1,13 +1,13 @@
 class ConfirmedUserGuard < Clearance::SignInGuard
   def call
-    if user_confirmed?
-      next_guard
-    else
+    if user_unconfirmed?
       failure I18n.t('mailer.confirm_your_email')
+    else
+      next_guard
     end
   end
 
-  def user_confirmed?
-    signed_in? && current_user.email_confirmed
+  def user_unconfirmed?
+    signed_in? && !current_user.email_confirmed
   end
 end

--- a/lib/confirmed_user_guard.rb
+++ b/lib/confirmed_user_guard.rb
@@ -8,6 +8,6 @@ class ConfirmedUserGuard < Clearance::SignInGuard
   end
 
   def user_unconfirmed?
-    signed_in? && !current_user.email_confirmed
+    signed_in? && current_user.unconfirmed?
   end
 end

--- a/lib/confirmed_user_guard.rb
+++ b/lib/confirmed_user_guard.rb
@@ -3,7 +3,7 @@ class ConfirmedUserGuard < Clearance::SignInGuard
     if user_confirmed?
       next_guard
     else
-      failure I18n.t("flashes.confirm_your_email")
+      failure I18n.t('mailer.confirm_your_email')
     end
   end
 

--- a/lib/mailer_preview.rb
+++ b/lib/mailer_preview.rb
@@ -1,0 +1,9 @@
+class MailerPreview < ActionMailer::Preview
+  def email_reset
+    Mailer.email_reset(User.last)
+  end
+
+  def email_confirmation
+    Mailer.email_confirmation(User.last)
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     handle
     password "password12345"
     api_key "secret123"
+    email_confirmed true
   end
 
   factory :dependency do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -71,7 +71,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         refute ActionMailer::Base.deliveries.empty?
         email = ActionMailer::Base.deliveries.last
         assert_equal ['foo@bar.com'], email.to
-        assert_equal ['help@rubygems.org'], email.from
+        assert_equal ['no-reply@mailer.rubygems.org'], email.from
         assert_equal 'Please confirm your email address with rubygems.org', email.subject
       end
 

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -42,4 +42,50 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context 'on GET to new' do
+    setup do
+      get :new
+    end
+
+    should respond_with :success
+    should render_template :new
+
+    should 'display resend instructions' do
+      assert page.has_content?('We will email you confirmation link to activate your account.')
+    end
+  end
+
+  context 'on POST to create' do
+    context 'user exists' do
+      setup do
+        create(:user, email: 'foo@bar.com')
+        post :create, email_confirmation: { email: 'foo@bar.com' }
+        Delayed::Worker.new.work_off
+      end
+
+      should respond_with :redirect
+      should redirect_to('the homepage') { root_url }
+
+      should 'deliver confirmation email' do
+        refute ActionMailer::Base.deliveries.empty?
+        email = ActionMailer::Base.deliveries.last
+        assert_equal ['foo@bar.com'], email.to
+        assert_equal ['help@rubygems.org'], email.from
+        assert_equal 'Please confirm your email address with rubygems.org', email.subject
+      end
+
+      should 'promise to send email if account exists' do
+        assert_equal flash[:notice], 'We will email you confirmation link to activate your account if one exists.'
+      end
+    end
+
+    context 'user does not exist' do
+      should 'not deliver confirmation email' do
+        Mailer.expects(:email_confirmation).times(0)
+        post :create, email_confirmation: { email: 'someone@else.com' }
+        Delayed::Worker.new.work_off
+      end
+    end
+  end
 end

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -72,7 +72,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         email = ActionMailer::Base.deliveries.last
         assert_equal ['foo@bar.com'], email.to
         assert_equal ['no-reply@mailer.rubygems.org'], email.from
-        assert_equal 'Please confirm your email address with rubygems.org', email.subject
+        assert_equal 'Please confirm your email address with RubyGems.org', email.subject
       end
 
       should 'promise to send email if account exists' do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class EmailConfirmationsControllerTest < ActionController::TestCase
+  context 'on GET to update' do
+    context 'user exists and token has not expired' do
+      setup do
+        @user = create(:user)
+        get :update, token: @user.confirmation_token
+      end
+
+      should 'should confirm user account' do
+        assert @user.email_confirmed
+      end
+      should 'sign in user' do
+        assert cookies[:remember_token]
+      end
+    end
+
+    context 'user does not exist' do
+      setup { get :update, token: Clearance::Token.new }
+
+      should 'warn about invalid url' do
+        assert_equal flash[:alert], 'Please double check the URL or try submitting it again.'
+      end
+      should 'not sign in user' do
+        refute cookies[:remember_token]
+      end
+    end
+
+    context 'token has expired' do
+      setup do
+        user = create(:user)
+        user.update_attribute('token_expires_at', 2.minutes.ago)
+        get :update, token: user.confirmation_token
+      end
+
+      should 'warn about invalid url' do
+        assert_equal flash[:alert], 'Please double check the URL or try submitting it again.'
+      end
+      should 'not sign in user' do
+        refute cookies[:remember_token]
+      end
+    end
+  end
+end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -4,7 +4,8 @@ class SessionsControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when login and password are correct" do
       setup do
-        User.expects(:authenticate).with('login', 'pass').returns User.new
+        user = User.new(email_confirmed: true)
+        User.expects(:authenticate).with('login', 'pass').returns user
         post :create, session: { who: 'login', password: 'pass' }
       end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -52,7 +52,7 @@ class UsersControllerTest < ActionController::TestCase
         refute ActionMailer::Base.deliveries.empty?
         email = ActionMailer::Base.deliveries.last
         assert_equal ['foo@bar.com'], email.to
-        assert_equal ['help@rubygems.org'], email.from
+        assert_equal ['no-reply@mailer.rubygems.org'], email.from
         assert_equal 'Please confirm your email address with rubygems.org', email.subject
       end
     end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -36,5 +36,25 @@ class UsersControllerTest < ActionController::TestCase
         assert_not_equal "nonono", User.where(email: 'foo@bar.com').pluck(:api_key).first
       end
     end
+
+    context 'confirmation mail' do
+      setup do
+        post :create, user: { email: 'foo@bar.com', password: 'secretpassword', handle: 'foo' }
+        Delayed::Worker.new.work_off
+      end
+
+      should 'set email_confirmation_token' do
+        user = User.find_by_name('foo')
+        assert_not_nil user.confirmation_token
+      end
+
+      should 'deliver confirmation mail' do
+        refute ActionMailer::Base.deliveries.empty?
+        email = ActionMailer::Base.deliveries.last
+        assert_equal ['foo@bar.com'], email.to
+        assert_equal ['help@rubygems.org'], email.from
+        assert_equal 'Please confirm your email address with rubygems.org', email.subject
+      end
+    end
   end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -53,7 +53,7 @@ class UsersControllerTest < ActionController::TestCase
         email = ActionMailer::Base.deliveries.last
         assert_equal ['foo@bar.com'], email.to
         assert_equal ['no-reply@mailer.rubygems.org'], email.from
-        assert_equal 'Please confirm your email address with rubygems.org', email.subject
+        assert_equal 'Please confirm your email address with RubyGems.org', email.subject
       end
     end
   end

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -1,0 +1,8 @@
+module EmailHelpers
+  def last_email_link
+    Delayed::Worker.new.work_off
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = /href="([^"]*)"/.match(body)
+    link[1]
+  end
+end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'helpers/email_helpers'
 
 class EmailConfirmationTest < SystemTest
   setup do
@@ -22,12 +23,9 @@ class EmailConfirmationTest < SystemTest
   test 'requesting confirmation mail with email of existing user' do
     request_confirmation_mail @user.email
 
-    Delayed::Worker.new.work_off
-    body = ActionMailer::Base.deliveries.last.to_s
-    link = /href="([^"]*)"/.match(body)
-    assert_not_nil link[1]
-
-    visit link[1]
+    link = last_email_link
+    assert_not_nil link
+    visit link
 
     assert page.has_content? 'Sign out'
     assert page.has_selector? '#flash_notice', text: 'Your email address have been verified'

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class EmailConfirmationTest < SystemTest
+  setup do
+    @user = create(:user)
+  end
+
+  def request_confirmation_mail(email)
+    visit sign_in_path
+
+    click_link "Didn't receive confirmation mail?"
+    fill_in 'Email address', with: email
+    click_button 'Resend Confirmation'
+  end
+
+  test 'requesting confirmation mail does not tell if a user exists' do
+    request_confirmation_mail 'someone@example.com'
+
+    assert page.has_content? 'We will email you confirmation link to activate your account if one exists.'
+  end
+
+  test 'requesting confirmation mail with email of existing user' do
+    request_confirmation_mail @user.email
+
+    Delayed::Worker.new.work_off
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = /href="([^"]*)"/.match(body)
+    assert_not_nil link[1]
+
+    visit link[1]
+
+    assert page.has_content? 'Sign out'
+    assert page.has_selector? '#flash_notice', text: 'Your email address have been verified'
+  end
+end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -8,7 +8,7 @@ class PasswordResetTest < SystemTest
   def forgot_password_with(email)
     visit sign_in_path
 
-    click_link "Forgot Password?"
+    click_link "Forgot password?"
     fill_in "Email address", with: email
     click_button "Reset password"
   end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -67,12 +67,9 @@ class ProfileTest < SystemTest
       "an email within the next few minutes. It contains instructions "\
       "for reconfirming your account with your new email address."
 
-    Delayed::Worker.new.work_off
-    body = ActionMailer::Base.deliveries.last.to_s
-    link = /href="([^"]*)"/.match(body)
-    assert_not_nil link[1]
-
-    visit link[1]
+    link = last_email_link
+    assert_not_nil link
+    visit link
 
     assert page.has_content? "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address have been verified"

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -43,6 +43,23 @@ class SignInTest < SystemTest
     assert page.has_content? "Bad email or password"
   end
 
+  test "signing in with unconfirmed email" do
+    visit sign_up_path
+
+    fill_in "Email", with: "email@person.com"
+    fill_in "Handle", with: "nick"
+    fill_in "Password", with: "secretpassword"
+    click_button "Sign up"
+
+    visit sign_in_path
+    fill_in "Email or Handle", with: "email@person.com"
+    fill_in "Password", with: "secretpassword"
+    click_button "Sign in"
+
+    assert page.has_content? "Sign in"
+    assert page.has_content? "Please confirm your email address with the link sent to you email."
+  end
+
   test "signing out" do
     visit sign_in_path
     fill_in "Email or Handle", with: "nick@example.com"

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -64,12 +64,9 @@ class SignUpTest < SystemTest
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"
 
-    Delayed::Worker.new.work_off
-    body = ActionMailer::Base.deliveries.last.to_s
-    link = /href="([^"]*)"/.match(body)
-    assert_not_nil link[1]
-
-    visit link[1]
+    link = last_email_link
+    assert_not_nil link
+    visit link
 
     assert page.has_content? "Sign out"
     assert page.has_selector? '#flash_notice', text: "Your email address have been verified"

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -9,7 +9,7 @@ class SignUpTest < SystemTest
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"
 
-    assert page.has_content? "Sign out"
+    assert page.has_selector? '#flash_notice', text: "A confirmation mail has been sent to your email address."
   end
 
   test "sign up with no handle" do
@@ -54,6 +54,25 @@ class SignUpTest < SystemTest
     visit sign_up_path
     assert_equal current_path, "/"
     assert page.has_content? "Sign up is temporarily disabled."
+  end
+
+  test "email confirmation" do
+    visit sign_up_path
+
+    fill_in "Email", with: "email@person.com"
+    fill_in "Handle", with: "nick"
+    fill_in "Password", with: "secretpassword"
+    click_button "Sign up"
+
+    Delayed::Worker.new.work_off
+    body = ActionMailer::Base.deliveries.last.to_s
+    link = /href="([^"]*)"/.match(body)
+    assert_not_nil link[1]
+
+    visit link[1]
+
+    assert page.has_content? "Sign out"
+    assert page.has_selector? '#flash_notice', text: "Your email address have been verified"
   end
 
   teardown do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'capybara/rails'
 require 'clearance/test_unit'
 require 'shoulda'
 require 'helpers/gem_helpers'
+require 'helpers/email_helpers'
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true
@@ -15,6 +16,7 @@ Aws.config[:stub_responses] = true
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
   include GemHelpers
+  include EmailHelpers
 
   setup do
     I18n.locale = :en

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -201,6 +201,19 @@ class UserTest < ActiveSupport::TestCase
       assert_equal rubygem_hook, all_hooks[rubygem.name].first
       assert_equal 1, all_hooks.keys.size
     end
+
+    context '#valid_confirmation_token?' do
+      should 'return false when email confirmation token has expired' do
+        @user.update_attribute(:token_expires_at, 2.minutes.ago)
+        refute @user.valid_confirmation_token?
+      end
+
+      should 'reutrn true when email confirmation token has not expired' do
+        two_minutes_in_future = Time.zone.now + 2.minutes
+        @user.update_attribute(:token_expires_at, two_minutes_in_future)
+        assert @user.valid_confirmation_token?
+      end
+    end
   end
 
   context "rubygems" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  def assert_resetting_email_changes(attr_name)
+    assert_changed(@user, attr_name) do
+      @user.update_attributes(email: 'some@one.com')
+    end
+  end
+
   should have_many(:ownerships)
   should have_many(:rubygems).through(:ownerships)
   should have_many(:subscribed_gems).through(:subscriptions)
@@ -163,6 +169,20 @@ class UserTest < ActiveSupport::TestCase
       my_rubygem = create(:rubygem)
       create(:ownership, user: @user, rubygem: my_rubygem)
       assert_equal [my_rubygem], @user.rubygems
+    end
+
+    context "email change" do
+      should "reset confirmation token" do
+        assert_resetting_email_changes :confirmation_token
+      end
+
+      should "unconfirm email" do
+        assert_resetting_email_changes :unconfirmed?
+      end
+
+      should "reset token_expires_at" do
+        assert_resetting_email_changes :token_expires_at
+      end
     end
 
     context "with subscribed gems" do


### PR DESCRIPTION
An email with activation link will be sent to user when they sign up or when they update their email.
`ConfirmedUserGuard` ensures that only confirmed accounts can sign in.
Confirmation token get expired after 15 minutes.
Users can request to resent the confirmation mail.

rubygems.org use to have email confirmation, which was removed around https://github.com/rubygems/rubygems.org/commit/059e53f72cb8e534b5907f1ef20edf8a9188fbd3. I don't have answer to why it was removed :sweat_smile: However, it means that this PR reused some of the left over code of the previous implementation.
