### PR TITLE
Fix n+1 in search show page

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -62,7 +62,7 @@ module RubygemSearchable
         result.response
         result
       else
-        legacy_search(query).with_versions.paginate(page: page)
+        legacy_search(query).paginate(page: page)
       end
     rescue Faraday::ConnectionFailed => e
       Honeybadger.notify(e)
@@ -133,7 +133,7 @@ module RubygemSearchable
       SQL
 
       where(conditions, query: "%#{query.strip}%")
-        .includes(:versions)
+        .includes(:latest_version, :gem_download)
         .references(:versions)
         .by_downloads
     end


### PR DESCRIPTION
This won't have any noticeable effect on `/api/v1/search`. In api search it would only make one fewer sql query per record because `gem_download` for gem.latest_version is now eager loaded.

On search show page this makes 60 fewer calls to database(2 per record).

`with_versions` is expendable because the search condition already [uses `versions.indexed` ](https://github.com/rubygems/rubygems.org/blob/master/app/models/concerns/rubygem_searchable.rb#L127)in its condition. 
