### PR TITLE
cache dependency api for 60 seconds

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::DependenciesController < Api::BaseController
   def index
     deps = GemDependent.new(gem_names).to_a
 
+    response.headers['Surrogate-Control'] = 'max-age=60'
     respond_to do |format|
       format.json { render json: deps }
       format.marshal { render text: Marshal.dump(deps) }


### PR DESCRIPTION
This will instruct Fastly to cache the dependency API for 60 seconds.

@indirect 