### PR TITLE
better cache headers for dependency api

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -5,7 +5,9 @@ class Api::V1::DependenciesController < Api::BaseController
   def index
     deps = GemDependent.new(gem_names).to_a
 
-    response.headers['Surrogate-Control'] = 'max-age=60'
+    expires_in 30, public: true
+    fastly_expires_in 60
+
     respond_to do |format|
       format.json { render json: deps }
       format.marshal { render text: Marshal.dump(deps) }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def fastly_expires_in(seconds)
+    response.headers['Surrogate-Control'] = "max-age=#{seconds}"
+  end
+
   def redirect_to_root
     redirect_to root_path
   end


### PR DESCRIPTION
@indirect @segiddins 
We need to set the Cache-Control header to public also, because of our Fastly config. I want private to really mean private. This also gives clients 30 seconds to cache, if they desire.