### PR TITLE
Remove cache on compact index versions response

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -4,16 +4,7 @@ class GemInfo
   end
 
   def compact_index_info
-    info = Rails.cache.read("info/#{@rubygem_name}")
-    if info
-      StatsD.increment "compact_index.memcached.info.hit"
-      info
-    else
-      StatsD.increment "compact_index.memcached.info.miss"
-      compute_compact_index_info.tap do |compact_index_info|
-        Rails.cache.write("info/#{@rubygem_name}", compact_index_info)
-      end
-    end
+    compute_compact_index_info
   end
 
   def self.ordered_names

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -161,13 +161,10 @@ class Pusher
 
   def expire_api_memcached
     Rails.cache.delete("deps/v1/#{rubygem.name}")
-    Rails.cache.delete("versions")
     Rails.cache.delete("names")
   end
 
   def set_info_checksum
-    # expire info cache of previous version
-    Rails.cache.delete("info/#{rubygem.name}")
     checksum = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(rubygem.name).compact_index_info))
     version.update_attribute :info_checksum, checksum
   end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -165,6 +165,8 @@ class Pusher
   end
 
   def set_info_checksum
+    # expire info cache of previous version
+    Rails.cache.delete("info/#{rubygem.name}")
     checksum = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(rubygem.name).compact_index_info))
     version.update_attribute :info_checksum, checksum
   end

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -83,7 +83,6 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     assert_match file_contents, @response.body
     assert_match(/#{gem_b_match}#{gem_a_match}/, @response.body)
     assert_equal etag(@response.body), @response.headers['ETag']
-    assert_not_nil Rails.cache.read('versions')
   end
 
   test "/versions partial response" do
@@ -130,6 +129,7 @@ eos
     assert_response :success
     assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers['ETag']
+    assert_equal expected, CompactIndex.info(Rails.cache.read("info/gemA"))
   end
 
   test "/info partial response" do

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -130,7 +130,6 @@ eos
     assert_response :success
     assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers['ETag']
-    assert_equal expected, CompactIndex.info(Rails.cache.read("info/gemA"))
   end
 
   test "/info partial response" do

--- a/test/unit/gem_info_test.rb
+++ b/test/unit/gem_info_test.rb
@@ -27,6 +27,20 @@ class GemInfoTest < ActiveSupport::TestCase
       info = GemInfo.new('example').compact_index_info
       assert_equal @expected_info, info
     end
+
+    should 'write cache' do
+      Rails.cache.stubs(:write)
+      info = GemInfo.new('example').compact_index_info
+      assert_received(Rails.cache, :write) { |cache| cache.with("info/example", info) }
+    end
+
+    should 'read from cache when cache exists' do
+      GemInfo.new('example').compact_index_info
+      Rails.cache.stubs(:read)
+      info = GemInfo.new('example').compact_index_info
+      assert_received(Rails.cache, :read) { |cache| cache.with("info/example") }
+      assert_equal @expected_info, info
+    end
   end
 
   context '.ordered_names' do
@@ -68,20 +82,6 @@ class GemInfoTest < ActiveSupport::TestCase
 
     should "return all versions created after given date and ordered by created_at" do
       versions = GemInfo.compact_index_versions(4.days.ago)
-      assert_equal @expected_versions, versions
-    end
-
-    should 'write cache' do
-      Rails.cache.stubs(:write)
-      versions = GemInfo.compact_index_versions(4.days.ago)
-      assert_received(Rails.cache, :write) { |cache| cache.with("versions", versions) }
-    end
-
-    should 'read from cache when cache exists' do
-      GemInfo.compact_index_versions(4.days.ago)
-      Rails.cache.stubs(:read)
-      versions = GemInfo.compact_index_versions(4.days.ago)
-      assert_received(Rails.cache, :read) { |cache| cache.with("versions") }
       assert_equal @expected_versions, versions
     end
   end

--- a/test/unit/gem_info_test.rb
+++ b/test/unit/gem_info_test.rb
@@ -27,20 +27,6 @@ class GemInfoTest < ActiveSupport::TestCase
       info = GemInfo.new('example').compact_index_info
       assert_equal @expected_info, info
     end
-
-    should 'write cache' do
-      Rails.cache.stubs(:write)
-      info = GemInfo.new('example').compact_index_info
-      assert_received(Rails.cache, :write) { |cache| cache.with("info/example", info) }
-    end
-
-    should 'read from cache when cache exists' do
-      GemInfo.new('example').compact_index_info
-      Rails.cache.stubs(:read)
-      info = GemInfo.new('example').compact_index_info
-      assert_received(Rails.cache, :read) { |cache| cache.with("info/example") }
-      assert_equal @expected_info, info
-    end
   end
 
   context '.ordered_names' do

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -302,6 +302,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "expire API memcached" do
+        assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@rubygem.name}") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@rubygem.name}") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
       end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -302,9 +302,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "expire API memcached" do
-        assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@rubygem.name}") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@rubygem.name}") }
-        assert_received(Rails.cache, :delete) { |cache| cache.with("versions") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
       end
 


### PR DESCRIPTION
Per @indirect, this cache is causing discrepancies between the responses
that are returned by the Bundler API and Rubygems.org's API. Since
Rubygems.org is now behind the Fastly CDN, having this cache is no
longer necessary.

For reference, this cache layer was introduced via 801eb12.