### PR TITLE
instruct Fastly to cache versions api endpoint for 60 seconds

### DIFF
--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -4,6 +4,9 @@ class Api::V1::VersionsController < Api::BaseController
   def show
     return unless stale?(@rubygem)
 
+    expires_in 0, public: true
+    fastly_expires_in 60
+
     if @rubygem.public_versions.count.nonzero?
       respond_to do |format|
         format.json { render json: @rubygem.public_versions }


### PR DESCRIPTION
This is not the compact index versions endpoint, but the `/api/v1/versions/*.json` endpoint. This is our next highest traffic endpoint which is currently not being cached.