### PR TITLE
Simplify gem cache purging logic

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -128,8 +128,7 @@ class Pusher
     @version_id = version.id
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
-    expire_api_memcached
-    Fastly.delay.purge_api_cdn(rubygem.name)
+    GemCachePurger.call(rubygem.name)
     enqueue_web_hook_jobs
     update_remote_bundler_api
     StatsD.increment 'push.success'
@@ -157,11 +156,6 @@ class Pusher
     jobs.each do |job|
       job.fire(@protocol, @host_with_port, rubygem, version)
     end
-  end
-
-  def expire_api_memcached
-    Rails.cache.delete("deps/v1/#{rubygem.name}")
-    Rails.cache.delete("names")
   end
 
   def set_info_checksum

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -33,10 +33,4 @@ class Fastly
     Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
     json
   end
-
-  def self.purge_api_cdn(gem_name)
-    ["info/#{gem_name}", "versions", "names"].each do |path|
-      purge path
-    end
-  end
 end

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -1,0 +1,9 @@
+class GemCachePurger
+  def self.call(gem_name)
+    # We need to purge from Fastly and from Memcached
+    ["deps/v1/#{gem_name}", "info/#{gem_name}", "names"].each do |path|
+      Rails.cache.delete(path)
+      Fastly.delay.purge(path)
+    end
+  end
+end

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -1,9 +1,12 @@
 class GemCachePurger
   def self.call(gem_name)
     # We need to purge from Fastly and from Memcached
-    ["deps/v1/#{gem_name}", "info/#{gem_name}", "names"].each do |path|
+    ["info/#{gem_name}", "names"].each do |path|
       Rails.cache.delete(path)
       Fastly.delay.purge(path)
     end
+
+    Rails.cache.delete("deps/v1/#{gem_name}")
+    Fastly.delay.purge("versions")
   end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -225,7 +225,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
         @request.env["RAW_POST_DATA"] = gem_file("test-1.0.0.gem").read
-        assert_difference 'Delayed::Job.count', 3 do
+        assert_difference 'Delayed::Job.count', 6 do
           post :create
         end
       end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -225,7 +225,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
         @request.env["RAW_POST_DATA"] = gem_file("test-1.0.0.gem").read
-        assert_difference 'Delayed::Job.count', 6 do
+        assert_difference 'Delayed::Job.count', 5 do
           post :create
         end
       end

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -67,7 +67,7 @@ class DeletionTest < ActiveSupport::TestCase
   end
 
   should "enque job for updating ES index, spec index and purging cdn" do
-    assert_difference 'Delayed::Job.count', 5 do
+    assert_difference 'Delayed::Job.count', 8 do
       delete_gem
     end
 

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -21,8 +21,7 @@ class DeletionTest < ActiveSupport::TestCase
 
   context "with deleted gem" do
     setup do
-      Rails.cache.stubs(:delete)
-      Fastly.stubs(:purge)
+      GemCachePurger.stubs(:call)
       delete_gem
       @gem_name = @version.rubygem.name
     end
@@ -51,18 +50,8 @@ class DeletionTest < ActiveSupport::TestCase
       assert_nil RubygemFs.instance.get("gems/#{@version.full_name}.gem"), "Rubygem still exists!"
     end
 
-    should "expire API memcached" do
-      assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@gem_name}").twice }
-      assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@gem_name}") }
-      assert_received(Rails.cache, :delete) { |cache| cache.with("versions") }
-      assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
-    end
-
-    should "purge cdn cache" do
-      Delayed::Worker.new.work_off
-      assert_received(Fastly, :purge) { |path| path.with("info/#{@gem_name}").twice }
-      assert_received(Fastly, :purge) { |path| path.with("versions").twice }
-      assert_received(Fastly, :purge) { |path| path.with("names").twice }
+    should "call GemCachePurger" do
+      assert_received(GemCachePurger, :call) { |obj| obj.with(@gem_name).once }
     end
   end
 
@@ -84,15 +73,6 @@ class DeletionTest < ActiveSupport::TestCase
     assert_nil deletion.rubygem
     deletion.valid?
     assert_equal deletion.rubygem, @version.rubygem.name
-  end
-
-  test "expire API memcached" do
-    Rails.cache.write("deps/v1/#{@version.rubygem.name}", "omg!")
-    refute_nil Rails.cache.fetch("deps/v1/#{@version.rubygem.name}")
-
-    delete_gem
-
-    assert_nil Rails.cache.fetch("deps/v1/#{@version.rubygem.name}")
   end
 
   teardown do

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -56,7 +56,7 @@ class DeletionTest < ActiveSupport::TestCase
   end
 
   should "enque job for updating ES index, spec index and purging cdn" do
-    assert_difference 'Delayed::Job.count', 8 do
+    assert_difference 'Delayed::Job.count', 7 do
       delete_gem
     end
 

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class GemCachePurgerTest < ActiveSupport::TestCase
+  context "#call" do
+    setup do
+      Rails.cache.stubs(:delete)
+      Fastly.stubs(:purge)
+
+      @gem_name = 'test123'
+      GemCachePurger.call(@gem_name)
+    end
+
+    should "expire API memcached" do
+      assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@gem_name}") }
+      assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@gem_name}") }
+      assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
+    end
+
+    should "purge cdn cache" do
+      Delayed::Worker.new.work_off
+      assert_received(Fastly, :purge) { |path| path.with("info/#{@gem_name}") }
+      assert_received(Fastly, :purge) { |path| path.with("names") }
+    end
+  end
+end

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -12,14 +12,15 @@ class GemCachePurgerTest < ActiveSupport::TestCase
 
     should "expire API memcached" do
       assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@gem_name}") }
-      assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@gem_name}") }
       assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
+      assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@gem_name}") }
     end
 
     should "purge cdn cache" do
       Delayed::Worker.new.work_off
       assert_received(Fastly, :purge) { |path| path.with("info/#{@gem_name}") }
       assert_received(Fastly, :purge) { |path| path.with("names") }
+      assert_received(Fastly, :purge) { |path| path.with("versions") }
     end
   end
 end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -302,7 +302,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "expire API memcached" do
-        assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@rubygem.name}") }
+        assert_received(Rails.cache, :delete) { |cache| cache.with("info/#{@rubygem.name}").twice }
         assert_received(Rails.cache, :delete) { |cache| cache.with("deps/v1/#{@rubygem.name}") }
         assert_received(Rails.cache, :delete) { |cache| cache.with("names") }
       end
@@ -315,7 +315,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "enque job for updating ES index, spec index and purging cdn" do
-        assert_difference 'Delayed::Job.count', 3 do
+        assert_difference 'Delayed::Job.count', 6 do
           @cutter.save
         end
       end


### PR DESCRIPTION
Roll everything up into a "service object" to avoid duplication across the codebase.

cc @indirect @dwradcliffe 
