### PR TITLE
add Rack::Deflater middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module Gemcutter
     config.middleware.insert 0, Rack::UTF8Sanitizer
     config.middleware.use "Redirector" unless Rails.env.development?
     config.middleware.use Rack::Attack
+    config.middleware.use Rack::Deflater
 
     config.active_record.include_root_in_json = false
     config.active_record.raise_in_transactional_callbacks = true

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -168,4 +168,10 @@ END
     assert_response :not_found
     assert_equal nil, @response.headers['ETag']
   end
+
+  test "/info with gzip" do
+    get info_path(gem_name: 'gemA'), nil, 'Accept-Encoding' => 'gzip'
+    assert_response :success
+    assert_equal('gzip', @response.headers['Content-Encoding'])
+  end
 end

--- a/test/integration/encoding_test.rb
+++ b/test/integration/encoding_test.rb
@@ -5,4 +5,10 @@ class EncodingTest < ActionDispatch::IntegrationTest
     get "/api/v1/dependencies?gems=vagrant,vagrant-login,vagrant-share,vagrant%ADvbguest"
     assert_response :success
   end
+
+  test "gzip not supported" do
+    get '/'
+    assert_response :success
+    assert_equal(nil, @response.headers['Content-Encoding'])
+  end
 end


### PR DESCRIPTION
This provides us with automatic gzip handling and adds the necessary `Vary` header. This is necessary for the compact index endpoints, and may be beneficial for other endpoints as well.

@segiddins @indirect @evanphx 