### PR TITLE
Remove Bundler API post hook

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -2,7 +2,6 @@ require 'digest/sha2'
 
 class Pusher
   attr_reader :user, :spec, :message, :code, :rubygem, :body, :version, :version_id, :size
-  attr_accessor :bundler_api_url
 
   def initialize(user, body, protocol = nil, host_with_port = nil)
     @user = user

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -132,29 +132,6 @@ class PusherTest < ActiveSupport::TestCase
       assert_includes @cutter.message, %{package content (data.tar.gz) is missing}
     end
 
-    should "post info to the remote bundler API" do
-      @cutter.pull_spec
-
-      @cutter.spec.stubs(:platform).returns Gem::Platform.new("x86-java1.6")
-
-      @cutter.bundler_api_url = "http://test.com"
-
-      obj = mock
-      post_data = nil
-
-      obj.stubs(:post).with { |*value| post_data = value }
-      @cutter.update_remote_bundler_api obj
-
-      _, payload = post_data
-
-      params = JSON.load payload
-
-      assert_equal "test",  params["name"]
-      assert_equal "0.0.0", params["version"]
-      assert_equal "x86-java-1.6", params["platform"]
-      assert_equal false, params["prerelease"]
-    end
-
     context "initialize new gem with find if one does not exist" do
       setup do
         spec = mock


### PR DESCRIPTION
Since the Bundler API is shutting down, we don't want to try and make a
request there, since it will fail.

cc @indirect @dwradcliffe