### PR TITLE
Ability to star gems

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -34,6 +34,9 @@
 .gem__sha {
   margin-top: 16px; }
 
+.gem__ghbtn {
+    margin-bottom: 15px; }
+
 .gem__owners {
   margin-top: 16px; }
   .gem__owners img {

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -15,6 +15,14 @@ module RubygemsHelper
     link_to(text, url, rel: 'nofollow', class: ['gem__link', 't-list__item']) if url.present?
   end
 
+  def link_to_github(rubygem)
+    if !rubygem.linkset.code.nil? && URI(rubygem.linkset.code).host == "github.com"
+      URI(@rubygem.linkset.code)
+    elsif !rubygem.linkset.home.nil? && URI(rubygem.linkset.home).host == "github.com"
+      URI(rubygem.linkset.home)
+    end
+  end
+
   def link_to_directory
     ("A".."Z").map do |letter|
       link_to(letter, rubygems_path(letter: letter), class: "gems__nav-link")

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -58,6 +58,10 @@
   </div>
 
   <div class="gem__aside l-col--r--pad">
+    <% if @rubygem.linkset.present? && github_link = link_to_github(@rubygem) %>
+      <iframe class="gem__ghbtn" src="https://ghbtns.com/github-btn.html?user=<%= github_link.path.split('/').second %>&repo=<%= github_link.path.split('/').third %>&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+    <% end %>
+
     <% if @latest_version.indexed %>
       <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
         <h2 class="gem__downloads__heading t-text--s">


### PR DESCRIPTION
Closes #1424 

Most gem authors who decide to share their source code have filled their github url in the `homepage` instead of `source code`. ( I can't figure out the reason? ). Hence, If the github url is not present in the source code link then it seems appropriate to check the host of homepage link too. The same approach is implemented in this PR.
Kindly review the changes.
![ghbtn](https://cloud.githubusercontent.com/assets/14155445/19354208/f6cb6c42-9133-11e6-9588-11a3d73c3288.png)
