### PR TITLE
User AMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'mime-types', '~> 2.99', require: 'mime/types/columnar'
 gem 'rails', '~> 4.2.7'
 gem 'rails-i18n'
 
+gem 'active_model_serializers'
 gem 'autoprefixer-rails'
 gem 'aws-sdk', '~> 2.2'
 gem 'clearance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.4)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi (= 0.1.1.beta6)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -76,6 +81,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
@@ -157,6 +164,11 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    jsonapi (0.1.1.beta6)
+      jsonapi-parser (= 0.1.1.beta3)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta3)
+    jsonapi-renderer (0.1.1.beta1)
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -289,6 +301,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   autoprefixer-rails
   aws-sdk (~> 2.2)
   bourne

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::OwnersController < Api::BaseController
 
   def show
     respond_to do |format|
-      format.json { render json: @rubygem.owners }
+      format.json { render json: @rubygem.owners, each_serializer: UserSerializer }
       format.yaml { render yaml: @rubygem.owners }
     end
   end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ProfilesController < Api::BaseController
   def show
     @user = User.find_by_slug!(params[:id])
     respond_to do |format|
-      format.json { render json: @user }
+      format.json { render json: @user, serializer: UserSerializer }
       format.yaml { render yaml: @user }
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,30 +78,6 @@ class User < ActiveRecord::Base
     all
   end
 
-  def payload
-    attrs = { "id" => id, "handle" => handle }
-    attrs["email"] = email unless hide_email
-    attrs
-  end
-
-  def as_json(*)
-    payload
-  end
-
-  def to_xml(options = {})
-    payload.to_xml(options.merge(root: 'user'))
-  end
-
-  def to_yaml(*args)
-    payload.to_yaml(*args)
-  end
-
-  def encode_with(coder)
-    coder.tag = nil
-    coder.implicit = true
-    coder.map = payload
-  end
-
   def set_unconfirmed_email
     self.attributes = { unconfirmed_email: email, email: email_was }
     generate_confirmation_token

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,10 @@
+class ApplicationSerializer < ActiveModel::Serializer
+  def to_xml(options = {})
+    attributes.to_xml(options)
+  end
+
+  def to_yaml(*args)
+    attrs = ActiveSupport::HashWithIndifferentAccess.new(attributes)
+    attrs.to_yaml(*args)
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,14 @@
+class UserSerializer < ApplicationSerializer
+  attributes :id, :handle
+  attribute :email, unless: :email_hidden?
+
+  delegate :email, to: :object
+
+  def to_xml(options = {})
+    super(options.merge(root: 'user'))
+  end
+
+  def email_hidden?
+    object.hide_email
+  end
+end

--- a/config/initializers/yaml_renderer.rb
+++ b/config/initializers/yaml_renderer.rb
@@ -1,4 +1,7 @@
 ActionController::Renderers.add :yaml do |obj, _|
-  data = JSON.load(obj.to_json).to_yaml
+  # Create a serializable resource instance
+  serializable_resource = ActiveModelSerializers::SerializableResource.new(obj)
+
+  data = serializable_resource.as_json.to_yaml
   send_data data, type: 'text/yaml'
 end

--- a/test/serializers/user_serializer_test.rb
+++ b/test/serializers/user_serializer_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class UserSerializerTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @serializable_user = UserSerializer.new(@user)
+  end
+
+  context "JSON" do
+    setup do
+      @json_user = JSON.parse(@serializable_user.to_json)
+    end
+
+    should "have id, handle and email" do
+      expected_user = { "id" => @user.id, "handle" => @user.handle, "email" => @user.email }
+      assert_equal expected_user, @json_user
+    end
+  end
+
+  context "XML" do
+    setup do
+      @xml_user = Nokogiri.parse(@serializable_user.to_xml)
+    end
+
+    should "have id, handle and email" do
+      assert_equal "user", @xml_user.root.name
+      assert_equal %w(email handle id), @xml_user.root.children.select(&:element?).map(&:name).sort
+      assert_equal @user.id, @xml_user.at_css("id").content.to_i
+      assert_equal @user.handle, @xml_user.at_css("handle").content
+      assert_equal @user.email, @xml_user.at_css("email").content
+    end
+  end
+
+  context "YAML" do
+    setup do
+      @yaml_user = YAML.load(@serializable_user.to_yaml)
+    end
+
+    should "have id, handle and email" do
+      expected_user = { "id" => @user.id, "handle" => @user.handle, "email" => @user.email }
+      assert_equal expected_user, @yaml_user
+    end
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -111,25 +111,6 @@ class UserTest < ActiveSupport::TestCase
       assert_nil User.authenticate(@user.email, "bad")
     end
 
-    should "have email and handle on JSON" do
-      json = JSON.parse(@user.to_json)
-      hash = { "id" => @user.id, "email" => @user.email, 'handle' => @user.handle }
-      assert_equal hash, json
-    end
-
-    should "have email and handle on XML" do
-      xml = Nokogiri.parse(@user.to_xml)
-      assert_equal "user", xml.root.name
-      assert_equal %w(id handle email), xml.root.children.select(&:element?).map(&:name)
-      assert_equal @user.email, xml.at_css("email").content
-    end
-
-    should "have email and handle on YAML" do
-      yaml = YAML.load(@user.to_yaml)
-      hash = { 'id' => @user.id, 'email' => @user.email, 'handle' => @user.handle }
-      assert_equal hash, yaml
-    end
-
     should "create api key" do
       assert_not_nil @user.api_key
     end
@@ -259,20 +240,6 @@ class UserTest < ActiveSupport::TestCase
     should "total their number of pushed rubygems except yanked gems" do
       @rubygems.first.versions.first.update! indexed: false
       assert_equal @user.total_rubygems_count, 2
-    end
-  end
-
-  context "yaml" do
-    setup do
-      @user = create(:user)
-    end
-
-    should "return its payload" do
-      assert_equal @user.payload, YAML.load(@user.to_yaml)
-    end
-
-    should "nest properly" do
-      assert_equal [@user.payload], YAML.load([@user].to_yaml)
     end
   end
 end


### PR DESCRIPTION
Related: #1409 

Following test is removed, because Array.to_yaml is not suppose to work (check `[].to_yml). `each_serializer` ensures that response is array. Equivalent integration test for this makes more sense and it [already exists](https://github.com/rubygems/rubygems.org/blob/master/test/functional/api/v1/owners_controller_test.rb#L24-L27).

``` diff
-    should "nest properly" do
-      assert_equal [@user.payload], YAML.load([@user].to_yaml)
-    end
```
