### PR TITLE
Delete info cache after setting info_checksum

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -61,8 +61,6 @@ class GemInfo
 
   private_class_method :versions_after
 
-  private
-
   def compute_compact_index_info
     group_by_columns =
       "number, platform, sha256, info_checksum, required_ruby_version, required_rubygems_version, versions.created_at"

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -165,9 +165,9 @@ class Pusher
   end
 
   def set_info_checksum
-    # expire info cache of previous version
-    Rails.cache.delete("info/#{rubygem.name}")
-    checksum = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(rubygem.name).compact_index_info))
+    gem_info = GemInfo.new(rubygem.name).compute_compact_index_info
+    checksum = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
     version.update_attribute :info_checksum, checksum
+    Rails.cache.delete("info/#{rubygem.name}")
   end
 end


### PR DESCRIPTION
closes: #1455 

I couldn't decide if method rename is required. Probably method to get the gem info directly (currently [`compute_compact_index_info`](https://github.com/rubygems/rubygems.org/blob/master/app/models/gem_info.rb#L66)) should be called `compact_index_info`? [One for cache](https://github.com/rubygems/rubygems.org/blob/master/app/models/gem_info.rb#L6) could be `fetch_compact_index_info`.

Also, Couldn't [`versions_after`](https://github.com/rubygems/rubygems.org/blob/master/app/models/gem_info.rb#L31-L33) be removed?
