### PR TITLE
Compress CSS in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'rack'
 gem 'rack-utf8_sanitizer'
 gem 'rdoc'
 gem 'rest-client', require: 'rest_client'
+gem 'sass', require: false
 gem 'shoryuken', '~> 2.0.2', require: false
 gem 'statsd-instrument', '~> 2.0.6'
 gem 'uglifier', '>= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-graphviz (1.2.2)
     ruby-progressbar (1.8.1)
+    sass (3.4.22)
     shoryuken (2.0.11)
       aws-sdk-core (~> 2)
       celluloid (~> 0.16)
@@ -336,6 +337,7 @@ DEPENDENCIES
   rdoc
   rest-client
   rubocop
+  sass
   shoryuken (~> 2.0.2)
   shoulda
   sprockets-rails (~> 3.1.0)
@@ -349,4 +351,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Just removes the comments, really. Saves 2kb uncompressed, probably negligible compressed.
