### PR TITLE
Add dependencies count to version

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -241,23 +241,32 @@ class Version < ActiveRecord::Base
     gem_download.try(:count) || 0
   end
 
+  def runtime_dependencies_count
+    dependencies.runtime.length
+  end
+
+  def development_dependencies_count
+    dependencies.development.length
+  end
+
   def payload
     {
-      'authors'          => authors,
-      'built_at'         => built_at,
-      'created_at'       => created_at,
-      'description'      => description,
-      'downloads_count'  => downloads_count,
-      'metadata'         => metadata,
-      'number'           => number,
-      'summary'          => summary,
-      'platform'         => platform,
-      'rubygems_version' => required_rubygems_version,
-      'ruby_version'     => required_ruby_version,
-      'prerelease'       => prerelease,
-      'licenses'         => licenses,
-      'requirements'     => requirements,
-      'sha'              => sha256_hex
+      'authors'                    => authors,
+      'built_at'                   => built_at,
+      'created_at'                 => created_at,
+      'description'                => description,
+      'downloads_count'            => downloads_count,
+      'metadata'                   => metadata,
+      'number'                     => number,
+      'summary'                    => summary,
+      'platform'                   => platform,
+      'rubygems_version'           => required_rubygems_version,
+      'ruby_version'               => required_ruby_version,
+      'prerelease'                 => prerelease,
+      'licenses'                   => licenses,
+      'requirements'               => requirements,
+      'runtime_dependencies_count' => runtime_dependencies_count,
+      'sha'                        => sha256_hex
     }
   end
 

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -1,7 +1,7 @@
 <% if dependencies.present? && @latest_version.indexed %>
   <div class="l-half--l">
     <div class="dependencies" id="<%= dependencies.first.scope %>_dependencies">
-      <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %>:</h3>
+      <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies_count %>):</h3>
       <div class="t-list__items">
         <% dependencies.each do |dependency| %>
           <% if rubygem = dependency.rubygem %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -48,8 +48,8 @@
         </div>
       <% end %>
 
-      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime } %>
-      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development } %>
+      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime, :dependencies_count => @latest_version.runtime_dependencies_count } %>
+      <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development, :dependencies_count => @latest_version.development_dependencies_count } %>
 
       <% if @latest_version.requirements.present? %>
         <div class="l-half--l">

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -393,6 +393,10 @@ class RubygemsControllerTest < ActionController::TestCase
       assert page.has_content?(@runtime.rubygem.name)
       assert page.has_content?(@development.rubygem.name)
     end
+    should "show runtime and development dependencies count" do
+      assert page.has_content?(@version.runtime_dependencies_count)
+      assert page.has_content?(@version.development_dependencies_count)
+    end
   end
 
   context "On GET to show for a gem with dependencies that are unresolved" do

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -13,7 +13,7 @@ class VersionTest < ActiveSupport::TestCase
       json = @version.as_json
       fields = %w(number built_at summary description authors platform
                   ruby_version rubygems_version prerelease downloads_count licenses
-                  requirements sha metadata created_at)
+                  requirements runtime_dependencies_count sha metadata created_at)
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
@@ -28,6 +28,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
+      assert_equal @version.runtime_dependencies_count, json["runtime_dependencies_count"]
       assert_equal @version.created_at, json["created_at"]
     end
   end
@@ -41,7 +42,7 @@ class VersionTest < ActiveSupport::TestCase
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w(number built-at summary description authors platform
                   ruby-version rubygems-version prerelease downloads-count licenses
-                  requirements sha metadata created-at)
+                  requirements runtime-dependencies-count sha metadata created-at)
       assert_equal fields.map(&:to_s).sort,
         xml.root.children.map(&:name).reject { |t| t == "text" }.sort
       assert_equal @version.authors, xml.at_css("authors").content
@@ -57,6 +58,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
       assert_equal @version.requirements, xml.at_css("requirements").content
+      assert_equal @version.runtime_dependencies_count, xml.at_css("runtime-dependencies-count").content.to_i
       assert_equal(
         @version.created_at.to_i,
         xml.at_css("created-at").content.to_time(:utc).to_i
@@ -286,6 +288,14 @@ class VersionTest < ActiveSupport::TestCase
 
     should "have a default download count" do
       assert @version.downloads_count.zero?
+    end
+
+    should "have runtime dependencies count" do
+      assert_equal @version.runtime_dependencies_count, Version.find_by(rubygem: @version.rubygem).dependencies.runtime.count
+    end
+
+    should "have development dependencies count" do
+      assert_equal @version.development_dependencies_count, Version.find_by(rubygem: @version.rubygem).dependencies.development.count
     end
 
     should "give no version flag for the latest version" do


### PR DESCRIPTION
Based on #1115 I'm adding `runtime_dependencies_count` and `development_dependencies_count` for the users to view on the gems page and add `runtime_dependencies_count` key in the version API response.

Gems Page
<img width="669" alt="screen shot 2016-10-16 at 6 02 18 pm" src="https://cloud.githubusercontent.com/assets/7445868/19416727/cb2d1cd6-93ca-11e6-9563-b8b6ef04d60d.png">

New versions API response

```
[{
"authors":"David Heinemeier Hansson",
"built_at":"2016-08-10T00:00:00.000Z",
"created_at":"2016-09-09T12:27:53.343Z",
"description":"A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing.",
"downloads_count":0,
"metadata":{},
"number":"4.2.7.1",
"summary":"A toolkit for building modeling frameworks (part of Rails).",
"platform":"ruby",
"rubygems_version":"\u003e= 0",
"ruby_version":"\u003e= 1.9.3",
"prerelease":false,
"licenses":["MIT"],
"requirements":[],
"runtime_dependencies_count":2,
"sha":"65a7631d487b9642c6877dd404667991e36cdd75e588406c4d4c435557059f29"
}]
```
