### PR TITLE
New releases from all and popular gems

### DIFF
--- a/app/assets/stylesheets/modules/news.css
+++ b/app/assets/stylesheets/modules/news.css
@@ -1,0 +1,24 @@
+.news__nav-links {
+  margin-top: -5px;
+  margin-bottom: 28px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #c1c4ca;
+  text-align: center; }
+
+.news__nav-link {
+  margin-right: 10px;
+  margin-left: 10px;
+  padding-right: 20px;
+  padding-left: 20px;
+  display: inline-block;
+  border-radius: 15px;
+  font-weight: 800;
+  line-height: 30px;
+  color: #141c22;
+  transition-duration: 0.25s;
+  transition-property: background-color, color; }
+  .news__nav-link:focus, .news__nav-link:hover, .news__nav-link.is-active {
+    background-color: #e9573f;
+    color: white; }
+  .news__nav-link:focus {
+    outline: none; }

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -2,16 +2,20 @@ class NewsController < ApplicationController
   before_action :set_page, only: :index
 
   def show
-    @releases = Rubygem.joins(:latest_version)
-      .merge(Version.indexed.by_created_at.recent)
+    @versions = Version.joins(:rubygem)
+      .recent
+      .indexed
+      .by_created_at
       .paginate(page: @page, per_page: 10, total_entries: 100)
   end
 
   def popular
     @title = "New Releases — Popular Gems"
-    @releases = Rubygem.joins(:latest_version)
-      .by_downloads
-      .merge(Version.indexed.by_created_at.recent)
+    @versions = Version.joins(:rubygem)
+      .recent
+      .indexed
+      .by_created_at
+      .merge(Rubygem.by_downloads)
       .paginate(page: @page, per_page: 10, total_entries: 100)
 
     render :show

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,5 +1,5 @@
 class NewsController < ApplicationController
-  before_action :set_page, only: :index
+  before_action :set_page
 
   def show
     @versions = Version.joins(:rubygem)

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,0 +1,19 @@
+class NewsController < ApplicationController
+  before_action :set_page, only: :index
+
+  def show
+    @releases = Rubygem.joins(:latest_version)
+      .merge(Version.indexed.by_created_at.recent)
+      .paginate(page: @page, per_page: 10, total_entries: 100)
+  end
+
+  def popular
+    @title = "New Releases — Popular Gems"
+    @releases = Rubygem.joins(:latest_version)
+      .by_downloads
+      .merge(Version.indexed.by_created_at.recent)
+      .paginate(page: @page, per_page: 10, total_entries: 100)
+
+    render :show
+  end
+end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -11,11 +11,12 @@ class NewsController < ApplicationController
 
   def popular
     @title = "New Releases — Popular Gems"
-    @versions = Version.joins(:rubygem)
-      .recent
+    popular_gem_ids = Rubygem.by_downloads.limit(100).pluck(:id).uniq
+
+    @versions = Version.recent
       .indexed
       .by_created_at
-      .merge(Rubygem.by_downloads)
+      .where(rubygem_id: popular_gem_ids)
       .paginate(page: @page, per_page: 10, total_entries: 100)
 
     render :show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,8 @@ module ApplicationHelper
   def stats_graph_meter(gem, count)
     gem.downloads * 1.0 / count * 100
   end
+
+  def active?(path)
+    "is-active" if request.path_info == path
+  end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,6 +1,8 @@
 require 'digest/sha2'
 
 class Version < ActiveRecord::Base
+  RECENT_LIMIT = 7.days
+
   belongs_to :rubygem, touch: true
   has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, dependent: :destroy
   has_one :gem_download, proc { |m| where(rubygem_id: m.rubygem_id) }
@@ -119,6 +121,10 @@ class Version < ActiveRecord::Base
       .prerelease
       .order("rubygems.name asc, position desc")
       .pluck('rubygems.name', :number, :platform)
+  end
+
+  def self.recent
+    where(created_at: RECENT_LIMIT.ago.in_time_zone..Time.zone.now)
   end
 
   def self.most_recent

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,12 @@
               </a>
             <% end %>
 
+            <%- if request.path_info == '/news' %>
+              <%= link_to "News", news_url, class: "header__nav-link is-active" %>
+            <%- else %>
+              <%= link_to "News", news_url, class: "header__nav-link" %>
+            <%- end %>
+
             <%- if request.path_info == '/gems' %>
               <%= link_to "Gems", rubygems_url, class: "header__nav-link is-active" %>
             <%- else %>

--- a/app/views/news/_version.html.erb
+++ b/app/views/news/_version.html.erb
@@ -7,9 +7,6 @@
     <p class="gems__gem__desc t-text"><%= short_info(version.rubygem) %></p>
   </span>
   <p class="gems__gem__downloads__count">
-    <%= version.downloads_count %>
-    <span class="gems__gem__downloads__heading">
-      <%= t('rubygems.index.downloads') %>
-    </span>
+    <small class="gem__version__date"><%= nice_date_for(version.created_at) %></small>
   </p>
 <% end %>

--- a/app/views/news/_version.html.erb
+++ b/app/views/news/_version.html.erb
@@ -1,0 +1,15 @@
+<%= link_to rubygem_path(version.rubygem.name), class: 'gems__gem' do %>
+  <span class="gems__gem__info">
+    <h2 class="gems__gem__name">
+      <%= version.rubygem.name %>
+      <span class="gems__gem__version"><%= version.number %></span>
+    </h2>
+    <p class="gems__gem__desc t-text"><%= short_info(version.rubygem) %></p>
+  </span>
+  <p class="gems__gem__downloads__count">
+    <%= version.downloads_count %>
+    <span class="gems__gem__downloads__heading">
+      <%= t('rubygems.index.downloads') %>
+    </span>
+  </p>
+<% end %>

--- a/app/views/news/_version.html.erb
+++ b/app/views/news/_version.html.erb
@@ -1,4 +1,4 @@
-<%= link_to rubygem_path(version.rubygem.name), class: 'gems__gem' do %>
+<%= link_to rubygem_version_path(version.rubygem, version.slug), class: 'gems__gem' do %>
   <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= version.rubygem.name %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -1,4 +1,4 @@
-<% @title ||= "New Releases — All" %>
+<% @title ||= "New Releases — All Gems" %>
 
 <div class="news__nav-links">
   <%= link_to "All Gems", news_url, class: "news__nav-link #{active?(news_path)}" %>
@@ -6,8 +6,8 @@
 </div>
 
 <header class="gems__header">
-  <p class="gems__meter"><%= page_entries_info @releases, model: 'gem' %></p>
+  <p class="gems__meter"><%= page_entries_info @versions, model: 'gem' %></p>
 </header>
 
-<%= render partial: "rubygems/rubygem", collection: @releases %>
-<%= will_paginate @releases %>
+<%= render partial: "news/version", collection: @versions %>
+<%= will_paginate @versions %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -1,0 +1,13 @@
+<% @title ||= "New Releases — All" %>
+
+<div class="news__nav-links">
+  <%= link_to "All Gems", news_url, class: "news__nav-link #{active?(news_path)}" %>
+  <%= link_to "Popular Gems", popular_news_url, class: "news__nav-link #{active?(popular_news_path)}" %>
+</div>
+
+<header class="gems__header">
+  <p class="gems__meter"><%= page_entries_info @releases, model: 'gem' %></p>
+</header>
+
+<%= render partial: "rubygems/rubygem", collection: @releases %>
+<%= will_paginate @releases %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,9 @@ Rails.application.routes.draw do
     resources :profiles, only: :show
     resource :profile, only: [:edit, :update]
     resources :stats, only: :index
+    resource :news, path: 'news', only: [:show] do
+      get :popular, on: :collection
+    end
 
     resources :rubygems,
       only: [:index, :show, :edit, :update],


### PR DESCRIPTION
Ever wondered what new versions of gems were released lately? Or
new versions of popular gems?

This is what I’d like to provide with /news and /news/popular

Two simple endpoints to find a list of gems ordered by version release.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1K1K3M2q3R1n150Q1R42/Screen%20Shot%202016-10-18%20at%2011.41.27%20AM.png?X-CloudApp-Visitor-Id=2861&v=c5cce84e)
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0D2D15253L3d0X250z1q/Screen%20Shot%202016-10-18%20at%2011.42.16%20AM.png?X-CloudApp-Visitor-Id=2861&v=fd9f0bea)

I took the liberty to add a navigation item for these new routes since that sort of makes sense but I’m willing to part with it if nobody thinks it makes sense.

I haven’t taken the time to add any specs since I just wanted to prototype it and see if it made sense. So far I like it, and it’s very low impact so maintenance shouldn’t be too hard, but I’m sure I’m forgetting something.
