### PR TITLE
set surrogate keys for each gem requested

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,10 @@ Style/AndOr:
   Exclude:
     - app/controllers/internal/ping_controller.rb
 
+Style/AccessorMethodName:
+  Exclude:
+    - app/controllers/application_controller.rb
+
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 

--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -16,6 +16,7 @@ class Api::CompactIndexController < Api::BaseController
   end
 
   def info
+    set_surrogate_key "info/* gem/#{@rubygem.name}"
     return unless stale?(@rubygem)
     info_params = GemInfo.new(@rubygem.name).compact_index_info
     render_range CompactIndex.info(info_params)

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::DependenciesController < Api::BaseController
 
     expires_in 30, public: true
     fastly_expires_in 60
+    set_surrogate_key 'dependencyapi', gem_names.map { |name| "gem/#{name}" }
 
     respond_to do |format|
       format.json { render json: deps }

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::VersionsController < Api::BaseController
 
     expires_in 0, public: true
     fastly_expires_in 60
+    set_surrogate_key "gem/#{@rubygem.name}"
 
     if @rubygem.public_versions.count.nonzero?
       respond_to do |format|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,10 @@ class ApplicationController < ActionController::Base
     response.headers['Surrogate-Control'] = "max-age=#{seconds}"
   end
 
+  def set_surrogate_key(*surrogate_keys)
+    response.headers['Surrogate-Key'] = surrogate_keys.join(' ')
+  end
+
   def redirect_to_root
     redirect_to root_path
   end

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -70,6 +70,10 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
       assert_response :success
     end
 
+    should "return surrogate key header" do
+      assert_equal "dependencyapi gem/myrails gem/mybundler", @response.headers['Surrogate-Key']
+    end
+
     should "return body" do
       result = [
         {

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -75,6 +75,11 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
       assert_equal @response.headers['Last-Modified'], @rubygem.updated_at.httpdate
     end
 
+    should "return surrogate key header" do
+      get_show(@rubygem)
+      assert_equal "gem/#{@rubygem.name}", @response.headers['Surrogate-Key']
+    end
+
     should "return 304 when If-Modified-Since header is satisfied" do
       get_show(@rubygem)
       assert_response :success

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -132,6 +132,11 @@ eos
     assert_equal expected, CompactIndex.info(Rails.cache.read("info/gemA"))
   end
 
+  test "/info has surrogate key header" do
+    get info_path(gem_name: 'gemA')
+    assert_equal "info/* gem/gemA", @response.headers['Surrogate-Key']
+  end
+
   test "/info partial response" do
     expected = <<-eos
 ---


### PR DESCRIPTION
This will set the surrogate key headers for the endpoints that we are caching in Fastly. This will simplify the Fastly config, and allows us to purge by specific gem in the future.

@indirect @segiddins @sonalkr132 