### PR TITLE
Override find_user_for_create method of Clearance::PasswordsController

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,2 +1,12 @@
 class PasswordsController < Clearance::PasswordsController
+  def find_user_for_create
+    Clearance.configuration.user_model
+      .find_by_normalized_email password_params[:email]
+  end
+
+  private
+
+  def password_params
+    params.require(:password).permit(:email)
+  end
 end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class PasswordsControllerTest < ActionController::TestCase
+  context "on POST to create" do
+    context "when missing a parameter" do
+      should "raises parameter missing" do
+        post :create
+        assert_response :bad_request
+        assert page.has_content?("Request is missing param 'password'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes:
NoMethodError: undefined method `[]' for nil:NilClass
https://app.honeybadger.io/projects/40972/faults/31533774

origin:
https://github.com/thoughtbot/clearance/blob/75e33bb0d0cd42aa97345d3496fd9e3e3ab73a05/app/controllers/clearance/passwords_controller.rb#L81

I have reported https://github.com/thoughtbot/clearance/issues/715
