### PR TITLE
Require password for profile update

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_root, unless: :signed_in?, except: :show
+  before_action :verify_password, only: :update
 
   def edit
     @user = current_user
@@ -35,5 +36,11 @@ class ProfilesController < ApplicationController
 
   def params_user
     params.require(:user).permit(*User::PERMITTED_ATTRS)
+  end
+
+  def verify_password
+    return if current_user.authenticated?(params[:user][:password])
+    flash[:notice] = t('.request_denied')
+    redirect_to edit_profile_path
   end
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -40,6 +40,15 @@
     <%= form.email_field :email, :class => 'form__input' %>
   </div>
 
+  <p class='form__field__instructions'>
+    <%= t('.enter_password') %>
+  </p>
+  <div class="password_field">
+    <%= form.label :password, :class => 'form__label' %>
+    <%= form.password_field :password, :class => 'form__input' %>
+  </div>
+
+
   <div class="profile-checkbox form__checkbox">
     <%= form.check_box :hide_email, :class => 'form__checkbox__input' %>
     <%= form.label :hide_email, t('.hide_email'), :class => 'form__checkbox__label' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
       title: Edit profile
       hide_email: Hide email in public profile
       optional_twitter_username: Optional Twitter username. Will be displayed publicly
+      enter_password: Please enter your account's password
       reset_password:
         title: Reset password
         text: "Need a new password? No problem. %{link}"
@@ -106,6 +107,8 @@ en:
         link_text: gem commands
         reset: Reset my API key
         confirm_reset: Are you sure? This cannot be undone.
+    update:
+      request_denied: This request was denied. We could not verify your password.
 
   rubygems:
     dependencies:

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -83,7 +83,7 @@ class ProfilesControllerTest < ActionController::TestCase
           @handle = "john_m_doe"
           @user = create(:user, handle: "johndoe")
           sign_in_as(@user)
-          put :update, user: { handle: @handle }
+          put :update, user: { handle: @handle, password: @user.password }
         end
 
         should respond_with :redirect
@@ -101,7 +101,7 @@ class ProfilesControllerTest < ActionController::TestCase
           @hide_email = true
           @user = create(:user, handle: "johndoe")
           sign_in_as(@user)
-          put :update, user: { handle: @handle, hide_email: @hide_email }
+          put :update, user: { handle: @handle, hide_email: @hide_email, password: @user.password }
         end
 
         should respond_with :redirect
@@ -110,6 +110,20 @@ class ProfilesControllerTest < ActionController::TestCase
 
         should "update email toggle" do
           assert_equal @hide_email, User.last.hide_email
+        end
+      end
+
+      context "updating without password" do
+        setup do
+          @user = create(:user, handle: "johndoe")
+          sign_in_as(@user)
+          put :update, user: { handle: "doejohn" }
+        end
+
+        should set_flash.to("This request was denied. We could not verify your password.")
+        should redirect_to("the profile edit page") { edit_profile_path }
+        should "not update handle" do
+          assert_equal "johndoe", @user.handle
         end
       end
     end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -20,6 +20,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Handle", with: "nick2"
+    fill_in "Password", with: "password12345"
     click_button "Update"
 
     assert page.has_content? "nick2"
@@ -33,6 +34,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Handle", with: "nick2"
+    fill_in "Password", with: "password12345"
     click_button "Update"
 
     assert page.has_content? "Handle has already been taken"
@@ -44,6 +46,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Handle", with: "nick1" * 10
+    fill_in "Password", with: "password12345"
     click_button "Update"
 
     assert page.has_content? "Handle is too long (maximum is 40 characters)"
@@ -56,6 +59,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Email address", with: "nick2@example.com"
+    fill_in "Password", with: "password12345"
     click_button "Update"
 
     click_link "Sign out"
@@ -69,6 +73,7 @@ class ProfileTest < SystemTest
     visit profile_path("nick1")
     click_link "Edit Profile"
 
+    fill_in "Password", with: "password12345"
     check "Hide email in public profile"
     click_button "Update"
 
@@ -82,6 +87,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Twitter username", with: "nick1"
+    fill_in "Password", with: "password12345"
     click_button "Update"
 
     visit profile_path("nick1")


### PR DESCRIPTION
This could alternatively have been implemented as callback in users model (password error would have been elegantly reported as form error). However, it would mean that every user update requires password which might not have been as convenient, for example: api key can be reset with CLI.