### PR TITLE
Remove runtime dependencies count from versions payload

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -265,7 +265,6 @@ class Version < ActiveRecord::Base
       'prerelease'                 => prerelease,
       'licenses'                   => licenses,
       'requirements'               => requirements,
-      'runtime_dependencies_count' => runtime_dependencies_count,
       'sha'                        => sha256_hex
     }
   end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -13,7 +13,7 @@ class VersionTest < ActiveSupport::TestCase
       json = @version.as_json
       fields = %w(number built_at summary description authors platform
                   ruby_version rubygems_version prerelease downloads_count licenses
-                  requirements runtime_dependencies_count sha metadata created_at)
+                  requirements sha metadata created_at)
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
@@ -28,7 +28,6 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
-      assert_equal @version.runtime_dependencies_count, json["runtime_dependencies_count"]
       assert_equal @version.created_at, json["created_at"]
     end
   end
@@ -42,7 +41,7 @@ class VersionTest < ActiveSupport::TestCase
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w(number built-at summary description authors platform
                   ruby-version rubygems-version prerelease downloads-count licenses
-                  requirements runtime-dependencies-count sha metadata created-at)
+                  requirements sha metadata created-at)
       assert_equal fields.map(&:to_s).sort,
         xml.root.children.map(&:name).reject { |t| t == "text" }.sort
       assert_equal @version.authors, xml.at_css("authors").content
@@ -58,7 +57,6 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary.to_s, xml.at_css("summary").content
       assert_equal @version.licenses, xml.at_css("licenses").content
       assert_equal @version.requirements, xml.at_css("requirements").content
-      assert_equal @version.runtime_dependencies_count, xml.at_css("runtime-dependencies-count").content.to_i
       assert_equal(
         @version.created_at.to_i,
         xml.at_css("created-at").content.to_time(:utc).to_i


### PR DESCRIPTION
It makes versions#show 4 times more expensive. versions#show is one of the most used endpoint.
[This](https://github.com/rubygems/rubygems.org/pull/1474#issuecomment-256248533) comment's benchmark show that `includes(:dependencies)` won't help with n+1 it is creating on versions#show.