### PR TITLE
consolidate code that generates links

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -11,8 +11,8 @@ module RubygemsHelper
     end
   end
 
-  def link_to_page(text, url)
-    link_to(text, url, rel: 'nofollow', class: ['gem__link', 't-list__item']) if url.present?
+  def link_to_page(id, url)
+    link_to(t(".links.#{id}"), url, rel: 'nofollow', class: ['gem__link', 't-list__item'], id: id) if url.present?
   end
 
   def link_to_directory
@@ -65,14 +65,12 @@ module RubygemsHelper
   end
 
   def download_link(version)
-    link_to t('.links.download'), "/downloads/#{version.full_name}.gem",
-      class: 'gem__link t-list__item', id: :download
+    link_to_page :download, "/downloads/#{version.full_name}.gem"
   end
 
   def documentation_link(version, linkset)
     return unless linkset.nil? || linkset.docs.blank?
-    link_to t('.links.docs'), version.documentation_path,
-      class: 'gem__link t-list__item', id: :docs
+    link_to_page :docs, version.documentation_path
   end
 
   def badge_link(rubygem)

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -123,7 +123,7 @@
       <% if @latest_version.indexed %>
         <% if @rubygem.linkset.present? %>
           <%- Linkset::LINKS.each do |link| %>
-            <%= link_to_page t("rubygems.show.links.#{link}"), @rubygem.linkset.public_send(link) %>
+            <%= link_to_page link, @rubygem.linkset.public_send(link) %>
           <%- end %>
         <% end %>
 

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -94,22 +94,23 @@ class RubygemsHelperTest < ActionView::TestCase
       @linkset = build(:linkset)
       @linkset.wiki = nil
       @linkset.code = ""
+      @virtual_path = "rubygems.show"
     end
 
     should "create link for homepage" do
-      assert_match @linkset.home, link_to_page("Homepage", @linkset.home)
+      assert_match @linkset.home, link_to_page(:home, @linkset.home)
     end
 
     should "be a nofollow link" do
-      assert_match 'rel="nofollow"', link_to_page("Homepage", @linkset.home)
+      assert_match 'rel="nofollow"', link_to_page(:home, @linkset.home)
     end
 
     should "not create link for wiki" do
-      assert_nil link_to_page("Wiki", @linkset.wiki)
+      assert_nil link_to_page(:wiki, @linkset.wiki)
     end
 
     should "not create link for code" do
-      assert_nil link_to_page("Code", @linkset.code)
+      assert_nil link_to_page(:code, @linkset.code)
     end
   end
 


### PR DESCRIPTION
In wanting to push #1234 (or #724) forward, I extracted the common logic around generating links.

The other PRs generate the documentation link much the same way as the wiki link.
So this makes them generated with a common function.

The larger goal being to just have `show.html.erb` generate the list of links in a single loop.

1. We lookup the localized labels using the full form `"rubygems.show.links.#{name}"` and `.links.#{name}` - this PR converges them. (I can converge on the full version if you prefer)
2. This adds an `:id` to all links, in order to simplify generation.

Thanks