### PR TITLE
Reset confirmation token on email verification

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,7 +123,7 @@ class User < ActiveRecord::Base
   end
 
   def confirm_email!
-    update(email_confirmed: true)
+    update!(email_confirmed: true, confirmation_token: nil)
   end
 
   # confirmation token expires after 15 minutes

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -30,4 +30,16 @@ class EmailConfirmationTest < SystemTest
     assert page.has_content? 'Sign out'
     assert page.has_selector? '#flash_notice', text: 'Your email address have been verified'
   end
+
+  test 're-using confirmation link does not sign in user' do
+    request_confirmation_mail @user.email
+
+    link = last_email_link
+    visit link
+    click_link 'Sign out'
+
+    visit link
+    assert page.has_content? 'Sign in'
+    assert page.has_selector? '#flash_alert', text: 'Please double check the URL or try submitting it again.'
+  end
 end


### PR DESCRIPTION
Although confirmation token expire after 15 minutes, I am sure someone on HO will report this as missing best practice if it is not fixed.