### PR TITLE
Disable web hook after it has failed for a number of times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'shoryuken', '~> 2.1.0', require: false
 gem 'statsd-instrument', '~> 2.1.0'
 gem 'uglifier', '>= 1.0.3'
 gem 'unicorn'
-gem 'validates_formatting_of'
 gem 'will_paginate'
 gem 'elasticsearch-model', '~> 0.1.7'
 gem 'elasticsearch-rails', '~> 0.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,8 +279,6 @@ GEM
     unicorn (5.2.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    validates_formatting_of (0.9.0)
-      activemodel
     will_paginate (3.1.5)
     xml-simple (1.1.5)
     xpath (2.0.0)
@@ -346,7 +344,6 @@ DEPENDENCIES
   toxiproxy (~> 0.1.3)
   uglifier (>= 1.0.3)
   unicorn
-  validates_formatting_of
   will_paginate
   xml-simple
   yajl-ruby

--- a/app/models/linkset.rb
+++ b/app/models/linkset.rb
@@ -4,11 +4,11 @@ class Linkset < ActiveRecord::Base
   LINKS = %w(home code docs wiki mail bugs).freeze
 
   LINKS.each do |url|
-    validates_formatting_of url.to_sym,
-      using: :url,
-      allow_nil: true,
-      allow_blank: true,
-      message: "does not appear to be a valid URL"
+    validates url.to_sym,
+      format: { with: Patterns::URL_VALIDATION_REGEXP,
+                allow_nil: true,
+                allow_blank: true,
+                message: "does not appear to be a valid URL" }
   end
 
   def empty?

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -4,7 +4,9 @@ class WebHook < ActiveRecord::Base
   belongs_to :user
   belongs_to :rubygem
 
-  validates_formatting_of :url, using: :url, message: "does not appear to be a valid URL"
+  validates :url,
+    format: { with: Patterns::URL_VALIDATION_REGEXP,
+              message: "does not appear to be a valid URL" }
   validate :unique_hook, on: :create
 
   def self.global

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -1,12 +1,13 @@
 module Patterns
   extend ActiveSupport::Concern
 
-  SPECIAL_CHARACTERS = ".-_".freeze
-  ALLOWED_CHARACTERS = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+".freeze
-  ROUTE_PATTERN      = /#{ALLOWED_CHARACTERS}/
-  LAZY_ROUTE_PATTERN = /#{ALLOWED_CHARACTERS}?/
-  NAME_PATTERN       = /\A#{ALLOWED_CHARACTERS}\Z/
-  GEM_NAME_BLACKLIST = %w(
+  URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+  SPECIAL_CHARACTERS    = ".-_".freeze
+  ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+".freeze
+  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
+  LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/
+  NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/
+  GEM_NAME_BLACKLIST    = %w(
     abbrev
     base64
     benchmark

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -56,6 +56,12 @@ class WebHookTest < ActiveSupport::TestCase
                             url: @url)
       assert webhook.valid?
     end
+
+    should "not able to create a webhook with an invalid url" do
+      webhook = WebHook.new(user: @user,
+                            url: "invalid-url")
+      refute webhook.valid?
+    end
   end
 
   context "with a webhook for a gem" do
@@ -127,6 +133,12 @@ class WebHookTest < ActiveSupport::TestCase
       webhook = WebHook.new(user: @user,
                             url: @url)
       assert webhook.valid?
+    end
+
+    should "not able to create a webhook with an invalid url" do
+      webhook = WebHook.new(user: @user,
+                            url: "invalid-url")
+      refute webhook.valid?
     end
   end
 


### PR DESCRIPTION
Related #1434 

This PR contains the following implementation:

- Hooks are disabled after 10 failures. 

  I just chose 10 randomly. This has to be discussed. Maybe we can set the threshold to 5?

- `api/v1/web_hooks/fire` re-enables the failed webhook and renders a message for the same.

   When a user runs `api/v1/web_hooks/fire` with parameters same as an already created webhook, the    webhook is enabled again if it was disabled.
- Global hooks are not disabled 

   Global hooks can't be created by the user. Disabling them doesn't make much sense.

- Used [regex](https://github.com/mdespuits/validates_formatting_of/blob/664b7c8b1ae8c9016549944fc833737c74f1d752/lib/validates_formatting_of/method.rb#L19) instead of `validates_formatting_of` gem.