### PR TITLE
task to remove invalid URLs in linkset

### DIFF
--- a/lib/tasks/linkset.rake
+++ b/lib/tasks/linkset.rake
@@ -1,0 +1,22 @@
+namespace :linkset do
+  def invalid_links
+    Linkset.where.not("home ~* ? or home = ''",
+      '\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?')
+  end
+
+  desc "Remove invalid URLs in linkset"
+  task clean: :environment do
+    begin
+      Linkset.transaction do
+        puts "Removing invalid home urls..."
+        invalid_links.each do |link|
+          link.update_attribute("home", link.home.strip.to_s)
+        end
+        affected = invalid_links.update_all(["home = ?", nil])
+        puts "Successfully removed #{affected} urls in home"
+      end
+    rescue
+      puts "Error: Couldn't update urls"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1494 
Related: #1493 

- To remove the invalid URLs run `bundle exec rake linkset:clean`
- The regexp use to check the validity of the url is used by the [validates_formatting_of](https://github.com/mdespuits/validates_formatting_of) gem and can be found [here](https://github.com/mdespuits/validates_formatting_of/blob/664b7c8b1ae8c9016549944fc833737c74f1d752/lib/validates_formatting_of/method.rb#L19).