### PR TITLE
Refactoring deletions_controller_test.rb

### DIFF
--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -9,9 +9,9 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
     context "for a gem SomeGem with a version 0.1.0" do
       setup do
-        @rubygem  = create(:rubygem, name: "SomeGem")
-        @v1       = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "ruby")
-        create(:ownership, user: @user, rubygem: @rubygem)
+        @rubygem   = create(:rubygem, name: "SomeGem")
+        @v1        = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "ruby")
+        @ownership = create(:ownership, user: @user, rubygem: @rubygem)
         RubygemFs.instance.store("gems/#{@v1.full_name}.gem", "")
       end
 
@@ -99,9 +99,11 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "ON DELETE to create for someone else's gem" do
         setup do
-          @other_user = create(:user)
-          @request.env["HTTP_AUTHORIZATION"] = @other_user.api_key
-          delete :create, gem_name: @rubygem.to_param, version: '0.1.0'
+          other_user = create(:user)
+          other_rubygem = create(:rubygem, name: "SomeOtherGem")
+          create(:version, rubygem: other_rubygem, number: "0.1.0", platform: "ruby")
+          create(:ownership, user: other_user, rubygem: other_rubygem)
+          delete :create, gem_name: other_rubygem.to_param, version: '0.1.0'
         end
         should respond_with :forbidden
         should "not record the deletion" do


### PR DESCRIPTION
As pointed out by @sonalkr132 [here](https://github.com/rubygems/rubygems.org/pull/1427/files/1769133130ff75ab84716c34ec787438b245d1f6#r84617286) . The context `ON DELETE to create for someone else's gem` belongs inside `with a confirmed user authenticated` therefore, it would seem appropriate not to change the value of `@request.env["HTTP_AUTHORIZATION"]` inside the context. 

Just a small change. :v:  