### PR TITLE
Set empty strings to nil before saving linkset

### DIFF
--- a/app/models/linkset.rb
+++ b/app/models/linkset.rb
@@ -1,5 +1,6 @@
 class Linkset < ActiveRecord::Base
   belongs_to :rubygem
+  before_save :empty_to_nil
 
   LINKS = %w(home code docs wiki mail bugs).freeze
 
@@ -17,5 +18,13 @@ class Linkset < ActiveRecord::Base
 
   def update_attributes_from_gem_specification!(spec)
     update_attributes!(home: spec.homepage)
+  end
+
+  private
+
+  def empty_to_nil
+    LINKS.each do |url|
+      self[url] = nil if self[url].blank?
+    end
   end
 end


### PR DESCRIPTION
> Currently there are home: 13460, docs: 8995, wiki: 13706, bugs: 9333, mail: 16010, code: 1259 links with empty strings. We allow the pushing of gem with empty strings as links here, so this count will keep on increasing.

This PR converts empty strings to `nil` before it gets saved in `linkset`.

Related #1499  #1494 