### PR TITLE
Use Version#created_at instead of Version#built_at

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -9,7 +9,7 @@ module PagesHelper
 
   def subtitle
     subtitle = "v#{version_number}"
-    subtitle += " - #{nice_date_for(version.built_at)}" if version.try(:built_at)
+    subtitle += " - #{nice_date_for(version.created_at)}"
     subtitle
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -259,8 +259,8 @@ class Rubygem < ActiveRecord::Base
     version
   end
 
-  def first_built_date
-    versions.by_earliest_built_at.limit(1).last.built_at
+  def first_created_date
+    versions.by_earliest_created_at.first.created_at
   end
 
   # returns days left before the reserved namespace will be released

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -85,16 +85,12 @@ class Version < ActiveRecord::Base
     order(:position)
   end
 
-  def self.by_built_at
-    order(built_at: :desc)
-  end
-
-  def self.by_earliest_built_at
-    order(built_at: :asc)
-  end
-
   def self.by_created_at
     order(created_at: :desc)
+  end
+
+  def self.by_earliest_created_at
+    order(created_at: :asc)
   end
 
   def self.rows_for_index

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -1,6 +1,6 @@
 <li class="gem__version-wrap">
   <%= link_to version.number, rubygem_version_url(version.rubygem, version.slug), :class => 't-list__item' %>
-  <small class="gem__version__date">- <%= nice_date_for(version.built_at) %></small>
+  <small class="gem__version__date">- <%= nice_date_for(version.created_at) %></small>
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -4,7 +4,7 @@
     <p><%= t('.not_hosted_notice') %></p>
   </div>
 <% else %>
-  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@rubygem.first_built_date)) %>:</h3>
+  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@rubygem.first_created_date)) %>:</h3>
   <div class="versions">
     <ul class="t-list__items">
       <%= render @versions %>

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -275,7 +275,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render info about the gem" do
       assert page.has_content?(@rubygem.name)
       assert page.has_content?(@latest_version.number)
-      css = "small:contains('#{@latest_version.built_at.to_date.to_formatted_s(:long)}')"
+      css = "small:contains('#{@latest_version.created_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
       assert page.has_content?("Links")
     end

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -109,7 +109,7 @@ class VersionsControllerTest < ActionController::TestCase
     should "render other versions" do
       assert page.has_content?("Versions")
       assert page.has_content?(@version.number)
-      css = "small:contains('#{@version.built_at.to_date.to_formatted_s(:long)}')"
+      css = "small:contains('#{@version.created_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
     end
     should "renders owner gems overview link" do

--- a/test/unit/helpers/pages_helper_test.rb
+++ b/test/unit/helpers/pages_helper_test.rb
@@ -27,13 +27,7 @@ class PagesHelperTest < ActionView::TestCase
     end
 
     should "return subtitle with release date and version number if both exist" do
-      assert_equal "v#{@version_last.number} - #{nice_date_for(@version_last.built_at)}", subtitle
-    end
-
-    should "return subtitle with release date and version number if built_at doesn't exist" do
-      @version_last.built_at = nil
-      @version_last.save
-      assert_equal "v#{@version_last.number}", subtitle
+      assert_equal "v#{@version_last.number} - #{nice_date_for(@version_last.created_at)}", subtitle
     end
   end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -118,14 +118,14 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.versions.most_recent
     end
 
-    should "can find when the first built date was" do
+    should "can find when the first created date was" do
       travel_to Time.zone.now do
-        create(:version, rubygem: @rubygem, number: "3.0.0", built_at: 1.day.ago)
-        create(:version, rubygem: @rubygem, number: "2.0.0", built_at: 2.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0", built_at: 3.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0.beta", built_at: 4.days.ago)
+        create(:version, rubygem: @rubygem, number: "3.0.0", created_at: 1.day.ago)
+        create(:version, rubygem: @rubygem, number: "2.0.0", created_at: 2.days.ago)
+        create(:version, rubygem: @rubygem, number: "1.0.0", created_at: 3.days.ago)
+        create(:version, rubygem: @rubygem, number: "1.0.0.beta", created_at: 4.days.ago)
 
-        assert_equal 4.days.ago.to_date, @rubygem.first_built_date.to_date
+        assert_equal 4.days.ago.to_date, @rubygem.first_created_date.to_date
       end
     end
 


### PR DESCRIPTION
It appears that `Version#built_at` isn't the most reliable date for when a version was published, see https://rubygems.org/gems/metadata-json-lint 

<img width="627" alt="screen shot 2016-11-18 at 8 47 02 pm" src="https://cloud.githubusercontent.com/assets/1060/20447433/af758372-add6-11e6-9603-6ed46074ddd3.png">

I already added `#created_at` to the API, this pr switches the last couple of instances of the view from using `built_at` to `created_at` and removes unused methods on `Rubygem`