### PR TITLE
Remove unnecessary purging of info cache

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -134,6 +134,5 @@ class Pusher
     gem_info = GemInfo.new(rubygem.name).compute_compact_index_info
     checksum = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
     version.update_attribute :info_checksum, checksum
-    Rails.cache.delete("info/#{rubygem.name}")
   end
 end


### PR DESCRIPTION
@dwradcliffe was right [here](https://github.com/rubygems/rubygems.org/pull/1466#issuecomment-267779450).
info cache is purged in `after_write` method using GemCachePurger.