### PR TITLE
Fixing profile updating

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,6 +6,10 @@ class PasswordsController < Clearance::PasswordsController
 
   private
 
+  def url_after_update
+    dashboard_path
+  end
+
   def password_params
     params.require(:password).permit(:email)
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -40,7 +40,7 @@ class ProfilesController < ApplicationController
   end
 
   def verify_password
-    return if current_user.authenticated?(params[:user][:password])
+    return if current_user.authenticated?(params[:user].delete(:password))
     flash[:notice] = t('.request_denied')
     redirect_to edit_profile_path
   end

--- a/lib/mailer_preview.rb
+++ b/lib/mailer_preview.rb
@@ -6,4 +6,8 @@ class MailerPreview < ActionMailer::Preview
   def email_confirmation
     Mailer.email_confirmation(User.last)
   end
+
+  def change_password
+    ClearanceMailer.change_password(User.last)
+  end
 end

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -126,6 +126,22 @@ class ProfilesControllerTest < ActionController::TestCase
           assert_equal "johndoe", @user.handle
         end
       end
+
+      context "updating with old format password" do
+        setup do
+          @handle = "updated_user"
+          @user = build(:user, handle: "old_user", password: "old")
+          @user.save(validate: false)
+          sign_in_as(@user)
+          put :update, user: { handle: @handle, password: @user.password }
+        end
+
+        should respond_with :redirect
+
+        should "update handle" do
+          assert_equal @handle, @user.handle
+        end
+      end
     end
   end
 

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -34,6 +34,7 @@ class PasswordResetTest < SystemTest
 
     fill_in "Password", with: "secret54321"
     click_button "Save this password"
+    assert_equal dashboard_path, page.current_path
 
     click_link "Sign out"
 


### PR DESCRIPTION
When updating profile info (like nickname) it pushed password info as well. That prevented updates if it's an old account with short password that doesn't pass current validation.

Fixes: #1517