### PR TITLE
Validate email confirmation on sign up and profile update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,14 +4,12 @@ class User < ActiveRecord::Base
   is_gravtastic default: "retro"
 
   PERMITTED_ATTRS = [
-    :bio,
     :email,
     :handle,
     :hide_email,
-    :location,
     :password,
-    :website,
-    :twitter_username
+    :twitter_username,
+    :email_confirmation
   ].freeze
 
   has_many :rubygems, through: :ownerships
@@ -40,6 +38,7 @@ class User < ActiveRecord::Base
 
   validates :twitter_username, length: { within: 0..20 }, allow_nil: true
   validates :password, length: { within: 10..200 }, allow_nil: true, unless: :skip_password_validation?
+  validates :email, confirmation: true, if: :email_changed?
 
   def self.authenticate(who, password)
     user = find_by(email: who.downcase) || find_by(handle: who)

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -40,6 +40,11 @@
     <%= form.email_field :email, :class => 'form__input' %>
   </div>
 
+  <div class="text_field">
+    <%= form.label :email_confirmation, :class => 'form__label' %>
+    <%= form.email_field :email_confirmation, :class => 'form__input' %>
+  </div>
+
   <p class='form__field__instructions'>
     <%= t('.enter_password') %>
   </p>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -5,6 +5,10 @@
   <%= form.email_field :email, :class => 'form__input' %>
 </div>
 <div class="text_field">
+  <%= form.label :email_confirmation, :class => 'form__label' %>
+  <%= form.email_field :email_confirmation, :class => 'form__input' %>
+</div>
+<div class="text_field">
   <%= form.label :handle, :class => 'form__label' %>
   <%= form.text_field :handle, :class => 'form__input' %>
 </div>

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -59,6 +59,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Email address", with: "nick2@example.com"
+    fill_in "Email confirmation", with: "nick2@example.com"
     fill_in "Password", with: "password12345"
     click_button "Update"
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -46,7 +46,8 @@ class SignInTest < SystemTest
   test "signing in with unconfirmed email" do
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Handle", with: "nick"
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -4,7 +4,8 @@ class SignUpTest < SystemTest
   test "sign up" do
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Handle", with: "nick"
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"
@@ -15,7 +16,8 @@ class SignUpTest < SystemTest
   test "sign up with no handle" do
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Password", with: "password"
     click_button "Sign up"
 
@@ -25,7 +27,8 @@ class SignUpTest < SystemTest
   test "sign up with bad handle" do
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Handle", with: "thisusernameiswaytoolongseriouslywaytoolong"
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"
@@ -37,7 +40,8 @@ class SignUpTest < SystemTest
     create(:user, handle: "nick")
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Handle", with: "nick"
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"
@@ -56,10 +60,34 @@ class SignUpTest < SystemTest
     assert page.has_content? "Sign up is temporarily disabled."
   end
 
-  test "email confirmation" do
+  test "sign up with no email confirmation" do
     visit sign_up_path
 
-    fill_in "Email", with: "email@person.com"
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Handle", with: "nick"
+    fill_in "Password", with: "secretpassword"
+    click_button "Sign up"
+
+    assert page.has_content? "Email confirmation doesn't match Email address"
+  end
+
+  test "sign up with mismatched email confirmation" do
+    visit sign_up_path
+
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email1@person.com"
+    fill_in "Handle", with: "nick"
+    fill_in "Password", with: "secretpassword"
+    click_button "Sign up"
+
+    assert page.has_content? "Email confirmation doesn't match Email address"
+  end
+
+  test "email verification" do
+    visit sign_up_path
+
+    fill_in "Email address", with: "email@person.com"
+    fill_in "Email confirmation", with: "email@person.com"
     fill_in "Handle", with: "nick"
     fill_in "Password", with: "secretpassword"
     click_button "Sign up"


### PR DESCRIPTION
Closes: #1512

Users will be required to retype their email in email confirmation field.
Sign up page - Profile update page
![screenshot from 2016-12-22 14-36-30](https://cloud.githubusercontent.com/assets/7680662/21420559/660a144e-c854-11e6-8261-7312771ef639.png)
