### PR TITLE
Store and display pusher of gem versions

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -37,15 +37,15 @@
 .gem__ghbtn {
     margin-bottom: 15px; }
 
-.gem__owners {
+.gem__gravatars {
   margin-top: 16px; }
-  .gem__owners img {
+  .gem__gravatars img {
     margin-right: 12px;
     margin-bottom: 12px;
     height: 32px;
     width: 32px;
     border-radius: 16px; }
-  .gem__owners a:hover:before {
+  .gem__gravatars a:hover:before {
     content: "";
     height: 32px;
     width: 32px;

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -39,34 +39,6 @@ module RubygemsHelper
     end
   end
 
-  def subscribe_link(rubygem)
-    if signed_in?
-      style = if rubygem.subscribers.find_by_id(current_user.id)
-                'display:none'
-              else
-                'display:inline-block'
-              end
-      link_to t('.links.subscribe'), rubygem_subscription_path(rubygem),
-        class: ['toggler', 'gem__link', 't-list__item'], id: 'subscribe',
-        method: :post, remote: true, style: style
-    else
-      link_to t('.links.subscribe'), sign_in_path,
-        class: [:toggler, 'gem__link', 't-list__item'], id: :subscribe
-    end
-  end
-
-  def unsubscribe_link(rubygem)
-    return unless signed_in?
-    style = if rubygem.subscribers.find_by_id(current_user.id)
-              'display:inline-block'
-            else
-              'display:none'
-            end
-    link_to t('.links.unsubscribe'), rubygem_subscription_path(rubygem),
-      class: [:toggler, 'gem__link', 't-list__item'], id: 'unsubscribe',
-      method: :delete, remote: true, style: style
-  end
-
   def atom_link(rubygem)
     link_to t(".links.rss"), rubygem_versions_path(rubygem, format: 'atom'),
       class: 'gem__link t-list__item', id: :rss
@@ -91,6 +63,12 @@ module RubygemsHelper
     report_abuse_url = 'http://help.rubygems.org/discussion/new' \
       "?discussion[private]=1&discussion[title]=" + encoded_title
     link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: 'gem__link t-list__item'
+  end
+
+  def link_to_pusher(handle)
+    user = User.find_by_slug!(handle)
+    link_to gravatar(48, "gravatar-#{user.id}", user), profile_path(user.display_id),
+      alt: handle, title: handle
   end
 
   def links_to_owners(rubygem)

--- a/app/helpers/rubygems_subscription_helper.rb
+++ b/app/helpers/rubygems_subscription_helper.rb
@@ -1,0 +1,29 @@
+module RubygemsSubscriptionHelper
+  def subscribe_link(rubygem)
+    if signed_in?
+      style = if rubygem.subscribers.find_by_id(current_user.id)
+                'display:none'
+              else
+                'display:inline-block'
+              end
+      link_to t('.links.subscribe'), rubygem_subscription_path(rubygem),
+        class: ['toggler', 'gem__link', 't-list__item'], id: 'subscribe',
+        method: :post, remote: true, style: style
+    else
+      link_to t('.links.subscribe'), sign_in_path,
+        class: [:toggler, 'gem__link', 't-list__item'], id: :subscribe
+    end
+  end
+
+  def unsubscribe_link(rubygem)
+    return unless signed_in?
+    style = if rubygem.subscribers.find_by_id(current_user.id)
+              'display:inline-block'
+            else
+              'display:none'
+            end
+    link_to t('.links.unsubscribe'), rubygem_subscription_path(rubygem),
+      class: [:toggler, 'gem__link', 't-list__item'], id: 'unsubscribe',
+      method: :delete, remote: true, style: style
+  end
+end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -82,7 +82,8 @@ class Pusher
     @version = @rubygem.versions.new number: spec.version.to_s,
                                      platform: spec.original_platform.to_s,
                                      size: size,
-                                     sha256: sha256
+                                     sha256: sha256,
+                                     pushed_by: user.handle
 
     true
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -150,6 +150,7 @@ class Rubygem < ActiveRecord::Base
       'version_downloads' => version.downloads_count,
       'platform'          => version.platform,
       'authors'           => version.authors,
+      'pushed_by'         => version.pushed_by,
       'info'              => version.info,
       'licenses'          => version.licenses,
       'metadata'          => version.metadata,

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -1,4 +1,11 @@
 <div class="gem__members">
+    <% if latest_version.pushed_by.present? %>
+      <h3 class="t-list__heading"><%= t '.publish_header' %>:</h3>
+      <div class="gem__gravatars">
+        <%= link_to_pusher(latest_version.pushed_by) %>
+      </div>
+    <% end %>
+
   <% if latest_version.authors.present? %>
     <h3 class="t-list__heading"><%= t '.authors_header' %>:</h3>
     <ul class="t-list__items">
@@ -10,7 +17,7 @@
 
   <% if rubygem.owners.present? %>
     <h3 class="t-list__heading"><%= t '.owners_header' %>:</h3>
-    <div class="gem__owners">
+    <div class="gem__gravatars">
       <%= links_to_owners(rubygem) %>
     </div>
   <% end %>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -4,7 +4,6 @@
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>
-
   <span class="gem__version__date">(<%= number_to_human_size(version.size) %>)</span>
   <% if version.yanked? -%>
     <span class="gem__version__date"><%= t '.yanked' %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
       title: 'Gems'
       downloads: Downloads
     gem_members:
+      publish_header: Published by
       authors_header: Authors
       owners_header: Owners
       sha_256_checksum: SHA 256 checksum

--- a/db/migrate/20161222090545_add_pushed_by_to_versions.rb
+++ b/db/migrate/20161222090545_add_pushed_by_to_versions.rb
@@ -1,0 +1,5 @@
+class AddPushedByToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :pushed_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160929104437) do
+ActiveRecord::Schema.define(version: 20161222090545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,6 +177,7 @@ ActiveRecord::Schema.define(version: 20160929104437) do
     t.string   "required_rubygems_version"
     t.string   "info_checksum"
     t.string   "yanked_info_checksum"
+    t.string   "pushed_by"
   end
 
   add_index "versions", ["built_at"], name: "index_versions_on_built_at", using: :btree


### PR DESCRIPTION
Closes #1421 .
Currently we don't store the user who pushed a particular gem version. This PR implements the said feature.
![publishedby](https://cloud.githubusercontent.com/assets/14155445/21447697/70232a2c-c8a6-11e6-88fe-f6ebcf7cf6cf.png)
