### PR TITLE
Cleaning up locale files and enforcing consistency

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,181 +1,24 @@
 de:
-  title: "RubyGems.org"
-  subtitle: "Ihre Community des Gem-Hostingservices"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "Zugriff verweigert. Bitte melden Sie sich unter https://rubygems.org mit einem Konto an"
-  feed_subscribed: "RubyGems.org | Abonnierte Gems"
-  feed_latest: "RubyGems.org | Neueste Gems"
-  time_ago: "seit %{duration}"
-  form_disable_with: "Bitte warten..."
-  update: Aktualisieren
   edit: Bearbeiten
-  sign_in: "Anmelden"
-  sign_up: "Registrieren"
-  locale_name: "Deutsch"
-  this_rubygem_could_not_be_found: "Dieses Ruby Gem konnte nicht gefunden werden."
-
-  dashboards:
-    show:
-      latest: "Letzte Aktualisierungen"
-      latest_title: "Neueste Aktualisierungen RSS Feed"
-      no_subscriptions: "Du hast noch keine Gems abonniert. Besuche %{gem_link} um das Gem zu abonnieren!"
-      gem_link_text: "Gem-Seite"
-      mine: "Meine Gems"
-      no_owned: "Du hast noch keine Gems gepusht. Schau doch vielleicht die Dokumentation auf %{creating_link} an und %{migrating_link} ein Gem from RubyForge."
-      creating_link_text: 'Erstellen'
-      migrating_link_text: 'Migrieren'
-      my_subscriptions: 'Abonnements'
-
-  home:
-    index:
-      downloads_counting: 'Gezählte Downloads'
-      find_blurb: "Finde, installiere und veröffentliche RubyGems."
-      learn:
-        install_rubygems: "Installiere RubyGems"
-
-  layouts:
-    application:
-      header:
-        dashboard: "Dashboard"
-        sign_in: "Anmelden"
-        sign_up: "Registrieren"
-        sign_out: "Abmelden"
-        search_gem: "Suche Gems&hellip;"
-      footer:
-        status: "Status"
-        uptime: "Betriebszeit"
-        source_code: "Code"
-        data: "Daten"
-        discussion_forum: "Diskussion"
-        statistics: "Statistiken"
-        blog: "Blog"
-        about: "Über uns"
-        help: "Hilfe"
-        guides: "Dokumentation"
-        contribute: "Beitragen"
-        supported_by: "Unterstützt von"
-        hosted_by: "Gehostet von"
-        designed_by: "Design von"
-        resolved_with: "Aufgelöst mit"
-        optimized_by: "Optimiert mit"
-        tracking_by: "Getrackt von"
-        monitored_by: "Überwacht von"
-        gems_served_by: "Gems angeboten von"
-
-  pages:
-    about:
-      title: Über uns
-      purpose:
-        header: "Willkommen in %{site}, die Community für Ruby Gem-Hostingservice. Die Gründe sind vielfältig:"
-        better_api: Bereitstellen eines besseren APIs für den Umgang mit Gems
-        transparent_pages: Erstellen transparenter und zugänglicher Projektseiten
-        enable_community: Der Gemeinschaft ermöglichen, die Webseite zu verbessern und zu erweitern
-      founding: "Das Projekt wurde im April 2009 von %{founder} gestartet und hat seitdem über %{contributors} und %{downloads}. Ab dem Release von RubyGems 1.3.6 wurde die Website von Gemcutter zu %{title} umbenannt, um eine zentrale Rolle in der Ruby-Community zu verfestigen."
-      support: "Obwohl RubyGems.org nicht von einem bestimmten Unternehmen ausgeführt wird, haben viele Unternehmen uns bereits unterstützt. Das aktuelle Design, die Illustrationen und die Front-End-Entwicklung für dieser Webseite wurden von %{dockyard} erstellt. %{github} hat auch von unschätzbarem Wert uns geholfen den Code mit anderen Entwicklern zuteilen, um an dem Code leichter zusammenarbeiten. Die Website wurde mit %{heroku} gestartet, dessen großen Dienst uns geholfen, RubyGems als eine praktikable Lösung zu erweisen, wo die ganze Gemeinschaft darauf verlassen kann. Our infrastructure is currently hosted on %{aws}."
-      technical: "Einige Einblicke in die technischen Aspekte dieser Webseite: Es ist 100% in Ruby geschrieben. Die Hauptseite ist verwendet die %{rails}-Software. Die Gems werden in %{s3}, served by %{fastly}, gehostet und die Zeit zwischen der Veröffentlichung eines neuen Gems und nachdem er bereit zur Installation freigegeben ist, ist minimal. Für mehr Informationen siehe %{source_code} (%{license}) auf GitHub."
-
-  passwords:
-    edit:
-      title: Zurücksetzen des Passworts
-      submit: Speichern dieses Passworts
-    new:
-      title: Ändere dein Passwort
-      will_email_notice: Wir senden dir einen Link damit du dein Passwort ändern kannst.
-      submit: Zurücksetzen des Passworts
-
-  profiles:
-    edit:
-      title: Bearbeite Profil
-      hide_email: Verberge E-Mails in öffentlichem Profil
-      reset_password:
-        title: Zurücksetzen des Passworts
-        text: "Brauchst du ein neues Passwort? Kein Problem. %{link}"
-        link_text: Jetzt ein neues Passwort zuschicken lassen.
-      api_access:
-        title: API-Zugang
-        key_is: "Dein API-Schlüssel ist %{key}."
-        credentials: "Wenn du %{gem_commands_link} über das Terminal oder über die Kommandozeile verwenden möchtest, dann brauchst du die %{gem_credentials_file}-Datei, die du mit dem folgenden Befehl erzeugen kannst:"
-        link_text: Gem-Befehle
-        reset: Zurücksetzen meines API-Schlüssels
-        confirm_reset: Sind Sie sicher? Das kann nicht rückgängig gemacht werden.
-
-  rubygems:
-    dependencies:
-      header: "%{title} Abhängigkeiten"
-    edit:
-      title: "Bearbeite Links"
-      subtitle: "für %{gem}"
-      other_fields_notice: Alle anderen Felder können nur durch eine gepushte, aktualisierte Version deines Gems bearbeitet werden.
-    index:
-      title: 'Gems'
-      downloads: Downloads
-    aside:
-      links:
-        header: Links
-        home: Startseite
-        code: Quellcode
-        docs: Dokumentation
-        wiki: Wiki
-        mail: Mailingliste
-        bugs: Bug Tracker
-        download: Download
-        subscribe: Abonniere
-        unsubscribe: Storniere
-        report_abuse: Missbrauch melden
-        badge: Abzeichen
-        rss: RSS
-      downloads_for_this_version: "Für diese Version"
-      bundler_header: Gemfile
-      copy_to_clipboard: In die Zwischenablage kopieren
-      copied: Kopiert!
-      install: installieren
-      required_ruby_version: Erforderliche Ruby-Version
-    show:
-      not_hosted_notice: Dieses Gem wird aktuell nicht auf RubyGems.org gehostet.
-      authors_header: Autoren
-      owners_header: Besitzer
-      versions_header: Versionen
-      show_all_versions: "Zeige alle Versionen (%{count} total)"
-      licenses_header: Lizenz
-      no_licenses: k.A.
-      requirements_header: Anforderungen
-      sha_256_checksum: SHA 256-Prüfsumme
-
-  searches:
-    show:
-      subtitle: "für %{query}"
-      exact_match: Exakte Übereinstimmung
-
-  sessions:
-    new:
-      forgot_password: "Passwort vergessen?"
-
-  stats:
-    index:
-      total_downloads: Downloads insgesamt
-      total_gems: Gems insgesamt
-      total_users: Benutzer insgesamt
-      all_time_most_downloaded: Am meisten Heruntergeladen in der gesamten Zeit
-
-  users:
-    new:
-      have_account: "Haben Sie schon einen Account?"
-
-  versions:
-    index:
-      title: "Alle Versionen von %{name}"
-      versions_since: "%{count} Versionen seit %{since}"
-      not_hosted_notice: Dieses Gem wird nicht gerade von RubyGems.org gehostet.
-    version:
-      yanked: "yanked"
-
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | Neueste Gems
+  feed_subscribed: RubyGems.org | Abonnierte Gems
+  footer_about:
+  form_disable_with: Bitte warten...
+  help_url: http://help.rubygems.org
+  locale_name: Deutsch
+  none:
+  not_found:
+  please_sign_up: Zugriff verweigert. Bitte melden Sie sich unter https://rubygems.org mit einem Konto an
+  sign_in: Anmelden
+  sign_up: Registrieren
+  subtitle: Ihre Community des Gem-Hostingservices
+  this_rubygem_could_not_be_found: Dieses Ruby Gem konnte nicht gefunden werden.
+  time_ago: seit %{duration}
+  title: RubyGems.org
+  update: Aktualisieren
   activerecord:
     attributes:
-      user:
-        avatar: Avatar
-        email: E-Mail-Adresse
-        handle: Benutzername
-        password: Passwort
       linkset:
         bugs: Bug Tracker URL
         code: Quellcode URL
@@ -183,22 +26,214 @@ de:
         mail: Mailingliste URL
         wiki: Wiki URL
       session:
-        who: E-Mail oder Benutzername
         password: Passwort
-
+        who: E-Mail oder Benutzername
+      user:
+        avatar: Avatar
+        email: E-Mail-Adresse
+        handle: Benutzername
+        password: Passwort
+  dashboards:
+    show:
+      creating_link_text: Erstellen
+      gem_link_text: Gem-Seite
+      latest: Letzte Aktualisierungen
+      latest_title: Neueste Aktualisierungen RSS Feed
+      migrating_link_text: Migrieren
+      mine: Meine Gems
+      my_subscriptions: Abonnements
+      no_owned: Du hast noch keine Gems gepusht. Schau doch vielleicht die Dokumentation auf %{creating_link} an und %{migrating_link} ein Gem from RubyForge.
+      no_subscriptions: Du hast noch keine Gems abonniert. Besuche %{gem_link} um das Gem zu abonnieren!
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
+  home:
+    index:
+      downloads_counting: Gezählte Downloads
+      find_blurb: Finde, installiere und veröffentliche RubyGems.
+      learn:
+        install_rubygems: Installiere RubyGems
+  layouts:
+    application:
+      footer:
+        about: Über uns
+        api: API
+        blog: Blog
+        contribute: Beitragen
+        data: Daten
+        designed_by: Design von
+        discussion_forum: Diskussion
+        gems_served_by: Gems angeboten von
+        guides: Dokumentation
+        help: Hilfe
+        hosted_by: Gehostet von
+        logging_by:
+        monitored_by: Überwacht von
+        optimized_by: Optimiert mit
+        resolved_with: Aufgelöst mit
+        security: Security
+        source_code: Code
+        statistics: Statistiken
+        status: Status
+        supported_by: Unterstützt von
+        tested_by:
+        tracking_by: Getrackt von
+        uptime: Betriebszeit
+      header:
+        dashboard: Dashboard
+        search_gem: Suche Gems&hellip;
+        sign_in: Anmelden
+        sign_out: Abmelden
+        sign_up: Registrieren
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
+  pages:
+    about:
+      founding: Das Projekt wurde im April 2009 von %{founder} gestartet und hat seitdem über %{contributors} und %{downloads}. Ab dem Release von RubyGems 1.3.6 wurde die Website von Gemcutter zu %{title} umbenannt, um eine zentrale Rolle in der Ruby-Community zu verfestigen.
+      support: Obwohl RubyGems.org nicht von einem bestimmten Unternehmen ausgeführt wird, haben viele Unternehmen uns bereits unterstützt. Das aktuelle Design, die Illustrationen und die Front-End-Entwicklung für dieser Webseite wurden von %{dockyard} erstellt. %{github} hat auch von unschätzbarem Wert uns geholfen den Code mit anderen Entwicklern zuteilen, um an dem Code leichter zusammenarbeiten. Die Website wurde mit %{heroku} gestartet, dessen großen Dienst uns geholfen, RubyGems als eine praktikable Lösung zu erweisen, wo die ganze Gemeinschaft darauf verlassen kann. Our infrastructure is currently hosted on %{aws}.
+      technical: 'Einige Einblicke in die technischen Aspekte dieser Webseite: Es ist 100% in Ruby geschrieben. Die Hauptseite ist verwendet die %{rails}-Software. Die Gems werden in %{s3}, served by %{fastly}, gehostet und die Zeit zwischen der Veröffentlichung eines neuen Gems und nachdem er bereit zur Installation freigegeben ist, ist minimal. Für mehr Informationen siehe %{source_code} (%{license}) auf GitHub.'
+      title: Über uns
+      purpose:
+        better_api: Bereitstellen eines besseren APIs für den Umgang mit Gems
+        enable_community: Der Gemeinschaft ermöglichen, die Webseite zu verbessern und zu erweitern
+        header: 'Willkommen in %{site}, die Community für Ruby Gem-Hostingservice. Die Gründe sind vielfältig:'
+        transparent_pages: Erstellen transparenter und zugänglicher Projektseiten
+  passwords:
+    edit:
+      submit: Speichern dieses Passworts
+      title: Zurücksetzen des Passworts
+    new:
+      submit: Zurücksetzen des Passworts
+      title: Ändere dein Passwort
+      will_email_notice: Wir senden dir einen Link damit du dein Passwort ändern kannst.
+  profiles:
+    edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Verberge E-Mails in öffentlichem Profil
+      optional_twitter_username:
+      title: Bearbeite Profil
+      api_access:
+        confirm_reset: Sind Sie sicher? Das kann nicht rückgängig gemacht werden.
+        credentials: 'Wenn du %{gem_commands_link} über das Terminal oder über die Kommandozeile verwenden möchtest, dann brauchst du die %{gem_credentials_file}-Datei, die du mit dem folgenden Befehl erzeugen kannst:'
+        key_is: Dein API-Schlüssel ist %{key}.
+        link_text: Gem-Befehle
+        reset: Zurücksetzen meines API-Schlüssels
+        title: API-Zugang
+      reset_password:
+        link_text: Jetzt ein neues Passwort zuschicken lassen.
+        text: Brauchst du ein neues Passwort? Kein Problem. %{link}
+        title: Zurücksetzen des Passworts
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied: Kopiert!
+      copy_to_clipboard: In die Zwischenablage kopieren
+      downloads_for_this_version: Für diese Version
+      install: installieren
+      required_ruby_version: Erforderliche Ruby-Version
+      required_rubygems_version:
+      links:
+        badge: Abzeichen
+        bugs: Bug Tracker
+        code: Quellcode
+        docs: Dokumentation
+        download: Download
+        header: Links
+        home: Startseite
+        mail: Mailingliste
+        report_abuse: Missbrauch melden
+        reverse_dependencies: Reverse dependencies
+        rss: RSS
+        subscribe: Abonniere
+        unsubscribe: Storniere
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
+    dependencies:
+      header: "%{title} Abhängigkeiten"
+    edit:
+      other_fields_notice: Alle anderen Felder können nur durch eine gepushte, aktualisierte Version deines Gems bearbeitet werden.
+      subtitle: für %{gem}
+      title: Bearbeite Links
+    gem_members:
+      authors_header: Autoren
+      owners_header: Besitzer
+      sha_256_checksum: SHA 256-Prüfsumme
+    index:
+      downloads: Downloads
+      title: Gems
+    show:
+      licenses_header: Lizenz
+      no_licenses: k.A.
+      requirements_header: Anforderungen
+      show_all_versions: Zeige alle Versionen (%{count} total)
+      versions_header: Versionen
+      yanked_notice:
+    show_yanked:
+      not_hosted_notice: Dieses Gem wird aktuell nicht auf RubyGems.org gehostet.
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
+  searches:
+    show:
+      exact_match: Exakte Übereinstimmung
+      subtitle: für %{query}
+  sessions:
+    new:
+      forgot_password: Passwort vergessen?
+      resend_confirmation:
+  stats:
+    index:
+      all_time_most_downloaded: Am meisten Heruntergeladen in der gesamten Zeit
+      total_downloads: Downloads insgesamt
+      total_gems: Gems insgesamt
+      total_users: Benutzer insgesamt
+  users:
+    create:
+      email_sent:
+    new:
+      have_account: Haben Sie schon einen Account?
+  versions:
+    index:
+      not_hosted_notice: Dieses Gem wird nicht gerade von RubyGems.org gehostet.
+      title: Alle Versionen von %{name}
+      versions_since: "%{count} Versionen seit %{since}"
+    version:
+      yanked:
   will_paginate:
-    previous_label: "Zurück"
-    next_label: "Nächstes"
+    next_label: Nächstes
     page_gap: "…"
+    previous_label: Zurück
     page_entries_info:
+      multi_page: Zeige %{model} %{from} - %{to} von %{count} insgesamt
+      multi_page_html: Zeige %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> von <b>%{count}</b> insgesamt
       single_page:
-        zero:  "Kein %{model} gefunden"
-        one:   "Zeige 1 %{model}"
-        other: "Zeige alle %{count} %{model}"
+        one: Zeige 1 %{model}
+        other: Zeige alle %{count} %{model}
+        zero: Kein %{model} gefunden
       single_page_html:
-        zero:  "Kein %{model} gefunden"
-        one:   "Zeige <b>1</b> %{model}"
-        other: "Zeige <b>alle&nbsp;%{count}</b> %{model}"
-
-      multi_page: "Zeige %{model} %{from} - %{to} von %{count} insgesamt"
-      multi_page_html: "Zeige %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> von <b>%{count}</b> insgesamt"
+        one: Zeige <b>1</b> %{model}
+        other: Zeige <b>alle&nbsp;%{count}</b> %{model}
+        zero: Kein %{model} gefunden

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,217 +1,24 @@
 en:
-  title: "RubyGems.org"
-  subtitle: "your community gem host"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "Access Denied. Please sign up for an account at https://rubygems.org"
-  feed_subscribed: "RubyGems.org | Subscribed Gems"
-  feed_latest: "RubyGems.org | Latest Gems"
-  time_ago: "%{duration} ago"
-  form_disable_with: "Please wait..."
-  update: Update
   edit: Edit
-  sign_in: "Sign in"
-  sign_up: "Sign up"
-  footer_about: 'RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.'
-  locale_name: "English"
-  this_rubygem_could_not_be_found: "This rubygem could not be found."
-  not_found: "Not Found"
   failure_when_forbidden: Please double check the URL or try submitting it again.
+  feed_latest: RubyGems.org | Latest Gems
+  feed_subscribed: RubyGems.org | Subscribed Gems
+  footer_about: RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
+  form_disable_with: Please wait...
+  help_url: http://help.rubygems.org
+  locale_name: English
   none: None
-
-  dashboards:
-    show:
-      latest: "Latest Updates"
-      latest_title: "Latest Updates RSS Feed"
-      no_subscriptions: "You're not subscribed to any gems yet. Visit a %{gem_link} to subscribe to one!"
-      gem_link_text: "gem page"
-      mine: "My Gems"
-      no_owned: "You haven't pushed any gems yet. Perhaps check out the guides on %{creating_link} a gem or %{migrating_link} a gem from RubyForge."
-      creating_link_text: 'creating'
-      migrating_link_text: 'migrating'
-      my_subscriptions: 'Subscriptions'
-
-  home:
-    index:
-      downloads_counting: 'downloads &amp; counting'
-      find_blurb: "Find, install, and publish RubyGems."
-      learn:
-        install_rubygems: "Install RubyGems"
-
-  layouts:
-    application:
-      header:
-        dashboard: "Dashboard"
-        sign_in: "Sign in"
-        sign_up: "Sign up"
-        sign_out: "Sign out"
-        search_gem: "Search Gems&hellip;"
-      footer:
-        status: "Status"
-        uptime: "Uptime"
-        source_code: "Code"
-        data: "Data"
-        discussion_forum: "Discuss"
-        statistics: "Stats"
-        blog: "Blog"
-        about: "About"
-        help: "Help"
-        api: "API"
-        guides: "Guides"
-        contribute: "Contribute"
-        security: "Security"
-        supported_by: "Supported by"
-        hosted_by: "Hosted by"
-        designed_by: "Designed by"
-        resolved_with: "Resolved with"
-        optimized_by: "Optimized by"
-        tracking_by: "Tracking by"
-        monitored_by: "Monitored by"
-        gems_served_by: "Gems served by"
-        logging_by: "Logging by"
-        tested_by: "Tested by"
-
-  pages:
-    about:
-      title: About
-      purpose:
-        header: "Welcome to %{site}, the Ruby community's gem hosting service. The purpose of this project is three-fold:"
-        better_api: Provide a better API for dealing with gems
-        transparent_pages: Create more transparent and accessible project pages
-        enable_community: Enable the community to improve and enhance the site
-      founding: "The project was started in April 2009 by %{founder}, and has since grown to include the contributions of over %{contributors} and %{downloads}. As of the RubyGems 1.3.6 release, the site has been renamed to %{title} from Gemcutter to solidify the site's central role in the Ruby community."
-      support: "Although RubyGems.org is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove RubyGems as a viable solution that the whole community could rely on. Our infrastructure is currently hosted on %{aws}."
-      technical: "Some insights into the technical aspects of the site: It's 100% Ruby. The main site is a %{rails} application. Gems are hosted on %{s3}, served by %{fastly}, and the time between publishing a new gem and having it ready for installation is usually just a few seconds. For more info, %{source_code}, which is %{license} over at GitHub."
-
-  passwords:
-    edit:
-      title: Reset password
-      submit: Save this password
-    new:
-      title: Change your password
-      will_email_notice: We will email you a link to change your password.
-      submit: Reset password
-
-  profiles:
-    edit:
-      title: Edit profile
-      email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
-      hide_email: Hide email in public profile
-      optional_twitter_username: Optional Twitter username. Will be displayed publicly
-      enter_password: Please enter your account's password
-      reset_password:
-        title: Reset password
-        text: "Need a new password? No problem. %{link}"
-        link_text: Request a new one here.
-      api_access:
-        title: API Access
-        key_is: "Your API key is %{key}."
-        credentials: "If you want to use %{gem_commands_link} from the command line, you'll need a %{gem_credentials_file} file, which you can generate using the following command:"
-        link_text: gem commands
-        reset: Reset my API key
-        confirm_reset: Are you sure? This cannot be undone.
-    update:
-      confirmation_mail_sent: You will receive an email within the next few minutes. It contains instructions for confirming your new email address.
-      updated: Your profile was updated.
-      request_denied: This request was denied. We could not verify your password.
-
-  rubygems:
-    blacklisted:
-      blacklisted_namespace: This namespace is reserved by rubygems.org.
-    dependencies:
-      header: "%{title} Dependencies"
-    edit:
-      title: "Edit links"
-      subtitle: "for %{gem}"
-      other_fields_notice: All other fields can only be edited by pushing an updated version of your gem.
-    index:
-      title: 'Gems'
-      downloads: Downloads
-    gem_members:
-      authors_header: Authors
-      owners_header: Owners
-      sha_256_checksum: SHA 256 checksum
-    show_yanked:
-      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
-      reserved_namespace:
-        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
-             If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
-        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/>
-               If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
-    aside:
-      links:
-        header: Links
-        home: Homepage
-        code: Source Code
-        docs: Documentation
-        wiki: Wiki
-        mail: Mailing List
-        bugs: Bug Tracker
-        download: Download
-        subscribe: Subscribe
-        unsubscribe: Unsubscribe
-        report_abuse: Report Abuse
-        badge: Badge
-        rss: RSS
-        reverse_dependencies: Reverse dependencies
-      downloads_for_this_version: "For this version"
-      bundler_header: Gemfile
-      copy_to_clipboard: Copy to clipboard
-      copied: Copied!
-      install: install
-      required_ruby_version: Required Ruby Version
-      required_rubygems_version: Required Rubygems Version
-    show:
-      yanked_notice: "This version has been yanked, and it is not available for download directly or for other gems that may have depended on it."
-      versions_header: Versions
-      show_all_versions: "Show all versions (%{count} total)"
-      licenses_header: License
-      no_licenses: N/A
-      requirements_header: Requirements
-
-  reverse_dependencies:
-    index:
-      title: "Reverse dependencies for %{name}"
-    reverse_dependencies:
-      search_reverse_dependencies: "Search reverse dependencies Gems&hellip;"
-
-  searches:
-    show:
-      subtitle: "for %{query}"
-      exact_match: Exact match
-
-  sessions:
-    new:
-      forgot_password: "Forgot password?"
-      resend_confirmation: Didn't receive confirmation mail?
-
-  stats:
-    index:
-      total_downloads: Total downloads
-      total_gems: Total gems
-      total_users: Total users
-      all_time_most_downloaded: All Time Most Downloaded
-
-  users:
-    new:
-      have_account: "Already have an account?"
-    create:
-      email_sent: A confirmation mail has been sent to your email address.
-
-  versions:
-    index:
-      title: "All versions of %{name}"
-      versions_since: "%{count} versions since %{since}"
-      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
-    version:
-      yanked: "yanked"
-
+  not_found: Not Found
+  please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
+  sign_in: Sign in
+  sign_up: Sign up
+  subtitle: your community gem host
+  this_rubygem_could_not_be_found: This rubygem could not be found.
+  time_ago: "%{duration} ago"
+  title: RubyGems.org
+  update: Update
   activerecord:
     attributes:
-      user:
-        avatar: Avatar
-        email: Email address
-        handle: Handle
-        password: Password
       linkset:
         bugs: Bug Tracker URL
         code: Source Code URL
@@ -219,43 +26,214 @@ en:
         mail: Mailing List URL
         wiki: Wiki URL
       session:
-        who: Email or Handle
         password: Password
-
-  will_paginate:
-    previous_label: "Previous"
-    next_label: "Next"
-    page_gap: "…"
-    page_entries_info:
-      single_page:
-        zero:  "No %{model} found"
-        one:   "Displaying 1 %{model}"
-        other: "Displaying all %{count} %{model}"
-      single_page_html:
-        zero:  "No %{model} found"
-        one:   "Displaying <b>1</b> %{model}"
-        other: "Displaying <b>all&nbsp;%{count}</b> %{model}"
-
-      multi_page: "Displaying %{model} %{from} - %{to} of %{count} in total"
-      multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total"
-
-  mailer:
-    confirmation_subject: Please confirm your email address with RubyGems.org
-    confirm_your_email: Please confirm your email address with the link sent to you email.
-    email_confirmation:
-      welcome_message: Welcome to RubyGems.org! Click the link below to verify your email.
-      confirmation_link: Confirm email address
-    email_reset:
-      visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
-
+        who: Email or Handle
+      user:
+        avatar: Avatar
+        email: Email address
+        handle: Handle
+        password: Password
+  dashboards:
+    show:
+      creating_link_text: creating
+      gem_link_text: gem page
+      latest: Latest Updates
+      latest_title: Latest Updates RSS Feed
+      migrating_link_text: migrating
+      mine: My Gems
+      my_subscriptions: Subscriptions
+      no_owned: You haven't pushed any gems yet. Perhaps check out the guides on %{creating_link} a gem or %{migrating_link} a gem from RubyForge.
+      no_subscriptions: You're not subscribed to any gems yet. Visit a %{gem_link} to subscribe to one!
   email_confirmations:
-    update:
-      confirmed_email: Your email address has been verified.
-    new:
-      title: Resend confirmation email
-      will_email_notice: We will email you confirmation link to activate your account.
-      submit: Resend Confirmation
     create:
       promise_resend: We will email you confirmation link to activate your account if one exists.
+    new:
+      submit: Resend Confirmation
+      title: Resend confirmation email
+      will_email_notice: We will email you confirmation link to activate your account.
     unconfirmed_email:
-      try_again: "Something went wrong. Please try again."
+      try_again: Something went wrong. Please try again.
+    update:
+      confirmed_email: Your email address has been verified.
+  home:
+    index:
+      downloads_counting: downloads &amp; counting
+      find_blurb: Find, install, and publish RubyGems.
+      learn:
+        install_rubygems: Install RubyGems
+  layouts:
+    application:
+      footer:
+        about: About
+        api: API
+        blog: Blog
+        contribute: Contribute
+        data: Data
+        designed_by: Designed by
+        discussion_forum: Discuss
+        gems_served_by: Gems served by
+        guides: Guides
+        help: Help
+        hosted_by: Hosted by
+        logging_by: Logging by
+        monitored_by: Monitored by
+        optimized_by: Optimized by
+        resolved_with: Resolved with
+        security: Security
+        source_code: Code
+        statistics: Stats
+        status: Status
+        supported_by: Supported by
+        tested_by: Tested by
+        tracking_by: Tracking by
+        uptime: Uptime
+      header:
+        dashboard: Dashboard
+        search_gem: Search Gems&hellip;
+        sign_in: Sign in
+        sign_out: Sign out
+        sign_up: Sign up
+  mailer:
+    confirm_your_email: Please confirm your email address with the link sent to you email.
+    confirmation_subject: Please confirm your email address with RubyGems.org
+    email_confirmation:
+      confirmation_link: Confirm email address
+      welcome_message: Welcome to RubyGems.org! Click the link below to verify your email.
+    email_reset:
+      visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
+  pages:
+    about:
+      founding: The project was started in April 2009 by %{founder}, and has since grown to include the contributions of over %{contributors} and %{downloads}. As of the RubyGems 1.3.6 release, the site has been renamed to %{title} from Gemcutter to solidify the site's central role in the Ruby community.
+      support: Although RubyGems.org is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove RubyGems as a viable solution that the whole community could rely on. Our infrastructure is currently hosted on %{aws}.
+      technical: 'Some insights into the technical aspects of the site: It''s 100% Ruby. The main site is a %{rails} application. Gems are hosted on %{s3}, served by %{fastly}, and the time between publishing a new gem and having it ready for installation is usually just a few seconds. For more info, %{source_code}, which is %{license} over at GitHub.'
+      title: About
+      purpose:
+        better_api: Provide a better API for dealing with gems
+        enable_community: Enable the community to improve and enhance the site
+        header: 'Welcome to %{site}, the Ruby community''s gem hosting service. The purpose of this project is three-fold:'
+        transparent_pages: Create more transparent and accessible project pages
+  passwords:
+    edit:
+      submit: Save this password
+      title: Reset password
+    new:
+      submit: Reset password
+      title: Change your password
+      will_email_notice: We will email you a link to change your password.
+  profiles:
+    edit:
+      email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
+      enter_password: Please enter your account's password
+      hide_email: Hide email in public profile
+      optional_twitter_username: Optional Twitter username. Will be displayed publicly
+      title: Edit profile
+      api_access:
+        confirm_reset: Are you sure? This cannot be undone.
+        credentials: 'If you want to use %{gem_commands_link} from the command line, you''ll need a %{gem_credentials_file} file, which you can generate using the following command:'
+        key_is: Your API key is %{key}.
+        link_text: gem commands
+        reset: Reset my API key
+        title: API Access
+      reset_password:
+        link_text: Request a new one here.
+        text: Need a new password? No problem. %{link}
+        title: Reset password
+    update:
+      confirmation_mail_sent: You will receive an email within the next few minutes. It contains instructions for confirming your new email address.
+      request_denied: This request was denied. We could not verify your password.
+      updated: Your profile was updated.
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied: Copied!
+      copy_to_clipboard: Copy to clipboard
+      downloads_for_this_version: For this version
+      install: install
+      required_ruby_version: Required Ruby Version
+      required_rubygems_version: Required Rubygems Version
+      links:
+        badge: Badge
+        bugs: Bug Tracker
+        code: Source Code
+        docs: Documentation
+        download: Download
+        header: Links
+        home: Homepage
+        mail: Mailing List
+        report_abuse: Report Abuse
+        reverse_dependencies: Reverse dependencies
+        rss: RSS
+        subscribe: Subscribe
+        unsubscribe: Unsubscribe
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace: This namespace is reserved by rubygems.org.
+    dependencies:
+      header: "%{title} Dependencies"
+    edit:
+      other_fields_notice: All other fields can only be edited by pushing an updated version of your gem.
+      subtitle: for %{gem}
+      title: Edit links
+    gem_members:
+      authors_header: Authors
+      owners_header: Owners
+      sha_256_checksum: SHA 256 checksum
+    index:
+      downloads: Downloads
+      title: Gems
+    show:
+      licenses_header: License
+      no_licenses: N/A
+      requirements_header: Requirements
+      show_all_versions: Show all versions (%{count} total)
+      versions_header: Versions
+      yanked_notice: This version has been yanked, and it is not available for download directly or for other gems that may have depended on it.
+    show_yanked:
+      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
+      reserved_namespace:
+        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+  reverse_dependencies:
+    index:
+      title: "Reverse dependencies for %{name}"
+  searches:
+    show:
+      exact_match: Exact match
+      subtitle: for %{query}
+  sessions:
+    new:
+      forgot_password: Forgot password?
+      resend_confirmation: Didn't receive confirmation mail?
+  stats:
+    index:
+      all_time_most_downloaded: All Time Most Downloaded
+      total_downloads: Total downloads
+      total_gems: Total gems
+      total_users: Total users
+  users:
+    create:
+      email_sent: A confirmation mail has been sent to your email address.
+    new:
+      have_account: Already have an account?
+  versions:
+    index:
+      not_hosted_notice: This gem is not currently hosted on RubyGems.org.
+      title: All versions of %{name}
+      versions_since: "%{count} versions since %{since}"
+    version:
+      yanked: yanked
+  will_paginate:
+    next_label: Next
+    page_gap: "…"
+    previous_label: Previous
+    page_entries_info:
+      multi_page: Displaying %{model} %{from} - %{to} of %{count} in total
+      multi_page_html: Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total
+      single_page:
+        one: Displaying 1 %{model}
+        other: Displaying all %{count} %{model}
+        zero: No %{model} found
+      single_page_html:
+        one: Displaying <b>1</b> %{model}
+        other: Displaying <b>all&nbsp;%{count}</b> %{model}
+        zero: No %{model} found

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,22 @@
 es:
+  edit: Editar
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | Gemas Nuevas
+  feed_subscribed: RubyGems.org | Subscripciones de Gemas
+  footer_about: RubyGems.org es el servicio de alojamiento de gemas de la comunidad de Ruby. Publica tus gemas de manera instantánea e instalalas. Usa la API para interactuar y buscar información de las gemas disponibles. Conviértete en contribuidor y mejora este sitio con tus cambios.
+  form_disable_with: Un momento por favor...
+  help_url: http://help.rubygems.org
+  locale_name: Español
+  none:
+  not_found:
+  please_sign_up: Acceso negado. Por favor, primero crea una cuenta en https://rubygems.org
+  sign_in: Ingresar
+  sign_up: Registro
+  subtitle: alojamiento de gemas para la comunidad
+  this_rubygem_could_not_be_found: La gema no ha sido encontrada.
+  time_ago: hace %{duration}
+  title: RubyGems.org
+  update: Actualizar
   activerecord:
     attributes:
       linkset:
@@ -15,66 +33,34 @@ es:
         email: Dirección email
         handle: Usuario
         password: Contraseña
-    errors:
-      messages:
-        record_invalid:
-      models:
-      template:
-        body:
-        header:
   dashboards:
     show:
       creating_link_text: crear
       gem_link_text: página de alguna gema
-      latest: "Últimas Actualizaciones"
+      latest: Últimas Actualizaciones
       latest_title: Feed RSS con últimas actualizaciones
       migrating_link_text: migrar
       mine: Mis Gemas
       my_subscriptions: Subscripciones
       no_owned: Aún no has registrado ninguna gema. Tal vez puedes revisar las guías para %{creating_link} una gema o %{migrating_link} una gema de RubyForge.
       no_subscriptions: Aún no te has subscrito a ningua gema. ¡Visita la %{gem_link} para subscribirte!
-  download_count:
-  edit: Editar
-  feed_latest: RubyGems.org | Gemas Nuevas
-  feed_subscribed: RubyGems.org | Subscripciones de Gemas
-  flashes:
-    failure_after_create:
-  footer_about: RubyGems.org es el servicio de alojamiento de gemas de la comunidad de Ruby. Publica tus gemas de manera instantánea e instalalas. Usa la API para interactuar y buscar información de las gemas disponibles. Conviértete en contribuidor y mejora este sitio con tus cambios.
-  form_disable_with: Un momento por favor...
-  help_url: http://help.rubygems.org
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
   home:
     index:
       downloads_counting: descargas y contando
       find_blurb: Encuentra, instala, y publica RubyGems.
-      footer:
-        status: Estado
-        uptime:
-      gems_header:
-      leaderboards:
-        downloaded:
-        header:
-        new:
-        no_downloaded:
-        updated:
       learn:
-        browse_docs:
-        docs_subtitle:
-        gem_specification:
-        header:
         install_rubygems: Instalar RubyGems
-        rubygems_subtitle:
-        spec_subtitle:
-      pitch:
-        api:
-        content:
-        contribute:
-        publish:
-      share:
-        build:
-        deploy:
-        header:
-        update:
-      welcome_blurb:
   layouts:
     application:
       footer:
@@ -89,39 +75,43 @@ es:
         guides: Guías
         help: Ayuda
         hosted_by: Alojamiento
-        mobile:
+        logging_by:
         monitored_by: Monitoreo
         optimized_by: Optimización
         resolved_with: DNS
+        security: Security
         source_code: Código fuente
         statistics: Estadísticas
         status: Estado
         supported_by: Soporte
+        tested_by:
         tracking_by: Rastreo
         uptime: Uptime
       header:
-        all_gems:
         dashboard: Dashboard
         search_gem: Buscar gemas&hellip;
         sign_in: Ingresar
         sign_out: Cerrar sesión
         sign_up: Registro
-  locale_name: Español
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
   pages:
     about:
       founding: El proyecto comenzó en Abril del 2009 por %{founder}, y desde entonces ha crecido para incluir las contribuciones de %{contributors} y %{downloads}. A partir de RubyGems 1.3.6 el sitio se renombró de Gemcutter a %{title} para hacer más claro el rol del mismo en la comunidad de Ruby.
+      support: A pesar de que Gemcutter no es mantenido por una compañía en específico, muchas de ellas nos han ayudado. El diseño actual, las ilustraciones y el desarrollo de front-end del sitio fue cortesía de %{dockyard}. %{github} también ha sido invaluable por ayudarnos a colaborar y compartir código de manera sencilla. El sitio comenzó en %{heroku}, cuyo excelente servicio ayudó a probar que Gemcutter es una solución viable en la que toda la comunidad puede confiar. Our infrastructure is currently hosted on %{aws}.
+      technical: 'Algunos aspectos técnicos del sitio: Es 100% Ruby. El sitio principal es una aplicación de %{rails}. Las gemas se almacenan en %{s3}, served by %{fastly}, y el tiempo entre que se publica una gema y que está lista para instalarse es mínimo. Para más información, %{source_code}, cuya licencia es %{license} en GitHub.'
+      title: Acerca de
       purpose:
         better_api: Otorgar una mejor API para manejar las gemas
         enable_community: Permitirle a la comunidad contribuir para mejorar este sitio
         header: 'Bienvenido a %{site}, el servicio de alojamiento de gemas para la comunidad de Ruby. Este proyecto tiene 3 objetivos:'
         transparent_pages: Crear páginas de proyecto más accesibles y transparentes
-      subtitle:
-      support: A pesar de que Gemcutter no es mantenido por una compañía en específico, muchas de ellas nos han ayudado. El diseño actual, las ilustraciones y el desarrollo de front-end del sitio fue cortesía de %{dockyard}. %{github} también ha sido invaluable por ayudarnos a colaborar y compartir código de manera sencilla. El sitio comenzó en %{heroku}, cuyo excelente servicio ayudó a probar que Gemcutter es una solución viable en la que toda la comunidad puede confiar. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Algunos aspectos técnicos del sitio: Es 100% Ruby. El sitio principal es una aplicación de %{rails}. Las gemas se almacenan en %{s3}, served by %{fastly}, y el tiempo entre que se publica una gema y que está lista para instalarse es mínimo. Para más información, %{source_code}, cuya licencia es %{license} en GitHub.'
-      title: Acerca de
-    create:
-      notice:
-      title:
   passwords:
     edit:
       submit: Guardar esta contraseña
@@ -130,9 +120,13 @@ es:
       submit: Reestablecer contraseña
       title: Cambiar contraseña
       will_email_notice: Te enviaremos un email con un enlace para cambiar tu contraseña.
-  please_sign_up: Acceso negado. Por favor, primero crea una cuenta en https://rubygems.org
   profiles:
     edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Esconder email en perfil público
+      optional_twitter_username:
+      title: Editar perfil
       api_access:
         confirm_reset: "¿Estás seguro? Este cambio no puede deshacerse."
         credentials: 'Si quieres usar %{gem_commands_link} desde la línea de comandos, vas a necesitar un archivo llamado %{gem_credentials_file}, el cual puedes generar usando el siguiente comando:'
@@ -140,49 +134,68 @@ es:
         link_text: comandos de gem
         reset: Reestablecer llave API
         title: Acceso a API
-      change: Cambiar
-      hide_email: Esconder email en perfil público
       reset_password:
         link_text: Pide una nueva aquí.
         text: "¿Necesitas otra contraseña? No hay problema. %{link}"
         title: Reestablecer contraseña
-      title: Editar perfil
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
   rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied:
+      copy_to_clipboard:
+      downloads_for_this_version: Para esta versión
+      install: instalar
+      required_ruby_version:
+      required_rubygems_version:
+      links:
+        badge: Badge
+        bugs: Registro de bugs
+        code: Código fuente
+        docs: Documentación
+        download: Descargar
+        header: Enlaces
+        home: Sitio
+        mail: Lista de correo
+        report_abuse: Reportar abuso
+        reverse_dependencies:
+        rss: RSS
+        subscribe: Suscribirse
+        unsubscribe: Unsubscribe
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
     dependencies:
       header: dependencias de %{title}
     edit:
       other_fields_notice: Los otros campos solo pueden ser editados al envíar una versión nueva de tu gema.
       subtitle: para %{gem}
       title: Editar ligas
-    index:
-      subtitle:
-      title: Gemas
-    aside:
-      links:
-        header: Enlaces
-        home: Sitio
-        code: Código fuente
-        docs: Documentación
-        wiki: Wiki
-        mail: Lista de correo
-        bugs: Registro de bugs
-        download: Descargar
-        subscribe: Suscribirse
-        report_abuse: Reportar abuso
-      downloads_for_this_version: Para esta versión
-      bundler_header: Gemfile
-      install: instalar
-    show:
+    gem_members:
       authors_header: Autores
+      owners_header: Administradores
+      sha_256_checksum: SHA 256 checksum
+    index:
+      downloads: Downloads
+      title: Gemas
+    show:
       licenses_header: Licencia
       no_licenses: N/D
-      not_hosted_notice: Esta gema no se encuentra alojada en Gemcutter.
-      owners_header: Administradores
       requirements_header: Requerimientos
       show_all_versions: Muestra todas las versiones (%{count} total)
-      stats_header:
       versions_header: Versiones
       yanked_notice: Esta gema ya no está disponible para descarga directa o para otras gemas que dependan de ella.
+    show_yanked:
+      not_hosted_notice: Esta gema no se encuentra alojada en Gemcutter.
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
   searches:
     show:
       exact_match: Resultado exacto
@@ -190,25 +203,16 @@ es:
   sessions:
     new:
       forgot_password: "¿Olvidaste tu contraseña?"
-  sign_in: Ingresar
-  sign_up: Registro
+      resend_confirmation:
   stats:
     index:
-      gem_count:
-      user_count:
-    show:
-      current_rank:
-      daily_downloads:
-      for:
-      overview:
-      total_downloads: Descargas totales
-  subtitle: alojamiento de gemas para la comunidad
-  this_rubygem_could_not_be_found: La gema no ha sido encontrada.
-  time_ago: hace %{duration}
-  title: RubyGems.org
-  update: Actualizar
-  url:
+      all_time_most_downloaded:
+      total_downloads:
+      total_gems:
+      total_users:
   users:
+    create:
+      email_sent:
     new:
       have_account: "¿Ya estás registrado?"
   versions:
@@ -218,3 +222,18 @@ es:
       versions_since: "%{count} versiones desde %{since}"
     version:
       yanked: eliminada
+  will_paginate:
+    next_label:
+    page_gap: "…"
+    previous_label:
+    page_entries_info:
+      multi_page:
+      multi_page_html:
+      single_page:
+        one:
+        other:
+        zero:
+      single_page_html:
+        one:
+        other:
+        zero:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,208 +1,239 @@
 fr:
-  title: "RubyGems.org"
-  subtitle: "votre communauté d'hébergement des gems"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "Accès refusé. Inscrivez-vous sur https://rubygems.org"
-  feed_subscribed: "RubyGems.org | Gems abonnés"
-  feed_latest: "RubyGems.org | Derniers Gems"
-  time_ago: "il y a %{duration}"
-  form_disable_with: "Veuillez patienter..."
-  update: "Mise à jour"
-  edit: "Modification"
-  sign_in: "Connexion"
-  sign_up: "Inscription"
-  footer_about: "RubyGems.org est le service d&rsquo;hébergement de la communauté Ruby. Publiez vos gems instantanément et utilisez-les. Utilisez l'API pour interagir et trouver des informations sur les gems disponibles. Contribuez et améliorez ce site avec nous !"
-  locale_name: "Français"
-  this_rubygem_could_not_be_found: "Rubygem introuvable."
-
-  dashboards:
-    show:
-      latest: "Dernières mises à jour"
-      latest_title: "Flux RSS des dernières mises à jour"
-      no_subscriptions: "Vous n'avez pas encore d'abonnements. Visitez %{gem_link} pour vous y abonner !"
-      gem_link_text: "une page de gem"
-      mine: "Mes Gems"
-      no_owned: "Vous n'avez pas encore publié de gem. Vous pouvez vérifier les guides de %{creating_link} ou de %{migrating_link} de gems depuis RubyForge."
-      creating_link_text: "création"
-      migrating_link_text: "migration"
-      my_subscriptions: "Abonnements"
-
-  home:
-    index:
-      downloads_counting: "téléchargements à ce jour"
-      find_blurb: "Trouvez, installez et publiez des RubyGems."
-      learn:
-        install_rubygems: "Installez RubyGems"
-
-  layouts:
-    application:
-      header:
-        dashboard: "Dashboard"
-        sign_in: "Connexion"
-        sign_up: "Inscription"
-        sign_out: "Déconnexion"
-        search_gem: "Recherche de Gems&hellip;"
-      footer:
-        status: "Statut"
-        uptime: "Uptime"
-        source_code: "Code"
-        data: "Données"
-        discussion_forum: "Discussions"
-        statistics: "Stats"
-        blog: "Blog"
-        about: "À propos"
-        help: "Aide"
-        api: "API"
-        guides: "Guides"
-        contribute: "Contribuer"
-        supported_by: "Soutenu par"
-        hosted_by: "Hébergé par"
-        designed_by: "Design par"
-        resolved_with: "Résolu par"
-        optimized_by: "Optimisé par"
-        tracking_by: "Tracking par"
-        monitored_by: "Monitoring par"
-        gems_served_by: "Gems mis à disposition par"
-
-  pages:
-    about:
-      title: "À propos"
-      purpose:
-        header: "Bienvenue sur %{site}, le service d'hébergement des gems de la communauté Ruby. Ce projet a trois objectifs :"
-        better_api: "Fournir une meilleure API pour gérer les gems"
-        transparent_pages: "Créer des pages de projet plus accessibles et transparentes"
-        enable_community: "Permettre à la communauté d'améliorer ce site"
-      founding: "Le projet a commencé en avril 2009 par %{founder}, et a grandi avec les contribution de %{contributors} et %{downloads}. À la sortie de RubyGems 1.3.6, ce site a été renommé de Gemcutter à %{title} pour ancrer son rôle central dans la communauté Ruby."
-      support: "Bien que Gemcutter n'appartienne à aucune entreprise en particulier, il a reçu l'aide de nombreuses d'entre elles. Le design actuel, les illustrations, et développement front-end de ce site nous ont été offerts par %{dockyard}. Nous n'aurions pas pu collaborer et partager de code facilement sans %{github}. Ce site s'est lancé sur %{heroku}, dont l'excellent service a fait de Gemcutter une solution viable pour que la communauté s'y appuie en toute confiance. Our infrastructure is currently hosted on %{aws}."
-      technical: "Quelques informations sur les aspects techniques de ce site : il est en Ruby à 100%. Le site principal est une application %{rails}. Les Gems sont hébergés sur %{s3}, served by %{fastly}, permettant un record de vitesse entre le moment de publication et de mise à disposition de gems. Pour davantage d'informations, le %{source_code} est disponible sous licence %{license} sur GitHub."
-
-  passwords:
-    edit:
-      title: "Nouveau mot de passe"
-      submit: "Enregistrer ce mot de passe"
-    new:
-      title: "Changement de mot de passe"
-      will_email_notice: "Nous vous enverrons un email pour changer votre mot de passe."
-      submit: "Réinitialisez votre mot de passe"
-
-  profiles:
-    edit:
-      title: "Modification de profil"
-      hide_email: "Ne pas afficher l'email dans le profil public"
-      reset_password:
-        title: "Renvoi de mot de passe"
-        text: "Besoin d'un nouveau mot de passe ? Pas de problème. %{link}"
-        link_text: "Demandez un nouveau mot de passe ici."
-      api_access:
-        title: "Accès API"
-        key_is: "Votre clé API est %{key}."
-        credentials: "Si vous voulez utiliser %{gem_commands_link} de la ligne de commande, vous aurez besoin d'un fichier %{gem_credentials_file}, que vous pouvez générer avec la commande suivante :"
-        link_text: "des commandes gems"
-        reset: "Remise à zéro de votre clé API"
-        confirm_reset: "Êtes-vous sûr ? Cette action ne peut être annulée."
-
-  rubygems:
-    dependencies:
-      header: "Dépendances de %{title}"
-    edit:
-      title: "Modifier les liens"
-      subtitle: "pour %{gem}"
-      other_fields_notice: "Tous les autres champs ne sont modifiables qu'en soumettant une nouvelle version de votre gem."
-    index:
-      title: "Gems"
-      downloads: Téléchargements
-    aside:
-      links:
-        header: "Liens"
-        home: "Page d'accueil"
-        code: "Code Source"
-        docs: "Documentation"
-        wiki: "Wiki"
-        mail: "Liste de diffusion"
-        bugs: "Suivi de bugs"
-        download: "Télécharger"
-        subscribe: "Abonnement"
-        unsubscribe: "Désabonement"
-        report_abuse: Signaler un abus
-        badge: Badge
-        rss: RSS
-      downloads_for_this_version: "Pour cette version"
-      bundler_header: "Gemfile"
-      copy_to_clipboard: Copier
-      copied: Copié!
-      install: "installation"
-      required_ruby_version: Version de Ruby requise
-    show:
-      not_hosted_notice: "Gem non hébergé sur Rubygems pour le moment."
-      yanked_notice: "Retrait de Gem : disponible ni directement, ni pour les gems qui en dépendraient."
-      authors_header: "Auteurs"
-      owners_header: "Propriétaires"
-      versions_header: "Versions"
-      show_all_versions: "Voir toutes les versions (%{count})"
-      licenses_header: "Licence"
-      no_licenses: "aucune"
-      requirements_header: "Dépendances"
-      sha_256_checksum: Total de contrôle SHA 256
-
-  searches:
-    show:
-      subtitle: "pour %{query}"
-      exact_match: "Titre exact"
-
-  sessions:
-    new:
-      forgot_password: "Mot de passe oublié ?"
-
-  stats:
-    index:
-      total_downloads: "Total de téléchargements"
-      total_gems: "Total de gems"
-      total_users: "Total d'utilisateurs"
-      all_time_most_downloaded: "Gems les plus téléchargés"
-
-  users:
-    new:
-      have_account: "Vous avez déjà un compte ?"
-
-  versions:
-    index:
-      title: "Toutes les versions de %{name}"
-      versions_since: "%{count} versions depuis %{since}"
-      not_hosted_notice: "Gem non hébergé sur Rubygems."
-    version:
-      yanked: "retiré"
-
+  edit: Modification
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | Derniers Gems
+  feed_subscribed: RubyGems.org | Gems abonnés
+  footer_about: RubyGems.org est le service d&rsquo;hébergement de la communauté Ruby. Publiez vos gems instantanément et utilisez-les. Utilisez l'API pour interagir et trouver des informations sur les gems disponibles. Contribuez et améliorez ce site avec nous !
+  form_disable_with: Veuillez patienter...
+  help_url: http://help.rubygems.org
+  locale_name: Français
+  none:
+  not_found:
+  please_sign_up: Accès refusé. Inscrivez-vous sur https://rubygems.org
+  sign_in: Connexion
+  sign_up: Inscription
+  subtitle: votre communauté d'hébergement des gems
+  this_rubygem_could_not_be_found: Rubygem introuvable.
+  time_ago: il y a %{duration}
+  title: RubyGems.org
+  update: Mise à jour
   activerecord:
     attributes:
-      user:
-        avatar: "Avatar"
-        email: "Adresse e-mail"
-        handle: "Pseudonyme"
-        password: "Mot de passe"
       linkset:
-        bugs: "URL du suivi de bugs"
-        code: "URL du code source"
-        docs: "URL de la documentation"
-        mail: "URL de la liste de diffusion"
-        wiki: "URL du wiki"
+        bugs: URL du suivi de bugs
+        code: URL du code source
+        docs: URL de la documentation
+        mail: URL de la liste de diffusion
+        wiki: URL du wiki
       session:
-        who: "Email ou pseudonyme"
-        password: "Mot de passe"
-
+        password: Mot de passe
+        who: Email ou pseudonyme
+      user:
+        avatar: Avatar
+        email: Adresse e-mail
+        handle: Pseudonyme
+        password: Mot de passe
+  dashboards:
+    show:
+      creating_link_text: création
+      gem_link_text: une page de gem
+      latest: Dernières mises à jour
+      latest_title: Flux RSS des dernières mises à jour
+      migrating_link_text: migration
+      mine: Mes Gems
+      my_subscriptions: Abonnements
+      no_owned: Vous n'avez pas encore publié de gem. Vous pouvez vérifier les guides de %{creating_link} ou de %{migrating_link} de gems depuis RubyForge.
+      no_subscriptions: Vous n'avez pas encore d'abonnements. Visitez %{gem_link} pour vous y abonner !
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
+  home:
+    index:
+      downloads_counting: téléchargements à ce jour
+      find_blurb: Trouvez, installez et publiez des RubyGems.
+      learn:
+        install_rubygems: Installez RubyGems
+  layouts:
+    application:
+      footer:
+        about: À propos
+        api: API
+        blog: Blog
+        contribute: Contribuer
+        data: Données
+        designed_by: Design par
+        discussion_forum: Discussions
+        gems_served_by: Gems mis à disposition par
+        guides: Guides
+        help: Aide
+        hosted_by: Hébergé par
+        logging_by:
+        monitored_by: Monitoring par
+        optimized_by: Optimisé par
+        resolved_with: Résolu par
+        security: Security
+        source_code: Code
+        statistics: Stats
+        status: Statut
+        supported_by: Soutenu par
+        tested_by:
+        tracking_by: Tracking par
+        uptime: Uptime
+      header:
+        dashboard: Dashboard
+        search_gem: Recherche de Gems&hellip;
+        sign_in: Connexion
+        sign_out: Déconnexion
+        sign_up: Inscription
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
+  pages:
+    about:
+      founding: Le projet a commencé en avril 2009 par %{founder}, et a grandi avec les contribution de %{contributors} et %{downloads}. À la sortie de RubyGems 1.3.6, ce site a été renommé de Gemcutter à %{title} pour ancrer son rôle central dans la communauté Ruby.
+      support: Bien que Gemcutter n'appartienne à aucune entreprise en particulier, il a reçu l'aide de nombreuses d'entre elles. Le design actuel, les illustrations, et développement front-end de ce site nous ont été offerts par %{dockyard}. Nous n'aurions pas pu collaborer et partager de code facilement sans %{github}. Ce site s'est lancé sur %{heroku}, dont l'excellent service a fait de Gemcutter une solution viable pour que la communauté s'y appuie en toute confiance. Our infrastructure is currently hosted on %{aws}.
+      technical: 'Quelques informations sur les aspects techniques de ce site : il est en Ruby à 100%. Le site principal est une application %{rails}. Les Gems sont hébergés sur %{s3}, served by %{fastly}, permettant un record de vitesse entre le moment de publication et de mise à disposition de gems. Pour davantage d''informations, le %{source_code} est disponible sous licence %{license} sur GitHub.'
+      title: À propos
+      purpose:
+        better_api: Fournir une meilleure API pour gérer les gems
+        enable_community: Permettre à la communauté d'améliorer ce site
+        header: 'Bienvenue sur %{site}, le service d''hébergement des gems de la communauté Ruby. Ce projet a trois objectifs :'
+        transparent_pages: Créer des pages de projet plus accessibles et transparentes
+  passwords:
+    edit:
+      submit: Enregistrer ce mot de passe
+      title: Nouveau mot de passe
+    new:
+      submit: Réinitialisez votre mot de passe
+      title: Changement de mot de passe
+      will_email_notice: Nous vous enverrons un email pour changer votre mot de passe.
+  profiles:
+    edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Ne pas afficher l'email dans le profil public
+      optional_twitter_username:
+      title: Modification de profil
+      api_access:
+        confirm_reset: Êtes-vous sûr ? Cette action ne peut être annulée.
+        credentials: 'Si vous voulez utiliser %{gem_commands_link} de la ligne de commande, vous aurez besoin d''un fichier %{gem_credentials_file}, que vous pouvez générer avec la commande suivante :'
+        key_is: Votre clé API est %{key}.
+        link_text: des commandes gems
+        reset: Remise à zéro de votre clé API
+        title: Accès API
+      reset_password:
+        link_text: Demandez un nouveau mot de passe ici.
+        text: Besoin d'un nouveau mot de passe ? Pas de problème. %{link}
+        title: Renvoi de mot de passe
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied: Copié!
+      copy_to_clipboard: Copier
+      downloads_for_this_version: Pour cette version
+      install: installation
+      required_ruby_version: Version de Ruby requise
+      required_rubygems_version:
+      links:
+        badge: Badge
+        bugs: Suivi de bugs
+        code: Code Source
+        docs: Documentation
+        download: Télécharger
+        header: Liens
+        home: Page d'accueil
+        mail: Liste de diffusion
+        report_abuse: Signaler un abus
+        reverse_dependencies:
+        rss: RSS
+        subscribe: Abonnement
+        unsubscribe: Désabonement
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
+    dependencies:
+      header: Dépendances de %{title}
+    edit:
+      other_fields_notice: Tous les autres champs ne sont modifiables qu'en soumettant une nouvelle version de votre gem.
+      subtitle: pour %{gem}
+      title: Modifier les liens
+    gem_members:
+      authors_header: Auteurs
+      owners_header: Propriétaires
+      sha_256_checksum: Total de contrôle SHA 256
+    index:
+      downloads: Téléchargements
+      title: Gems
+    show:
+      licenses_header: Licence
+      no_licenses: aucune
+      requirements_header: Dépendances
+      show_all_versions: Voir toutes les versions (%{count})
+      versions_header: Versions
+      yanked_notice: 'Retrait de Gem : disponible ni directement, ni pour les gems qui en dépendraient.'
+    show_yanked:
+      not_hosted_notice: Gem non hébergé sur Rubygems pour le moment.
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
+  searches:
+    show:
+      exact_match: Titre exact
+      subtitle: pour %{query}
+  sessions:
+    new:
+      forgot_password: Mot de passe oublié ?
+      resend_confirmation:
+  stats:
+    index:
+      all_time_most_downloaded: Gems les plus téléchargés
+      total_downloads: Total de téléchargements
+      total_gems: Total de gems
+      total_users: Total d'utilisateurs
+  users:
+    create:
+      email_sent:
+    new:
+      have_account: Vous avez déjà un compte ?
+  versions:
+    index:
+      not_hosted_notice: Gem non hébergé sur Rubygems.
+      title: Toutes les versions de %{name}
+      versions_since: "%{count} versions depuis %{since}"
+    version:
+      yanked: retiré
   will_paginate:
-      previous_label: "Précédent"
-      next_label: "Suivant"
-      page_gap: "…"
-      page_entries_info:
-        single_page:
-          zero:  "Aucun %{model} trouvé"
-          one:   "1 %{model} affiché"
-          other: "Les %{count} %{model} affichés"
-        single_page_html:
-          zero:  "Aucun %{model} trouvé"
-          one:   "<b>1</b> %{model} affiché"
-          other: "Les <b>%{count}</b> %{model} affichés"
-
-        multi_page: "%{model} de %{from} à %{to} parmi %{count} au total"
-        multi_page_html: "%{model} de <b>%{from}</b> à <b>%{to}</b> parmi <b>%{count}</b> au total"
-
+    next_label: Suivant
+    page_gap: "…"
+    previous_label: Précédent
+    page_entries_info:
+      multi_page: "%{model} de %{from} à %{to} parmi %{count} au total"
+      multi_page_html: "%{model} de <b>%{from}</b> à <b>%{to}</b> parmi <b>%{count}</b> au total"
+      single_page:
+        one: 1 %{model} affiché
+        other: Les %{count} %{model} affichés
+        zero: Aucun %{model} trouvé
+      single_page_html:
+        one: "<b>1</b> %{model} affiché"
+        other: Les <b>%{count}</b> %{model} affichés
+        zero: Aucun %{model} trouvé

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,199 +1,239 @@
 nl:
-  update: Wijzig
-  sign_in: Inloggen
-  locale_name: "Nederlands"
-  sign_up: Aanmelden
-  footer_about: "RubyGems.org is de gem hosting service van de Ruby community. Publiceer and installeer je gems direct. Gebruik de API om meer informatie van beschikbare gems te vinden. Word een deelnemer en verbeter de site met jouw aanpassingen."
-  time_ago: ! '%{duration} geleden'
-  download_count: ! '%{count} downloads'
-  title: RubyGems.org
-  please_sign_up: Toegang geweigerd. Schrijf je in voor een account op https://rubygems.org
-  feed_latest: RubyGems.org | Recente Gems
-  form_disable_with: Een moment geduld...
   edit: Wijzig
-  url: https://rubygems.org
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | Recente Gems
   feed_subscribed: RubyGems.org | Geabonneerde Gems
-  subtitle: De gem host voor de community
+  footer_about: RubyGems.org is de gem hosting service van de Ruby community. Publiceer and installeer je gems direct. Gebruik de API om meer informatie van beschikbare gems te vinden. Word een deelnemer en verbeter de site met jouw aanpassingen.
+  form_disable_with: Een moment geduld...
   help_url: http://help.rubygems.org
-  home:
-    index:
-      share:
-        update: Bijwerken naar de laatste RubyGems versie
-        deploy: Eenvoudig je gem deployen
-        build: Je gem bouwen
-        header: delen
-      gems_header: van %{gem_count} gems totaal sinds juli 2009
-      welcome_blurb: Welcome bij de RubyGem host voor de community.
-      learn:
-        browse_docs: Bekijk de documentatie
-        gem_specification: Gem Specificatie
-        spec_subtitle: Het gezicht van jouw gem's voor de wereld.
-        header: leren
-        docs_subtitle: Gedetailleerde uitleg, stap voor stap instructies en naslagwerk
-        install_rubygems: Installeer RubyGems
-        rubygems_subtitle: Ruby’s bewezen packaging systeem
-      leaderboards:
-        new: Nieuwe Gems
-        no_downloaded: Geen downloads vandaag
-        updated: Zojuist gewijzigd
-        downloaded: Meest gedownload vandaag
-        header: ranglijsten
-      pitch:
-        content: ! '%{rubygems} is dé hosting service voor de Ruby community. %{publish} je gems kinderlijk eenvoudig. %{api} om informatie over de beschikbare gems op te vragen. %{contribute} en verbeter de site met je eigen wijzigingen.'
-        api: Gebruik de API
-        publish: Publiceer en installeer
-        contribute: Draag je steentje bij
-      find_blurb: Vind je gems makkelijker en publiceer ze sneller.
-  users:
-    new:
-      have_account: Heb je al een account?
-  stats:
-    index:
-      gem_count: ! '%{count} gems'
-      user_count: ! '%{count} gebruikers'
-    show:
-      current_rank: huidige positie
-      overview: Statistiekenoverzicht
-      for: Statistieken voor %{for}
-      total_downloads: ! 'Downloads totaal'
-      daily_downloads: ! '%{count} downloads vandaag'
+  locale_name: Nederlands
+  none:
+  not_found:
+  please_sign_up: Toegang geweigerd. Schrijf je in voor een account op https://rubygems.org
+  sign_in: Inloggen
+  sign_up: Aanmelden
+  subtitle: De gem host voor de community
+  this_rubygem_could_not_be_found: This rubygem could not be found.
+  time_ago: "%{duration} geleden"
+  title: RubyGems.org
+  update: Wijzig
   activerecord:
-    errors:
-      messages:
-        record_invalid:
     attributes:
+      linkset:
+        bugs: Bugtracker-URL
+        code: source code URL
+        docs: Documentatie-URL
+        mail: Mailing-list-URL
+        wiki: Wiki URL
       session:
         password: Wachtwoord
         who: Email of Gebruikersnaam
-      linkset:
-        mail: Mailing-list-URL
-        bugs: Bugtracker-URL
-        docs: Documentatie-URL
-        code: source code URL
-        wiki: Wiki URL
       user:
-        handle: Gebruikersnaam
-        email: Emailadres
         avatar: Avatar
+        email: Emailadres
+        handle: Gebruikersnaam
         password: Wachtwoord
-  rubygems:
+  dashboards:
+    show:
+      creating_link_text: aanmaken
+      gem_link_text: gem pagina
+      latest: Laatste wijzigingen
+      latest_title: RSS Feed met Laatste wijzigingen 
+      migrating_link_text: migreren
+      mine: Mijn Gems
+      my_subscriptions: Mijn abonnementen
+      no_owned: Je hebt nog geen gems gepubliceerd. Bekijk de instructies voor het %{creating_link} van een gem of het  %{migrating_link} van een gem vanaf RubyForge.
+      no_subscriptions: Je bent nog niet geabonneerd op een of meerdere gems. Bezoek een %{gem_link} en abonneer je erop.
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
+  home:
     index:
-      title: alle gems
-      subtitle: die beginnen met %{prefix}
+      downloads_counting:
+      find_blurb: Vind je gems makkelijker en publiceer ze sneller.
+      learn:
+        install_rubygems: Installeer RubyGems
+  layouts:
+    application:
+      footer:
+        about: Over
+        api: API
+        blog: Blog
+        contribute: Bijdragen
+        data: Data
+        designed_by: Ontwerp
+        discussion_forum: Forum
+        gems_served_by:
+        guides: Leren
+        help: Help
+        hosted_by: Hosting
+        logging_by:
+        monitored_by: Monitoring
+        optimized_by: Optimalisatie
+        resolved_with: DNS
+        security: Security
+        source_code: code
+        statistics: Stats
+        status: Status
+        supported_by: Ondersteunding
+        tested_by:
+        tracking_by: Tracking
+        uptime: Uptime
+      header:
+        dashboard: dashboard
+        search_gem: Gems Zoeken&hellip;
+        sign_in: inloggen
+        sign_out: uitloggen
+        sign_up: aanmelden
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
+  pages:
+    about:
+      founding: Het project is gestart in april 2009 door %{founder} en is sindsdien uitgegroeid tot een dienst met bijdragen van meer dan %{contributors} en %{downloads}. Sinds de RubyGems 1.3.6 release, is de site hernoemd van Gemcutter naar %{title} om de centrale rol in de Ruby community te verstevigen.
+      support: Hoewel rubygems.org niet wordt gerund door één specifiek bedrijf, zijn er vele die ons tot hier geholpen hebben. Het huidige design van de site is gesponsord door %{dockyard}. %{github} is van onschatbare waarde geweest om code te delen en er samen aan te werken. De site is begonnen op  %{heroku}, waarvan de geweldige service heeft geholpen om te bewijzen dat rubygems.org een oplossing is waar de hele community op kan bouwen. Our infrastructure is currently hosted on %{aws}.
+      technical: 'Een klein inkijkje in de technische aspecten van de site: Het is 100% Ruby. The main site is a %{rails}-applicatie. Gems worden gehost op %{s3}, served by %{fastly}, en de tijd tussen het publiceren van een nieuwe gem en het beschikbaar zijn voor installatie is minimaal. Voor meer informatie, %{source_code} op GitHub. De code is %{license}'
+      title: Over
+      purpose:
+        better_api: Een betere API ter beschikking te stellen voor het beheren van gems.
+        enable_community: De community in staat te stellen de site te verbeteren en uit te breiden.
+        header: 'Welkom bij %{site}, dé hosting service voor de Ruby community. Het doel van dit poroject is drieledig:'
+        transparent_pages: Het maken van meer transparante en toegankelijke projectpagina's.
+  passwords:
+    edit:
+      submit: Sla dit wachtwoord op
+      title: reset wachtwoord
+    new:
+      submit: Wachtwoord wijzigen
+      title: wachtwoord wijzigen
+      will_email_notice: We sturen een link om je wachtwoord te wijzigen.
+  profiles:
+    edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email:
+      optional_twitter_username:
+      title: Wijzig profiel
+      api_access:
+        confirm_reset: Weet je het zeker? Dit kan niet ongedaan worden gemaakt.
+        credentials: 'Als je de %{gem_commands_link} vanaf de command-line wilt gebruiken, heb je een %{gem_credentials_file} bestand nodig. Je kunt deze genereren met het volgende commando:'
+        key_is: Je API key is %{key}
+        link_text: gem commando’s
+        reset: Reset mijn API key
+        title: API toegang
+      reset_password:
+        link_text: Vraag hier een nieuwe aan.
+        text: Nieuw wachtwoord nodig? Geen probleem. %{link}
+        title: Reset wachtwoord
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied:
+      copy_to_clipboard:
+      downloads_for_this_version: Voor deze versie
+      install: Installeer
+      required_ruby_version: Required Ruby Version
+      required_rubygems_version: Required Rubygems Version
+      links:
+        badge: Badge
+        bugs: Bug-tracker
+        code: source code
+        docs: Documentatie
+        download: Download
+        header: Links
+        home: Startpagina
+        mail: Mailing-list
+        report_abuse:
+        reverse_dependencies:
+        rss: RSS
+        subscribe:
+        unsubscribe:
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
     dependencies:
       header: "%{title} afhankelijkheden"
     edit:
-      title: Wijzig gem links
       other_fields_notice: Alle andere velden kunnen alleen gewijzigd worden door een nieuwe versie van de gem te publiceren.
       subtitle: voor %{gem}
-    aside:
-      links:
-        home: Startpagina
-        mail: Mailing-list
-        bugs: Bug-tracker
-        docs: Documentatie
-        code: source code
-        wiki: Wiki
-        header: Links
-      downloads_for_this_version: ! 'Voor deze versie'
-      bundler_header: Gemfile
-      install: Installeer
-    show:
-      stats_header: Statistieken
-      authors_header: Auteurs
-      versions_header: Versies
-      not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org.
+      title: Wijzig gem links
+    gem_members:
+      authors_header:
       owners_header: Eigenaren
-      show_all_versions: Toon alle versies (%{count} totaal)
-  dashboards:
+      sha_256_checksum: SHA 256 checksum
+    index:
+      downloads: Downloads
+      title: alle gems
     show:
-      gem_link_text: gem pagina
-      latest_title: RSS Feed met Laatste wijzigingen 
-      no_subscriptions: Je bent nog niet geabonneerd op een of meerdere gems. Bezoek een %{gem_link} en abonneer je erop.
-      mine: Mijn Gems
-      creating_link_text: aanmaken
-      migrating_link_text: migreren
-      latest: Laatste wijzigingen
-      my_subscriptions: Mijn abonnementen
-      no_owned: Je hebt nog geen gems gepubliceerd. Bekijk de instructies voor het %{creating_link} van een gem of het  %{migrating_link} van een gem vanaf RubyForge.
-  sessions:
-    new:
-      forgot_password: Wachtwoord vergeten?
-  passwords:
-    new:
-      title: wachtwoord wijzigen
-      submit: Wachtwoord wijzigen
-      will_email_notice: We sturen een link om je wachtwoord te wijzigen.
-    edit:
-      title: reset wachtwoord
-      submit: Sla dit wachtwoord op
-  pages:
-    about:
-      title: Over
-      support: Hoewel rubygems.org niet wordt gerund door één specifiek bedrijf, zijn er vele die ons tot hier geholpen hebben. Het huidige design van de site is gesponsord door %{dockyard}. %{github} is van onschatbare waarde geweest om code te delen en er samen aan te werken. De site is begonnen op  %{heroku}, waarvan de geweldige service heeft geholpen om te bewijzen dat rubygems.org een oplossing is waar de hele community op kan bouwen. Our infrastructure is currently hosted on %{aws}.
-      subtitle: wat dit is
-      founding: Het project is gestart in april 2009 door %{founder} en is sindsdien uitgegroeid tot een dienst met bijdragen van meer dan %{contributors} en %{downloads}. Sinds de RubyGems 1.3.6 release, is de site hernoemd van Gemcutter naar %{title} om de centrale rol in de Ruby community te verstevigen.
-      purpose:
-        transparent_pages: Het maken van meer transparante en toegankelijke projectpagina's.
-        enable_community: De community in staat te stellen de site te verbeteren en uit te breiden.
-        better_api: Een betere API ter beschikking te stellen voor het beheren van gems.
-        header: ! 'Welkom bij %{site}, dé hosting service voor de Ruby community. Het doel van dit poroject is drieledig:'
-      technical: ! 'Een klein inkijkje in de technische aspecten van de site: Het is 100% Ruby. The main site is a %{rails}-applicatie. Gems worden gehost op %{s3}, served by %{fastly}, en de tijd tussen het publiceren van een nieuwe gem en het beschikbaar zijn voor installatie is minimaal. Voor meer informatie, %{source_code} op GitHub. De code is %{license}'
-    create:
-      title: aanmaken
-      notice: Deze pagaina is verplaatst naar the nieuwe rubygems.org support site.
+      licenses_header: License
+      no_licenses: N/A
+      requirements_header: Requirements
+      show_all_versions: Toon alle versies (%{count} totaal)
+      versions_header: Versies
+      yanked_notice:
+    show_yanked:
+      not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org.
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
   searches:
     show:
       exact_match: Exacte match
       subtitle: voor %{query}
+  sessions:
+    new:
+      forgot_password: Wachtwoord vergeten?
+      resend_confirmation:
+  stats:
+    index:
+      all_time_most_downloaded:
+      total_downloads:
+      total_gems:
+      total_users:
+  users:
+    create:
+      email_sent:
+    new:
+      have_account: Heb je al een account?
   versions:
     index:
-      title: alle versies van %{name}
       not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org
-      versions_since: ! '%{count} versies sinds %{since}'
+      title: alle versies van %{name}
+      versions_since: "%{count} versies sinds %{since}"
     version:
       yanked: verwijderd
-  profiles:
-    edit:
-      title: Wijzig profiel
-      api_access:
-        confirm_reset: Weet je het zeker? Dit kan niet ongedaan worden gemaakt.
-        title: API toegang
-        key_is: Je API key is %{key}
-        link_text: gem commando’s
-        reset: Reset mijn API key
-        credentials: ! 'Als je de %{gem_commands_link} vanaf de command-line wilt gebruiken, heb je een %{gem_credentials_file} bestand nodig. Je kunt deze genereren met het volgende commando:'
-      reset_password:
-        title: Reset wachtwoord
-        text: Nieuw wachtwoord nodig? Geen probleem. %{link}
-        link_text: Vraag hier een nieuwe aan.
-  layouts:
-    application:
-      footer:
-        status: Status
-        uptime: Uptime
-        source_code: code
-        data: Data
-        discussion_forum: Forum
-        statistics: Stats
-        blog: Blog
-        about: Over
-        help: Help
-        api: API
-        hosted_by: Hosting
-        optimized_by: Optimalisatie
-        contribute: Bijdragen
-        guides: Leren
-        designed_by: Ontwerp
-        supported_by: Ondersteunding
-        tracking_by: Tracking
-        resolved_with: DNS
-        monitored_by: Monitoring
-        mobile: Mobiel
-      header:
-        sign_in: inloggen
-        sign_out: uitloggen
-        dashboard: dashboard
-        sign_up: aanmelden
-        all_gems: alle gems
-        search_gem: "Gems Zoeken&hellip;"
+  will_paginate:
+    next_label:
+    page_gap: "…"
+    previous_label:
+    page_entries_info:
+      multi_page:
+      multi_page_html:
+      single_page:
+        one:
+        other:
+        zero:
+      single_page_html:
+        one:
+        other:
+        zero:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,170 +1,24 @@
 pt-BR:
-  title: "RubyGems.org"
-  subtitle: "o host de gems da sua comunidade"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "Accesso Negado. Por favor se registre em https://rubygems.org"
-  feed_subscribed: "RubyGems.org | Gems do seu Feed"
-  feed_latest: "RubyGems.org | Últimas Gems"
+  edit: Editar
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | Últimas Gems
+  feed_subscribed: RubyGems.org | Gems do seu Feed
+  footer_about: RubyGems.org é o serviço de hospedagem de gems da comunidade Ruby. Publique e instale suas gems instantaneamente. Use a API para interagir e encontrar mais informações sobre gems disponíveis. Torne-se um contribuidor e melhore o site com suas mudanças.
+  form_disable_with: Atualizando...
+  help_url: http://help.rubygems.org
+  locale_name: Português do Brasil
+  none:
+  not_found:
+  please_sign_up: Accesso Negado. Por favor se registre em https://rubygems.org
+  sign_in: Fazer Login
+  sign_up: Cadastrar
+  subtitle: o host de gems da sua comunidade
+  this_rubygem_could_not_be_found: A rubygem não foi encontrada.
   time_ago: "%{duration} atrás"
-  form_disable_with: "Atualizando..."
-  update: "Atualizar"
-  edit: "Editar"
-  sign_in: "Fazer Login"
-  sign_up: "Cadastrar"
-  footer_about: "RubyGems.org é o serviço de hospedagem de gems da comunidade Ruby. Publique e instale suas gems instantaneamente. Use a API para interagir e encontrar mais informações sobre gems disponíveis. Torne-se um contribuidor e melhore o site com suas mudanças."
-  locale_name: "Português do Brasil"
-  this_rubygem_could_not_be_found: "A rubygem não foi encontrada."
-
-  dashboards:
-    show:
-      latest: "Últimas Atualizações"
-      latest_title: "Últimas Atualizações | Feed RSS"
-      no_subscriptions: "Você ainda não está observando nenhuma gem. Visite uma %{gem_link} para poder observá-la!"
-      gem_link_text: "Página da gem"
-      mine: "Minhas Gems"
-      no_owned: "Você ainda não enviou nenhuma gem. Verifique os guias sobre %{creating_link} uma gem ou %{migrating_link} uma gem do RubyForge."
-      creating_link_text: 'criar'
-      migrating_link_text: 'migrar'
-      my_subscriptions: 'Observando'
-
-  home:
-    index:
-      downloads_counting: 'downloads'
-      find_blurb: "Encontre, instale e publique RubyGems."
-      learn:
-        install_rubygems: "Instalar o RubyGems"
-
-  layouts:
-    application:
-      header:
-        dashboard: "Painel de Controle"
-        sign_in: "Fazer Login"
-        sign_up: "Cadastrar"
-        sign_out: "Sair"
-        search_gem: "Buscar Gems&hellip;"
-      footer:
-        status: "Status"
-        uptime: "Uptime"
-        source_code: "Código Fonte"
-        data: "Dump de Dados"
-        discussion_forum: "Fóruns"
-        statistics: "Estatísticas"
-        blog: "Blog"
-        about: "Sobre o Rubygems"
-        help: "Ajuda"
-        api: "API"
-        guides: "Guias"
-        contribute: "Como Contribuir"
-        supported_by: "Patrocínio"
-        hosted_by: "Hospedagem"
-        designed_by: "Design"
-        resolved_with: "DNS"
-        optimized_by: "Otimizações"
-        tracking_by: "Coleta de Dados"
-        monitored_by: "Monitoramento"
-        gems_served_by: "Provisionamento"
-
-  pages:
-    about:
-      title: Sobre o Rubygems
-      purpose:
-        header: "Bem vindo ao %{site}, o serviço de hospedagem de gems da comunidade Ruby. Este projeto tem três propósitos:"
-        better_api: Prover uma API melhor para lidar com gems
-        transparent_pages: Criar páginas mais acessíveis e transparentes para os projetos
-        enable_community: Empoderar a comunidade para melhorar o site
-      founding: "Este projeto foi iniciado em Abril de 2009 por %{founder}, e desde então tem crescido para incluir as contribuições de %{contributors} e %{downloads}. A partir do lançamento do RubyGems 1.3.6 o site foi renomeado de Gemcutter para %{title} para solidificar o papel centra do site na comunidade Ruby."
-      support: "Pelo Gemcutter não ser mantido por uma empresa específica, o projeto contou e conta com a contribuição de muitas pessoas. O design atual, ilustrações e o frontend do site foram criados pela %{dockyard}. Nós também contamos com ajuda do %{github} por nos ajudar a compartilhar código facilmente. Este site foi inicialmente hospedado no %{heroku}, que nos ajudaram a validar o Gemcutter como uma solução viável para toda a comunidade Ruby.  Our infrastructure is currently hosted on %{aws}."
-      technical: "Alguns aspectos técnicos sobre este site: 100% Ruby. A parte principal é um aplicativo %{rails}. As gems são hospedadas no %{s3}, served by %{fastly}, e o tempo de espera entre publicar uma nova gem e disponibilidade para instalação é mínimo. Para mais informações, verifique o %{source_code}, com a licença %{license} no GitHub."
-
-  passwords:
-    edit:
-      title: Resetar senha
-      submit: Salvar senha
-    new:
-      title: Alterar senha
-      will_email_notice: Você vai receber um email com o link para atualizar sua senha.
-      submit: Resetar senha
-
-  profiles:
-    edit:
-      title: Editar Perfil
-      hide_email: Não mostrar meu email
-      reset_password:
-        title: Resetar senha
-        text: "Esqueceu sua senha? Sem problema. %{link}"
-        link_text: Solicitar uma nova senha.
-      api_access:
-        title: Acesso à API
-        key_is: "A chave da sua API é %{key}."
-        credentials: "Se você quiser usar %{gem_commands_link} pela linha comando, você vai precisar de um arquivo %{gem_credentials_file}. Para gerar este arquivo rode o seguinte comando:"
-        link_text: gems
-        reset: Resetar minha chave da API
-        confirm_reset: Tem certeza?
-
-  rubygems:
-    dependencies:
-      header: "%{title} | Dependências"
-    edit:
-      title: "Editar links"
-      subtitle: "%{gem}"
-      other_fields_notice: Os outros campos só podem ser editados quando você submeter uma versão atualizada da sua gem.
-    index:
-      title: 'Gems'
-    aside:
-      links:
-        header: Links
-        home: Homepage
-        code: Código Fonte
-        docs: Documentação
-        wiki: Wiki
-        mail: Lista de Emails
-        bugs: Bug Tracker
-      downloads_for_this_version: "Desta versão"
-      bundler_header: Gemfile
-      install: instalar
-    show:
-      not_hosted_notice: Esta gem não está hospedada no Gemcutter.
-      yanked_notice: "Esta gem foi removida, e não está mais disponível para download."
-      authors_header: Autores
-      owners_header: Donos
-      versions_header: Versões
-      show_all_versions: "Mostrar todas as versões (%{count})"
-      licenses_header: Licença
-      no_licenses: N/A
-      requirements_header: Requisitos
-
-  searches:
-    show:
-      subtitle: "para %{query}"
-      exact_match: Busca exata
-
-  sessions:
-    new:
-      forgot_password: "Esqueceu sua Senha?"
-
-  stats:
-    index:
-      total_downloads: "Total de downloads"
-
-  users:
-    new:
-      have_account: "Já tem uma conta?"
-
-  versions:
-    index:
-      title: "Todas as versões para %{name}"
-      versions_since: "%{count} versões desde %{since}"
-      not_hosted_notice: Esta gem não está hospdada no Gemcutter.
-    version:
-      yanked: "removida"
-
+  title: RubyGems.org
+  update: Atualizar
   activerecord:
     attributes:
-      user:
-        avatar: Avatar
-        email: Email
-        handle: Usuário
-        password: Senha
       linkset:
         bugs: URL do Bug Tracker
         code: URL do Código Fonte
@@ -172,5 +26,214 @@ pt-BR:
         mail: URL da Lista de Emails
         wiki: URL da Wiki
       session:
-        who: Email ou Usuário
         password: Senha
+        who: Email ou Usuário
+      user:
+        avatar: Avatar
+        email: Email
+        handle: Usuário
+        password: Senha
+  dashboards:
+    show:
+      creating_link_text: criar
+      gem_link_text: Página da gem
+      latest: Últimas Atualizações
+      latest_title: Últimas Atualizações | Feed RSS
+      migrating_link_text: migrar
+      mine: Minhas Gems
+      my_subscriptions: Observando
+      no_owned: Você ainda não enviou nenhuma gem. Verifique os guias sobre %{creating_link} uma gem ou %{migrating_link} uma gem do RubyForge.
+      no_subscriptions: Você ainda não está observando nenhuma gem. Visite uma %{gem_link} para poder observá-la!
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
+  home:
+    index:
+      downloads_counting: downloads
+      find_blurb: Encontre, instale e publique RubyGems.
+      learn:
+        install_rubygems: Instalar o RubyGems
+  layouts:
+    application:
+      footer:
+        about: Sobre o Rubygems
+        api: API
+        blog: Blog
+        contribute: Como Contribuir
+        data: Dump de Dados
+        designed_by: Design
+        discussion_forum: Fóruns
+        gems_served_by: Provisionamento
+        guides: Guias
+        help: Ajuda
+        hosted_by: Hospedagem
+        logging_by:
+        monitored_by: Monitoramento
+        optimized_by: Otimizações
+        resolved_with: DNS
+        security: Security
+        source_code: Código Fonte
+        statistics: Estatísticas
+        status: Status
+        supported_by: Patrocínio
+        tested_by:
+        tracking_by: Coleta de Dados
+        uptime: Uptime
+      header:
+        dashboard: Painel de Controle
+        search_gem: Buscar Gems&hellip;
+        sign_in: Fazer Login
+        sign_out: Sair
+        sign_up: Cadastrar
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
+  pages:
+    about:
+      founding: Este projeto foi iniciado em Abril de 2009 por %{founder}, e desde então tem crescido para incluir as contribuições de %{contributors} e %{downloads}. A partir do lançamento do RubyGems 1.3.6 o site foi renomeado de Gemcutter para %{title} para solidificar o papel centra do site na comunidade Ruby.
+      support: Pelo Gemcutter não ser mantido por uma empresa específica, o projeto contou e conta com a contribuição de muitas pessoas. O design atual, ilustrações e o frontend do site foram criados pela %{dockyard}. Nós também contamos com ajuda do %{github} por nos ajudar a compartilhar código facilmente. Este site foi inicialmente hospedado no %{heroku}, que nos ajudaram a validar o Gemcutter como uma solução viável para toda a comunidade Ruby.  Our infrastructure is currently hosted on %{aws}.
+      technical: 'Alguns aspectos técnicos sobre este site: 100% Ruby. A parte principal é um aplicativo %{rails}. As gems são hospedadas no %{s3}, served by %{fastly}, e o tempo de espera entre publicar uma nova gem e disponibilidade para instalação é mínimo. Para mais informações, verifique o %{source_code}, com a licença %{license} no GitHub.'
+      title: Sobre o Rubygems
+      purpose:
+        better_api: Prover uma API melhor para lidar com gems
+        enable_community: Empoderar a comunidade para melhorar o site
+        header: 'Bem vindo ao %{site}, o serviço de hospedagem de gems da comunidade Ruby. Este projeto tem três propósitos:'
+        transparent_pages: Criar páginas mais acessíveis e transparentes para os projetos
+  passwords:
+    edit:
+      submit: Salvar senha
+      title: Resetar senha
+    new:
+      submit: Resetar senha
+      title: Alterar senha
+      will_email_notice: Você vai receber um email com o link para atualizar sua senha.
+  profiles:
+    edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Não mostrar meu email
+      optional_twitter_username:
+      title: Editar Perfil
+      api_access:
+        confirm_reset: Tem certeza?
+        credentials: 'Se você quiser usar %{gem_commands_link} pela linha comando, você vai precisar de um arquivo %{gem_credentials_file}. Para gerar este arquivo rode o seguinte comando:'
+        key_is: A chave da sua API é %{key}.
+        link_text: gems
+        reset: Resetar minha chave da API
+        title: Acesso à API
+      reset_password:
+        link_text: Solicitar uma nova senha.
+        text: Esqueceu sua senha? Sem problema. %{link}
+        title: Resetar senha
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied:
+      copy_to_clipboard:
+      downloads_for_this_version: Desta versão
+      install: instalar
+      required_ruby_version:
+      required_rubygems_version:
+      links:
+        badge: Badge
+        bugs:
+        code: Código Fonte
+        docs: Documentação
+        download: Download
+        header: Links
+        home: Homepage
+        mail: Lista de Emails
+        report_abuse: Report Abuse
+        reverse_dependencies:
+        rss: RSS
+        subscribe: Subscribe
+        unsubscribe: Unsubscribe
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace: This namespace is reserved by rubygems.org.
+    dependencies:
+      header:
+    edit:
+      other_fields_notice: Os outros campos só podem ser editados quando você submeter uma versão atualizada da sua gem.
+      subtitle: "%{gem}"
+      title: Editar links
+    gem_members:
+      authors_header: Autores
+      owners_header: Donos
+      sha_256_checksum: SHA 256 checksum
+    index:
+      downloads: Downloads
+      title: Gems
+    show:
+      licenses_header: Licença
+      no_licenses: N/A
+      requirements_header: Requisitos
+      show_all_versions: Mostrar todas as versões (%{count})
+      versions_header: Versões
+      yanked_notice: Esta gem foi removida, e não está mais disponível para download.
+    show_yanked:
+      not_hosted_notice: Esta gem não está hospedada no Gemcutter.
+      reserved_namespace:
+        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+  reverse_dependencies:
+    index:
+      title: "Reverse dependencies for %{name}"
+  searches:
+    show:
+      exact_match: Busca exata
+      subtitle: para %{query}
+  sessions:
+    new:
+      forgot_password: Esqueceu sua Senha?
+      resend_confirmation:
+  stats:
+    index:
+      all_time_most_downloaded:
+      total_downloads: Total de downloads
+      total_gems: Total gems
+      total_users: Total users
+  users:
+    create:
+      email_sent:
+    new:
+      have_account: Já tem uma conta?
+  versions:
+    index:
+      not_hosted_notice: Esta gem não está hospdada no Gemcutter.
+      title: Todas as versões para %{name}
+      versions_since: "%{count} versões desde %{since}"
+    version:
+      yanked: removida
+  will_paginate:
+    next_label:
+    page_gap: "…"
+    previous_label:
+    page_entries_info:
+      multi_page:
+      multi_page_html:
+      single_page:
+        one:
+        other:
+        zero:
+      single_page_html:
+        one:
+        other:
+        zero:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,192 +1,239 @@
 zh-CN:
-  title: "RubyGems.org"
-  subtitle: "Ruby 社区 Gem 托管"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "拒绝访问。请先在 https://rubygems.org 上注册一个账号。"
-  feed_subscribed: "RubyGems.org | 订阅 Gems"
-  feed_latest: "RubyGems.org | 最新 Gems"
-  time_ago: "%{duration} 前"
-  form_disable_with: "请稍后..."
-  update: 更新
   edit: 编辑
-  sign_in: "登录"
-  sign_up: "注册"
-  footer_about: "RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。"
-  locale_name: "简体中文"
-
-  dashboards:
-    show:
-      latest: "最近更新"
-      latest_title: "最近更新 RSS 订阅"
-      no_subscriptions: "你目前没有订阅任何 Gem，访问 %{gem_link} 可以订阅一个！"
-      gem_link_text: "Gem 页面"
-      mine: "我的 Gems"
-      no_owned: "你没有发布过任何一个 Gem。可以尝试阅读 %{creating_link} 教程，或看看 %{migrating_link} 教程。"
-      creating_link_text: '创建'
-      migrating_link_text: '迁移'
-      my_subscriptions: '我的订阅'
-
-  home:
-    index:
-      find_blurb: "寻找、安装以及发布 RubyGems"
-      downloads_counting: '总下载次数'
-      footer:
-        status: "状态"
-        uptime: "服务状况"
-      learn:
-        install_rubygems: "安装 RubyGems"
-
-  layouts:
-    application:
-      header:
-        dashboard: "控制台"
-        sign_in: "登录"
-        sign_up: "注册"
-        sign_out: "退出"
-      footer:
-        status: "状态"
-        uptime: "服务状况"
-        source_code: "源代码"
-        data: "数据"
-        discussion_forum: "讨论"
-        statistics: "统计"
-        blog: "博客"
-        about: "关于"
-        help: "帮助"
-        api: "API"
-        guides: "教程"
-        contribute: "贡献"
-        supported_by: "支持"
-        hosted_by: "托管"
-        designed_by: "设计"
-        resolved_with: "解析"
-        optimized_by: "优化"
-        tracking_by: "追踪"
-        monitored_by: "监控"
-        gems_served_by: "服务"
-
-  pages:
-    about:
-      title: 关于
-      purpose:
-        header: "欢迎来到 %{site}, 这是 Ruby 社区的 Gem 托管服务。此项目有三个目的："
-        better_api: 提供更好的 API 来为 Gems 服务
-        transparent_pages: 构建更透明以及便于浏览的项目页面
-        enable_community: 可以让社区来改善本站
-      founding: "此项目创立由 %{founder} 于2009年4月，发展过程中有超过 %{contributors} 贡献者以及 %{downloads}。自从 RubyGems 1.3.6 发布以后，本站名称由 Gemcutter 改名为 %{title}，从而巩固在 Ruby 社区网站中和核心作用。"
-      support: "虽然 Gemcutter 不是由一个具体的公司来运作，但也有很多的帮助让我们走出了这么远。目前的设计、插画、以及网站的前端开发都是由 %{dockyard} 提供支持。%{github} 帮助我们轻松的协助和共享代码。本站最初部署在 %{heroku}，其一流的服务，有助于证明 Gemcutter 是可以依赖、可行的解决方案。Our infrastructure is currently hosted on %{aws}."
-      technical: "关于本站的一些技术方案：100% Ruby。主站基于 %{rails}。Gems 文件放在 %{s3}, served by %{fastly}, 上面，它能缩短在 Gem 提交到可以下载之间的耗时。更多的信息可以在 GitHub 上阅读 %{source_code}，基于 %{license} 协议。"
-
-  passwords:
-    edit:
-      title: 重置密码
-      submit: 更新密码
-    new:
-      title: 修改密码
-      will_email_notice: 我们将会通过 Email 发送修改密码的链接给你。
-      submit: 重置密码
-
-  profiles:
-    edit:
-      title: 修改个人资料
-      hide_email: 在公开的个人资料里面隐藏我的 Email
-      change: 更换
-      reset_password:
-        title: 重置密码
-        text: "需要一个新密码？没问题，访问 %{link}"
-        link_text: 这里找回密码
-      api_access:
-        title: API 访问
-        key_is: "你的 API Key：%{key}。"
-        credentials: "如果你希望在命令行中使用 %{gem_commands_link}，你需要一个 %{gem_credentials_file} 文件，可用下面的命令生成："
-        link_text: Gem 命令
-        reset: 重置 API Key
-        confirm_reset: 确定要重置吗？此动作执行后将无法撤销
-
-  rubygems:
-    dependencies:
-      header: "%{title} 依赖关系"
-    edit:
-      title: "编辑链接"
-      subtitle: "%{gem}"
-      other_fields_notice: 其他字段的信息你只能通过发布一个新版本的 Gem 来修改。
-    index:
-      title: 'Gems'
-    aside:
-      links:
-        header: 相关链接
-        home: 主页
-        code: 源代码
-        docs: 文档
-        wiki: Wiki
-        mail: 邮件列表
-        bugs: Bug Tracker
-        download: 下载
-        subscribe: 订阅
-        unsubscribe: 取消订阅
-        report_abuse: 举报投诉
-        badge: 徽章
-        rss: RSS
-      downloads_for_this_version: "这个版本"
-      bundler_header: Gemfile
-      install: 安装
-    show:
-      not_hosted_notice: 这个 Gem 目前没有托管在 Gemcutter。
-      yanked_notice: "这个 Gem 版本已经 yanked（废弃了），他无法提供下载，也无法被其他的 Gem 依赖。"
-      authors_header: 作者
-      owners_header: 所有者
-      versions_header: 版本列表
-      show_all_versions: "显示所有 (%{count} 个版本)"
-      licenses_header: License
-      no_licenses: N/A
-      requirements_header: 要求
-
-  searches:
-    show:
-      subtitle: "%{query}"
-      exact_match: 精确匹配
-
-  sessions:
-    new:
-      forgot_password: "忘记了密码？"
-
-  stats:
-    index:
-      total_downloads: "下载总次数"
-
-  users:
-    new:
-      have_account: "已经有账号了？"
-
-  versions:
-    index:
-      title: "%{name} 的所有版本"
-      versions_since: "自 %{since} 以来有 %{count} 个版本"
-      not_hosted_notice: 此 Gem 目前没有托管在 Gemcutter。
-    version:
-      yanked: "已废弃"
-
-  flashes:
-    failure_after_create: 创建失败
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | 最新 Gems
+  feed_subscribed: RubyGems.org | 订阅 Gems
+  footer_about: RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。
+  form_disable_with: 请稍后...
+  help_url: http://help.rubygems.org
+  locale_name: 简体中文
+  none:
+  not_found:
+  please_sign_up: 拒绝访问。请先在 https://rubygems.org 上注册一个账号。
+  sign_in: 登录
+  sign_up: 注册
+  subtitle: Ruby 社区 Gem 托管
+  this_rubygem_could_not_be_found:
+  time_ago: "%{duration} 前"
+  title: RubyGems.org
+  update: 更新
   activerecord:
-    errors:
-      template:
-        body: '下面的字段存在问题：'
-        header:
-          one: 1 错误导致 %{model} 保存失败
-          other: "%{count} 个错误导致 %{model} 保存失败"
     attributes:
-      user:
-        avatar: 头像
-        email: Email
-        handle: 账号
-        password: 密码
       linkset:
-        bugs: Bug Tracker URL
+        bugs:
         code: 源代码 URL
         docs: 文档 URL
         mail: 邮件列表 URL
         wiki: Wiki URL
       session:
-        who: Email / 账号
         password: 密码
+        who: Email / 账号
+      user:
+        avatar: 头像
+        email: Email
+        handle: 账号
+        password: 密码
+  dashboards:
+    show:
+      creating_link_text: 创建
+      gem_link_text: Gem 页面
+      latest: 最近更新
+      latest_title: 最近更新 RSS 订阅
+      migrating_link_text: 迁移
+      mine: 我的 Gems
+      my_subscriptions: 我的订阅
+      no_owned: 你没有发布过任何一个 Gem。可以尝试阅读 %{creating_link} 教程，或看看 %{migrating_link} 教程。
+      no_subscriptions: 你目前没有订阅任何 Gem，访问 %{gem_link} 可以订阅一个！
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
+  home:
+    index:
+      downloads_counting: 总下载次数
+      find_blurb: 寻找、安装以及发布 RubyGems
+      learn:
+        install_rubygems: 安装 RubyGems
+  layouts:
+    application:
+      footer:
+        about: 关于
+        api: API
+        blog: 博客
+        contribute: 贡献
+        data: 数据
+        designed_by: 设计
+        discussion_forum: 讨论
+        gems_served_by: 服务
+        guides: 教程
+        help: 帮助
+        hosted_by: 托管
+        logging_by:
+        monitored_by: 监控
+        optimized_by: 优化
+        resolved_with: 解析
+        security:
+        source_code: 源代码
+        statistics: 统计
+        status: 状态
+        supported_by: 支持
+        tested_by:
+        tracking_by: 追踪
+        uptime: 服务状况
+      header:
+        dashboard: 控制台
+        search_gem:
+        sign_in: 登录
+        sign_out: 退出
+        sign_up: 注册
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
+  pages:
+    about:
+      founding: 此项目创立由 %{founder} 于2009年4月，发展过程中有超过 %{contributors} 贡献者以及 %{downloads}。自从 RubyGems 1.3.6 发布以后，本站名称由 Gemcutter 改名为 %{title}，从而巩固在 Ruby 社区网站中和核心作用。
+      support: 虽然 Gemcutter 不是由一个具体的公司来运作，但也有很多的帮助让我们走出了这么远。目前的设计、插画、以及网站的前端开发都是由 %{dockyard} 提供支持。%{github} 帮助我们轻松的协助和共享代码。本站最初部署在 %{heroku}，其一流的服务，有助于证明 Gemcutter 是可以依赖、可行的解决方案。Our infrastructure is currently hosted on %{aws}.
+      technical: 关于本站的一些技术方案：100% Ruby。主站基于 %{rails}。Gems 文件放在 %{s3}, served by %{fastly}, 上面，它能缩短在 Gem 提交到可以下载之间的耗时。更多的信息可以在 GitHub 上阅读 %{source_code}，基于 %{license} 协议。
+      title: 关于
+      purpose:
+        better_api: 提供更好的 API 来为 Gems 服务
+        enable_community: 可以让社区来改善本站
+        header: 欢迎来到 %{site}, 这是 Ruby 社区的 Gem 托管服务。此项目有三个目的：
+        transparent_pages: 构建更透明以及便于浏览的项目页面
+  passwords:
+    edit:
+      submit: 更新密码
+      title: 重置密码
+    new:
+      submit: 重置密码
+      title: 修改密码
+      will_email_notice: 我们将会通过 Email 发送修改密码的链接给你。
+  profiles:
+    edit:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: 在公开的个人资料里面隐藏我的 Email
+      optional_twitter_username:
+      title: 修改个人资料
+      api_access:
+        confirm_reset: 确定要重置吗？此动作执行后将无法撤销
+        credentials: 如果你希望在命令行中使用 %{gem_commands_link}，你需要一个 %{gem_credentials_file} 文件，可用下面的命令生成：
+        key_is: 你的 API Key：%{key}。
+        link_text: Gem 命令
+        reset: 重置 API Key
+        title: API 访问
+      reset_password:
+        link_text: 这里找回密码
+        text: 需要一个新密码？没问题，访问 %{link}
+        title: 重置密码
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
+  rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied:
+      copy_to_clipboard:
+      downloads_for_this_version: 这个版本
+      install: 安装
+      required_ruby_version:
+      required_rubygems_version:
+      links:
+        badge: 徽章
+        bugs:
+        code: 源代码
+        docs: 文档
+        download: 下载
+        header: 相关链接
+        home: 主页
+        mail: 邮件列表
+        report_abuse: 举报投诉
+        reverse_dependencies:
+        rss: RSS
+        subscribe: 订阅
+        unsubscribe: 取消订阅
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
+    dependencies:
+      header: "%{title} 依赖关系"
+    edit:
+      other_fields_notice: 其他字段的信息你只能通过发布一个新版本的 Gem 来修改。
+      subtitle: "%{gem}"
+      title: 编辑链接
+    gem_members:
+      authors_header: 作者
+      owners_header: 所有者
+      sha_256_checksum: SHA 256 checksum
+    index:
+      downloads:
+      title:
+    show:
+      licenses_header:
+      no_licenses:
+      requirements_header: 要求
+      show_all_versions: 显示所有 (%{count} 个版本)
+      versions_header: 版本列表
+      yanked_notice: 这个 Gem 版本已经 yanked（废弃了），他无法提供下载，也无法被其他的 Gem 依赖。
+    show_yanked:
+      not_hosted_notice: 这个 Gem 目前没有托管在 Gemcutter。
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
+  searches:
+    show:
+      exact_match: 精确匹配
+      subtitle: "%{query}"
+  sessions:
+    new:
+      forgot_password: 忘记了密码？
+      resend_confirmation:
+  stats:
+    index:
+      all_time_most_downloaded:
+      total_downloads: 下载总次数
+      total_gems:
+      total_users:
+  users:
+    create:
+      email_sent:
+    new:
+      have_account: 已经有账号了？
+  versions:
+    index:
+      not_hosted_notice: 此 Gem 目前没有托管在 Gemcutter。
+      title: "%{name} 的所有版本"
+      versions_since: 自 %{since} 以来有 %{count} 个版本
+    version:
+      yanked: 已废弃
+  will_paginate:
+    next_label:
+    page_gap: "…"
+    previous_label:
+    page_entries_info:
+      multi_page:
+      multi_page_html:
+      single_page:
+        one:
+        other:
+        zero:
+      single_page_html:
+        one:
+        other:
+        zero:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,183 +1,239 @@
 zh-TW:
-  title: "RubyGems.org"
-  subtitle: "Ruby 社群 Gem 套件管理平台"
-  help_url: "http://help.rubygems.org"
-  please_sign_up: "無法存取，請先在 https://rubygems.org 上註冊帳號"
-  feed_subscribed: "RubyGems.org | 訂閱 Gems"
-  feed_latest: "RubyGems.org | 最新 Gems"
+  edit: 編輯
+  failure_when_forbidden:
+  feed_latest: RubyGems.org | 最新 Gems
+  feed_subscribed: RubyGems.org | 訂閱 Gems
+  footer_about: RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。
+  form_disable_with: 請稍候...
+  help_url: http://help.rubygems.org
+  locale_name: 正體中文
+  none:
+  not_found:
+  please_sign_up: 無法存取，請先在 https://rubygems.org 上註冊帳號
+  sign_in: 登入
+  sign_up: 註冊
+  subtitle: Ruby 社群 Gem 套件管理平台
+  this_rubygem_could_not_be_found:
   time_ago: "%{duration} 前"
-  form_disable_with: "請稍候..."
-  update: "更新"
-  edit: "編輯"
-  sign_in: "登入"
-  sign_up: "註冊"
-  footer_about: "RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。"
-  locale_name: "正體中文"
-
+  title: RubyGems.org
+  update: 更新
+  activerecord:
+    attributes:
+      linkset:
+        bugs: Bug 追蹤 URL
+        code: 原始碼 URL
+        docs: 文件 URL
+        mail: 郵件群組 URL
+        wiki: Wiki URL
+      session:
+        password: 密碼
+        who: Email / 帳號
+      user:
+        avatar: 頭像
+        email: Email
+        handle: 帳號
+        password: 密碼
   dashboards:
     show:
-      latest: "最近更新"
-      latest_title: "最新的 RSS Feed"
-      no_subscriptions: "你還沒有訂閱過 Gem，前往 %{gem_link} 來訂閱！"
-      gem_link_text: "Gem 頁面"
-      mine: "我的 Gems"
-      no_owned: "你尚未發佈任何 Gem。可以閱讀 %{creating_link} 教學，或參考 %{migrating_link} 教學來將你的 Gem 從 RubyForge 遷移過來。"
-      creating_link_text: 'Gem 建立'
-      migrating_link_text: 'Gem 轉移'
-      my_subscriptions: '我的訂閱'
-
+      creating_link_text: Gem 建立
+      gem_link_text: Gem 頁面
+      latest: 最近更新
+      latest_title: 最新的 RSS Feed
+      migrating_link_text: Gem 轉移
+      mine: 我的 Gems
+      my_subscriptions: 我的訂閱
+      no_owned: 你尚未發佈任何 Gem。可以閱讀 %{creating_link} 教學，或參考 %{migrating_link} 教學來將你的 Gem 從 RubyForge 遷移過來。
+      no_subscriptions: 你還沒有訂閱過 Gem，前往 %{gem_link} 來訂閱！
+  email_confirmations:
+    create:
+      promise_resend:
+    new:
+      submit:
+      title:
+      will_email_notice:
+    unconfirmed_email:
+      try_again:
+    update:
+      confirmed_email:
   home:
     index:
-      downloads_counting: '總下載次數'
-      find_blurb: "搜尋、安裝以及發佈 RubyGems"
+      downloads_counting: 總下載次數
+      find_blurb: 搜尋、安裝以及發佈 RubyGems
       learn:
-        install_rubygems: "安裝 RubyGems"
-      footer:
-        status: "狀態"
-        uptime: "上線時間"
-
+        install_rubygems: 安裝 RubyGems
   layouts:
     application:
-      header:
-        dashboard: "控制台"
-        sign_in: "登入"
-        sign_up: "註冊"
-        sign_out: "登出"
       footer:
-        status: "狀態"
-        uptime: "上線時間"
-        source_code: "原始碼"
-        data: "資料"
-        discussion_forum: "討論群組"
-        statistics: "統計"
-        blog: "部落格"
-        about: "關於"
-        help: "說明"
-        api: "API"
-        guides: "教學文件"
-        contribute: "貢獻"
-        supported_by: "支持"
-        hosted_by: "托管"
-        designed_by: "設計"
-        resolved_with: "解析"
-        optimized_by: "優化"
-        tracking_by: "追蹤"
-        monitored_by: "監控"
-        gems_served_by: "服務"
-
+        about: 關於
+        api: API
+        blog: 部落格
+        contribute: 貢獻
+        data: 資料
+        designed_by: 設計
+        discussion_forum: 討論群組
+        gems_served_by: 服務
+        guides: 教學文件
+        help: 說明
+        hosted_by: 托管
+        logging_by:
+        monitored_by: 監控
+        optimized_by: 優化
+        resolved_with: 解析
+        security:
+        source_code: 原始碼
+        statistics: 統計
+        status: 狀態
+        supported_by: 支持
+        tested_by:
+        tracking_by: 追蹤
+        uptime: 上線時間
+      header:
+        dashboard: 控制台
+        search_gem:
+        sign_in: 登入
+        sign_out: 登出
+        sign_up: 註冊
+  mailer:
+    confirm_your_email:
+    confirmation_subject:
+    email_confirmation:
+      confirmation_link:
+      welcome_message:
+    email_reset:
+      visit_link_instructions:
   pages:
     about:
+      founding: 本專案由 %{founder} 於 2009 年 4 月創立，發展過程中有超過 %{contributors} 貢獻者以及 %{downloads}。自 RubyGems 1.3.6 發佈以來，本站名稱由 Gemcutter 更名為 %{title}，本站自此之後成為 Ruby 社群的核心網站。
+      support: 雖然 Gemcutter 並不是由一個特定的公司運作，但在發展過程中接受了許多來源的幫助。目前的設計、圖像以及網站的前端開發是由 %{dockyard} 提供。%{github} 也幫助我們能更容易地協作和分享原始碼。本站部署在 %{heroku} 上，其一流的服務，更有助於證明 Gemcutter 是一個可以穩定、可行的解決方案。Our infrastructure is currently hosted on %{aws}.
+      technical: 關於本站的技術資訊：100% Ruby。主站是一個 %{rails} 應用程式。Gems 架設在 %{s3} 上, served by %{fastly}, 使得 Gem 從發佈到提供下載的時間大幅縮短。詳細資訊可從 GitHub 上的 %{source_code} 查看（遵守 %{license} 協議）。
       title: 關於
       purpose:
-        header: "歡迎來到 %{site}，這裡是 Ruby 社群 Gem 套件管理服務。此專案的建立有以下三個目的："
-        better_api: "提供更好的 Gem API"
-        transparent_pages: "建立更透明、更易於瀏覽的 Gem 專案頁面"
-        enable_community: "讓社群能透過眾人的力量來改善本站"
-      founding: "本專案由 %{founder} 於 2009 年 4 月創立，發展過程中有超過 %{contributors} 貢獻者以及 %{downloads}。自 RubyGems 1.3.6 發佈以來，本站名稱由 Gemcutter 更名為 %{title}，本站自此之後成為 Ruby 社群的核心網站。"
-      support: "雖然 Gemcutter 並不是由一個特定的公司運作，但在發展過程中接受了許多來源的幫助。目前的設計、圖像以及網站的前端開發是由 %{dockyard} 提供。%{github} 也幫助我們能更容易地協作和分享原始碼。本站部署在 %{heroku} 上，其一流的服務，更有助於證明 Gemcutter 是一個可以穩定、可行的解決方案。Our infrastructure is currently hosted on %{aws}."
-      technical: "關於本站的技術資訊：100% Ruby。主站是一個 %{rails} 應用程式。Gems 架設在 %{s3} 上, served by %{fastly}, 使得 Gem 從發佈到提供下載的時間大幅縮短。詳細資訊可從 GitHub 上的 %{source_code} 查看（遵守 %{license} 協議）。"
-
+        better_api: 提供更好的 Gem API
+        enable_community: 讓社群能透過眾人的力量來改善本站
+        header: 歡迎來到 %{site}，這裡是 Ruby 社群 Gem 套件管理服務。此專案的建立有以下三個目的：
+        transparent_pages: 建立更透明、更易於瀏覽的 Gem 專案頁面
   passwords:
     edit:
-      title: "重設密碼"
-      submit: "更新密碼"
+      submit: 更新密碼
+      title: 重設密碼
     new:
-      title: "修改密碼"
-      will_email_notice: "系統將會寄一封包含重設密碼連結的電子郵件給你"
-      submit: "更新密碼"
-
+      submit: 更新密碼
+      title: 修改密碼
+      will_email_notice: 系統將會寄一封包含重設密碼連結的電子郵件給你
   profiles:
     edit:
-      title: "編輯個人檔案"
-      hide_email: "在公開的個人頁面中隱藏 email"
-      reset_password:
-        title: "重設密碼"
-        text: "需要重設密碼？沒問題。 %{link}"
-        link_text: "從這裡設定新密碼"
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: 在公開的個人頁面中隱藏 email
+      optional_twitter_username:
+      title: 編輯個人檔案
       api_access:
+        confirm_reset: 確定要重設嗎？此動作無法還原
+        credentials: 如果你需要從 command line 中執行 %{gem_commands_link}，你需要先準備 %{gem_credentials_file} 這個檔案，用以下的指令可以產生：
+        key_is: 你的 API key 是 %{key}。
+        link_text: Gem 指令
+        reset: 重設 API key
         title: API 存取
-        key_is: "你的 API key 是 %{key}。"
-        credentials: "如果你需要從 command line 中執行 %{gem_commands_link}，你需要先準備 %{gem_credentials_file} 這個檔案，用以下的指令可以產生："
-        link_text: "Gem 指令"
-        reset: "重設 API key"
-        confirm_reset: "確定要重設嗎？此動作無法還原"
-
+      reset_password:
+        link_text: 從這裡設定新密碼
+        text: 需要重設密碼？沒問題。 %{link}
+        title: 重設密碼
+    update:
+      confirmation_mail_sent:
+      request_denied:
+      updated:
   rubygems:
+    aside:
+      bundler_header: Gemfile
+      copied:
+      copy_to_clipboard:
+      downloads_for_this_version: 這個版本
+      install: 安裝
+      required_ruby_version:
+      required_rubygems_version:
+      links:
+        badge: 徽章
+        bugs: Bug 追蹤
+        code: 原始碼
+        docs: 文件
+        download: 下載
+        header: 相關連結
+        home: 首頁
+        mail: 郵件群組
+        report_abuse: 舉報投訴
+        reverse_dependencies:
+        rss: RSS
+        subscribe: 訂閱
+        unsubscribe: 取消訂閱
+        wiki: Wiki
+    blacklisted:
+      blacklisted_namespace:
     dependencies:
       header: "%{title} 相依性套件"
     edit:
-      title: "編輯連結"
+      other_fields_notice: 其他設定欄位只能透過發佈一個新版本的 Gem 來修改
       subtitle: "%{gem}"
-      other_fields_notice: "其他設定欄位只能透過發佈一個新版本的 Gem 來修改"
+      title: 編輯連結
+    gem_members:
+      authors_header: 作者
+      owners_header: 擁有者
+      sha_256_checksum: SHA 256 checksum
     index:
-      title: 'Gems'
-    aside:
-      links:
-        header: "相關連結"
-        home: "首頁"
-        code: "原始碼"
-        docs: "文件"
-        wiki: "Wiki"
-        mail: "郵件群組"
-        bugs: "Bug 追蹤"
-        download: "下載"
-        subscribe: "訂閱"
-        unsubscribe: "取消訂閱"
-        report_abuse: "舉報投訴"
-        badge: "徽章"
-        rss: RSS
-      downloads_for_this_version: "這個版本"
-      bundler_header: Gemfile
-      install: "安裝"
+      downloads:
+      title:
     show:
-      not_hosted_notice: "這個 Gem 目前沒有在 Gemcutter 上"
-      yanked_notice: "這個 Gem 版本已被移除，因此無法提供下載，也無法被其他的 Gem 相依。"
-      authors_header: "作者"
-      owners_header: "擁有者"
-      versions_header: "版本列表"
-      show_all_versions: "顯示所有版本（共 %{count}）"
-      licenses_header: License
-      no_licenses: N/A
-      requirements_header: "必填"
-
+      licenses_header:
+      no_licenses:
+      requirements_header: 必填
+      show_all_versions: 顯示所有版本（共 %{count}）
+      versions_header: 版本列表
+      yanked_notice: 這個 Gem 版本已被移除，因此無法提供下載，也無法被其他的 Gem 相依。
+    show_yanked:
+      not_hosted_notice: 這個 Gem 目前沒有在 Gemcutter 上
+      reserved_namespace:
+        one:
+        other:
+  reverse_dependencies:
+    index:
+      title:
   searches:
     show:
+      exact_match: 完全符合
       subtitle: "%{query}"
-      exact_match: "完全符合"
-
   sessions:
     new:
-      forgot_password: "忘記密碼？"
-
+      forgot_password: 忘記密碼？
+      resend_confirmation:
   stats:
     index:
-      total_downloads: "總下載次數"
-
+      all_time_most_downloaded:
+      total_downloads: 總下載次數
+      total_gems:
+      total_users:
   users:
+    create:
+      email_sent:
     new:
-      have_account: "已經註冊過了？"
-
+      have_account: 已經註冊過了？
   versions:
     index:
+      not_hosted_notice: 這個 Gem 目前沒有在 Gemcutter 上
       title: "%{name} 的所有版本"
-      versions_since: "自從 %{since} 以來，有 %{count} 個版本"
-      not_hosted_notice: "這個 Gem 目前沒有在 Gemcutter 上"
+      versions_since: 自從 %{since} 以來，有 %{count} 個版本
     version:
-      yanked: "已被移除"
-
-  activerecord:
-    attributes:
-      user:
-        avatar: "頭像"
-        email: "Email"
-        handle: "帳號"
-        password: "密碼"
-      linkset:
-        bugs: "Bug 追蹤 URL"
-        code: "原始碼 URL"
-        docs: "文件 URL"
-        mail: "郵件群組 URL"
-        wiki: "Wiki URL"
-      session:
-        who: "Email / 帳號"
-        password: "密碼"
+      yanked: 已被移除
+  will_paginate:
+    next_label:
+    page_gap: "…"
+    previous_label:
+    page_entries_info:
+      multi_page:
+      multi_page_html:
+      single_page:
+        one:
+        other:
+        zero:
+      single_page_html:
+        one:
+        other:
+        zero:

--- a/test/integration/i18n_test.rb
+++ b/test/integration/i18n_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class I18nTest < ActionDispatch::IntegrationTest
+  def collect_combined_keys(hash, ns = nil)
+    hash.collect do |k, v|
+      keys = []
+      keys << collect_combined_keys(v, "#{ns}.#{k}") if v.is_a?(Hash)
+      keys << "#{ns}.#{k}"
+    end.flatten
+  end
+
+  test "translation consistency" do
+    locales_path = File.expand_path('../../../config/locales', __FILE__)
+    locales = Dir.glob("#{locales_path}/*.yml").collect do |file_path|
+      File.basename(file_path, '.yml')
+    end
+
+    # collecting all locales
+    locale_keys = {}
+    locales.each do |locale|
+      translations = YAML.load_file("#{locales_path}/#{locale}.yml")
+      locale_keys[locale] = collect_combined_keys(translations[locale])
+    end
+
+    # Using en as reference
+    reference = locale_keys[locales.delete('en')]
+    assert reference.present?
+
+    locale_keys.each do |locale, keys|
+      missing = reference - keys
+      assert missing.blank?, "#{locale} locale is missing: #{missing.join(', ')}"
+      extra = keys - reference
+      assert extra.blank?, "#{locale} locale has extra: #{extra.join(', ')}"
+    end
+  end
+end


### PR DESCRIPTION
Currently locale files are a mess. None of them structurally match :en locale so it's hard to tell what is translated and what is not. This PR is an effort to clean everything up and make it very hard to screw it up in the future.

- Normalized :en locale without changing anything
- Cleaned up all other locales so they structurally match :en. Added missing keys, removed unused ones. :es was exceptionally bad. So line 123 in en.yml will have exactly same key for all locales.
- Used this script to help me: https://gist.github.com/GBH/de15af9cb51054c34b6ad947009584df but didn't commit it as it should not be needed going forward
- Added a integration test that enforces locale files structure: https://github.com/GBH/rubygems.org/blob/fix/i18n_cleanup/test/integration/i18n_test.rb 
it will complain if you have missing/extra keys in other locales compared to :en

This is only a cleanup. There might be unused keys in :en, but you'll need something like i18n-tasks gem to deal with this. This PR is a foundation for a more manageable locales.

Cheers