### PR TITLE
Remove unused function, append to collection and fix unsafe used of params

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,4 @@
 class Api::BaseController < ApplicationController
-  skip_before_action :require_ssl
-
   private
 
   def find_rubygem_by_name

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -106,7 +106,7 @@ class Rubygem < ActiveRecord::Base
   end
 
   def public_versions_with_extra_version(extra_version)
-    versions = public_versions(5)
+    versions = public_versions(5).to_a
     versions << extra_version
     versions.uniq.sort_by(&:position)
   end

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -31,7 +31,7 @@
       <p>
         Maybe you mean
         <%= suggestions.map do |term|
-          link_to term, search_path(params.except(:controller, :action).merge query: term)
+          link_to term, search_path(params: { query: term }), only_path: true
         end.to_sentence(last_word_connector: ' or ').html_safe %>?
       </p>
     </div>


### PR DESCRIPTION
`require_ssl` method was removed in https://github.com/rubygems/rubygems.org/commit/be8d688dbb0d567aa57f752f538a1130df236022
Rails 5 won't allow appending to `Relation`.
Reusing params in ES suggestion view would show error for unsafe use of
params in rails 5.