### PR TITLE
Remove render_template and assigns from tests

### DIFF
--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -20,7 +20,6 @@ class DashboardsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
       should "render links" do
         @gems.each do |g|
           assert page.has_content?(g.name)
@@ -50,7 +49,6 @@ class DashboardsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template 'versions/feed'
 
       should "render posts with platform-specific titles and links of all subscribed versions" do
         @subscribed_versions.each do |v|

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -49,7 +49,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :new
 
     should 'display resend instructions' do
       assert page.has_content?('We will email you confirmation link to activate your account.')

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -8,7 +8,6 @@ class HomeControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
 
     should "display counts" do
       assert page.has_content?("11,000,000")

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -27,12 +27,8 @@ class ProfilesControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
-      should "assign the last 10 most downloaded gems" do
-        assert_equal @rubygems[0..9], assigns[:rubygems]
-      end
-      should "assign the extra gems you own" do
-        assert_equal [@rubygems.last], assigns[:extra_rubygems]
+      should "display all gems of user" do
+        11.times { |i| assert page.has_content? @rubygems[i].name }
       end
     end
 
@@ -42,14 +38,15 @@ class ProfilesControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
+      should "render user show page" do
+        assert page.has_content? @user.handle
+      end
     end
 
     context "on GET to show with id" do
       setup { get :show, id: @user.id }
 
       should respond_with :success
-      should render_template :show
       should "render Email link" do
         assert page.has_content?("Email Me")
         assert page.has_selector?("a[href='mailto:#{@user.email}']")
@@ -63,7 +60,6 @@ class ProfilesControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
       should "not render Email link" do
         refute page.has_content?("Email Me")
         refute page.has_selector?("a[href='mailto:#{@user.email}']")
@@ -74,7 +70,9 @@ class ProfilesControllerTest < ActionController::TestCase
       setup { get :edit }
 
       should respond_with :success
-      should render_template :edit
+      should "render user edit page" do
+        assert page.has_content? "Edit profile"
+      end
     end
 
     context "on PUT to update" do

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -15,7 +15,6 @@ class RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
       should "renders owner gems overview links" do
         @owners.each do |owner|
           assert page.has_selector?("a[href='#{profile_path(owner.display_id)}']")
@@ -44,7 +43,6 @@ class RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
       should "not render edit link" do
         refute page.has_selector?("a[href='#{edit_rubygem_path(@rubygem)}']")
       end
@@ -57,7 +55,6 @@ class RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show
       should "render edit link" do
         assert page.has_selector?("a[href='#{edit_rubygem_path(@rubygem)}']")
       end
@@ -97,7 +94,6 @@ class RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :edit
       should "render form" do
         assert page.has_selector?("form")
         assert page.has_selector?("input#linkset_code")
@@ -161,7 +157,6 @@ class RubygemsControllerTest < ActionController::TestCase
         put :update, id: @rubygem.to_param, linkset: { code: @url }
       end
       should respond_with :success
-      should render_template :edit
       should "not update linkset" do
         assert_not_equal @url, Rubygem.last.linkset.code
       end
@@ -183,7 +178,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
     should "render links" do
       @gems.each do |g|
         assert page.has_content?(g.name)
@@ -235,7 +229,6 @@ class RubygemsControllerTest < ActionController::TestCase
       get :index, letter: "z"
     end
     should respond_with :success
-    should render_template :index
     should "render links" do
       assert page.has_content?(@zgem.name)
       assert page.has_selector?("a[href='#{rubygem_path(@zgem)}']")
@@ -254,7 +247,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
     should "render links" do
       @gems.each do |g|
         assert page.has_content?(g.name)
@@ -271,7 +263,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "render info about the gem" do
       assert page.has_content?(@rubygem.name)
       assert page.has_content?(@latest_version.number)
@@ -316,7 +307,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "render info about the gem" do
       assert page.has_content?(@rubygem.name)
       assert page.has_content?(@versions[0].number)
@@ -346,7 +336,6 @@ class RubygemsControllerTest < ActionController::TestCase
     context 'when signed out' do
       setup { get :show, id: @rubygem.to_param }
       should respond_with :success
-      should render_template :show_yanked
       should "render info about the gem" do
         assert page.has_content?("This gem is not currently hosted on RubyGems.org")
         assert page.has_no_content?('Versions')
@@ -372,7 +361,6 @@ class RubygemsControllerTest < ActionController::TestCase
       end
 
       should respond_with :success
-      should render_template :show_yanked
       should "render info about the gem" do
         assert page.has_content?("The RubyGems.org team has reserved this gem name for 1 more day.")
         assert page.has_no_content?('Versions')
@@ -389,7 +377,6 @@ class RubygemsControllerTest < ActionController::TestCase
       get :show, id: @rubygem.to_param
     end
     should respond_with :success
-    should render_template :show_yanked
     should "render info about the gem" do
       assert page.has_content?("This gem is not currently hosted on RubyGems.org.")
     end
@@ -406,7 +393,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "show runtime dependencies and development dependencies" do
       assert page.has_content?(@runtime.rubygem.name)
       assert page.has_content?(@development.rubygem.name)
@@ -427,7 +413,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "show unresolved dependencies" do
       assert page.has_content?(@unresolved.name)
     end
@@ -450,7 +435,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "show only dependencies that have rubygem" do
       assert page.has_content?(@runtime.rubygem.name)
       assert page.has_no_content?('1.2.0')
@@ -466,7 +450,6 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "show runtime dependencies and development dependencies" do
       assert page.has_content?(@runtime.rubygem.name)
     end
@@ -486,7 +469,9 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :blacklisted
+    should "render blacklisted page" do
+      assert page.has_content? "This namespace is reserved by rubygems.org."
+    end
   end
 
   context "When not logged in" do

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -9,7 +9,6 @@ class SearchesControllerTest < ActionController::TestCase
     setup { get :show }
 
     should respond_with :success
-    should render_template :show
     should "see no results" do
       refute page.has_content?("Results")
     end
@@ -24,7 +23,9 @@ class SearchesControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
+    should "see no results" do
+      refute page.has_content?("Results")
+    end
   end
 
   context 'on GET to show with search parameters' do
@@ -39,7 +40,6 @@ class SearchesControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "see sinatra on the page in the results" do
       assert page.has_content?(@sinatra.name)
       assert page.has_selector?("a[href='#{rubygem_path(@sinatra)}']")
@@ -70,7 +70,6 @@ class SearchesControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "see sinatra on the page in the results" do
       page.assert_text(@sinatra.name)
       page.assert_selector("a[href='#{rubygem_path(@sinatra)}']")
@@ -105,7 +104,9 @@ class SearchesControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
+    should "see no results" do
+      refute page.has_content?("Results")
+    end
   end
 
   context 'on GET to show with search parameters and no results' do
@@ -125,7 +126,6 @@ class SearchesControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :show
     should "see sinatra on the page in the suggestions" do
       page.assert_text('Maybe you mean')
       assert page.find('.search__suggestions').has_content?(@sinatra.name)

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -24,8 +24,11 @@ class SessionsControllerTest < ActionController::TestCase
       end
 
       should respond_with :unauthorized
-      should render_template 'sessions/new'
       should set_flash.now[:notice]
+
+      should "render sign in page" do
+        assert page.has_content? "Sign in"
+      end
 
       should "not sign in the user" do
         refute @controller.request.env[:clearance].signed_in?

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -18,7 +18,6 @@ class StatsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
 
     should "display number of gems" do
       assert page.has_content?("1,337")

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -12,7 +12,6 @@ class VersionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
 
     should "show all related versions" do
       @versions.each do |version|
@@ -56,7 +55,6 @@ class VersionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template :index
     should "show not hosted notice" do
       assert page.has_content?('This gem is not currently hosted')
     end
@@ -76,7 +74,6 @@ class VersionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template "rubygems/show"
     should "render info about the gem" do
       assert page.has_content?(@rubygem.name)
     end
@@ -102,7 +99,6 @@ class VersionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should render_template "rubygems/show"
     should "show yanked notice" do
       assert page.has_content?("This version has been yanked")
     end


### PR DESCRIPTION
They are deprecated in rails 5.
Reasoning:  instance variables and which template is rendered in a
controller action are internals of a controller, and controller
tests should not care about them.

Check: https://github.com/rails/rails/issues/18950

Related: https://github.com/rubygems/rubygems.org/pull/1341/commits/3d919dbcf35db32bfcbe55ca6097b6019b65efea, https://github.com/rubygems/rubygems.org/pull/1341/commits/ec5bc3c2ba261ecfd72386c6ccbdfaedfc4217e6, https://github.com/rubygems/rubygems.org/pull/1341