### PR TITLE
Fix responsiveness of reserve dependencies page

### DIFF
--- a/app/assets/stylesheets/modules/gems.css
+++ b/app/assets/stylesheets/modules/gems.css
@@ -46,6 +46,16 @@
   .gems__gem:focus {
     outline: none; }
 
+@media (min-width: 900px) {
+  .reverse__dependencies .gems__gem__info {
+      width: 69%; }
+}
+
+@media (min-width: 600px) and (max-width: 899px) {
+  .reverse__dependencies .gems__gem__info {
+      width: 60%; }
+}
+
 .gems__gem__info {
   display: block;
   color: #141c22; }

--- a/app/views/reverse_dependencies/_reverse_dependencies.html.erb
+++ b/app/views/reverse_dependencies/_reverse_dependencies.html.erb
@@ -9,4 +9,6 @@
   <% end %>
 </header>
 
-<%= render dependencies %>
+<div class="reverse__dependencies">
+  <%= render dependencies %>
+</div>


### PR DESCRIPTION
Fixes this:
![screenshot from 2016-12-29 19-51-01](https://cloud.githubusercontent.com/assets/7680662/21545903/2054475a-ce01-11e6-996f-031b5905ba1e.png)

with:
![screenshot from 2016-12-29 20-02-59](https://cloud.githubusercontent.com/assets/7680662/21546025/0266cd34-ce02-11e6-9ddb-b512833b6ba7.png)

