### PR TITLE
Update minitest from 5.9.1 to 5.10.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     metaclass (0.0.4)
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -171,7 +171,7 @@ END
   test "/info with nonexistent gem" do
     get info_path(gem_name: 'donotexist')
     assert_response :not_found
-    assert_equal nil, @response.headers['ETag']
+    assert_nil @response.headers['ETag']
   end
 
   test "/info with gzip" do

--- a/test/integration/encoding_test.rb
+++ b/test/integration/encoding_test.rb
@@ -9,6 +9,6 @@ class EncodingTest < ActionDispatch::IntegrationTest
   test "gzip not supported" do
     get '/'
     assert_response :success
-    assert_equal(nil, @response.headers['Content-Encoding'])
+    assert_nil @response.headers['Content-Encoding']
   end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -381,10 +381,6 @@ class RubygemTest < ActiveSupport::TestCase
       end
     end
 
-    should "return current version" do
-      assert_equal @rubygem.versions.first, @rubygem.versions.most_recent
-    end
-
     should "return name with version for #to_s" do
       @rubygem.save
       create(:version, number: "0.0.0", rubygem: @rubygem)

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -6,7 +6,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "#as_json" do
     setup do
-      @version = create(:version)
+      @version = create(:version, summary: "some words")
     end
 
     should "only have relevant API fields" do


### PR DESCRIPTION
minitest recommends to use assert_nil if expecting nil.
In MT6 it will fail.