### PR TITLE
Store updated email in unconfirmed_email 

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -152,5 +152,8 @@ a.page__heading {
 .push--bottom {
   margin-bottom: 60px; }
 
+.push--bottom-s {
+  margin-bottom: 15px; }
+
 .push--s {
   margin-top: 20px; }

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -24,6 +24,17 @@ class EmailConfirmationsController < ApplicationController
     redirect_to root_path, notice: t('.promise_resend')
   end
 
+  # used to resend confirmation mail for unconfirmed_email validation
+  def unconfirmed
+    if current_user.regenerate_confirmation_token && current_user.save
+      Mailer.delay.email_reset(current_user)
+      flash[:notice] = t('profiles.update.confirmation_mail_sent')
+    else
+      flash[:notice] = t('.try_again')
+    end
+    redirect_to edit_profile_path
+  end
+
   private
 
   def confirmation_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,17 +16,13 @@ class ProfilesController < ApplicationController
   def update
     @user = current_user.clone
     if @user.update_attributes(params_user)
-      if @user.unconfirmed?
+      if @user.unconfirmed_email
         Mailer.delay.email_reset(current_user)
-        sign_out
-        flash[:notice] = "You will receive an email within the next few " \
-                         "minutes. It contains instructions for reconfirming " \
-                         "your account with your new email address."
-        redirect_to_root
+        flash[:notice] = t('.confirmation_mail_sent')
       else
-        flash[:notice] = "Your profile was updated."
-        redirect_to edit_profile_path
+        flash[:notice] = t('.updated')
       end
+      redirect_to edit_profile_path
     else
       current_user.reload
       render :edit

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -5,7 +5,7 @@ class Mailer < ActionMailer::Base
   def email_reset(user)
     @user = User.find(user['id'])
     mail from: Clearance.configuration.mailer_sender,
-         to: @user.email,
+         to: @user.unconfirmed_email,
          subject: I18n.t('mailer.confirmation_subject',
            default: 'Please confirm your email address with RubyGems.org')
   end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -35,6 +35,12 @@
     </div>
   </div>
 
+  <% if current_user.unconfirmed_email %>
+    <p class='form__field__instructions'>
+      <%= t('.email_awaiting_confirmation', unconfirmed_email: current_user.unconfirmed_email) %>
+    </p>
+  <% end %>
+
   <div class="text_field">
     <%= form.label :email, :class => 'form__label' %>
     <%= form.email_field :email, :class => 'form__input' %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -36,9 +36,12 @@
   </div>
 
   <% if current_user.unconfirmed_email %>
-    <p class='form__field__instructions'>
-      <%= t('.email_awaiting_confirmation', unconfirmed_email: current_user.unconfirmed_email) %>
-    </p>
+    <div class="push--bottom-s">
+      <p class='form__field__instructions'>
+        <%= t('.email_awaiting_confirmation', unconfirmed_email: current_user.unconfirmed_email) %>
+      </p>
+      <%= link_to "Resend confirmation", unconfirmed_email_confirmations_path, method: :patch, class: 'form__field__instructions t-link' %>
+    </div>
   <% end %>
 
   <div class="text_field">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
   profiles:
     edit:
       title: Edit profile
+      email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
       hide_email: Hide email in public profile
       optional_twitter_username: Optional Twitter username. Will be displayed publicly
       enter_password: Please enter your account's password
@@ -109,6 +110,8 @@ en:
         reset: Reset my API key
         confirm_reset: Are you sure? This cannot be undone.
     update:
+      confirmation_mail_sent: You will receive an email within the next few minutes. It contains instructions for confirming your new email address.
+      updated: Your profile was updated.
       request_denied: This request was denied. We could not verify your password.
 
   rubygems:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,3 +257,5 @@ en:
       submit: Resend Confirmation
     create:
       promise_resend: We will email you confirmation link to activate your account if one exists.
+    unconfirmed_email:
+      try_again: "Something went wrong. Please try again."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
 
   resource :email_confirmations, only: [:new, :create] do
     get 'confirm/:token', to: 'email_confirmations#update', as: :update
+    patch 'unconfirmed'
   end
 
   # login path is "/session" => "session#create"

--- a/db/migrate/20161231080902_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20161231080902_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160929104437) do
+ActiveRecord::Schema.define(version: 20161231080902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 20160929104437) do
     t.string   "handle"
     t.boolean  "hide_email"
     t.string   "twitter_username"
+    t.string   "unconfirmed_email"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -142,6 +142,30 @@ class ProfilesControllerTest < ActionController::TestCase
           assert_equal @handle, @user.handle
         end
       end
+
+      context "updating email with existing email" do
+        setup do
+          create(:user, email: "cannotchange@tothis.com")
+          put :update, user: { email: "cannotchange@tothis.com", password: @user.password }
+        end
+
+        should "not set unconfirmed_email" do
+          assert page.has_content? "Email address has already been taken"
+          refute_equal "cannotchange@tothis.com", @user.unconfirmed_email
+        end
+      end
+
+      context "updating email with existing unconfirmed_email" do
+        setup do
+          create(:user, unconfirmed_email: "cannotchange@tothis.com")
+          put :update, user: { email: "cannotchange@tothis.com", password: @user.password }
+        end
+
+        should "not set unconfirmed_email" do
+          assert page.has_content? "Email address has already been taken"
+          refute_equal "cannotchange@tothis.com", @user.unconfirmed_email
+        end
+      end
     end
   end
 

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -53,7 +53,7 @@ class ProfileTest < SystemTest
     assert page.has_link?("nick1", href: "/profiles/nick1")
   end
 
-  test "changing email signs out user and asks to confirm email" do
+  test "changing email does not change email and asks to confirm email" do
     sign_in
     visit profile_path("nick1")
     click_link "Edit Profile"
@@ -62,17 +62,18 @@ class ProfileTest < SystemTest
     fill_in "Password", with: "password12345"
     click_button "Update"
 
-    assert page.has_content? "Sign in"
+    assert page.has_selector? "input[value='nick@example.com']"
     assert page.has_selector? '#flash_notice', text: "You will receive "\
       "an email within the next few minutes. It contains instructions "\
-      "for reconfirming your account with your new email address."
+      "for confirming your new email address."
 
     link = last_email_link
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
+    visit edit_profile_path
+    assert page.has_selector? "input[value='nick2@example.com']"
   end
 
   test "disabling email on profile" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -176,8 +176,8 @@ class UserTest < ActiveSupport::TestCase
         assert_resetting_email_changes :confirmation_token
       end
 
-      should "unconfirm email" do
-        assert_resetting_email_changes :unconfirmed?
+      should "store unconfirm email" do
+        assert_resetting_email_changes :unconfirmed_email
       end
 
       should "reset token_expires_at" do


### PR DESCRIPTION
Closes #1512 

After update of email, new email address will be stored in `unconfirmed_email` until it is confirmed. Until new email email address is confirmed, user will see following and their old email will remain their effective email address.
![screenshot from 2017-01-05 11-36-03](https://cloud.githubusercontent.com/assets/7680662/21670591/5dd5324e-d33b-11e6-8ef1-36b0e8fbdd2c.png)

