### PR TITLE
Re-add github stars

### DIFF
--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -1,4 +1,8 @@
 <div class="gem__aside l-col--r--pad">
+  <% if @rubygem.linkset.present? && github_link = link_to_github(@rubygem) %>
+    <iframe class="gem__ghbtn" src="https://ghbtns.com/github-btn.html?user=<%= github_link.path.split('/').second %>&repo=<%= github_link.path.split('/').third %>&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+  <% end %>
+
   <% if @latest_version.indexed %>
     <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
       <h2 class="gem__downloads__heading t-text--s">


### PR DESCRIPTION
Rolls back changes made in #1493 .
Can be merged after the task in #1499 is run in production.

![ghbtn](https://cloud.githubusercontent.com/assets/14155445/19354208/f6cb6c42-9133-11e6-9588-11a3d73c3288.png)