### PR TITLE
Use @versions query to detect any public versions

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -25,7 +25,7 @@ class RubygemsController < ApplicationController
       render 'blacklisted'
     else
       @versions = @rubygem.public_versions(5)
-      if @rubygem.public_versions.any?
+      if @versions.to_a.any?
         render 'show'
       else
         render 'show_yanked'


### PR DESCRIPTION
before:

```ruby
@versions = @rubygem.public_versions(5)
if @rubygem.public_versions.any?
```

2 queries:

- look up first 5 `versions` records with public `criteria`.
- ask database if there are records in `versions` with `public` criteria.


after:

```ruby
@versions = @rubygem.public_versions(5)
if @versions.to_a.any?
```

1 queries:

- look up first 5 `versions` records with public `criteria`.
- see if anything just returned (forcing the first query to execute, assuming it will be displayed)

-----

I may have missed something here and it is only really saving a `count(*)`.
Don't think this is static page cached, but maybe this PR is overthinking things.

