### PR TITLE
handle IP spoofing exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,10 @@ class ApplicationController < ActionController::Base
     render plain: "Request is missing param '#{e.param}'", status: :bad_request
   end
 
+  rescue_from ActionDispatch::RemoteIp::IpSpoofAttackError do
+    render status: :forbidden
+  end
+
   protected
 
   def fastly_expires_in(seconds)


### PR DESCRIPTION
Rails leaves this up to the application to decide how to handle. We just want to return an error and be done with it.