### PR TITLE
Order downloads by rubygem_id before updating ES index

### DIFF
--- a/test/helpers/es_helper.rb
+++ b/test/helpers/es_helper.rb
@@ -1,0 +1,15 @@
+module ESHelper
+  def import_and_refresh
+    Rubygem.import
+    Rubygem.__elasticsearch__.refresh_index!
+    # wait for indexing to finish
+    Rubygem.__elasticsearch__.client.cluster.health wait_for_status: 'yellow'
+  end
+
+  def es_downloads(id)
+    response = Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
+                                                    type: 'rubygem',
+                                                    id: id
+    response['_source']['downloads']
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'clearance/test_unit'
 require 'shoulda'
 require 'helpers/gem_helpers'
 require 'helpers/email_helpers'
+require 'helpers/es_helper'
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true

--- a/test/unit/fastly_log_processor_test.rb
+++ b/test/unit/fastly_log_processor_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include ESHelper
 
 class FastlyLogProcessorTest < ActiveSupport::TestCase
   setup do
@@ -18,6 +19,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
     }
     @job = FastlyLogProcessor.new('test-bucket', 'fastly-fake.log')
     create(:gem_download)
+    Rubygem.__elasticsearch__.create_index! force: true
   end
 
   teardown do
@@ -53,6 +55,8 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
       create(:version, rubygem: json, number: '1.8.3', platform: 'java')
       create(:version, rubygem: json, number: '1.8.3')
       create(:version, rubygem: json, number: '1.8.2')
+
+      import_and_refresh
     end
 
     context '#perform' do
@@ -60,6 +64,7 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
         json = Rubygem.find_by_name('json')
         assert_equal 0, GemDownload.count_for_rubygem(json.id)
         3.times { @job.perform }
+        assert_equal 7, es_downloads(json.id)
         assert_equal 7, GemDownload.count_for_rubygem(json.id)
       end
 
@@ -76,15 +81,19 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
 
         json = Rubygem.find_by_name('json')
         assert_equal 7, GemDownload.count_for_rubygem(json.id)
+        assert_equal 7, es_downloads(json.id)
         assert_equal "processed", @log_ticket.reload.status
       end
 
       should "not run if already processed" do
-        assert_equal 0, Rubygem.find_by_name('json').downloads
+        json = Rubygem.find_by_name('json')
+        assert_equal 0, json.downloads
+        assert_equal 0, es_downloads(json.id)
         @log_ticket.update(status: 'processed')
         @job.perform
 
-        assert_equal 0, Rubygem.find_by_name('json').downloads
+        assert_equal 0, es_downloads(json.id)
+        assert_equal 0, json.downloads
       end
 
       should "not mark as processed if anything fails" do
@@ -104,7 +113,9 @@ class FastlyLogProcessorTest < ActiveSupport::TestCase
 
         @job = FastlyLogProcessor.new('test-bucket', 'fastly-fake.log')
         @job.perform
-        assert_equal 0, Rubygem.find_by_name('json').downloads
+        json = Rubygem.find_by_name('json')
+        assert_equal 0, json.downloads
+        assert_equal 0, es_downloads(json.id)
       end
 
       should "only process the right file" do

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include ESHelper
 
 class RubygemSearchableTest < ActiveSupport::TestCase
   setup do
@@ -36,13 +37,6 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         assert_equal v, json[k]
       end
     end
-  end
-
-  def import_and_refresh
-    Rubygem.import
-    Rubygem.__elasticsearch__.refresh_index!
-    # wait for indexing to finish
-    Rubygem.__elasticsearch__.client.cluster.health wait_for_status: 'yellow'
   end
 
   context 'filter' do


### PR DESCRIPTION
[`where(rubygem_id: gem_ids, version_id: 0)`](https://github.com/rubygems/rubygems.org/blob/master/app/models/gem_download.rb#L101) does not guarantee that order of returned records will be same that of gem_ids. [Zipping it with `updates_by_gem`](https://github.com/rubygems/rubygems.org/blob/master/app/models/gem_download.rb#L102) mixes up initial downloads and updates. 

Related:  #1309
Failing build without this patch: [travis](https://travis-ci.org/sonalkr132/rubygems.org/jobs/191236193#L1129)