### PR TITLE
rescue URI::InvalidURIError in link_to_github helper

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -21,6 +21,8 @@ module RubygemsHelper
     elsif !rubygem.linkset.home.nil? && URI(rubygem.linkset.home).host == "github.com"
       URI(rubygem.linkset.home)
     end
+  rescue URI::InvalidURIError
+    nil
   end
 
   def link_to_directory

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -139,4 +139,45 @@ class RubygemsHelperTest < ActionView::TestCase
       assert simple_markup(text).html_safe?
     end
   end
+
+  context "link_to_github" do
+    context "with invalid uri" do
+      setup do
+        linkset = build(:linkset, code: "http://github.com/\#{github_username}/\#{project_name}")
+        @rubygem = build(:rubygem, linkset: linkset)
+      end
+
+      should "not raise error" do
+        assert_nothing_raised { link_to_github(@rubygem) }
+      end
+
+      should "return nil" do
+        assert_nil link_to_github(@rubygem)
+      end
+    end
+
+    context "with valid code uri and github as host" do
+      setup do
+        @github_link = "http://github.com/user/project"
+        linkset = build(:linkset, code: @github_link)
+        @rubygem = build(:rubygem, linkset: linkset)
+      end
+
+      should "return parsed uri" do
+        assert_equal URI(@github_link), link_to_github(@rubygem)
+      end
+    end
+
+    context "with valid home uri and github as host" do
+      setup do
+        @github_link = "http://github.com/user/project"
+        linkset = build(:linkset, home: @github_link)
+        @rubygem = build(:rubygem, linkset: linkset)
+      end
+
+      should "return parsed uri" do
+        assert_equal URI(@github_link), link_to_github(@rubygem)
+      end
+    end
+  end
 end


### PR DESCRIPTION
uri like `http://github.com/\#{github_username}/\#{project_name}`
(and others) passes our regex validation but blows up in the helper
method. It seems unlikely that we will find a perfect regex.
Alternatively, we can first encode the uri with `URI.encode(uri)`
and then parse it. However, in certain cases(like the one mentioned
above) it would leave us with a dead star icon on gem show page.

Related: https://app.honeybadger.io/projects/40972/faults/32295278
https://app.honeybadger.io/projects/40972/faults/32295278