### PR TITLE
sandbox iframe used for github star

### DIFF
--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -1,6 +1,6 @@
 <div class="gem__aside l-col--r--pad">
   <% if @rubygem.linkset.present? && github_link = link_to_github(@rubygem) %>
-    <iframe class="gem__ghbtn" src="https://ghbtns.com/github-btn.html?user=<%= github_link.path.split('/').second %>&repo=<%= github_link.path.split('/').third %>&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+    <iframe class="gem__ghbtn" src="https://ghbtns.com/github-btn.html?user=<%= github_link.path.split('/').second %>&repo=<%= github_link.path.split('/').third %>&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px" sandbox="allow-scripts allow-popups"></iframe>
   <% end %>
 
   <% if @latest_version.indexed %>


### PR DESCRIPTION
iframe only needs permission to excute script and open new window.
It doesn't need other permission like form submission, navigation of
top-level browsing content etc. Sandboxing is not supported by IE 10
and below.
Read: https://msdn.microsoft.com/en-us/hh563496