### PR TITLE
Fix missing translation in reverse dep search

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -196,6 +196,8 @@ de:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: Exakte Übereinstimmung

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,8 @@ en:
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"
+    reverse_dependencies:
+      search_reverse_dependencies: "Search reverse dependencies Gems&hellip;"
   searches:
     show:
       exact_match: Exact match

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -196,6 +196,8 @@ es:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: Resultado exacto

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -196,6 +196,8 @@ fr:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: Titre exact

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -196,6 +196,8 @@ nl:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: Exacte match

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -196,6 +196,8 @@ pt-BR:
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: Busca exata

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -196,6 +196,8 @@ zh-CN:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: 精确匹配

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -196,6 +196,8 @@ zh-TW:
   reverse_dependencies:
     index:
       title:
+    reverse_dependencies:
+      search_reverse_dependencies:
   searches:
     show:
       exact_match: 完全符合


### PR DESCRIPTION
Fixes:
![screenshot from 2017-01-13 18-15-43](https://cloud.githubusercontent.com/assets/7680662/21930516/71ef906c-d9bc-11e6-896c-60553da6b1d6.png)

[It was possibly left out in rebase](https://github.com/rubygems/rubygems.org/pull/1522/files#diff-37c9b835927e3c363588f172de9bb6faL174).