### PR TITLE
Remove methods only used in rake task from version model

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -330,37 +330,7 @@ class Version < ActiveRecord::Base
     raw.unpack("m0").first.unpack("H*").first
   end
 
-  def recalculate_sha256
-    key = "gems/#{full_name}.gem"
-    file = RubygemFs.instance.get(key)
-    Digest::SHA2.base64digest(file) if file
-  end
-
-  def recalculate_sha256!
-    update_attributes(sha256: recalculate_sha256)
-  end
-
-  def recalculate_metadata!
-    metadata = get_spec_attribute('metadata')
-    update(metadata: metadata || {})
-  end
-
-  def assign_required_rubygems_version!
-    required_rubygems_version = get_spec_attribute('required_rubygems_version')
-    update_column(:required_rubygems_version, required_rubygems_version.to_s)
-  end
-
   private
-
-  def get_spec_attribute(attribute_name)
-    key = "gems/#{full_name}.gem"
-    file = RubygemFs.instance.get(key)
-    return nil unless file
-    spec = Gem::Package.new(StringIO.new(file)).spec
-    spec.send(attribute_name)
-  rescue Gem::Package::FormatError
-    nil
-  end
 
   def platform_and_number_are_unique
     return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -1,3 +1,5 @@
+require "tasks/helpers/gemcutter_tasks_helper"
+
 namespace :gemcutter do
   namespace :index do
     desc "Update the index"
@@ -34,7 +36,7 @@ namespace :gemcutter do
       total = without_sha256.count
       i = 0
       without_sha256.find_each do |version|
-        version.recalculate_sha256!
+        GemcutterTaskshelper.recalculate_sha256!(version)
         i += 1
         print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
       end
@@ -48,7 +50,7 @@ namespace :gemcutter do
       i = 0
       total = Version.count
       Version.find_each do |version|
-        actual_sha256 = version.recalculate_sha256
+        actual_sha256 = GemcutterTaskshelper.recalculate_sha256(version.full_name)
         if actual_sha256 && version.sha256 != actual_sha256
           puts "#{version.full_name}.gem has sha256 '#{actual_sha256}', " \
             "but '#{version.sha256}' was expected."
@@ -71,7 +73,7 @@ namespace :gemcutter do
       i = 0
       puts "Total: #{total}"
       without_metadata.find_each do |version|
-        version.recalculate_metadata!
+        GemcutterTaskshelper.recalculate_metadata!(version)
         i += 1
         print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
       end
@@ -91,7 +93,7 @@ namespace :gemcutter do
       i = 0
       puts "Total: #{total}"
       without_required_rubygems_version.find_each do |version|
-        version.assign_required_rubygems_version!
+        GemcutterTaskshelper.assign_required_rubygems_version!(version)
         i += 1
         print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
       end

--- a/lib/tasks/helpers/gemcutter_tasks_helper.rb
+++ b/lib/tasks/helpers/gemcutter_tasks_helper.rb
@@ -1,0 +1,34 @@
+module GemcutterTaskshelper
+  module_function
+
+  def recalculate_sha256(version_full_name)
+    key = "gems/#{version_full_name}.gem"
+    file = RubygemFs.instance.get(key)
+    Digest::SHA2.base64digest(file) if file
+  end
+
+  def recalculate_sha256!(version)
+    sha256 = recalculate_sha256(version.full_name)
+    version.update_attributes(sha256: sha256)
+  end
+
+  def recalculate_metadata!(version)
+    metadata = get_spec_attribute(version.full_name, 'metadata')
+    version.update(metadata: metadata || {})
+  end
+
+  def assign_required_rubygems_version!(version)
+    required_rubygems_version = get_spec_attribute(version.full_name, 'required_rubygems_version')
+    version.update_column(:required_rubygems_version, required_rubygems_version.to_s)
+  end
+
+  def get_spec_attribute(version_full_name, attribute_name)
+    key = "gems/#{version_full_name}.gem"
+    file = RubygemFs.instance.get(key)
+    return nil unless file
+    spec = Gem::Package.new(StringIO.new(file)).spec
+    spec.send(attribute_name)
+  rescue Gem::Package::FormatError
+    nil
+  end
+end


### PR DESCRIPTION
These were one-time-use rake tasks. I like a 30 lines shorter version.rb file, which is closing in 400 lines.