### PR TITLE
Update yanked_info_checksum before deleting info cache

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -50,10 +50,8 @@ class Deletion < ActiveRecord::Base
   end
 
   def set_yanked_info_checksum
-    # expire info cache of last version
-    Rails.cache.delete("info/#{rubygem}")
-    gem_info = GemInfo.new(version.rubygem.name)
-    checksum = Digest::MD5.hexdigest(CompactIndex.info(gem_info.compact_index_info))
+    compact_index_info = GemInfo.new(version.rubygem.name).compute_compact_index_info
+    checksum = Digest::MD5.hexdigest(CompactIndex.info(compact_index_info))
     version.update_attribute :yanked_info_checksum, checksum
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -50,8 +50,7 @@ class Deletion < ActiveRecord::Base
   end
 
   def set_yanked_info_checksum
-    compact_index_info = GemInfo.new(version.rubygem.name).compute_compact_index_info
-    checksum = Digest::MD5.hexdigest(CompactIndex.info(compact_index_info))
+    checksum = GemInfo.new(version.rubygem.name).info_checksum
     version.update_attribute :yanked_info_checksum, checksum
   end
 end

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -16,6 +16,11 @@ class GemInfo
     end
   end
 
+  def info_checksum
+    compact_index_info = CompactIndex.info(compute_compact_index_info)
+    Digest::MD5.hexdigest(compact_index_info)
+  end
+
   def self.ordered_names
     names = Rails.cache.read('names')
     if names
@@ -82,6 +87,8 @@ class GemInfo
   end
 
   private_class_method :map_gem_versions, :execute_raw_sql
+
+  private
 
   def compute_compact_index_info
     group_by_columns =

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -131,8 +131,7 @@ class Pusher
   end
 
   def set_info_checksum
-    gem_info = GemInfo.new(rubygem.name).compute_compact_index_info
-    checksum = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
+    checksum = GemInfo.new(rubygem.name).info_checksum
     version.update_attribute :info_checksum, checksum
   end
 end


### PR DESCRIPTION
Deleting info cache before updating yanked_info_checksum is not safe.
Cache will be expired with `expire_cache` in `after_commit`.

Related: #1466