### PR TITLE
Add a script to restore a yanked version

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -7,11 +7,17 @@ class Deletion < ActiveRecord::Base
 
   before_validation :record_metadata
   after_create :remove_from_index, :set_yanked_info_checksum
-  after_commit :remove_from_storage
+  after_commit :remove_from_storage, on: :create
   after_commit :expire_cache
   after_commit :update_search_index
 
   attr_accessor :version
+
+  def restore!
+    restore_to_index
+    restore_to_storage
+    destroy!
+  end
 
   private
 
@@ -30,6 +36,7 @@ class Deletion < ActiveRecord::Base
   end
 
   def expire_cache
+    purge_fastly
     GemCachePurger.call(rubygem)
   end
 
@@ -38,9 +45,22 @@ class Deletion < ActiveRecord::Base
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
   end
 
+  def restore_to_index
+    version.update!(indexed: true, yanked_at: nil, yanked_info_checksum: nil)
+    Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
+  end
+
   def remove_from_storage
     RubygemFs.instance.remove("gems/#{@version.full_name}.gem")
     RubygemFs.instance.remove("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+  end
+
+  def restore_to_storage
+    RubygemFs.instance.restore("gems/#{@version.full_name}.gem")
+    RubygemFs.instance.restore("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+  end
+
+  def purge_fastly
     Fastly.delay.purge("gems/#{@version.full_name}.gem")
     Fastly.delay.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
   end

--- a/script/restore_version
+++ b/script/restore_version
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+gem_name, version_number, platform = *ARGV
+
+if gem_name.nil? || version_number.nil?
+  abort "Usage: script/restore_version GEM_NAME VESRION_NUMBER [PLATFORM]"
+end
+
+ENV['RAILS_ENV'] ||= 'production'
+require_relative '../config/environment'
+
+rubygem = Rubygem.find_by_name!(gem_name)
+slug = version_number
+slug << "-#{platform}" unless platform.blank?
+version = Version.find_from_slug!(rubygem, slug)
+raise "Version #{slug} for #{gem_name} was not found" unless version
+
+deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform)
+raise "Deletion record for version: #{version.full_name} was not found" unless deletion
+
+deletion.version = version
+deletion.restore!


### PR DESCRIPTION
closes: #1548 

`RubygemFs::Local` does not implement `restore` method as there is
no way to restore a deleted file locally. This script won't work in
development env.