### PR TITLE
Remove builder from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'rails-i18n'
 
 gem 'autoprefixer-rails'
 gem 'aws-sdk', '~> 2.2'
-gem 'builder'
 gem 'clearance'
 gem 'clearance-deprecated_password_strategies'
 gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,6 @@ DEPENDENCIES
   autoprefixer-rails
   aws-sdk (~> 2.2)
   bourne
-  builder
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
   capistrano-rails (~> 1.1)


### PR DESCRIPTION
It was added in 97702a265d69f9800caa6a588ac6ad40c05c9720 so that we can get around *some* failure with `dasherize` method in builder 3.0.1 We are way past 3.0.1.