### PR TITLE
Add change log links to gem page

### DIFF
--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -2,6 +2,7 @@ class Links
   # Links available for indexed gems
   LINKS = {
     'home'     => 'homepage_uri',
+    'changelog' => 'changelog_uri',
     'code'     => 'source_code_uri',
     'docs'     => 'documentation_uri',
     'wiki'     => 'wiki_uri',
@@ -54,10 +55,11 @@ class Links
 
   # define getters for each of the uris (both short `home` or long `homepage_uri` versions)
   # don't define for download_uri since it has special logic and is already defined
+  # using a try because linkset does not define all the uri attributes
   LINKS.each do |short, long|
     unless method_defined?(long)
       define_method(long) do
-        version.metadata[long].presence || linkset&.public_send(short)
+        version.metadata[long].presence || linkset.try(short)
       end
     end
     alias_method short, long

--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -1,19 +1,19 @@
 class Links
   # Links available for indexed gems
   LINKS = {
-    'home'     => 'homepage_uri',
+    'home'      => 'homepage_uri',
     'changelog' => 'changelog_uri',
-    'code'     => 'source_code_uri',
-    'docs'     => 'documentation_uri',
-    'wiki'     => 'wiki_uri',
-    'mail'     => 'mailing_list_uri',
-    'bugs'     => 'bug_tracker_uri',
-    'download' => 'download_uri'
+    'code'      => 'source_code_uri',
+    'docs'      => 'documentation_uri',
+    'wiki'      => 'wiki_uri',
+    'mail'      => 'mailing_list_uri',
+    'bugs'      => 'bug_tracker_uri',
+    'download'  => 'download_uri'
   }.freeze
 
   # Links available for non-indexed gems
   NON_INDEXED_LINKS = {
-    'docs'     => 'documentation_uri'
+    'docs'      => 'documentation_uri'
   }.freeze
 
   attr_accessor :rubygem, :version, :linkset

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -155,6 +155,7 @@ class Rubygem < ActiveRecord::Base
       'mailing_list_uri'  => versioned_links.mailing_list_uri,
       'source_code_uri'   => versioned_links.source_code_uri,
       'bug_tracker_uri'   => versioned_links.bug_tracker_uri,
+      'changelog_uri'     => versioned_links.changelog_uri,
       'dependencies'      => {
         'development' => deps.select { |r| r.rubygem && 'development' == r.scope },
         'runtime'     => deps.select { |r| r.rubygem && 'runtime' == r.scope }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -21,6 +21,7 @@ de:
     attributes:
       linkset:
         bugs: Bug Tracker URL
+        changelog: Changelog
         code: Quellcode URL
         docs: Dokumentation URL
         mail: Mailingliste URL
@@ -154,6 +155,7 @@ de:
       links:
         badge: Abzeichen
         bugs: Bug Tracker
+        changelog: Changelog
         code: Quellcode
         docs: Dokumentation
         download: Download

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
     attributes:
       linkset:
         bugs: Bug Tracker URL
+        changelog: Changelog URL
         code: Source Code URL
         docs: Documentation URL
         mail: Mailing List URL
@@ -154,6 +155,7 @@ en:
       links:
         badge: Badge
         bugs: Bug Tracker
+        changelog: Changelog
         code: Source Code
         docs: Documentation
         download: Download

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,7 @@ es:
     attributes:
       linkset:
         bugs: URL del registro de Bugs
+        changelog: URL del Changelog
         code: URL del código fuente
         docs: URL de la documentación
         mail: URL de la lista de correo
@@ -154,6 +155,7 @@ es:
       links:
         badge: Badge
         bugs: Registro de bugs
+        changelog: Changelog
         code: Código fuente
         docs: Documentación
         download: Descargar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -21,6 +21,7 @@ fr:
     attributes:
       linkset:
         bugs: URL du suivi de bugs
+        changelog:
         code: URL du code source
         docs: URL de la documentation
         mail: URL de la liste de diffusion
@@ -154,6 +155,7 @@ fr:
       links:
         badge: Badge
         bugs: Suivi de bugs
+        changelog:
         code: Code Source
         docs: Documentation
         download: Télécharger

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -21,6 +21,7 @@ nl:
     attributes:
       linkset:
         bugs: Bugtracker-URL
+        changelog:
         code: source code URL
         docs: Documentatie-URL
         mail: Mailing-list-URL
@@ -154,6 +155,7 @@ nl:
       links:
         badge: Badge
         bugs: Bug-tracker
+        changelog:
         code: source code
         docs: Documentatie
         download: Download

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -21,6 +21,7 @@ pt-BR:
     attributes:
       linkset:
         bugs: URL do Bug Tracker
+        changelog:
         code: URL do Código Fonte
         docs: URL da Documentação
         mail: URL da Lista de Emails
@@ -154,6 +155,7 @@ pt-BR:
       links:
         badge: Badge
         bugs:
+        changelog:
         code: Código Fonte
         docs: Documentação
         download: Download

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -21,6 +21,7 @@ zh-CN:
     attributes:
       linkset:
         bugs:
+        changelog:
         code: 源代码 URL
         docs: 文档 URL
         mail: 邮件列表 URL
@@ -154,6 +155,7 @@ zh-CN:
       links:
         badge: 徽章
         bugs:
+        changelog:
         code: 源代码
         docs: 文档
         download: 下载

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -21,6 +21,7 @@ zh-TW:
     attributes:
       linkset:
         bugs: Bug 追蹤 URL
+        changelog:
         code: 原始碼 URL
         docs: 文件 URL
         mail: 郵件群組 URL
@@ -154,6 +155,7 @@ zh-TW:
       links:
         badge: 徽章
         bugs: Bug 追蹤
+        changelog:
         code: 原始碼
         docs: 文件
         download: 下載

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -457,7 +457,8 @@ class RubygemTest < ActiveSupport::TestCase
             "documentation_uri" => "http://example.com/docs",
             "mailing_list_uri" => "http://example.com/mail",
             "source_code_uri" => "http://example.com/code",
-            "bug_tracker_uri" => "http://example.com/bugs"
+            "bug_tracker_uri" => "http://example.com/bugs",
+            "changelog_uri" => "http://example.com/change"
           }
         )
 
@@ -469,6 +470,7 @@ class RubygemTest < ActiveSupport::TestCase
         assert_equal "http://example.com/mail", hash["mailing_list_uri"]
         assert_equal "http://example.com/code", hash["source_code_uri"]
         assert_equal "http://example.com/bugs", hash["bug_tracker_uri"]
+        assert_equal "http://example.com/change", hash["changelog_uri"]
       end
 
       should "return version documentation url if metadata and linkset docs is empty" do


### PR DESCRIPTION
Alternative to #728 

This reads the changelog uri from the metadata without requiring changing the `Linkset` table.

The core of the change is in `Links:58`

It dynamically generates methods for each of the link attributes.
The value is read from the metadata. If it is not present, it falls back to the value in the `Linkset`.
For changelog (and future uri values), it is not defined in linkset, so a `try` is used to be flexible here.


/cc @olivierlacan sorry it took me so long.
