### PR TITLE
Revert "Expire session when user signs in or signs out" and update clearance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     celluloid-supervision (0.20.6)
       timers (>= 4.1.1)
     choice (0.2.0)
-    clearance (1.15.1)
+    clearance (1.16.0)
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,6 @@ class SessionsController < Clearance::SessionsController
 
     sign_in(@user) do |status|
       if status.success?
-        reset_session
         StatsD.increment 'login.success'
         redirect_back_or(url_after_create)
       else
@@ -13,12 +12,6 @@ class SessionsController < Clearance::SessionsController
         render template: 'sessions/new', status: :unauthorized
       end
     end
-  end
-
-  def destroy
-    reset_session
-    sign_out
-    redirect_to url_after_destroy
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,7 +79,7 @@
               </a>
               <div class="header__popup__nav-links">
                 <%= link_to t('.header.dashboard'), dashboard_url, class: "header__nav-link" %>
-                <%= link_to t('.header.sign_out'), log_out_path, method: :delete, class: "header__nav-link" %>
+                <%= link_to t('.header.sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
               </div>
             <% else %>
               <%= link_to t('.header.sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_in'}" %>

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -4,4 +4,5 @@ Clearance.configure do |config|
   config.secure_cookie = true unless Rails.env.test? || Rails.env.development?
   config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
   config.sign_in_guards = [ConfirmedUserGuard]
+  config.rotate_csrf_on_sign_in = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,11 +151,7 @@ Rails.application.routes.draw do
     patch 'unconfirmed'
   end
 
-  # login path is "/session" => "session#create"
-  # and logout path is "/sign_out" => "session#destroy"
-  # Check: https://github.com/thoughtbot/clearance/blob/master/lib/generators/clearance/routes/templates/routes.rb#L2
-  resource :session, only: :create
-  delete '/sign_out' => 'sessions#destroy', as: 'log_out'
+  resource :session, only: [:create, :destroy]
 
   resources :passwords, only: [:new, :create]
 

--- a/test/integration/session_test.rb
+++ b/test/integration/session_test.rb
@@ -1,24 +1,23 @@
 require 'test_helper'
 
 class SessionTest < ActionDispatch::IntegrationTest
-  def retrive_authenticity_token
-    get edit_profile_path
+  def retrive_authenticity_token(path)
+    get path
     request.session[:_csrf_token]
   end
 
   setup do
     create(:user, handle: "johndoe", password: "chunkybacon")
+    @last_session_token = retrive_authenticity_token sign_in_path
     post session_path(session: { who: "johndoe", password: "chunkybacon" })
     ActionController::Base.allow_forgery_protection = true # default is false
-    @last_session_token = retrive_authenticity_token
-    delete log_out_path(authenticity_token: @last_session_token)
   end
 
   teardown do
     ActionController::Base.allow_forgery_protection = false
   end
 
-  test "authenticity_token of logged out user is invalid" do
+  test "authenticity_token of guest session should be invalid in authenticated session" do
     assert_raise ActionController::InvalidAuthenticityToken do
       post session_path(
         session: { who: "johndoe", password: "chunkybacon" },
@@ -30,8 +29,10 @@ class SessionTest < ActionDispatch::IntegrationTest
   end
 
   test "authenticity_token of previous user session is invalid in another session" do
+    @last_session_token = retrive_authenticity_token edit_profile_path
+    delete sign_out_path(authenticity_token: request.session[:_csrf_token])
+
     create(:user, handle: "bob", password: "lovesunicorns")
-    get sign_in_path
     post session_path(
       session: { who: "bob", password: "lovesunicorns" },
       authenticity_token: request.session[:_csrf_token]


### PR DESCRIPTION
This reverts commit 971c40f8b8e2fd149526605b50b5abdc364028a8.
Setting config.rotate_csrf_on_sign_in to `true` will cause the user's
CSRF token to be rotated on sign in and is recommended for all
Clearance applications.
`reset_session` or resetting csrf on sign out doesn't provide any added
value to security.