### PR TITLE
Add validation to metadata links

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -19,6 +19,8 @@ class Version < ActiveRecord::Base
 
   validate :platform_and_number_are_unique, on: :create
   validate :authors_format, on: :create
+  validate :metadata_links_format
+
   class AuthorType < Type::String
     def cast_value(value)
       if value.is_a?(Array)
@@ -359,5 +361,12 @@ class Version < ActiveRecord::Base
   def feature_release(number)
     feature_version = Gem::Version.new(number).segments[0, 2].join('.')
     Gem::Version.new(feature_version)
+  end
+
+  def metadata_links_format
+    Linkset::LINKS.each do |link|
+      errors.add(:metadata, "['#{link}'] does not appear to be a valid URL") if
+        metadata[link] && metadata[link] !~ Patterns::URL_VALIDATION_REGEXP
+    end
   end
 end

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -1,12 +1,13 @@
 module Patterns
   extend ActiveSupport::Concern
 
-  SPECIAL_CHARACTERS = ".-_".freeze
-  ALLOWED_CHARACTERS = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+".freeze
-  ROUTE_PATTERN      = /#{ALLOWED_CHARACTERS}/
-  LAZY_ROUTE_PATTERN = /#{ALLOWED_CHARACTERS}?/
-  NAME_PATTERN       = /\A#{ALLOWED_CHARACTERS}\Z/
-  GEM_NAME_BLACKLIST = %w(
+  SPECIAL_CHARACTERS    = ".-_".freeze
+  ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+".freeze
+  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
+  LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/
+  NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/
+  URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+  GEM_NAME_BLACKLIST    = %w(
     abbrev
     base64
     benchmark

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -670,6 +670,29 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @spec.required_ruby_version.to_s,      @version.required_ruby_version
       assert_equal @spec.required_rubygems_version.to_s,  @version.required_rubygems_version
     end
+
+    context "metadata" do
+      should "be invalid with empty string as link" do
+        assert_raise ActiveRecord::RecordInvalid do
+          @spec.metadata = { "home" => "" }
+          @version.update_attributes_from_gem_specification!(@spec)
+        end
+      end
+
+      should "be invalid with invalid link" do
+        assert_raise ActiveRecord::RecordInvalid do
+          @spec.metadata = { "home" => "http:/github.com/bestgemever" }
+          @version.update_attributes_from_gem_specification!(@spec)
+        end
+      end
+
+      should "be valid with valid link" do
+        assert_nothing_raised do
+          @spec.metadata = { "home" => "http://github.com/bestgemever" }
+          @version.update_attributes_from_gem_specification!(@spec)
+        end
+      end
+    end
   end
 
   context "indexes" do


### PR DESCRIPTION
User will see following when validation fails:
> There was a problem saving your gem: Metadata ['home'] does not appear to be a valid URL

I would propose that we should add same validation to `gem build` command so that people don't have to wait until after `gem push` fails.

Contrary to existing behavior of `Linkset`, it will fail when empty string is used as link. I believe it was allowed for `Linkset` because of existing data we had. We don't need to carry over the confusion to metadata links as well. If a user doesn't intended to provide a particular type of link, they can simply not specify that key/link in their metadata spec.