### PR TITLE
Override git_wrapper_path to remove brackets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,6 +9,12 @@ set :pty, true
 set :assets_roles, [:app]
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/cache', 'tmp/sockets')
 set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secret.rb', 'config/versions.list')
+set :git_wrapper_path, lambda {
+  # Try to avoid permissions issues when multiple users deploy the same app
+  # by using different file names in the same dir for each deployer and stage.
+  suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").shellescape
+  "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
+}
 
 namespace :deploy do
   desc 'Remove git cache for clean deploy'


### PR DESCRIPTION
Fixes:
02 chmod 700 /tmp/git-ssh-rubygems-staging-web-flow-(GitHub-Web-Flow)-via-Shipit.sh
02 bash: -c: line 0: syntax error near unexpected token `('
