### PR TITLE
Remove small brackets from git_wrapper_path suffix

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,7 +12,7 @@ set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/
 set :git_wrapper_path, lambda {
   # Try to avoid permissions issues when multiple users deploy the same app
   # by using different file names in the same dir for each deployer and stage.
-  suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").shellescape
+  suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").gsub(/[\(\)\s+]/, "-")
   "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
 }
 


### PR DESCRIPTION
`git_wrapper_path` is used in following rake task:
```Ruby
task :wrapper do
  on release_roles :all do
    execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path))
    upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
    execute :chmod, "700", fetch(:git_wrapper_path)
  end
end
```

`upload!` doesn't seem to know about escape characters and makes file with name `/tmp/git-ssh-rubygems-staging-web-flow\ \(GitHub\ Web\ Flow\)\ via\ Shipit.sh` (`shellescape` introduced escape character \). When same filename is passed to `chmod` in next line, it tries to find `/tmp/git-ssh-rubygems-staging-web-flow (GitHub Web Flow) via Shipit.sh` and fails with:
> Uploading /tmp/git-ssh-rubygems-staging-web-flow\ (GitHub\ Web\ Flow)\ via\ Shipit.sh 100.0%
02 chmod 700 /tmp/git-ssh-rubygems-staging-web-flow\ (GitHub\ Web\ Flow)\ via\ Shipit.sh
02 chmod: cannot access ‘/tmp/git-ssh-rubygems-staging-web-flow (GitHub Web Flow) via Shipit.sh’
02 : No such file or directory
