### PR TITLE
Introduce a v2 Dependency API endpoint

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -3,11 +3,11 @@ class Api::V1::DependenciesController < Api::BaseController
   GEM_REQUEST_LIMIT = 200
 
   def index
-    deps = GemDependent.new(gem_names).to_a
+    deps = dependent_reader.new(gem_names).to_a
 
     expires_in 30, public: true
     fastly_expires_in 60
-    set_surrogate_key 'dependencyapi', gem_names.map { |name| "gem/#{name}" }
+    set_surrogate_key surrogate_key, gem_names.map { |name| "gem/#{name}" }
 
     respond_to do |format|
       format.json { render json: deps }
@@ -16,6 +16,14 @@ class Api::V1::DependenciesController < Api::BaseController
   end
 
   private
+
+  def surrogate_key
+    'dependencyapi'
+  end
+
+  def dependent_reader
+    GemDependent
+  end
 
   def check_gem_count
     return render plain: '' if gem_names.empty?

--- a/app/controllers/api/v2/dependencies_controller.rb
+++ b/app/controllers/api/v2/dependencies_controller.rb
@@ -1,0 +1,11 @@
+class Api::V2::DependenciesController < Api::V1::DependenciesController
+  private
+
+  def surrogate_key
+    'dependencyapiv2'
+  end
+
+  def dependent_reader
+    GemDependentV2
+  end
+end

--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -1,6 +1,7 @@
 class GemDependent
   extend StatsD::Instrument
   DepKey = Struct.new(:name, :number, :platform, :required_ruby_version, :required_rubygems_version, :info_checksum)
+  DepKey::MEMBERS = DepKey.members.map(&:to_s)
 
   attr_reader :gem_names
 
@@ -49,7 +50,7 @@ class GemDependent
     dataset = ActiveRecord::Base.connection.execute(sanitize_sql)
 
     deps = dataset.group_by do |row|
-      DepKey.new(row['name'], row['number'], row['platform'], row['required_ruby_version'], row['required_rubygems_version'], row['info_checksum'])
+      DepKey.new(*DepKey::MEMBERS.map { |column| row[column] })
     end
 
     deps.map do |dep_key, gem_deps|

--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -1,6 +1,6 @@
 class GemDependent
   extend StatsD::Instrument
-  DepKey = Struct.new(:name, :number, :platform)
+  DepKey = Struct.new(:name, :number, :platform, :required_ruby_version, :required_rubygems_version, :info_checksum)
 
   attr_reader :gem_names
 
@@ -10,15 +10,15 @@ class GemDependent
   end
 
   def fetch_dependencies
-    @gem_names.each { |g| @gem_information[g] = "deps/v1/#{g}" }
+    @gem_names.each { |g| @gem_information[g] = gem_cache_key(g) }
 
     @gem_information.flat_map do |gem_name, cache_key|
       if (dependency = memcached_gem_info[cache_key])
         # Fetch the gem's dependencies from the cache
-        StatsD.increment 'gem_dependent.memcached.hit'
+        StatsD.increment statsd_hit_key
       else
         # Fetch the gem's dependencies from the database
-        StatsD.increment 'gem_dependent.memcached.miss'
+        StatsD.increment statsd_miss_key
         dependency = fetch_dependency_from_db(gem_name)
         Rails.cache.write(cache_key, dependency)
         memcached_gem_info[cache_key] = dependency
@@ -32,32 +32,49 @@ class GemDependent
 
   private
 
+  def gem_cache_key(g)
+    "deps/v1/#{g}"
+  end
+
+  def statsd_hit_key
+    'gem_dependent.memcached.hit'
+  end
+
+  def statsd_miss_key
+    'gem_dependent.memcached.miss'
+  end
+
   def fetch_dependency_from_db(gem_name)
     sanitize_sql = ActiveRecord::Base.send(:sanitize_sql_array, sql_query(gem_name))
     dataset = ActiveRecord::Base.connection.execute(sanitize_sql)
-    deps = {}
 
-    dataset.each do |row|
-      key = DepKey.new(row['name'], row['number'], row['platform'])
-      deps[key] = [] unless deps[key]
-      deps[key] << [row['dep_name'], row['requirements']] if row['dep_name']
+    deps = dataset.group_by do |row|
+      DepKey.new(row['name'], row['number'], row['platform'], row['required_ruby_version'], row['required_rubygems_version'], row['info_checksum'])
     end
 
     deps.map do |dep_key, gem_deps|
-      {
-        name:                  dep_key.name,
-        number:                dep_key.number,
-        platform:              dep_key.platform,
-        dependencies:          gem_deps
+      dependencies = gem_deps.select { |row| row['dep_name'] }.map { |row|
+        [row['dep_name'], row['requirements']]
       }
+
+      build_gem_payload dep_key, dependencies
     end
   end
   statsd_measure :fetch_dependency_from_db, 'gem_dependent.fetch_dependency_from_db'
 
+  def build_gem_payload(dep_key, dependencies)
+    {
+      name:                  dep_key.name,
+      number:                dep_key.number,
+      platform:              dep_key.platform,
+      dependencies:          dependencies
+    }
+  end
+
   def sql_query(gem_name)
-    ["SELECT rv.name, rv.number, rv.platform, d.requirements, for_dep_name.name dep_name
+    ["SELECT rv.name, rv.number, rv.platform, rv.info_checksum, rv.required_ruby_version, rv.required_rubygems_version, d.requirements, for_dep_name.name dep_name
       FROM
-        (SELECT r.name, v.number, v.platform, v.id AS version_id
+        (SELECT r.name, v.number, v.platform, v.info_checksum, v.required_ruby_version, v.required_rubygems_version, v.id AS version_id
         FROM rubygems AS r, versions AS v
         WHERE v.rubygem_id = r.id
           AND v.indexed is true AND r.name = ?) AS rv

--- a/app/models/gem_dependent.rb
+++ b/app/models/gem_dependent.rb
@@ -54,9 +54,9 @@ class GemDependent
     end
 
     deps.map do |dep_key, gem_deps|
-      dependencies = gem_deps.select { |row| row['dep_name'] }.map { |row|
+      dependencies = gem_deps.select { |row| row['dep_name'] }.map do |row|
         [row['dep_name'], row['requirements']]
-      }
+      end
 
       build_gem_payload dep_key, dependencies
     end
@@ -73,7 +73,8 @@ class GemDependent
   end
 
   def sql_query(gem_name)
-    ["SELECT rv.name, rv.number, rv.platform, rv.info_checksum, rv.required_ruby_version, rv.required_rubygems_version, d.requirements, for_dep_name.name dep_name
+    ["SELECT rv.name, rv.number, rv.platform, rv.info_checksum, rv.required_ruby_version, rv.required_rubygems_version,
+      d.requirements, for_dep_name.name dep_name
       FROM
         (SELECT r.name, v.number, v.platform, v.info_checksum, v.required_ruby_version, v.required_rubygems_version, v.id AS version_id
         FROM rubygems AS r, versions AS v

--- a/app/models/gem_dependent_v2.rb
+++ b/app/models/gem_dependent_v2.rb
@@ -1,0 +1,29 @@
+require 'gem_dependent'
+
+class GemDependentV2 < GemDependent
+  private
+
+  def build_gem_payload(dep_key, dependencies)
+    {
+      name:                      dep_key.name,
+      number:                    dep_key.number,
+      platform:                  dep_key.platform,
+      required_ruby_version:     dep_key.required_ruby_version,
+      required_rubygems_version: dep_key.required_rubygems_version,
+      checksum:                  dep_key.info_checksum,
+      dependencies:              dependencies
+    }
+  end
+
+  def gem_cache_key(g)
+    "deps/v2/#{g}"
+  end
+
+  def statsd_hit_key
+    'gem_dependent.v2.memcached.hit'
+  end
+
+  def statsd_miss_key
+    'gem_dependent.v2.memcached.miss'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,11 @@ Rails.application.routes.draw do
           number: /#{Gem::Version::VERSION_PATTERN}(?=\.json\z)|#{Gem::Version::VERSION_PATTERN}/
         }
       end
+
+      resources :dependencies,
+        only: [:index],
+        format: /marshal|json/,
+        defaults: { format: 'marshal' }
     end
 
     namespace :v1 do

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -181,7 +181,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     end
   end
 
-  def expected_results(payload, symbolize = false)
+  def expected_results(payload, _ = false)
     payload
   end
 
@@ -198,13 +198,13 @@ class Api::V2::DependenciesControllerTest < Api::V1::DependenciesControllerTest
   end
 
   def expected_results(payload, symbolize = false)
-    payload.map { |obj|
+    payload.map do |obj|
       v2_info = { "required_ruby_version"     => ">= 2.0.0",
                   "required_rubygems_version" => ">= 2.6.3",
                   "checksum"                  => nil }
       v2_info.symbolize_keys! if symbolize
       obj.merge v2_info
-    }
+    end
   end
 
   def surrogate_key_prefix

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -51,7 +51,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         'dependencies'      => []
       }]
 
-      assert_equal result, JSON.load(response.body)
+      assert_equal expected_results(result), JSON.load(response.body)
     end
   end
 
@@ -71,7 +71,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     end
 
     should "return surrogate key header" do
-      assert_equal "dependencyapi gem/myrails gem/mybundler", @response.headers['Surrogate-Key']
+      assert_equal "#{surrogate_key_prefix} gem/myrails gem/mybundler", @response.headers['Surrogate-Key']
     end
 
     should "return body" do
@@ -98,7 +98,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         }
       ]
 
-      assert_same_elements result, JSON.load(response.body)
+      assert_same_elements expected_results(result), JSON.load(response.body)
     end
   end
 
@@ -161,7 +161,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         dependencies:      []
       }]
 
-      assert_equal result, Marshal.load(response.body)
+      assert_equal expected_results(result, true), Marshal.load(response.body)
     end
   end
 
@@ -179,5 +179,35 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     should "return an error body" do
       assert_equal "Too many gems! (use --full-index instead)", response.body
     end
+  end
+
+  def expected_results(payload, symbolize = false)
+    payload
+  end
+
+  def surrogate_key_prefix
+    'dependencyapi'
+  end
+end
+
+class Api::V2::DependenciesControllerTest < Api::V1::DependenciesControllerTest
+  tests Api::V2::DependenciesController
+
+  should "be using v2 controller" do
+    assert_instance_of Api::V2::DependenciesController, @controller
+  end
+
+  def expected_results(payload, symbolize = false)
+    payload.map { |obj|
+      v2_info = { "required_ruby_version"     => ">= 2.0.0",
+                  "required_rubygems_version" => ">= 2.6.3",
+                  "checksum"                  => nil }
+      v2_info.symbolize_keys! if symbolize
+      obj.merge v2_info
+    }
+  end
+
+  def surrogate_key_prefix
+    'dependencyapiv2'
   end
 end

--- a/test/unit/gem_dependent_test.rb
+++ b/test/unit/gem_dependent_test.rb
@@ -1,10 +1,14 @@
 require 'test_helper'
 
 class GemDependentTest < ActiveSupport::TestCase
+  def test_class
+    GemDependent
+  end
+
   context "creating a new dependency_api" do
     setup do
       @gem = create(:rubygem)
-      @gem_dependent = GemDependent.new(@gem.name)
+      @gem_dependent = test_class.new(@gem.name)
     end
 
     should "have some state" do
@@ -15,7 +19,7 @@ class GemDependentTest < ActiveSupport::TestCase
   context "no gem_names" do
     should "return an ArgumentError" do
       assert_raises ArgumentError do
-        GemDependent.new.to_a
+        test_class.new.to_a
       end
     end
   end
@@ -34,7 +38,7 @@ class GemDependentTest < ActiveSupport::TestCase
         dependencies: []
       }
 
-      deps = GemDependent.new(["rack2"]).to_a
+      deps = test_class.new(["rack2"]).to_a
       result.each_pair do |k, v|
         assert_equal v, deps.first[k]
       end
@@ -52,7 +56,7 @@ class GemDependentTest < ActiveSupport::TestCase
       should "return all versions and platform" do
         result = [["0.1.3", "ruby"], ["0.1.2", "ruby"], ["0.1.2", "jruby"], ["0.2.2", "ruby"]]
 
-        deps = GemDependent.new(["rack"]).to_a
+        deps = test_class.new(["rack"]).to_a
         deps.map { |x| [x[:number], x[:platform]] }.each do |dep|
           assert_includes result, dep
         end
@@ -75,7 +79,7 @@ class GemDependentTest < ActiveSupport::TestCase
       should "return dependencies" do
         expected_deps = [["foo", ">= 0.0.0"], ["bar", ">= 0.0.0"]]
 
-        dep = GemDependent.new(["devise"]).to_a.first
+        dep = test_class.new(["devise"]).to_a.first
         assert_equal 'devise', dep[:name]
         assert_equal '1.0.0', dep[:number]
 
@@ -88,27 +92,47 @@ class GemDependentTest < ActiveSupport::TestCase
     context "non indexed versions" do
       setup do
         nokogiri = create(:rubygem, name: "nokogiri")
-        create(:version, number: "0.0.1", rubygem: nokogiri)
+        create(:version, number: "0.0.1", rubygem: nokogiri, info_checksum: 'abc')
         create(:version, number: "0.1.1", rubygem: nokogiri, indexed: false)
       end
 
       should "filter non indexed version" do
-        result = {
-          name: "nokogiri",
-          number: "0.0.1",
-          platform: "ruby",
-          dependencies: []
-        }
-
-        deps = GemDependent.new(["nokogiri"]).to_a
-        assert_equal [result], deps
+        deps = test_class.new(["nokogiri"]).to_a
+        assert_equal [full_result], deps
       end
     end
   end
 
   context "with gem_names which do not exist" do
     should "return empty array" do
-      assert_equal [], GemDependent.new(["does_not_exist"]).to_a
+      assert_equal [], test_class.new(["does_not_exist"]).to_a
     end
+  end
+
+  def full_result
+    {
+      name: "nokogiri",
+      number: "0.0.1",
+      platform: "ruby",
+      dependencies: []
+    }
+  end
+end
+
+class GemDependentV2Test < GemDependentTest
+  def test_class
+    GemDependentV2
+  end
+
+  def full_result
+    {
+      name: "nokogiri",
+      number: "0.0.1",
+      platform: "ruby",
+      required_ruby_version: ">= 2.0.0",
+      required_rubygems_version: ">= 2.6.3",
+      checksum: 'abc',
+      dependencies: []
+    }
   end
 end


### PR DESCRIPTION
This PR contains a new version of the dependency API endpoint.  It is the same as the v1 endpoint, except that the payloads include the required rubygems version, the required ruby version, and the checksum for the gem.

To show what it looks like, here is the v1 API:

```
[aaron@TC github (master)]$ curl -s http://localhost:3000/api/v1/dependencies.json?gems=nokogiri,choice | jq
[
  {
    "name": "nokogiri",
    "number": "1.7.0.1",
    "platform": "ruby",
    "dependencies": [
      [
        "mini_portile2",
        "~> 2.1.0"
      ]
    ]
  },
  {
    "name": "choice",
    "number": "0.2.0",
    "platform": "ruby",
    "dependencies": []
  }
]
```

Here is the V2 API:

```
[aaron@TC github (master)]$ curl -s http://localhost:3000/api/v2/dependencies.json?gems=nokogiri,choice | jq
[
  {
    "name": "nokogiri",
    "number": "1.7.0.1",
    "platform": "ruby",
    "required_ruby_version": ">= 2.1.0",
    "required_rubygems_version": ">= 0",
    "checksum": "7d0cebae5df8e20e70b4d7f93abaecb8",
    "dependencies": [
      [
        "mini_portile2",
        "~> 2.1.0"
      ]
    ]
  },
  {
    "name": "choice",
    "number": "0.2.0",
    "platform": "ruby",
    "required_ruby_version": ">= 0",
    "required_rubygems_version": ">= 0",
    "checksum": "7baf799c658f3790a674ef48f75285a7",
    "dependencies": []
  }
]
```

Since the V1 API did not contain required ruby version and required rubygems version, the resolver had to make separate requests for each gem in order to find whether or not the Ruby / RubyGems version was compatible.