### PR TITLE
Limit rubygems.reverse_dependencies to latest version of dependant

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::RubygemsController < Api::BaseController
 
   before_action :authenticate_with_api_key, only: [:index, :create]
   before_action :verify_authenticated_user, only: [:index, :create]
-  before_action :find_rubygem,              only: [:show]
+  before_action :find_rubygem,              only: [:show, :reverse_dependencies]
 
   before_action :cors_preflight_check, only: :show
   after_action  :cors_set_access_control_headers, only: :show
@@ -44,11 +44,11 @@ class Api::V1::RubygemsController < Api::BaseController
   def reverse_dependencies
     names = begin
       if params[:only] == "development"
-        Rubygem.reverse_development_dependencies(params[:id]).pluck(:name)
+        @rubygem.reverse_development_dependencies.pluck(:name)
       elsif params[:only] == "runtime"
-        Rubygem.reverse_runtime_dependencies(params[:id]).pluck(:name)
+        @rubygem.reverse_runtime_dependencies.pluck(:name)
       else
-        Rubygem.reverse_dependencies(params[:id]).pluck(:name)
+        @rubygem.reverse_dependencies.pluck(:name)
       end
     end
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -364,50 +364,34 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
   context "on GET to reverse_dependencies" do
     setup do
-      @dep_rubygem = create(:rubygem)
-      @gem_one = create(:rubygem)
-      @gem_two = create(:rubygem)
-      @gem_three = create(:rubygem)
-      @gem_four = create(:rubygem)
-      @gem_five = create(:rubygem)
-      @version_one_latest  = create(:version, rubygem: @gem_one, number: '0.2')
-      @version_one_earlier = create(:version, rubygem: @gem_one, number: '0.1')
-      @version_two_latest  = create(:version, rubygem: @gem_two, number: '1.0')
-      @version_two_earlier = create(:version, rubygem: @gem_two, number: '0.5')
-      @version_three = create(:version, rubygem: @gem_three, number: '1.7')
-      @version_four = create(:version, rubygem: @gem_four, number: '3.9')
-      @version_five = create(:version, rubygem: @gem_five, number: '4.5')
+      @dependency   = create(:rubygem)
+      @gem_one      = create(:rubygem)
+      @gem_two      = create(:rubygem)
+      @gem_three    = create(:rubygem)
+      version_one   = create(:version, rubygem: @gem_one)
+      version_two   = create(:version, rubygem: @gem_two)
+      version_three = create(:version, rubygem: @gem_three)
 
-      @version_one_latest.dependencies << create(:dependency,
-        version: @version_one_latest,
-        rubygem: @dep_rubygem)
-      @version_two_earlier.dependencies << create(:dependency,
-        version: @version_two_earlier,
-        rubygem: @dep_rubygem)
-      @version_three.dependencies << create(:dependency,
-        version: @version_three,
-        rubygem: @dep_rubygem)
-      @version_five.dependencies << create(:dependency, :development,
-        version: @version_five,
-        rubygem: @dep_rubygem)
+      create(:dependency, :runtime, version: version_one, rubygem: @dependency)
+      create(:dependency, :development, version: version_two, rubygem: @dependency)
+      create(:dependency, :runtime, version: version_three, rubygem: @dependency)
     end
 
     should "return names of reverse dependencies" do
-      get :reverse_dependencies, id: @dep_rubygem.to_param, format: "json"
+      get :reverse_dependencies, id: @dependency.to_param, format: "json"
       gems = JSON.load(@response.body)
 
-      assert_equal 4, gems.size
+      assert_equal 3, gems.size
 
       assert gems.include?(@gem_one.name)
       assert gems.include?(@gem_two.name)
       assert gems.include?(@gem_three.name)
-      refute gems.include?(@gem_four.name)
     end
 
     context "with only=development" do
       should "only return names of reverse development dependencies" do
         get :reverse_dependencies,
-          id: @dep_rubygem.to_param,
+          id: @dependency.to_param,
           only: "development",
           format: "json"
 
@@ -415,24 +399,23 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
         assert_equal 1, gems.size
 
-        assert gems.include?(@gem_five.name)
+        assert gems.include?(@gem_two.name)
       end
     end
 
     context "with only=runtime" do
       should "only return names of reverse development dependencies" do
         get :reverse_dependencies,
-          id: @dep_rubygem.to_param,
+          id: @dependency.to_param,
           only: "runtime",
           format: "json"
 
         gems = JSON.load(@response.body)
 
-        assert_equal 3, gems.size
+        assert_equal 2, gems.size
 
         assert gems.include?(@gem_one.name)
-        assert gems.include?(@gem_two.name)
-        assert gems.include?(@gem_three.name)
+        assert gems.include?(@gem_three .name)
       end
     end
   end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -201,67 +201,56 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context ".reverse_dependencies" do
+  context "with reverse dependencies" do
     setup do
-      @dep_rubygem = create(:rubygem)
-      @gem_one = create(:rubygem)
-      @gem_two = create(:rubygem)
-      @gem_three = create(:rubygem)
-      @gem_four = create(:rubygem)
-      @gem_five = create(:rubygem)
-      @version_one_latest  = create(:version, rubygem: @gem_one, number: '0.2')
-      @version_one_earlier = create(:version, rubygem: @gem_one, number: '0.1')
-      @version_two_latest  = create(:version, rubygem: @gem_two, number: '1.0')
-      @version_two_earlier = create(:version, rubygem: @gem_two, number: '0.5')
-      @version_three = create(:version, rubygem: @gem_three, number: '1.7')
-      @version_four = create(:version, rubygem: @gem_four, number: '3.9')
-      @version_five = create(:version, :yanked, rubygem: @gem_five, number: '6.66')
+      @dependency            = create(:rubygem)
+      @gem_one               = create(:rubygem)
+      @gem_two               = create(:rubygem)
+      gem_three              = create(:rubygem)
+      gem_four               = create(:rubygem)
+      version_one            = create(:version, rubygem: @gem_one)
+      version_two            = create(:version, rubygem: @gem_two)
+      _version_three_latest  = create(:version, rubygem: gem_three, number: '1.0')
+      version_three_earlier  = create(:version, rubygem: gem_three, number: '0.5')
+      yanked_version         = create(:version, :yanked, rubygem: gem_four)
 
-      @version_one_latest.dependencies << create(:dependency,
-        :runtime,
-        version: @version_one_latest,
-        rubygem: @dep_rubygem)
-      @version_two_earlier.dependencies << create(:dependency,
-        :development,
-        version: @version_two_earlier,
-        rubygem: @dep_rubygem)
-      @version_three.dependencies << create(:dependency,
-        :runtime,
-        version: @version_three,
-        rubygem: @dep_rubygem)
-      @version_five.dependencies << create(:dependency,
-        version: @version_five,
-        rubygem: @dep_rubygem)
+      create(:dependency, :runtime, version: version_one, rubygem: @dependency)
+      create(:dependency, :development, version: version_two, rubygem: @dependency)
+      create(:dependency, version: version_three_earlier, rubygem: @dependency)
+      create(:dependency, version: yanked_version, rubygem: @dependency)
     end
 
-    should "return all depended rubygems except yanked versions" do
-      gem_list = Rubygem.reverse_dependencies(@dep_rubygem.name)
+    context "#reverse_dependencies" do
+      should "return dependent gems of latest indexed version" do
+        gem_list = @dependency.reverse_dependencies
 
-      assert_equal 3, gem_list.size
+        assert_equal 2, gem_list.size
 
-      assert gem_list.include?(@gem_one)
-      assert gem_list.include?(@gem_two)
-      assert gem_list.include?(@gem_three)
-      refute gem_list.include?(@gem_four)
-      refute gem_list.include?(@gem_five)
+        assert gem_list.include?(@gem_one)
+        assert gem_list.include?(@gem_two)
+        refute gem_list.include?(@gem_three)
+        refute gem_list.include?(@gem_four)
+      end
     end
 
-    should "return runtime dependend rubygems" do
-      gem_list = Rubygem.reverse_runtime_dependencies(@dep_rubygem.name)
+    context "#reverse_runtime_dependencies" do
+      should "return runtime dependent rubygems" do
+        gem_list = @dependency.reverse_runtime_dependencies
+        assert_equal 1, gem_list.size
 
-      assert_equal 2, gem_list.size
-
-      assert gem_list.include?(@gem_one)
-      refute gem_list.include?(@gem_two)
+        assert gem_list.include?(@gem_one)
+        refute gem_list.include?(@gem_two)
+      end
     end
 
-    should "return development dependend rubygems" do
-      gem_list = Rubygem.reverse_development_dependencies(@dep_rubygem.name)
+    context "#reverse_development_dependencies" do
+      should "return development dependent rubygems" do
+        gem_list = @dependency.reverse_development_dependencies
+        assert_equal 1, gem_list.size
 
-      assert_equal 1, gem_list.size
-
-      assert gem_list.include?(@gem_two)
-      refute gem_list.include?(@gem_one)
+        assert gem_list.include?(@gem_two)
+        refute gem_list.include?(@gem_one)
+      end
     end
   end
 


### PR DESCRIPTION
`reverse_dependencies` already joins three tables(dependencies, versions
and rubygems), using `includes(:latest_version, :gem_download)` makes
the query very big and slow.
This is probably an awful solution but something needs to be done :sweat:. 95 percentile of `ReverseDependenciesController#index` is always 10+ seconds.