### PR TITLE
Update Content-Security-Policy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,9 +16,10 @@ class ApplicationController < ActionController::Base
     response.headers['Content-Security-Policy-Report-Only'] = "default-src 'self'; "\
       "script-src 'self' https://secure.gaug.es; "\
       "style-src 'self' https://fonts.googleapis.com; "\
-      "img-src 'self' https://secure.gaug.es https://gravatar.com; "\
-      "font-src https://fonts.gstatic.com; "\
-      "connect-src https://s3-us-west-2.amazonaws.com/rubygems-dumps/;"
+      "img-src 'self' https://secure.gaug.es https://gravatar.com https://secure.gravatar.com; "\
+      "font-src 'self' https://fonts.gstatic.com; "\
+      "connect-src https://s3-us-west-2.amazonaws.com/rubygems-dumps/; "\
+      "frame-src https://ghbtns.com"
   end
 
   def set_locale


### PR DESCRIPTION
There is one more report:
> [Report Only] Refused to load the font 'data:font/woff;base64,d09GRgABAAAAAGVUABEAAAAAxuQAAQABAAAAAAAAAAAAAAAAAAAAA…eLo4GBkcWhIzkkAqQkEggceHw5HFkM2VRZJFlYebR2MP5v3cDSu5GJwWUDW9xG1hQXAFAmKZU=' because it violates the following Content Security Policy directive: "font-src https://fonts.gstatic.com".

I am not sure what is that about or where is it coming from.