### PR TITLE
Expire remember_token cookie after 2 weeks

### DIFF
--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -5,4 +5,5 @@ Clearance.configure do |config|
   config.password_strategy = Clearance::PasswordStrategies::BCryptMigrationFromSHA1
   config.sign_in_guards = [ConfirmedUserGuard]
   config.rotate_csrf_on_sign_in = true
+  config.cookie_expiration = ->(_cookies) { 2.weeks.from_now.utc }
 end


### PR DESCRIPTION
Default expiration time is one year, which is too long.
https://github.com/thoughtbot/clearance/blob/5d29439ee4340738eacc8d5cd8bfbbb10a576f38/lib/clearance/configuration.rb#L25