### PR TITLE
Update CONTRIBUTING docs to use elasticsearch v1 on MacOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,9 @@ gems for your organization..**
 * Use Ruby 2.3.1
 * Use Rubygems 2.6.10
 * Install bundler: `gem install bundler`
-* Install Elastic Search: `brew install elasticsearch`
-  * Setup information: `brew info elasticsearch`
+* Install Elastic Search:
+  * ElasticSearch `1.*` is required. There isn't a homebrew package for `elasticsearch@1`, instead it's recommended to use [Docker](https://www.docker.com/)
+  * Pull ElasticSearch `1.7.6` from [hub.docker.com](https://hub.docker.com/_/elasticsearch/) and expose the container ports: `docker run -P elasticsearch:1.7.6`
 * Install PostgreSQL (>= 8.4.x): `brew install postgres`
   * Setup information: `brew info postgresql`
 * Install memcached: `brew install memcached`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ gems for your organization..**
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * ElasticSearch `1.*` is required. There isn't a homebrew package for `elasticsearch@1`, instead it's recommended to use [Docker](https://www.docker.com/)
-  * Pull ElasticSearch `1.7.6` from [hub.docker.com](https://hub.docker.com/_/elasticsearch/) and expose the container ports: `docker run -P elasticsearch:1.7.6`
+  * Pull ElasticSearch `1.5.2` from [hub.docker.com](https://hub.docker.com/_/elasticsearch/) and expose the container ports: `docker run -P elasticsearch:1.5.2`
 * Install PostgreSQL (>= 8.4.x): `brew install postgres`
   * Setup information: `brew info postgresql`
 * Install memcached: `brew install memcached`


### PR DESCRIPTION
The environment setup instructions for MacOS are a bit misleading. `brew install elasticsearch` will install v5 but only v1 is compatible.

I have amended the instructions to use v1 instead.