### PR TITLE
Ensure that test pass even when elasticsearch is default

### DIFF
--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -1,10 +1,7 @@
 require 'test_helper'
+include ESHelper
 
 class SearchesControllerTest < ActionController::TestCase
-  setup do
-    Rubygem.__elasticsearch__.create_index! force: true
-  end
-
   context 'on GET to show with no search parameters' do
     setup { get :show }
 
@@ -17,6 +14,7 @@ class SearchesControllerTest < ActionController::TestCase
   context 'on GET to show with search parameters for a rubygem without versions' do
     setup do
       @sinatra = create(:rubygem, name: "sinatra")
+      import_and_refresh
       assert_nil @sinatra.versions.most_recent
       assert @sinatra.reload.versions.count.zero?
       get :show, query: "sinatra"
@@ -36,6 +34,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra)
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
+      import_and_refresh
       get :show, query: "sinatra"
     end
 
@@ -61,10 +60,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra)
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
-      @sinatra.index_document
-      @sinatra_redux.index_document
-      @brando.index_document
-      Rubygem.__elasticsearch__.refresh_index!
+      import_and_refresh
       @request.cookies['new_search'] = 'true'
       get :show, query: 'sinatra'
     end
@@ -91,6 +87,7 @@ class SearchesControllerTest < ActionController::TestCase
     setup do
       @sinatra = create(:rubygem, name: "sinatra")
       create(:version, rubygem: @sinatra)
+      import_and_refresh
       get :show, query: "sinatra"
     end
 
@@ -117,10 +114,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra)
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
-      @sinatra.index_document
-      @sinatra_redux.index_document
-      @brando.index_document
-      Rubygem.__elasticsearch__.refresh_index!
+      import_and_refresh
       @request.cookies['new_search'] = 'true'
       get :show, query: "sinatre"
     end

--- a/test/helpers/es_helper.rb
+++ b/test/helpers/es_helper.rb
@@ -1,6 +1,6 @@
 module ESHelper
   def import_and_refresh
-    Rubygem.import
+    Rubygem.import force: true
     Rubygem.__elasticsearch__.refresh_index!
     # wait for indexing to finish
     Rubygem.__elasticsearch__.client.cluster.health wait_for_status: 'yellow'

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
+include ESHelper
 
 class SearchTest < SystemTest
   test "searching for a gem" do
     create(:rubygem, name: "LDAP", number: "1.0.0")
     create(:rubygem, name: "LDAP-PLUS", number: "1.0.0")
+    import_and_refresh
 
     visit search_path
 
@@ -19,6 +21,7 @@ class SearchTest < SystemTest
   test "searching for a yanked gem" do
     rubygem = create(:rubygem, name: "LDAP")
     create(:version, rubygem: rubygem, indexed: false)
+    import_and_refresh
 
     visit search_path
 
@@ -33,6 +36,7 @@ class SearchTest < SystemTest
     create(:version, rubygem: rubygem, number: "1.1.1", indexed: true)
     create(:version, rubygem: rubygem, number: "2.2.2", indexed: false)
     create(:version, rubygem: rubygem, number: "3.3.3", indexed: true)
+    import_and_refresh
 
     visit search_path
 
@@ -54,6 +58,7 @@ class SearchTest < SystemTest
     Rubygem.per_page = 1
     create(:rubygem, name: "ruby-ruby", number: '1.0.0')
     create(:rubygem, name: "ruby-gems", number: '1.0.0')
+    import_and_refresh
 
     visit '/search?query=ruby&script_name=javascript:alert(1)//'
     assert page.has_content? "ruby-ruby"

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -50,20 +50,14 @@ class SearchTest < SystemTest
     end
   end
 
-  setup do
-    3.times do |i|
-      rubygem = create(:rubygem, name: "ruby#{i}", number: '1.0.0')
-      rubygem.gem_download.update(count: i)
-    end
-    Rubygem.per_page = 2
-  end
-  teardown { Rubygem.per_page = 30 }
-
   test "params has non white listed keys" do
+    Rubygem.per_page = 1
+    create(:rubygem, name: "ruby-ruby", number: '1.0.0')
+    create(:rubygem, name: "ruby-gems", number: '1.0.0')
+
     visit '/search?query=ruby&script_name=javascript:alert(1)//'
-    refute page.has_content? "ruby0"
-    assert page.has_content? "ruby1"
-    assert page.has_content? "ruby2"
+    assert page.has_content? "ruby-ruby"
     assert page.has_link?("Next", href: "/search?page=2&query=ruby")
+    Rubygem.per_page = 30
   end
 end


### PR DESCRIPTION
This required that we `import_and_refresh` whenever we test *search*.