### PR TITLE
Add fiddle to blacklist

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -30,6 +30,7 @@ module Patterns
     expect
     fcntl
     fiber
+    fiddle
     fileutils
     find
     forwardable


### PR DESCRIPTION
The `fiddle` is a standard library of Ruby.