### PR TITLE
Add updated-since param to activities API

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -6,6 +6,9 @@ class Api::V1::ActivitiesController < Api::BaseController
 
   def just_updated
     versions = Version.just_updated(50)
+    if params[:since].present?
+      versions = versions.where("versions.created_at >= ?", params[:since])
+    end
     render_rubygems(versions)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
       resource :activity, only: [], format: /json|yaml/ do
         collection do
           get :latest
-          get :just_updated
+          get "just_updated/(:since)", to: "activities#just_updated"
         end
       end
 

--- a/test/functional/api/v1/activities_controller_test.rb
+++ b/test/functional/api/v1/activities_controller_test.rb
@@ -81,9 +81,9 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
         gem = create(:rubygem, name: 'example-gem')
         create(:version, rubygem: gem)
 
-        travel_to (Time.now + 4.days) do
-          create(:version, rubygem: gem, updated_at: Time.now - 1.day)
-          get :just_updated, format: :json, since: Time.now - 2.day
+        travel_to Time.current + 4.days do
+          create(:version, rubygem: gem, updated_at: Time.current - 1.day)
+          get :just_updated, format: :json, since: Time.current - 2.days
           gems = YAML.safe_load(@response.body)
 
           assert_equal 1, gems.length

--- a/test/functional/api/v1/activities_controller_test.rb
+++ b/test/functional/api/v1/activities_controller_test.rb
@@ -76,6 +76,20 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
         assert_equal 'sinatra', gems[3]['name']
         assert_equal @sinatra_version.number, gems[3]['version'], 'should have the latest version'
       end
+
+      should "return all gems that have been updated since a given date" do
+        gem = create(:rubygem, name: 'example-gem')
+        create(:version, rubygem: gem)
+
+        travel_to (Time.now + 4.days) do
+          create(:version, rubygem: gem, updated_at: Time.now - 1.day)
+          get :just_updated, format: :json, since: Time.now - 2.day
+          gems = YAML.safe_load(@response.body)
+
+          assert_equal 1, gems.length
+          assert_equal 'example-gem', gems[0]['name']
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add an optional :since param to the Activities#just_updated api endpoint. This
will allow users to get all the updated gems since a speficic point in time

I'm aware that this might not be the best fix, but I'm mostly curious if something like this would make it into the codebase.
After I have confirmation that this road is ok, I'll go ahead and also add this to the `just_created` endpoint.

I also need to update the docs for the API.

Fixes: #1266