### PR TITLE
Expire session after 2 weeks

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,6 +150,17 @@ class User < ActiveRecord::Base
       SELECT rubygem_id FROM ownerships GROUP BY rubygem_id HAVING count(rubygem_id) = 1)')
   end
 
+  def remember_me!
+    self.remember_token = Clearance::Token.new
+    self.remember_token_expires_at = Gemcutter::REMEMBER_FOR.from_now
+    save!(validate: false)
+    remember_token
+  end
+
+  def remember_me?
+    remember_token_expires_at && remember_token_expires_at > Time.zone.now
+  end
+
   private
 
   def update_email!

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,4 +38,5 @@ module Gemcutter
   PROTOCOL = config['protocol']
   HOST = config['host']
   DEFAULT_PAGINATION = 20
+  REMEMBER_FOR = 2.weeks
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -7,3 +7,26 @@ Clearance.configure do |config|
   config.rotate_csrf_on_sign_in = true
   config.cookie_expiration = ->(_cookies) { 2.weeks.from_now.utc }
 end
+
+class Clearance::Session
+  def current_user
+    return nil if remember_token.blank?
+    return @current_user if @current_user
+    user = user_from_remember_token(remember_token)
+
+    @current_user = user if user&.remember_me?
+  end
+
+  def sign_in(user)
+    @current_user = user
+    cookies[remember_token_cookie] = user && user.remember_me!
+    status = run_sign_in_stack
+
+    unless status.success?
+      @current_user = nil
+      cookies[remember_token_cookie] = nil
+    end
+
+    yield(status) if block_given?
+  end
+end

--- a/db/migrate/20170414205340_add_remember_token_expires_at.rb
+++ b/db/migrate/20170414205340_add_remember_token_expires_at.rb
@@ -1,0 +1,5 @@
+class AddRememberTokenExpiresAt < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :remember_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161231080902) do
+ActiveRecord::Schema.define(version: 20170414205340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 20161231080902) do
     t.boolean  "hide_email"
     t.string   "twitter_username"
     t.string   "unconfirmed_email"
+    t.datetime "remember_token_expires_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class DashboardTest < ActionDispatch::IntegrationTest
   setup do
-    @user = create(:user, remember_token_expires_at: 2.weeks.from_now)
+    @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     cookies[:remember_token] = @user.remember_token
 
     create(:rubygem, name: "arrakis", number: "1.0.0")

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class DashboardTest < ActionDispatch::IntegrationTest
   setup do
-    @user = create(:user)
+    @user = create(:user, remember_token_expires_at: 2.weeks.from_now)
     cookies[:remember_token] = @user.remember_token
 
     create(:rubygem, name: "arrakis", number: "1.0.0")

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -70,4 +70,16 @@ class SignInTest < SystemTest
 
     assert page.has_content? "Sign in"
   end
+
+  test "session expires in two weeks" do
+    visit sign_in_path
+    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Sign in"
+
+    travel 15.days do
+      visit edit_profile_path
+      assert page.has_content? "Sign in"
+    end
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -325,4 +325,38 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#remember_me!" do
+    setup do
+      @user = create(:user)
+      @user.remember_me!
+    end
+
+    should "set remember_token" do
+      assert_not_nil @user.remember_token
+    end
+
+    should "set expiry of remember_token to two weeks from now" do
+      expected_expiry = Gemcutter::REMEMBER_FOR.from_now
+      assert_in_delta expected_expiry, @user.remember_token_expires_at, 1.second
+    end
+  end
+
+  context "#remember_me?" do
+    setup { @user = create(:user) }
+
+    should "return false when remember_token_expires_at is not set" do
+      refute @user.remember_me?
+    end
+
+    should "return false when remember_token has expired" do
+      @user.update_attribute(:remember_token_expires_at, 1.second.ago)
+      refute @user.remember_me?
+    end
+
+    should "return true when remember_token has not expired" do
+      @user.update_attribute(:remember_token_expires_at, 1.second.from_now)
+      assert @user.remember_me?
+    end
+  end
 end


### PR DESCRIPTION
Clearance expires remember_token only when a [user logs out](https://github.com/thoughtbot/clearance/blob/master/lib/clearance/session.rb#L76) and reuses the same token on [sign in](https://github.com/thoughtbot/clearance/blob/master/lib/clearance/session.rb#L57).
[Sessions should timeout after some time](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Session_Expiration). https://github.com/rubygems/rubygems.org/pull/1586 would expire the cookie, however relying only on the client to expire session is not a great idea.

I would appreciate some feedback :speech_balloon:  on my implementation. I am not sure if it is too _hacky_  to be acceptable.