### PR TITLE
Limit number of pages on search pagination

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,7 @@
 class SearchesController < ApplicationController
-  before_action :set_page, only: :show
+  before_action :set_page, :limit_page, only: :show
+  # Limit max page as ES result window is upper bounded by 10_000 records
+  MAX_PAGE = 100
 
   def show
     return unless params[:query] && params[:query].is_a?(String)
@@ -9,6 +11,10 @@ class SearchesController < ApplicationController
   end
 
   private
+
+  def limit_page
+    render_404 if @page > MAX_PAGE
+  end
 
   def es_enabled?
     true

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -152,4 +152,12 @@ class SearchesControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "with page greater than 100" do
+    setup { get :show, page: 204 }
+
+    should "render 404 page" do
+      assert_response :not_found
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://app.honeybadger.io/projects/40972/faults/33345740
It was erroring for large page numbers:
```
org.elasticsearch.search.query.QueryPhaseExecutionException:
Result window is too large, from + size must be less than or equal to: [10000] but was [74520].

####
Parameters: {"utf8"=>"✓", "query"=>"%", "page"=>"2484"}
Rubygem Search (196.7ms) {index: "rubygems-development", type: "rubygem",
  body: {query: ...}, size: 30, from: 74490}  # `from` > 10_000 

```
[`terminate_after`](https://github.com/elastic/elasticsearch-ruby/blob/4a5f83c6c91bf89785902ce4b7b246be27bbf9ec/elasticsearch-api/lib/elasticsearch/api/actions/search.rb#L110) was considered but it doesn't seem to take precedence
over `from`.

cc: @karmi