### PR TITLE
Remove use of remote: true from gem subscription link

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -30,7 +30,7 @@ class EmailConfirmationsController < ApplicationController
       Mailer.delay.email_reset(current_user)
       flash[:notice] = t('profiles.update.confirmation_mail_sent')
     else
-      flash[:notice] = t('.try_again')
+      flash[:notice] = t('try_again')
     end
     redirect_to edit_profile_path
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -14,7 +14,7 @@ class SubscriptionsController < ApplicationController
   protected
 
   def redirect_to_rubygem(success)
-    flash[:notice] = t('try_again') unless success
+    flash[:error] = t('try_again') unless success
     redirect_to rubygem_path(@rubygem)
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,23 +3,18 @@ class SubscriptionsController < ApplicationController
 
   def create
     subscription = @rubygem.subscriptions.build(user: current_user)
-    render_toggle_or_unacceptable(subscription.try(:save))
+    redirect_to_rubygem(subscription.try(:save))
   end
 
   def destroy
     subscription = @rubygem.subscriptions.find_by_user_id(current_user.try(:id))
-    render_toggle_or_unacceptable(subscription.try(:destroy))
+    redirect_to_rubygem(subscription.try(:destroy))
   end
 
   protected
 
-  def render_toggle_or_unacceptable(success)
-    if success
-      respond_to do |format|
-        format.js { render :update }
-      end
-    else
-      render plain: '', status: :forbidden
-    end
+  def redirect_to_rubygem(success)
+    flash[:notice] = t('try_again') unless success
+    redirect_to rubygem_path(@rubygem)
   end
 end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -46,11 +46,11 @@ module RubygemsHelper
       if rubygem.subscribers.find_by_id(current_user.id)
         link_to t('.links.unsubscribe'), rubygem_subscription_path(rubygem),
           class: [:toggler, 'gem__link', 't-list__item'], id: 'unsubscribe',
-          method: :delete, remote: true
+          method: :delete
       else
         link_to t('.links.subscribe'), rubygem_subscription_path(rubygem),
           class: ['toggler', 'gem__link', 't-list__item'], id: 'subscribe',
-          method: :post, remote: true
+          method: :post
       end
     else
       link_to t('.links.subscribe'), sign_in_path,

--- a/app/views/subscriptions/update.js.erb
+++ b/app/views/subscriptions/update.js.erb
@@ -1,1 +1,0 @@
-$(".toggler").html('<%= subscribe_link(@rubygem) %>');

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -17,6 +17,7 @@ de:
   time_ago: seit %{duration}
   title: RubyGems.org
   update: Aktualisieren
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ de:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
   time_ago: "%{duration} ago"
   title: RubyGems.org
   update: Update
+  try_again: Something went wrong. Please try again.
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ en:
       submit: Resend Confirmation
       title: Resend confirmation email
       will_email_notice: We will email you confirmation link to activate your account.
-    unconfirmed_email:
-      try_again: Something went wrong. Please try again.
     update:
       confirmed_email: Your email address has been verified.
   home:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,6 +17,7 @@ es:
   time_ago: hace %{duration}
   title: RubyGems.org
   update: Actualizar
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ es:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -17,6 +17,7 @@ fr:
   time_ago: il y a %{duration}
   title: RubyGems.org
   update: Mise à jour
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ fr:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -17,6 +17,7 @@ nl:
   time_ago: "%{duration} geleden"
   title: RubyGems.org
   update: Wijzig
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ nl:
       submit: Bevestiging opnieuw versturen
       title: Bevestigingsemail opnieuw sturen
       will_email_notice: We zullen je een nieuwe email sturen met een bevestigingslink
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -17,6 +17,7 @@ pt-BR:
   time_ago: "%{duration} atrás"
   title: RubyGems.org
   update: Atualizar
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ pt-BR:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -17,6 +17,7 @@ zh-CN:
   time_ago: "%{duration} 前"
   title: RubyGems.org
   update: 更新
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ zh-CN:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -17,6 +17,7 @@ zh-TW:
   time_ago: "%{duration} 前"
   title: RubyGems.org
   update: 更新
+  try_again:
   activerecord:
     attributes:
       linkset:
@@ -52,8 +53,6 @@ zh-TW:
       submit:
       title:
       will_email_notice:
-    unconfirmed_email:
-      try_again:
     update:
       confirmed_email:
   home:

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -1,58 +1,55 @@
 require 'test_helper'
 
 class SubscriptionsControllerTest < ActionController::TestCase
-  context "When logged in" do
-    setup do
-      @user = create(:user)
-      sign_in_as(@user)
-    end
+  setup do
+    @rubygem = create(:rubygem, number: "0.0.1")
+    @user = create(:user)
+    sign_in_as(@user)
   end
 
   context "On POST to create for a gem that the user is not subscribed to" do
     setup do
-      @rubygem = create(:rubygem)
-      create(:version, rubygem: @rubygem)
-      post :create, rubygem_id: @rubygem.to_param, format: 'js'
+      post :create, rubygem_id: @rubygem.to_param
     end
 
-    should respond_with :success
-    should "toggle the subscribe link" do
-      assert_includes @response.body, 'Subscribe'
+    should redirect_to("rubygems show") { rubygem_path(@rubygem) }
+    should "not set flash error" do
+      assert_nil flash[:error]
     end
   end
 
   context "On POST to create for a gem that the user is subscribed to" do
     setup do
-      @rubygem = create(:rubygem)
-      create(:version, rubygem: @rubygem)
       create(:subscription, rubygem: @rubygem, user: @user)
-      post :create, rubygem_id: @rubygem.to_param, format: 'js'
+      post :create, rubygem_id: @rubygem.to_param
     end
 
-    should respond_with :forbidden
+    should redirect_to("rubygems show") { rubygem_path(@rubygem) }
+    should "set flash error" do
+      assert_equal flash[:error], "Something went wrong. Please try again."
+    end
   end
 
   context "On DELETE to destroy for a gem that the user is not subscribed to" do
     setup do
-      @rubygem = create(:rubygem)
-      create(:version, rubygem: @rubygem)
-      delete :destroy, rubygem_id: @rubygem.to_param, format: 'js'
+      delete :destroy, rubygem_id: @rubygem.to_param
     end
 
-    should respond_with :forbidden
+    should redirect_to("rubygems show") { rubygem_path(@rubygem) }
+    should "set flash error" do
+      assert_equal flash[:error], "Something went wrong. Please try again."
+    end
   end
 
   context "On DELETE to destroy for a gem that the user is subscribed to" do
     setup do
-      @rubygem = create(:rubygem)
-      create(:version, rubygem: @rubygem)
       create(:subscription, rubygem: @rubygem, user: @user)
-      delete :destroy, rubygem_id: @rubygem.to_param, format: 'js'
+      delete :destroy, rubygem_id: @rubygem.to_param
     end
 
-    should respond_with :success
-    should "toggle the subscribe link" do
-      assert_includes @response.body, 'Subscribe'
+    should redirect_to("rubygems show") { rubygem_path(@rubygem) }
+    should "not set flash error" do
+      assert_nil flash[:error]
     end
   end
 end


### PR DESCRIPTION
Resolves: http://help.rubygems.org/discussions/problems/26162-subscribing-to-gem-doesnt-work
Using `remote: true` would have required that we allow `unsafe-eval` to our CSP for `script-src`. `unsafe-eval` allows dynamic evaluation of JavaScript via `eval()`.
It is safer to write our own ajax request instead of using `remote: true`.