### PR TITLE
Add note about password reset link expiration

### DIFF
--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -5,3 +5,4 @@
   <%= link_to t('.confirmation_link'),
     update_email_confirmations_url(@user, token: @user.confirmation_token.html_safe) %>
 </p>
+<p><%= t('.link_expiration_explanation') %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -102,6 +102,7 @@ de:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
       welcome_message: Welcome to RubyGems.org! Click the link below to verify your email.
     email_reset:
       visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
+      link_expiration_explanation: Please keep in mind that this link is only valid for 15 minutes.
     deletion_complete:
       subject: Your account has been deleted from rubygems.org
       body: Your request for account deletion on rubygems.org has been processed. You can always create a new account using our %{sign_up} page.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -102,6 +102,7 @@ es:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -102,6 +102,7 @@ fr:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -102,6 +102,7 @@ nl:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation: Deze link is 15 minuten geldig.
     deletion_complete:
       subject:
       body:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -102,6 +102,7 @@ pt-BR:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -102,6 +102,7 @@ zh-CN:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -102,6 +102,7 @@ zh-TW:
       welcome_message:
     email_reset:
       visit_link_instructions:
+      link_expiration_explanation:
     deletion_complete:
       subject:
       body:


### PR DESCRIPTION
Password reset links expire after 15 minutes. We should note that in the
password reset email.

Fixes: #1606