### PR TITLE
Removed blacklist patterns for default gems of Ruby 2.5

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -13,12 +13,9 @@ module Patterns
     benchmark
     cgi
     cgi-session
-    cmath
     complex
     continuation
     coverage
-    csv
-    date
     delegate
     digest
     drb
@@ -26,11 +23,8 @@ module Patterns
     english
     enumerator
     erb
-    etc
     expect
-    fcntl
     fiber
-    fileutils
     find
     forwardable
     getoptlong
@@ -41,7 +35,6 @@ module Patterns
     irb
     jruby
     logger
-    mathn
     matrix
     mkmf
     monitor
@@ -73,7 +66,6 @@ module Patterns
     rss
     ruby
     rubygems
-    scanf
     securerandom
     set
     shellwords
@@ -95,10 +87,8 @@ module Patterns
     uninstall
     uri
     weakref
-    webrick
     win32ole
     yaml
-    zlib
     ubygems
   ).freeze
 end


### PR DESCRIPTION
It's part of a request for [Gemification Plan](https://bugs.ruby-lang.org/issues/5481). I've finished preparing to ship some default gems to rubygems.org from standard libraries. 

PS. Some gems have already reserved other users. I will ask to transfer its ownership after this pull request was deployed.