### PR TITLE
Remove inline style from error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,17 +3,18 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Page not found | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="500 error" style="width: 100%;" data="/images/sea_floor.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="404 error" src="/images/sea_floor.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 680px; text-align: center;">
-        <h1 style="margin-top: 25px; margin-bottom: 8px; font-weight: 200; font-size: 60px;">Page not found.</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66;">It will be mine. Oh yes. It will be mine.</p>
-        <a href="/" style="font-weight: 300; font-size: 18px; line-height: 1.66; text-decoration: none; color: #e9573f;">Back to RubyGems.org →</a>
+      <div class="content">
+        <h1>Page not found.</h1>
+        <p>It will be mine. Oh yes. It will be mine.</p>
+        <a href="/">Back to RubyGems.org →</a>
       </div>
     </div>
   </body>

--- a/public/422.html
+++ b/public/422.html
@@ -3,17 +3,18 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Change rejected | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="422 error" style="width: 100%;" data="/images/sea_level.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="422 error" src="/images/sea_level.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 680px; text-align: center;">
-        <h1 style="margin-top: 25px; margin-bottom: 8px; font-weight: 200; font-size: 60px; ">Change rejected.</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66; ">No way! Way! You tried to change something you didn&rsquo;t have access to.</p>
-        <a href="/" style="font-weight: 300; font-size: 18px; line-height: 1.66; text-decoration: none; color: #e9573f;">Back to RubyGems.org →</a>
+      <div class="content">
+        <h1>Change rejected.</h1>
+        <p>No way! Way! You tried to change something you didn&rsquo;t have access to.</p>
+        <a href="/">Back to RubyGems.org →</a>
       </div>
     </div>
   </body>

--- a/public/500.html
+++ b/public/500.html
@@ -3,24 +3,22 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-    <!--[if IE 7]>
-      <link href="/stylesheets/ie7.css" media="screen" rel="stylesheet" type="text/css" />
-    <![endif]-->
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Server error | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="500 error" style="width: 100%;" data="/images/sea_level.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="500 error" src="/images/sea_level.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 680px; text-align: center;">
-        <h1 style="margin-top: 25px; margin-bottom: 8px; font-weight: 200; font-size: 60px;">Server error.</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66; ">
+      <div class="content">
+        <h1>Server error.</h1>
+        <p>
           Looks like something blew up on our end. We&rsquo;ve been alerted of the problem, but feel free to open up an
-          <a style="text-decoration: none; color: #e9573f;" href="http://help.rubygems.org/">issue</a>
+          <a href="http://help.rubygems.org/">issue</a>
           if you want it fixed faster.
         </p>
-        <a href="/" style="font-weight: 300; font-size: 18px; line-height: 1.66;  text-decoration: none; color: #e9573f;">Back to RubyGems.org →</a>
+        <a href="/">Back to RubyGems.org →</a>
       </div>
     </div>
   </body>

--- a/public/502.html
+++ b/public/502.html
@@ -3,20 +3,18 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-    <!--[if IE 7]>
-      <link href="/stylesheets/ie7.css" media="screen" rel="stylesheet" type="text/css" />
-    <![endif]-->
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Unicorn! | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="502 error" style="width: 100%;" data="/images/sea_level.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="502 error" src="/images/sea_level.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 680px; text-align: center;">
-        <h1 style="margin-top: 25px; margin-bottom: 8px; font-weight: 200; font-size: 60px; ">Unicorn!</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66; ">The page likely timed out.</p>
-        <a href="/" style="font-weight: 300; font-size: 18px; line-height: 1.66;  text-decoration: none; color: #e9573f;">Back to RubyGems.org →</a>
+      <div class="content">
+        <h1>Unicorn!</h1>
+        <p>The page likely timed out.</p>
+        <a href="/">Back to RubyGems.org →</a>
       </div>
     </div>
   </body>

--- a/public/503.html
+++ b/public/503.html
@@ -3,20 +3,18 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-    <!--[if IE 7]>
-      <link href="/stylesheets/ie7.css" media="screen" rel="stylesheet" type="text/css" />
-    <![endif]-->
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Unicorn! | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="503 error" style="width: 100%;" data="/images/sea_level.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="503 error" src="/images/sea_level.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 680px; text-align: center;">
-        <h1 style="margin-top: 25px; margin-bottom: 8px; font-weight: 200; font-size: 60px; ">Unicorn!</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66; ">We are having a bad problem and the app server will not talk to us.</p>
-        <a href="/" style="font-weight: 300; font-size: 18px; line-height: 1.66;  text-decoration: none; color: #e9573f;">Back to RubyGems.org →</a>
+      <div class="content">
+        <h1>Unicorn!</h1>
+        <p>We are having a bad problem and the app server will not talk to us.</p>
+        <a href="/">Back to RubyGems.org →</a>
       </div>
     </div>
   </body>

--- a/public/maintenance/index.html
+++ b/public/maintenance/index.html
@@ -3,18 +3,19 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
     <title>Under maintenance | RubyGems.org</title>
   </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif">
-    <div style="margin-right: auto; margin-left: auto; width: 90%; max-width: 940px;">
-      <div style="padding-top: 60px; position: relative;">
-        <object height="530" type="image/svg+xml" alt="422 error" style="width: 100%;" data="/images/gem_wrench.svg"></object>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="under maintenance" src="/images/gem_wrench.svg"></img>
       </div>
-      <div style="margin-right: auto; margin-bottom: 120px; margin-left: auto; max-width: 720px; text-align: center;">
-        <h1 style="margin-top: 10px; margin-bottom: 8px; font-weight: 200; font-size: 60px; ">Sorry, under maintenance.</h1>
-        <p style="font-weight: 300; font-size: 18px; line-height: 1.66; ">
+      <div class="content">
+        <h1>Sorry, under maintenance.</h1>
+        <p>
           We&rsquo;ll be back to 100% soon. Some long migration or fixes are being put in place. Hold on! Please checkout
-          <a style="text-decoration: none; color: #e9573f;" href="https://status.rubygems.org/">status.rubygems.org</a>
+          <a href="https://status.rubygems.org/">status.rubygems.org</a>
           for more real-time status updates.
         </p>
       </div>

--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -1,0 +1,48 @@
+body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+h1{
+  margin-top: 25px;
+  margin-bottom: 8px;
+  font-weight: 200;
+  font-size: 60px;
+}
+
+p {
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 1.66;
+}
+
+a {
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 1.66;
+  text-decoration: none; color: #e9573f;
+}
+
+img {
+  width: 100%;
+}
+
+
+.wrapper {
+  margin-right: auto;
+  margin-left: auto;
+  width: 90%;
+  max-width: 940px;
+}
+
+.image__wrapper {
+  padding-top: 60px;
+  position: relative;
+}
+
+.content {
+  margin-right: auto;
+  margin-bottom: 120px;
+  margin-left: auto;
+  max-width: 720px;
+  text-align: center;
+}


### PR DESCRIPTION
They were failing our CSP. See http://rubygems.org/gems/cmath/versions
`object` was replaced with `img` tag because `object` is conventionally used
for external resources. It would have required we allow `self` in `frame-src`.