### PR TITLE
validate email length

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ActiveRecord::Base
   after_validation :set_unconfirmed_email, if: :email_changed?, on: :update
   before_create :generate_api_key, :generate_confirmation_token
 
+  validates :email, length: { maximum: 254 }
+
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {
     with: /\A[A-Za-z][A-Za-z_\-0-9]*\z/,

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -54,6 +54,14 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    context 'email' do
+      should "be less than 255 characters" do
+        user = build(:user, email: ("a" * 255) + "@example.com")
+        refute user.valid?
+        assert_contains user.errors[:email], "is too long (maximum is 254 characters)"
+      end
+    end
+
     context 'twitter_username' do
       should validate_length_of(:twitter_username)
       should allow_value("user123_32").for(:twitter_username)


### PR DESCRIPTION
Instead of letting the database deal with this we should fail as soon as possible.