### PR TITLE
Remove positional arguments from requests in test

### DIFF
--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -17,7 +17,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "ON DELETE to create for existing gem version" do
         setup do
-          delete :create, gem_name: @rubygem.to_param, version: @v1.number
+          delete :create, params: { gem_name: @rubygem.to_param, version: @v1.number }
         end
         should respond_with :success
         should "keep the gem, deindex, keep owner" do
@@ -38,7 +38,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "ON DELETE to create for version 0.1.1" do
           setup do
-            delete :create, gem_name: @rubygem.to_param, version: @v2.number
+            delete :create, params: { gem_name: @rubygem.to_param, version: @v2.number }
           end
           should respond_with :success
           should "keep the gem, deindex it, and keep the owners" do
@@ -61,7 +61,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "ON DELETE to create for version 0.1.1 and x86-darwin-10" do
           setup do
-            delete :create, gem_name: @rubygem.to_param, version: @v2.number, platform: @v2.platform
+            delete :create, params: { gem_name: @rubygem.to_param, version: @v2.number, platform: @v2.platform }
           end
           should respond_with :success
           should "keep the gem, deindex it, and keep the owners" do
@@ -85,7 +85,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "ON DELETE to create for existing gem with invalid version" do
         setup do
-          delete :create, gem_name: @rubygem.to_param, version: "0.2.0"
+          delete :create, params: { gem_name: @rubygem.to_param, version: "0.2.0" }
         end
         should respond_with :not_found
         should "not modify any versions" do
@@ -103,7 +103,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
           other_rubygem = create(:rubygem, name: "SomeOtherGem")
           create(:version, rubygem: other_rubygem, number: "0.1.0", platform: "ruby")
           create(:ownership, user: other_user, rubygem: other_rubygem)
-          delete :create, gem_name: other_rubygem.to_param, version: '0.1.0'
+          delete :create, params: { gem_name: other_rubygem.to_param, version: "0.1.0" }
         end
         should respond_with :forbidden
         should "not record the deletion" do
@@ -114,7 +114,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
       context "ON DELETE to create for an already deleted gem" do
         setup do
           Deletion.create!(user: @user, version: @v1)
-          delete :create, gem_name: @rubygem.to_param, version: @v1.number
+          delete :create, params: { gem_name: @rubygem.to_param, version: @v1.number }
         end
         should respond_with :unprocessable_entity
         should "not re-record the deletion" do
@@ -147,21 +147,21 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "ON PUT to destroy for version 0.1.0" do
         setup do
-          put :destroy, gem_name: @rubygem.to_param, version: @v1.number
+          put :destroy, params: { gem_name: @rubygem.to_param, version: @v1.number }
         end
         should respond_with :gone
       end
 
       context "ON PUT to destroy for version 0.1.2 and platform x86-darwin-10" do
         setup do
-          put :destroy, gem_name: @rubygem.to_param, version: @v3.number, platform: @v3.platform
+          put :destroy, params: { gem_name: @rubygem.to_param, version: @v3.number, platform: @v3.platform }
         end
         should respond_with :gone
       end
 
       context "ON PUT to destroy for version 0.1.1" do
         setup do
-          put :destroy, gem_name: @rubygem.to_param, version: @v2.number
+          put :destroy, params: { gem_name: @rubygem.to_param, version: @v2.number }
         end
         should respond_with :gone
       end

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
   # NO GEMS:
   context "On GET to index --> with empty gems param --> JSON" do
     setup do
-      get :index, gems: "", format: "json"
+      get :index, params: { gems: "" }, format: "json"
     end
 
     should "return 200" do
@@ -36,7 +36,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     setup do
       rubygem = create(:rubygem, name: "rails")
       create(:version, number: "1.0.0", rubygem_id: rubygem.id)
-      get :index, gems: "rails", format: "json"
+      get :index, params: { gems: "rails" }, format: "json"
     end
 
     should "return 200" do
@@ -63,7 +63,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
       create(:version, number: "1.0.0", rubygem_id: rubygem1.id)
       create(:version, number: "2.0.0", rubygem_id: rubygem2.id)
       create(:version, number: "3.0.0", rubygem_id: rubygem1.id)
-      get :index, gems: "myrails,mybundler", format: "json"
+      get :index, params: { gems: "myrails,mybundler" }, format: "json"
     end
 
     should "return 200" do
@@ -106,7 +106,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
   context "On GET to index --> with gems --> JSON" do
     setup do
       gems = Array.new(300) { create(:rubygem) }.join(',')
-      get :index, gems: gems, format: "json"
+      get :index, params: { gems: gems }, format: "json"
     end
 
     should "return 422" do
@@ -129,7 +129,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     setup do
       rubygem = create(:rubygem, name: "testgem")
       @version = create(:version, number: "1.0.0", rubygem_id: rubygem.id)
-      get :index, gems: "", format: "marshal"
+      get :index, params: { gems: "" }, format: "marshal"
     end
 
     should "return 200" do
@@ -146,7 +146,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     setup do
       rubygem = create(:rubygem, name: "testgem")
       create(:version, number: "1.0.0", rubygem_id: rubygem.id)
-      get :index, gems: "testgem", format: "marshal"
+      get :index, params: { gems: "testgem" }, format: "marshal"
     end
 
     should "return 200" do
@@ -169,7 +169,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
   context "On GET to index --> with gems --> Marshal" do
     setup do
       gems = Array.new(300) { create(:rubygem) }.join(',')
-      get :index, gems: gems, format: "marshal"
+      get :index, params: { gems: gems }, format: "marshal"
     end
 
     should "return 422" do

--- a/test/functional/api/v1/downloads_controller_test.rb
+++ b/test/functional/api/v1/downloads_controller_test.rb
@@ -31,7 +31,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
   end
 
   def get_show(version, format = 'json')
-    get :show, id: version.full_name, format: format
+    get :show, params: { id: version.full_name }, format: format
   end
 
   def self.should_respond_to(format, to_meth = :to_s)
@@ -78,7 +78,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
 
   context "on GET to show for an unknown gem" do
     setup do
-      get :show, id: "rials", format: 'json'
+      get :show, params: { id: "rials" }, format: 'json'
     end
 
     should "return a 404" do

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -18,7 +18,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         @rubygem.ownerships.create(user: @user)
 
         @request.env["HTTP_AUTHORIZATION"] = @user.api_key
-        get :show, rubygem_id: @rubygem.to_param, format: format
+        get :show, params: { rubygem_id: @rubygem.to_param }, format: format
       end
 
       should "return an array" do
@@ -51,7 +51,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
   context "on GET to owner gems with handle" do
     setup do
       @user = create(:user)
-      get :gems, handle: @user.handle, format: :json
+      get :gems, params: { handle: @user.handle }, format: :json
     end
 
     should respond_with :success
@@ -60,7 +60,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
   context "on GET to owner gems with id" do
     setup do
       @user = create(:user)
-      get :gems, handle: @user.id, format: :json
+      get :gems, params: { handle: @user.id }, format: :json
     end
 
     should respond_with :success
@@ -85,12 +85,12 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     end
 
     should "add other user as gem owner with email" do
-      post :create, rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json
+      post :create, params: { rubygem_id: @rubygem.to_param, email: @second_user.email }, format: :json
       assert @rubygem.owners.include?(@second_user)
     end
 
     should "add other user as gem owner with handle" do
-      post :create, rubygem_id: @rubygem.to_param, email: @third_user.handle, format: :json
+      post :create, params: { rubygem_id: @rubygem.to_param, email: @third_user.handle }, format: :json
       assert @rubygem.owners.include?(@third_user)
     end
   end
@@ -114,13 +114,14 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     end
 
     should "remove user as gem owner" do
-      delete :destroy, rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json
+      delete :destroy,
+        params: { rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json }
       refute @rubygem.owners.include?(@second_user)
     end
 
     should "not remove last gem owner" do
       @ownership.destroy
-      delete :destroy, rubygem_id: @rubygem.to_param, email: @user.email, format: :json
+      delete :destroy, params: { rubygem_id: @rubygem.to_param, email: @user.email, format: :json }
       assert @rubygem.owners.include?(@user)
       assert_equal 'Unable to remove owner.', @response.body
     end
@@ -138,7 +139,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     @user = create(:user)
     @request.env["HTTP_AUTHORIZATION"] = @user.api_key
     @request.accept = '*/*'
-    post :create, rubygem_id: 'bananas'
+    post :create, params: { rubygem_id: 'bananas' }
     assert_equal 'This rubygem could not be found.', @response.body
   end
 end

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
 
       context "on GET to show with id" do
         setup do
-          get :show, id: @user.id, format: format
+          get :show, params: { id: @user.id }, format: format
         end
 
         should respond_with :success
@@ -34,7 +34,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
 
       context "on GET to show with handle" do
         setup do
-          get :show, id: @user.handle, format: format
+          get :show, params: { id: @user.handle }, format: format
         end
 
         should respond_with :success
@@ -47,7 +47,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
       context "on GET to show when hide email" do
         setup do
           @user.update(hide_email: true)
-          get :show, id: @user.handle, format: format
+          get :show, params: { id: @user.handle }, format: format
         end
 
         should respond_with :success

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -23,7 +23,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem)
         create(:version, rubygem: @rubygem)
-        get :show, id: @rubygem.to_param, format: format
+        get :show, params: { id: @rubygem.to_param }, format: format
       end
 
       should_respond_to_show(&block)
@@ -33,7 +33,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem, name: 'foo.rb')
         create(:version, rubygem: @rubygem)
-        get :show, id: @rubygem.to_param, format: format
+        get :show, params: { id: @rubygem.to_param }, format: format
       end
 
       should_respond_to_show(&block)
@@ -43,7 +43,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem, name: "ZenTest", slug: "zentest")
         create(:version, rubygem: @rubygem)
-        get :show, id: "ZenTest", format: format
+        get :show, params: { id: "ZenTest" }, format: format
       end
 
       should_respond_to_show(&block)
@@ -70,7 +70,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem)
         assert @rubygem.versions.count.zero?
-        get :show, id: @rubygem.to_param, format: "json"
+        get :show, params: { id: @rubygem.to_param }, format: "json"
       end
 
       should respond_with :not_found
@@ -83,7 +83,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @name = generate(:name)
         refute Rubygem.exists?(name: @name)
-        get :show, id: @name, format: "json"
+        get :show, params: { id: @name }, format: "json"
       end
 
       should respond_with :not_found
@@ -96,7 +96,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem)
         create(:version, rubygem: @rubygem, number: "1.0.0", indexed: false)
-        get :show, id: @rubygem.to_param, format: "json"
+        get :show, params: { id: @rubygem.to_param }, format: "json"
       end
 
       should respond_with :not_found
@@ -116,7 +116,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         @missing_dependency.rubygem.update_column(:name, 'missing')
         @missing_dependency.update_column(:rubygem_id, nil)
 
-        get :show, id: @rubygem.to_param, format: "json"
+        get :show, params: { id: @rubygem.to_param }, format: "json"
       end
 
       should respond_with :success
@@ -135,7 +135,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     should "Returns the response CORS headers" do
       @request.env['HTTP_ORIGIN'] = 'https://pages.github.com/'
-      get :show, id: "ZenTest", format: 'json'
+      get :show, params: { id: "ZenTest" }, format: 'json'
 
       assert_equal 200, @response.status
       assert_equal '*', @response.headers['Access-Control-Allow-Origin']
@@ -145,7 +145,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     should 'Send the CORS preflight OPTIONS request' do
       @request.env['HTTP_ORIGIN'] = 'https://pages.github.com/'
-      process :show, 'OPTIONS', id: "ZenTest"
+      process :show, method: :options, params: { id: "ZenTest" }
 
       assert_equal 200, @response.status
       assert_equal '*', @response.headers['Access-Control-Allow-Origin']
@@ -348,7 +348,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     %w(json xml yaml).each do |format|
       context "on GET to show for an unknown gem with #{format} format" do
         setup do
-          get :show, id: "rials", format: format
+          get :show, params: { id: "rials" }, format: format
         end
 
         should "return a 404" do
@@ -378,7 +378,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     end
 
     should "return names of reverse dependencies" do
-      get :reverse_dependencies, id: @dependency.to_param, format: "json"
+      get :reverse_dependencies, params: { id: @dependency.to_param }, format: "json"
       gems = JSON.load(@response.body)
 
       assert_equal 3, gems.size
@@ -391,9 +391,9 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     context "with only=development" do
       should "only return names of reverse development dependencies" do
         get :reverse_dependencies,
-          id: @dependency.to_param,
-          only: "development",
-          format: "json"
+          params: { id: @dependency.to_param,
+                    only: "development",
+                    format: "json" }
 
         gems = JSON.load(@response.body)
 
@@ -406,9 +406,9 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     context "with only=runtime" do
       should "only return names of reverse development dependencies" do
         get :reverse_dependencies,
-          id: @dependency.to_param,
-          only: "runtime",
-          format: "json"
+          params: { id: @dependency.to_param,
+                    only: "runtime",
+                    format: "json" }
 
         gems = JSON.load(@response.body)
 

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -4,7 +4,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
   def self.should_respond_to(format)
     context "with query=match and with #{format.to_s.upcase}" do
       setup do
-        get :show, query: "match", format: format
+        get :show, params: { query: "match" }, format: format
       end
 
       should respond_with :success
@@ -54,17 +54,17 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
     end
 
     should "default to first page when page is 0" do
-      get :show, query: "match", page: 0, format: :json
+      get :show, params: { query: "match", page: 0 }, format: :json
       refute JSON.parse(response.body).empty?
     end
 
     should "default to first page when page is not a number" do
-      get :show, query: "match", page: "foo", format: :json
+      get :show, params: { query: "match", page: "foo" }, format: :json
       refute JSON.parse(response.body).empty?
     end
 
     should "default to first page when page cannot be converted to a number" do
-      get :show, query: "match", page: { "$acunetix" => "1" }, format: :json
+      get :show, params: { query: "match", page: { "$acunetix" => "1" } }, format: :json
       refute JSON.parse(response.body).empty?
     end
   end

--- a/test/functional/api/v1/versions_controller_test.rb
+++ b/test/functional/api/v1/versions_controller_test.rb
@@ -2,15 +2,15 @@ require 'test_helper'
 
 class Api::V1::VersionsControllerTest < ActionController::TestCase
   def get_show(rubygem, format = 'json')
-    get :show, id: rubygem.name, format: format
+    get :show, params: { id: rubygem.name, format: format }
   end
 
   def get_latest(rubygem, format = 'json')
-    get :latest, id: rubygem.name, format: format
+    get :latest, params: { id: rubygem.name, format: format }
   end
 
   def get_reverse_dependencies(rubygem, options = { format: 'json' })
-    get :reverse_dependencies, options.merge(id: rubygem.name)
+    get :reverse_dependencies, options.merge(params: { id: rubygem.name })
   end
 
   def set_cache_header
@@ -115,7 +115,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
 
   context "on GET to show for an unknown gem" do
     setup do
-      get :show, id: "nonexistent_gem", format: "json"
+      get :show, params: { id: "nonexistent_gem", format: "json" }
     end
 
     should "return a 404" do
@@ -187,7 +187,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should "return latest version" do
-      get :latest, id: @rubygem.name, format: "js", callback: "blah"
+      get :latest, params: { id: @rubygem.name, format: "js", callback: "blah" }
       assert_match(/blah\(.*\)\Z/, @response.body)
     end
   end
@@ -201,7 +201,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should "return latest version" do
-      get :latest, id: "blah", format: "json"
+      get :latest, params: { id: "blah", format: "json" }
       assert_equal "unknown", JSON.load(@response.body)['version']
     end
   end
@@ -213,7 +213,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should "return latest version" do
-      get :latest, id: @rubygem.name, format: "json"
+      get :latest, params: { id: @rubygem.name, format: "json" }
       assert_equal "unknown", JSON.load(@response.body)['version']
     end
   end
@@ -226,7 +226,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should "return most recent version" do
-      get :latest, id: @rubygem.name, format: "json"
+      get :latest, params: { id: @rubygem.name, format: "json" }
       assert_equal "2.0.0", JSON.load(@response.body)['version']
     end
   end
@@ -238,7 +238,7 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     end
 
     should "return license info" do
-      get :show, id: @rubygem.name, format: "json"
+      get :show, params: { id: @rubygem.name, format: "json" }
       assert_equal "MIT", JSON.load(@response.body).first['licenses']
     end
   end

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -11,7 +11,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
   context "When not logged in" do
     should "forbid access when creating a web hook" do
       rubygem = create(:rubygem)
-      post :create, gem_name: rubygem.name, url: "http://example.com"
+      post :create, params: { gem_name: rubygem.name, url: "http://example.com" }
       assert @response.body =~ /Access Denied/
       assert WebHook.count.zero?
     end
@@ -22,13 +22,13 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
     end
 
     should "forbid access when firing hooks" do
-      post :fire, gem_name: WebHook::GLOBAL_PATTERN, url: "http://example.com"
+      post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN, url: "http://example.com" }
       assert @response.body =~ /Access Denied/
     end
 
     should "forbid access when removing a web hook" do
       hook = create(:web_hook)
-      delete :remove, gem_name: hook.rubygem.name, url: hook.url
+      delete :remove, params: { gem_name: hook.rubygem.name, url: hook.url }
       assert @response.body =~ /Access Denied/
       assert_equal 1, WebHook.count
     end
@@ -64,8 +64,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
       context "On POST to fire for all gems" do
         setup do
           RestClient.stubs(:post)
-          post :fire, gem_name: WebHook::GLOBAL_PATTERN,
-                      url: @url
+          post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
+                                url: @url }
         end
         should respond_with :success
         should "say successfully deployed" do
@@ -78,8 +78,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
       context "On POST to fire for all gems that fails" do
         setup do
           RestClient.stubs(:post).raises(RestClient::Exception.new)
-          post :fire, gem_name: WebHook::GLOBAL_PATTERN,
-                      url: @url
+          post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
+                                url: @url }
         end
         should respond_with :bad_request
         should "say successfully deployed" do
@@ -99,8 +99,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
       context "On POST to fire for a specific gem" do
         setup do
           RestClient.stubs(:post)
-          post :fire, gem_name: @rubygem.name,
-                      url: @url
+          post :fire, params: { gem_name: @rubygem.name,
+                                url: @url }
         end
         should respond_with :success
         should "say successfully deployed" do
@@ -112,8 +112,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
       context "On POST to fire for a specific gem that fails" do
         setup do
           RestClient.stubs(:post).raises(RestClient::Exception.new)
-          post :fire, gem_name: @rubygem.name,
-                      url: @url
+          post :fire, params: { gem_name: @rubygem.name,
+                                url: @url }
         end
         should respond_with :bad_request
         should "say there was a problem" do
@@ -142,9 +142,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
         context "On DELETE to remove with owned hook for rubygem" do
           setup do
-            delete :remove,
-              gem_name: @rubygem.name,
-              url: @rubygem_hook.url
+            delete :remove, params: { gem_name: @rubygem.name,
+                                      url: @rubygem_hook.url }
           end
 
           should respond_with :success
@@ -161,9 +160,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
         context "On DELETE to remove with owned global hook" do
           setup do
-            delete :remove,
-              gem_name: WebHook::GLOBAL_PATTERN,
-              url: @global_hook.url
+            delete :remove, params: { gem_name: WebHook::GLOBAL_PATTERN,
+                                      url: @global_hook.url }
           end
 
           should respond_with :success
@@ -188,7 +186,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
         context "On DELETE to remove with owned hook for rubygem" do
           setup do
-            delete(:remove, gem_name: @rubygem.name, url: @rubygem_hook.url)
+            delete :remove, params: { gem_name: @rubygem.name, url: @rubygem_hook.url }
           end
 
           should respond_with :not_found
@@ -202,9 +200,8 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
         context "On DELETE to remove with global hook" do
           setup do
-            delete :remove,
-              gem_name: WebHook::GLOBAL_PATTERN,
-              url: @rubygem_hook.url
+            delete :remove, params: { gem_name: WebHook::GLOBAL_PATTERN,
+                                      url: @rubygem_hook.url }
           end
 
           should respond_with :not_found
@@ -219,7 +216,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to create hook for a gem that's hosted" do
         setup do
-          post :create, gem_name: @rubygem.name, url: @url
+          post :create, params: { gem_name: @rubygem.name, url: @url }
         end
 
         should respond_with :created
@@ -235,7 +232,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
       context "on POST to create hook that already exists" do
         setup do
           create(:web_hook, rubygem: @rubygem, url: @url, user: @user)
-          post :create, gem_name: @rubygem.name, url: @url
+          post :create, params: { gem_name: @rubygem.name, url: @url }
         end
 
         should respond_with :conflict
@@ -247,7 +244,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to create hook for all gems" do
         setup do
-          post :create, gem_name: WebHook::GLOBAL_PATTERN, url: @url
+          post :create, params: { gem_name: WebHook::GLOBAL_PATTERN, url: @url }
         end
 
         should respond_with :created
@@ -263,7 +260,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
     context "On POST to create a hook for a gem that doesn't exist here" do
       setup do
-        post :create, gem_name: "a gem that doesn't exist", url: @url
+        post :create, params: { gem_name: "a gem that doesn't exist", url: @url }
       end
 
       should_not_find_it
@@ -271,7 +268,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
     context "On DELETE to remove a hook for a gem that doesn't exist here" do
       setup do
-        delete :remove, gem_name: "a gem that doesn't exist", url: @url
+        delete :remove, params: { gem_name: "a gem that doesn't exist", url: @url }
       end
 
       should_not_find_it
@@ -280,7 +277,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
     context "on POST to global web hook that already exists" do
       setup do
         create(:global_web_hook, url: @url, user: @user)
-        post :create, gem_name: WebHook::GLOBAL_PATTERN, url: @url
+        post :create, params: { gem_name: WebHook::GLOBAL_PATTERN, url: @url }
       end
 
       should respond_with :conflict

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V2::VersionsControllerTest < ActionController::TestCase
   def get_show(rubygem, version, format = 'json')
-    get :show, rubygem_name: rubygem.name, number: version, format: format
+    get :show, params: { rubygem_name: rubygem.name, number: version, format: format }
   end
 
   def set_cache_header

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -5,7 +5,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     context 'user exists and token has not expired' do
       setup do
         @user = create(:user)
-        get :update, token: @user.confirmation_token
+        get :update, params: { token: @user.confirmation_token }
       end
 
       should 'should confirm user account' do
@@ -17,7 +17,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     end
 
     context 'user does not exist' do
-      setup { get :update, token: Clearance::Token.new }
+      setup { get :update, params: { token: Clearance::Token.new } }
 
       should 'warn about invalid url' do
         assert_equal flash[:alert], 'Please double check the URL or try submitting it again.'
@@ -31,7 +31,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       setup do
         user = create(:user)
         user.update_attribute('token_expires_at', 2.minutes.ago)
-        get :update, token: user.confirmation_token
+        get :update, params: { token: user.confirmation_token }
       end
 
       should 'warn about invalid url' do
@@ -59,7 +59,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     context 'user exists' do
       setup do
         create(:user, email: 'foo@bar.com')
-        post :create, email_confirmation: { email: 'foo@bar.com' }
+        post :create, params: { email_confirmation: { email: 'foo@bar.com' } }
         Delayed::Worker.new.work_off
       end
 
@@ -82,7 +82,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     context 'user does not exist' do
       should 'not deliver confirmation email' do
         Mailer.expects(:email_confirmation).times(0)
-        post :create, email_confirmation: { email: 'someone@else.com' }
+        post :create, params: { email_confirmation: { email: 'someone@else.com' } }
         Delayed::Worker.new.work_off
       end
     end

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -22,7 +22,7 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   should "use default locale on GET using invalid one" do
-    get :index, locale: 'foobar'
+    get :index, params: { locale: 'foobar' }
     assert_equal I18n.locale, I18n.default_locale
   end
 end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -13,7 +13,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "with valid params" do
       setup do
         @user = create(:user)
-        get :create, password: { email: @user.email }
+        get :create, params: { password: { email: @user.email } }
       end
 
       should "set a valid confirmation_token" do
@@ -30,7 +30,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "with valid confirmation_token" do
       setup do
-        get :edit, token: @user.confirmation_token, user_id: @user.id
+        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
       end
 
       should redirect_to("password edit page") { edit_user_password_path }
@@ -39,7 +39,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "with expired confirmation_token" do
       setup do
         @user.update_attribute(:token_expires_at, 1.minute.ago)
-        get :edit, token: @user.confirmation_token, user_id: @user.id
+        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
       end
 
       should redirect_to("the home page") { root_path }

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProfilesControllerTest < ActionController::TestCase
   context "for a user that doesn't exist" do
     should "render not found page" do
-      get :show, id: "unknown"
+      get :show, params: { id: "unknown" }
       assert_response :not_found
     end
   end
@@ -23,7 +23,7 @@ class ProfilesControllerTest < ActionController::TestCase
           end
         end.reverse
 
-        get :show, id: @user.handle
+        get :show, params: { id: @user.handle }
       end
 
       should respond_with :success
@@ -34,7 +34,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
     context "on GET to show with handle" do
       setup do
-        get :show, id: @user.handle
+        get :show, params: { id: @user.handle }
       end
 
       should respond_with :success
@@ -44,7 +44,7 @@ class ProfilesControllerTest < ActionController::TestCase
     end
 
     context "on GET to show with id" do
-      setup { get :show, id: @user.id }
+      setup { get :show, params: { id: @user.id } }
 
       should respond_with :success
       should "render Email link" do
@@ -56,7 +56,7 @@ class ProfilesControllerTest < ActionController::TestCase
     context "on GET to show when hide email" do
       setup do
         @user.update(hide_email: true)
-        get :show, id: @user.id
+        get :show, params: { id: @user.id }
       end
 
       should respond_with :success
@@ -81,7 +81,7 @@ class ProfilesControllerTest < ActionController::TestCase
           @handle = "john_m_doe"
           @user = create(:user, handle: "johndoe")
           sign_in_as(@user)
-          put :update, user: { handle: @handle, password: @user.password }
+          put :update, params: { user: { handle: @handle, password: @user.password } }
         end
 
         should respond_with :redirect
@@ -99,7 +99,8 @@ class ProfilesControllerTest < ActionController::TestCase
           @hide_email = true
           @user = create(:user, handle: "johndoe")
           sign_in_as(@user)
-          put :update, user: { handle: @handle, hide_email: @hide_email, password: @user.password }
+          put :update,
+            params: { user: { handle: @handle, hide_email: @hide_email, password: @user.password } }
         end
 
         should respond_with :redirect
@@ -115,7 +116,7 @@ class ProfilesControllerTest < ActionController::TestCase
         setup do
           @user = create(:user, handle: "johndoe")
           sign_in_as(@user)
-          put :update, user: { handle: "doejohn" }
+          put :update, params: { user: { handle: "doejohn" } }
         end
 
         should set_flash.to("This request was denied. We could not verify your password.")
@@ -131,7 +132,7 @@ class ProfilesControllerTest < ActionController::TestCase
           @user = build(:user, handle: "old_user", password: "old")
           @user.save(validate: false)
           sign_in_as(@user)
-          put :update, user: { handle: @handle, password: @user.password }
+          put :update, params: { user: { handle: @handle, password: @user.password } }
         end
 
         should respond_with :redirect
@@ -144,7 +145,7 @@ class ProfilesControllerTest < ActionController::TestCase
       context "updating email with existing email" do
         setup do
           create(:user, email: "cannotchange@tothis.com")
-          put :update, user: { email: "cannotchange@tothis.com", password: @user.password }
+          put :update, params: { user: { email: "cannotchange@tothis.com", password: @user.password } }
         end
 
         should "not set unconfirmed_email" do
@@ -156,7 +157,7 @@ class ProfilesControllerTest < ActionController::TestCase
       context "updating email with existing unconfirmed_email" do
         setup do
           create(:user, unconfirmed_email: "cannotchange@tothis.com")
-          put :update, user: { email: "cannotchange@tothis.com", password: @user.password }
+          put :update, params: { user: { email: "cannotchange@tothis.com", password: @user.password } }
         end
 
         should "not set unconfirmed_email" do
@@ -169,13 +170,13 @@ class ProfilesControllerTest < ActionController::TestCase
       context "correct password" do
         should "enqueue deletion request" do
           assert_difference 'Delayed::Job.count', 1 do
-            delete :destroy, user: { password: @user.password }
+            delete :destroy, params: { user: { password: @user.password } }
           end
         end
 
         context "redirect path and flash" do
           setup do
-            delete :destroy, user: { password: @user.password }
+            delete :destroy, params: { user: { password: @user.password } }
           end
 
           should redirect_to("the homepage") { root_url }
@@ -187,13 +188,13 @@ class ProfilesControllerTest < ActionController::TestCase
       context "incorrect password" do
         should "not enqueue deletion request" do
           assert_no_difference 'Delayed::Job.count' do
-            post :destroy, user: { password: 'youshallnotpass' }
+            post :destroy, params: { user: { password: 'youshallnotpass' } }
           end
         end
 
         context "redirect path and flash" do
           setup do
-            delete :destroy, user: { password: 'youshallnotpass' }
+            delete :destroy, params: { user: { password: 'youshallnotpass' } }
           end
 
           should redirect_to('the profile edit page') { edit_profile_path }

--- a/test/functional/reverse_dependencies_controller_test.rb
+++ b/test/functional/reverse_dependencies_controller_test.rb
@@ -24,29 +24,33 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
     end
 
     should "render template" do
-      get :index, rubygem_id: @rubygem_one.to_param
+      get :index, params: { rubygem_id: @rubygem_one.to_param }
       respond_with :success
       render_template :index
     end
 
     should "show reverse dependencies" do
-      get :index, rubygem_id: @rubygem_one.to_param
+      get :index, params: { rubygem_id: @rubygem_one.to_param }
       assert page.has_content?(@rubygem_two.name)
       refute page.has_content?(@rubygem_three.name)
     end
 
     should "search reverse dependencies" do
       get :index,
-        rubygem_id: @rubygem_two.to_param,
-        rdeps_query: @rubygem_three.name
+        params: {
+          rubygem_id: @rubygem_two.to_param,
+          rdeps_query: @rubygem_three.name
+        }
       assert page.has_content?(@rubygem_three.name)
       refute page.has_content?(@rubygem_four.name)
     end
 
     should "search only current reverse dependencies" do
       get :index,
-        rubygem_id: @rubygem_two.to_param,
-        rdeps_query: @rubygem_one.name
+        params: {
+          rubygem_id: @rubygem_two.to_param,
+          rdeps_query: @rubygem_one.name
+        }
       refute page.has_content?(@rubygem_one.name)
     end
   end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -11,7 +11,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @owners = [@user, create(:user)]
         @rubygem = create(:rubygem, owners: @owners, number: "1.0.0")
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -27,7 +27,7 @@ class RubygemsControllerTest < ActionController::TestCase
         @owners = [@user, create(:user)]
         @rubygem = create(:rubygem, owners: @owners, number: "1.0.0")
         @rubygem.linkset = nil
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -39,7 +39,7 @@ class RubygemsControllerTest < ActionController::TestCase
     context "On GET to show for another user's gem" do
       setup do
         @rubygem = create(:rubygem, number: "1.0.0")
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -51,7 +51,7 @@ class RubygemsControllerTest < ActionController::TestCase
     context "On GET to show for this user's gem" do
       setup do
         @rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -65,7 +65,7 @@ class RubygemsControllerTest < ActionController::TestCase
         @rubygem = create(:rubygem)
         create(:version, rubygem: @rubygem)
         create(:subscription, rubygem: @rubygem, user: @user)
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -79,7 +79,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem)
         create(:version, rubygem: @rubygem)
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -92,7 +92,7 @@ class RubygemsControllerTest < ActionController::TestCase
     context "On GET to edit for this user's gem" do
       setup do
         @rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
-        get :edit, id: @rubygem.to_param
+        get :edit, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -111,7 +111,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @other_user = create(:user)
         @rubygem = create(:rubygem, owners: [@other_user], number: "1.0.0")
-        get :edit, id: @rubygem.to_param
+        get :edit, params: { id: @rubygem.to_param }
       end
       should respond_with :redirect
       should redirect_to('the homepage') { root_url }
@@ -123,13 +123,15 @@ class RubygemsControllerTest < ActionController::TestCase
         @url = "https://github.com/qrush/gemcutter"
         @rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
         put :update,
-          id: @rubygem.to_param,
-          linkset: {
-            code: @url,
-            docs: 'http://docs.com',
-            wiki: 'http://wiki.com',
-            mail: 'http://mail.com',
-            bugs: 'http://bugs.com'
+          params: {
+            id: @rubygem.to_param,
+            linkset: {
+              code: @url,
+              docs: 'http://docs.com',
+              wiki: 'http://wiki.com',
+              mail: 'http://mail.com',
+              bugs: 'http://bugs.com'
+            }
           }
       end
       should respond_with :redirect
@@ -156,7 +158,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
         @url = "totally not a url"
-        put :update, id: @rubygem.to_param, linkset: { code: @url }
+        put :update, params: { id: @rubygem.to_param, linkset: { code: @url } }
       end
       should respond_with :success
       should "not update linkset" do
@@ -228,7 +230,7 @@ class RubygemsControllerTest < ActionController::TestCase
       @gems = (1..3).map { |n| create(:rubygem, name: "agem#{n}") }
       @zgem = create(:rubygem, name: "zeta")
       create(:version, rubygem: @zgem)
-      get :index, letter: "z"
+      get :index, params: { letter: "z" }
     end
     should respond_with :success
     should "render links" do
@@ -245,7 +247,7 @@ class RubygemsControllerTest < ActionController::TestCase
         gem
       end
       create(:rubygem, name: "zeta")
-      get :index, letter: "asdf"
+      get :index, params: { letter: "asdf" }
     end
 
     should respond_with :success
@@ -261,7 +263,7 @@ class RubygemsControllerTest < ActionController::TestCase
     setup do
       @latest_version = create(:version, created_at: 1.minute.ago)
       @rubygem = @latest_version.rubygem
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
     end
 
     should respond_with :success
@@ -281,17 +283,17 @@ class RubygemsControllerTest < ActionController::TestCase
     end
     should "render plural licenses header for other than one license" do
       @latest_version.update_attributes(licenses: nil)
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
       assert page.has_content?("Licenses")
 
       @latest_version.update_attributes(licenses: ["MIT", "GPL-2"])
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
       assert page.has_content?("Licenses")
     end
 
     should "render singular license header for one line license" do
       @latest_version.update_attributes(licenses: ["MIT"])
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
       assert page.has_content?("License")
       assert page.has_no_content?("Licenses")
     end
@@ -305,7 +307,7 @@ class RubygemsControllerTest < ActionController::TestCase
         create(:version, number: "1.9.9", rubygem: @rubygem, created_at: 1.minute.ago),
         create(:version, number: "1.9.9.rc4", rubygem: @rubygem, created_at: 2.days.ago)
       ]
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
     end
 
     should respond_with :success
@@ -336,7 +338,7 @@ class RubygemsControllerTest < ActionController::TestCase
       @rubygem = version.rubygem
     end
     context 'when signed out' do
-      setup { get :show, id: @rubygem.to_param }
+      setup { get :show, params: { id: @rubygem.to_param } }
       should respond_with :success
       should "render info about the gem" do
         assert page.has_content?("This gem is not currently hosted on RubyGems.org")
@@ -348,7 +350,7 @@ class RubygemsControllerTest < ActionController::TestCase
         @user = create(:user)
         sign_in_as @user
         create(:subscription, user: @user, rubygem: @rubygem)
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
       should "have unsubscribe link" do
         assert page.has_link? 'Unsubscribe'
@@ -359,7 +361,7 @@ class RubygemsControllerTest < ActionController::TestCase
         @rubygem.update_attributes(created_at: 30.days.ago, updated_at: 99.days.ago)
         @owner = create(:user)
         @rubygem.owners << @owner
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -376,7 +378,7 @@ class RubygemsControllerTest < ActionController::TestCase
   context "On GET to show for a gem with no versions" do
     setup do
       @rubygem = create(:rubygem)
-      get :show, id: @rubygem.to_param
+      get :show, params: { id: @rubygem.to_param }
     end
     should respond_with :success
     should "render info about the gem" do
@@ -391,7 +393,7 @@ class RubygemsControllerTest < ActionController::TestCase
       @development = create(:dependency, :development, version: @version)
       @runtime     = create(:dependency, :runtime,     version: @version)
 
-      get :show, id: @version.rubygem.to_param
+      get :show, params: { id: @version.rubygem.to_param }
     end
 
     should respond_with :success
@@ -411,7 +413,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
       @unresolved = create(:dependency, :unresolved, version: @version)
 
-      get :show, id: @version.rubygem.to_param
+      get :show, params: { id: @version.rubygem.to_param }
     end
 
     should respond_with :success
@@ -433,7 +435,7 @@ class RubygemsControllerTest < ActionController::TestCase
       @missing_dependency.rubygem.update_column(:name, 'missing')
       @missing_dependency.update_column(:rubygem_id, nil)
 
-      get :show, id: @version.rubygem.to_param
+      get :show, params: { id: @version.rubygem.to_param }
     end
 
     should respond_with :success
@@ -448,7 +450,7 @@ class RubygemsControllerTest < ActionController::TestCase
       @version = create(:version)
       @runtime = create(:dependency, :runtime, version: @version)
       @runtime.rubygem.update_column(:name, 'foo>0.1.1')
-      get :show, id: @version.rubygem.to_param
+      get :show, params: { id: @version.rubygem.to_param }
     end
 
     should respond_with :success
@@ -459,7 +461,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
   context "On GET to show for nonexistent gem" do
     setup do
-      get :show, id: "blahblah"
+      get :show, params: { id: "blahblah" }
     end
 
     should respond_with :not_found
@@ -467,7 +469,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
   context "On GET to show for a blacklisted gem" do
     setup do
-      get :show, id: Patterns::GEM_NAME_BLACKLIST.sample
+      get :show, params: { id: Patterns::GEM_NAME_BLACKLIST.sample }
     end
 
     should respond_with :success
@@ -481,7 +483,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem)
         create(:version, rubygem: @rubygem)
-        get :show, id: @rubygem.to_param
+        get :show, params: { id: @rubygem.to_param }
       end
 
       should respond_with :success
@@ -496,7 +498,7 @@ class RubygemsControllerTest < ActionController::TestCase
     context "On GET to edit" do
       setup do
         @rubygem = create(:rubygem)
-        get :edit, id: @rubygem.to_param
+        get :edit, params: { id: @rubygem.to_param }
       end
       should respond_with :redirect
       should redirect_to('the homepage') { root_url }
@@ -505,7 +507,7 @@ class RubygemsControllerTest < ActionController::TestCase
     context "On PUT to update" do
       setup do
         @rubygem = create(:rubygem)
-        put :update, id: @rubygem.to_param, linkset: {}
+        put :update, params: { id: @rubygem.to_param, linkset: {} }
       end
       should respond_with :redirect
       should redirect_to('the homepage') { root_url }

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -17,7 +17,7 @@ class SearchesControllerTest < ActionController::TestCase
       import_and_refresh
       assert_nil @sinatra.versions.most_recent
       assert @sinatra.reload.versions.count.zero?
-      get :show, query: "sinatra"
+      get :show, params: { query: "sinatra" }
     end
 
     should respond_with :success
@@ -35,7 +35,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
       import_and_refresh
-      get :show, query: "sinatra"
+      get :show, params: { query: "sinatra" }
     end
 
     should respond_with :success
@@ -62,7 +62,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @brando)
       import_and_refresh
       @request.cookies['new_search'] = 'true'
-      get :show, query: 'sinatra'
+      get :show, params: { query: 'sinatra' }
     end
 
     should respond_with :success
@@ -88,7 +88,7 @@ class SearchesControllerTest < ActionController::TestCase
       @sinatra = create(:rubygem, name: "sinatra")
       create(:version, rubygem: @sinatra)
       import_and_refresh
-      get :show, query: "sinatra"
+      get :show, params: { query: "sinatra" }
     end
 
     should respond_with :redirect
@@ -97,7 +97,7 @@ class SearchesControllerTest < ActionController::TestCase
 
   context 'on GET to show with non string search parameter' do
     setup do
-      get :show, query: { foo: "bar" }
+      get :show, params: { query: { foo: "bar" } }
     end
 
     should respond_with :success
@@ -116,7 +116,7 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @brando)
       import_and_refresh
       @request.cookies['new_search'] = 'true'
-      get :show, query: "sinatre"
+      get :show, params: { query: "sinatre" }
     end
 
     should respond_with :success
@@ -145,7 +145,7 @@ class SearchesControllerTest < ActionController::TestCase
       requires_toxiproxy
       Toxiproxy[:elasticsearch].down do
         @request.cookies['new_search'] = 'true'
-        get :show, query: 'sinatra'
+        get :show, params: { query: 'sinatra' }
         assert_response :success
         assert page.has_content?('Advanced search is currently unavailable. Falling back to legacy search.')
         assert page.has_content?('Displaying')

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -9,7 +9,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
 
   context "On POST to create for a gem that the user is not subscribed to" do
     setup do
-      post :create, rubygem_id: @rubygem.to_param
+      post :create, params: { rubygem_id: @rubygem.to_param }
     end
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }
@@ -21,7 +21,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
   context "On POST to create for a gem that the user is subscribed to" do
     setup do
       create(:subscription, rubygem: @rubygem, user: @user)
-      post :create, rubygem_id: @rubygem.to_param
+      post :create, params: { rubygem_id: @rubygem.to_param }
     end
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }
@@ -32,7 +32,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
 
   context "On DELETE to destroy for a gem that the user is not subscribed to" do
     setup do
-      delete :destroy, rubygem_id: @rubygem.to_param
+      delete :destroy, params: { rubygem_id: @rubygem.to_param }
     end
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }
@@ -44,7 +44,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
   context "On DELETE to destroy for a gem that the user is subscribed to" do
     setup do
       create(:subscription, rubygem: @rubygem, user: @user)
-      delete :destroy, rubygem_id: @rubygem.to_param
+      delete :destroy, params: { rubygem_id: @rubygem.to_param }
     end
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -12,7 +12,7 @@ class UsersControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when email and password are given" do
       should "create a user" do
-        post :create, user: { email: 'foo@bar.com', password: 'secret12345' }
+        post :create, params: { user: { email: 'foo@bar.com', password: 'secret12345' } }
         assert User.find_by(email: 'foo@bar.com')
       end
     end
@@ -27,19 +27,19 @@ class UsersControllerTest < ActionController::TestCase
 
     context "when extra parameters given" do
       should "create a user if parameters are ok" do
-        post :create, user: { email: 'foo@bar.com', password: 'secret12345', handle: 'foo' }
+        post :create, params: { user: { email: 'foo@bar.com', password: 'secret12345', handle: 'foo' } }
         assert_equal "foo", User.where(email: 'foo@bar.com').pluck(:handle).first
       end
 
       should "create a user but dont assign not valid parameters" do
-        post :create, user: { email: 'foo@bar.com', password: 'secret', api_key: 'nonono' }
+        post :create, params: { user: { email: 'foo@bar.com', password: 'secret', api_key: 'nonono' } }
         assert_not_equal "nonono", User.where(email: 'foo@bar.com').pluck(:api_key).first
       end
     end
 
     context 'confirmation mail' do
       setup do
-        post :create, user: { email: 'foo@bar.com', password: 'secretpassword', handle: 'foo' }
+        post :create, params: { user: { email: 'foo@bar.com', password: 'secretpassword', handle: 'foo' } }
         Delayed::Worker.new.work_off
       end
 

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -8,7 +8,7 @@ class VersionsControllerTest < ActionController::TestCase
         create(:version, rubygem: @rubygem)
       end
 
-      get :index, rubygem_id: @rubygem.name
+      get :index, params: { rubygem_id: @rubygem.name }
     end
 
     should respond_with :success
@@ -28,7 +28,7 @@ class VersionsControllerTest < ActionController::TestCase
       end
       @rubygem.reload
 
-      get :index, rubygem_id: @rubygem.name, format: "atom"
+      get :index, params: { rubygem_id: @rubygem.name, format: "atom" }
     end
 
     should respond_with :success
@@ -51,7 +51,7 @@ class VersionsControllerTest < ActionController::TestCase
   context "GET to index for gem with no versions" do
     setup do
       @rubygem = create(:rubygem)
-      get :index, rubygem_id: @rubygem.name
+      get :index, params: { rubygem_id: @rubygem.name }
     end
 
     should respond_with :success
@@ -70,7 +70,7 @@ class VersionsControllerTest < ActionController::TestCase
       @versions = (1..5).map do
         FactoryGirl.create(:version, rubygem: @rubygem)
       end
-      get :show, rubygem_id: @rubygem.name, id: @latest_version.number
+      get :show, params: { rubygem_id: @rubygem.name, id: @latest_version.number }
     end
 
     should respond_with :success
@@ -95,7 +95,7 @@ class VersionsControllerTest < ActionController::TestCase
       @version = create(:version, number: '1.0.1')
       @version.rubygem.owners << create(:user, handle: "johndoe")
       create(:version, number: "1.0.2", rubygem: @version.rubygem, indexed: false)
-      get :show, rubygem_id: @version.rubygem.name, id: "1.0.2"
+      get :show, params: { rubygem_id: @version.rubygem.name, id: "1.0.2" }
     end
 
     should respond_with :success

--- a/test/integration/about_page_test.rb
+++ b/test/integration/about_page_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AboutPageTest < ActionDispatch::IntegrationTest
   def assert_about_page_i18n(local)
-    get page_url("about"), locale: local
+    get page_url("about"), params: { locale: local }
 
     assert_response :success
     assert page.has_content? I18n.t('pages.about.title')

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -64,7 +64,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   end
 
   test "/names partial response" do
-    get names_path, nil, range: "bytes=15-"
+    get names_path, env: { range: "bytes=15-" }
 
     assert_response 206
     full_body = "---\ngemA\ngemA1\ngemA2\ngemB\n"
@@ -90,7 +90,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     full_response_body = @response.body
     partial_body = "1.0.0 013we2\ngemA 2.0.0 1cf94r\ngemA 1.2.0 13q4es\ngemA 2.1.0 e217fz\n"
 
-    get versions_path, nil, range: "bytes=229-"
+    get versions_path, env: { range: "bytes=229-" }
 
     assert_response 206
     assert_equal partial_body, @response.body
@@ -110,7 +110,7 @@ eos
 
     get versions_path
     full_response_body = @response.body
-    get versions_path, nil, range: "bytes=206-"
+    get versions_path, env: { range: "bytes=206-" }
     assert_equal etag(full_response_body), @response.headers['ETag']
     assert_equal expected, @response.body
   end
@@ -146,7 +146,7 @@ eos
 2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
 eos
 
-    get info_path(gem_name: 'gemA'), nil, range: "bytes=159-"
+    get info_path(gem_name: 'gemA'), env: { range: "bytes=159-" }
 
     assert_response 206
     assert_equal expected[159..-1], @response.body
@@ -175,7 +175,7 @@ END
   end
 
   test "/info with gzip" do
-    get info_path(gem_name: 'gemA'), nil, 'Accept-Encoding' => 'gzip'
+    get info_path(gem_name: 'gemA'), env: { 'Accept-Encoding' => 'gzip' }
     assert_response :success
     assert_equal('gzip', @response.headers['Content-Encoding'])
   end

--- a/test/integration/api/v2/version_information_test.rb
+++ b/test/integration/api/v2/version_information_test.rb
@@ -6,8 +6,8 @@ class VersionInformationTest < ActionDispatch::IntegrationTest
     create(:version, rubygem: @rubygem, number: '2.0.0')
   end
 
-  def request_endpoint(rubygem, version, format = 'json', http_params = {})
-    get api_v2_rubygem_version_path(rubygem.name, version, format: format), {}, http_params
+  def request_endpoint(rubygem, version, format = 'json')
+    get api_v2_rubygem_version_path(rubygem.name, version, format: format)
   end
 
   test "return gem version" do
@@ -41,11 +41,10 @@ class VersionInformationTest < ActionDispatch::IntegrationTest
   test "second get returns not modified" do
     request_endpoint(@rubygem, '2.0.0')
     assert_response :success
-    http_params = {
+    get api_v2_rubygem_version_path(@rubygem.name, '2.0.0', format: 'json'), headers: {
       "HTTP_IF_MODIFIED_SINCE" => @response.headers['Last-Modified'],
       "HTTP_IF_NONE_MATCH" => @response.etag
     }
-    request_endpoint(@rubygem, '2.0.0', 'json', http_params)
     assert_response :not_modified
   end
 

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -7,8 +7,7 @@ class GemsTest < ActionDispatch::IntegrationTest
   end
 
   test "gem page with a non valid HTTP_ACCEPT header" do
-    get rubygem_path(@rubygem), nil,
-      'HTTP_ACCEPT' => 'application/mercurial-0.1'
+    get rubygem_path(@rubygem), headers: { 'HTTP_ACCEPT' => 'application/mercurial-0.1' }
     assert page.has_content? "1.0.0"
   end
 

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -11,8 +11,9 @@ class OwnerTest < ActionDispatch::IntegrationTest
   end
 
   test "adding an owner" do
-    post api_v1_rubygem_owners_path(@rubygem), { email: @other_user.email },
-      "HTTP_AUTHORIZATION" => @user.api_key
+    post api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
     assert_response :success
 
     get rubygem_path(@rubygem)
@@ -22,8 +23,9 @@ class OwnerTest < ActionDispatch::IntegrationTest
 
   test "removing an owner" do
     create(:ownership, user: @other_user, rubygem: @rubygem)
-    delete api_v1_rubygem_owners_path(@rubygem), { email: @other_user.email },
-      "HTTP_AUTHORIZATION" => @user.api_key
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
 
     get rubygem_path(@rubygem)
     assert page.has_selector?("a[alt='#{@user.handle}']")
@@ -33,8 +35,9 @@ class OwnerTest < ActionDispatch::IntegrationTest
   test "transferring ownership" do
     create(:ownership, user: @other_user, rubygem: @rubygem)
 
-    delete api_v1_rubygem_owners_path(@rubygem), { email: @user.email },
-      "HTTP_AUTHORIZATION" => @user.api_key
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @user.email },
+      headers: { "HTTP_AUTHORIZATION" => @user.api_key }
 
     get rubygem_path(@rubygem)
     refute page.has_selector?("a[alt='#{@user.handle}']")
@@ -42,12 +45,14 @@ class OwnerTest < ActionDispatch::IntegrationTest
   end
 
   test "adding ownership without permission" do
-    post api_v1_rubygem_owners_path(@rubygem), { email: @other_user.email },
-      "HTTP_AUTHORIZATION" => @other_user.api_key
+    post api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
     assert_response :unauthorized
 
-    delete api_v1_rubygem_owners_path(@rubygem), { email: @other_user.email },
-      "HTTP_AUTHORIZATION" => @other_user.api_key
+    delete api_v1_rubygem_owners_path(@rubygem),
+      params: { email: @other_user.email },
+      headers: { "HTTP_AUTHORIZATION" => @other_user.api_key }
     assert_response :unauthorized
   end
 end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -71,9 +71,9 @@ class PushTest < ActionDispatch::IntegrationTest
 
   def push_gem(path)
     post api_v1_rubygems_path,
-      File.read(path),
-      "CONTENT_TYPE" => "application/octet-stream",
-      "HTTP_AUTHORIZATION" => @user.api_key
+      env: { 'RAW_POST_DATA' => File.read(path) },
+      headers: { "CONTENT_TYPE" => "application/octet-stream",
+                 "HTTP_AUTHORIZATION" => @user.api_key }
   end
 
   teardown do

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -14,7 +14,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
   context 'requests is lower than limit' do
     should 'allow sign in' do
       10.times do
-        post_via_redirect '/session', session: { who: @user.email, password: @user.password }
+        post_via_redirect '/session', params: { session: { who: @user.email, password: @user.password } }
         assert_equal 200, @response.status
       end
     end
@@ -22,21 +22,21 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should 'allow sign up' do
       10.times do
         user = build(:user)
-        post_via_redirect '/users', user: { email: user.email, password: user.password }
+        post_via_redirect '/users', params: { user: { email: user.email, password: user.password } }
         assert_equal 200, @response.status
       end
     end
 
     should 'allow forgot password' do
       10.times do
-        post '/passwords', password: { email: @user.email }
+        post '/passwords', params: { password: { email: @user.email } }
         assert_equal 200, @response.status
       end
     end
 
     should 'allow api_key show' do
       10.times do
-        get '/api/v1/api_key.json', nil, 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password)
+        get '/api/v1/api_key.json', env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
         assert_equal 200, @response.status
       end
     end
@@ -48,7 +48,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       end
 
       should 'return 401 for unauthorized request' do
-        post_via_redirect '/session', session: { password: @user.password }
+        post_via_redirect '/session', params: { session: { password: @user.password } }
         assert_equal 401, @response.status
       end
     end
@@ -57,7 +57,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
   context 'requests is higher than limit' do
     should 'throttle sign in' do
       (@limit + 1).times do |i|
-        post_via_redirect '/session', session: { who: @user.email, password: @user.password }
+        post_via_redirect '/session', params: { session: { who: @user.email, password: @user.password } }
         assert_equal 429, @response.status if i > @limit
       end
     end
@@ -65,21 +65,21 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should 'throttle sign up' do
       (@limit + 1).times do |i|
         user = build(:user)
-        post_via_redirect '/users', user: { email: user.email, password: user.password }
+        post_via_redirect '/users', params: { user: { email: user.email, password: user.password } }
         assert_equal 429, @response.status if i > @limit
       end
     end
 
     should 'throttle forgot password' do
       (@limit + 1).times do |i|
-        post '/passwords', password: { email: @user.email }
+        post '/passwords', params: { password: { email: @user.email } }
         assert_equal 429, @response.status if i > @limit
       end
     end
 
     should 'throttle api_key show' do
       (@limit + 1).times do |i|
-        get '/api/v1/api_key.json', nil, 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password)
+        get '/api/v1/api_key.json', env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
         assert_equal 429, @response.status if i > @limit
       end
     end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -50,7 +50,7 @@ class SearchTest < SystemTest
 
   test "search page with a non valid format" do
     assert_raises(ActionController::RoutingError) do
-      get search_path(format: :json), query: 'foobar'
+      get search_path(format: :json), params: { query: 'foobar' }
     end
   end
 

--- a/test/integration/session_test.rb
+++ b/test/integration/session_test.rb
@@ -39,7 +39,7 @@ class SessionTest < ActionDispatch::IntegrationTest
     )
 
     assert_raise ActionController::InvalidAuthenticityToken do
-      patch "/profile", user: { handle: "alice" }, authenticity_token: @last_session_token
+      patch "/profile", params: { user: { handle: "alice" }, authenticity_token: @last_session_token }
     end
 
     refute_equal request.session[:_csrf_token], @last_session_token


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Using positional arguments in functional tests has been deprecated,
in favor of keyword arguments, and will be removed in Rails 5.1.
Deprecated style:
```
get :show, { id: 1 }, nil, { notice: "This is a flash message" }
```
New keyword style:
```
get :show, params: { id: 1 }, flash: { notice: "This is a flash message" },
   session: nil # Can safely be omitted
```