### PR TITLE
Use follow_redirect! instead of post_via_redirect

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::OwnersController < Api::BaseController
     if owner
       ownership = @rubygem.ownerships.find_by(user_id: owner.id)
       if ownership.try(:safe_destroy)
-        render text: "Owner removed successfully."
+        render plain: "Owner removed successfully."
       else
         render plain: 'Unable to remove owner.', status: :forbidden
       end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -154,7 +154,7 @@ class SearchesControllerTest < ActionController::TestCase
   end
 
   context "with page greater than 100" do
-    setup { get :show, page: 204 }
+    setup { get :show, params: { page: 204 } }
 
     should "render 404 page" do
       assert_response :not_found

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -14,7 +14,8 @@ class RackAttackTest < ActionDispatch::IntegrationTest
   context 'requests is lower than limit' do
     should 'allow sign in' do
       10.times do
-        post_via_redirect '/session', params: { session: { who: @user.email, password: @user.password } }
+        post '/session', params: { session: { who: @user.email, password: @user.password } }
+        follow_redirect!
         assert_equal 200, @response.status
       end
     end
@@ -22,7 +23,8 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should 'allow sign up' do
       10.times do
         user = build(:user)
-        post_via_redirect '/users', params: { user: { email: user.email, password: user.password } }
+        post '/users', params: { user: { email: user.email, password: user.password } }
+        follow_redirect!
         assert_equal 200, @response.status
       end
     end
@@ -43,12 +45,12 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
     context 'params' do
       should 'return 400 for bad request' do
-        post_via_redirect '/session'
+        post '/session'
         assert_equal 400, @response.status
       end
 
       should 'return 401 for unauthorized request' do
-        post_via_redirect '/session', params: { session: { password: @user.password } }
+        post '/session', params: { session: { password: @user.password } }
         assert_equal 401, @response.status
       end
     end
@@ -57,7 +59,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
   context 'requests is higher than limit' do
     should 'throttle sign in' do
       (@limit + 1).times do |i|
-        post_via_redirect '/session', params: { session: { who: @user.email, password: @user.password } }
+        post '/session', params: { session: { who: @user.email, password: @user.password } }
         assert_equal 429, @response.status if i > @limit
       end
     end
@@ -65,7 +67,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should 'throttle sign up' do
       (@limit + 1).times do |i|
         user = build(:user)
-        post_via_redirect '/users', params: { user: { email: user.email, password: user.password } }
+        post '/users', params: { user: { email: user.email, password: user.password } }
         assert_equal 429, @response.status if i > @limit
       end
     end


### PR DESCRIPTION
DEPRECATION WARNING: `post_via_redirect` is deprecated and will be removed in Rails 5.1. Please use `follow_redirect!` manually after the request call for the same behavior.
DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response.
DEPRECATION WARNING: Using positional arguments in functional tests has been deprecated.

Turns out, we didn't need all the post_via_redirect we were using.