### PR TITLE
Specify rails version in migration file

### DIFF
--- a/db/migrate/20090527120326_clearance_create_users.rb
+++ b/db/migrate/20090527120326_clearance_create_users.rb
@@ -1,4 +1,4 @@
-class ClearanceCreateUsers < ActiveRecord::Migration
+class ClearanceCreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       t.string :email

--- a/db/migrate/20090527122639_create_rubygems.rb
+++ b/db/migrate/20090527122639_create_rubygems.rb
@@ -1,4 +1,4 @@
-class CreateRubygems < ActiveRecord::Migration
+class CreateRubygems < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rubygems do |table|
       table.string :name

--- a/db/migrate/20090527122649_create_versions.rb
+++ b/db/migrate/20090527122649_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :versions do |table|
       table.string :authors

--- a/db/migrate/20090527122658_create_dependencies.rb
+++ b/db/migrate/20090527122658_create_dependencies.rb
@@ -1,4 +1,4 @@
-class CreateDependencies < ActiveRecord::Migration
+class CreateDependencies < ActiveRecord::Migration[4.2]
   def self.up
     create_table :dependencies do |table|
       table.string :name

--- a/db/migrate/20090530145834_move_downloads_to_rubygems.rb
+++ b/db/migrate/20090530145834_move_downloads_to_rubygems.rb
@@ -1,4 +1,4 @@
-class MoveDownloadsToRubygems < ActiveRecord::Migration
+class MoveDownloadsToRubygems < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :versions, :downloads
     add_column :rubygems, :downloads, :integer, default: 0

--- a/db/migrate/20090530162119_add_slug_to_rubygems.rb
+++ b/db/migrate/20090530162119_add_slug_to_rubygems.rb
@@ -1,4 +1,4 @@
-class AddSlugToRubygems < ActiveRecord::Migration
+class AddSlugToRubygems < ActiveRecord::Migration[4.2]
   def self.up
     add_column :rubygems, :slug, :string
   end

--- a/db/migrate/20090601003056_move_dependencies_to_versions.rb
+++ b/db/migrate/20090601003056_move_dependencies_to_versions.rb
@@ -1,4 +1,4 @@
-class MoveDependenciesToVersions < ActiveRecord::Migration
+class MoveDependenciesToVersions < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :dependencies, :rubygem_id
     add_column :dependencies, :version_id, :integer

--- a/db/migrate/20090601115133_create_linksets.rb
+++ b/db/migrate/20090601115133_create_linksets.rb
@@ -1,4 +1,4 @@
-class CreateLinksets < ActiveRecord::Migration
+class CreateLinksets < ActiveRecord::Migration[4.2]
   def self.up
     create_table :linksets do |table|
       table.integer :rubygem_id

--- a/db/migrate/20090603212455_add_api_key_to_users.rb
+++ b/db/migrate/20090603212455_add_api_key_to_users.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToUsers < ActiveRecord::Migration
+class AddApiKeyToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :api_key, :string
   end

--- a/db/migrate/20090607004258_create_ownerships.rb
+++ b/db/migrate/20090607004258_create_ownerships.rb
@@ -1,4 +1,4 @@
-class CreateOwnerships < ActiveRecord::Migration
+class CreateOwnerships < ActiveRecord::Migration[4.2]
   def self.up
     create_table :ownerships do |table|
       table.belongs_to :rubygem

--- a/db/migrate/20090607011852_remove_user_id_from_rubygems.rb
+++ b/db/migrate/20090607011852_remove_user_id_from_rubygems.rb
@@ -1,4 +1,4 @@
-class RemoveUserIdFromRubygems < ActiveRecord::Migration
+class RemoveUserIdFromRubygems < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :rubygems, :user_id
   end

--- a/db/migrate/20090608111256_remove_token_from_rubygems.rb
+++ b/db/migrate/20090608111256_remove_token_from_rubygems.rb
@@ -1,4 +1,4 @@
-class RemoveTokenFromRubygems < ActiveRecord::Migration
+class RemoveTokenFromRubygems < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :rubygems, :token
   end

--- a/db/migrate/20090610115456_add_requirements.rb
+++ b/db/migrate/20090610115456_add_requirements.rb
@@ -1,4 +1,4 @@
-class AddRequirements < ActiveRecord::Migration
+class AddRequirements < ActiveRecord::Migration[4.2]
   def self.up
     create_table :requirements  do |t|
       t.integer "version_id"

--- a/db/migrate/20090610121103_rename_requirement_to_name.rb
+++ b/db/migrate/20090610121103_rename_requirement_to_name.rb
@@ -1,4 +1,4 @@
-class RenameRequirementToName < ActiveRecord::Migration
+class RenameRequirementToName < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :dependencies, :requirement, :name
   end

--- a/db/migrate/20090610121428_remove_version_from_dependencies.rb
+++ b/db/migrate/20090610121428_remove_version_from_dependencies.rb
@@ -1,4 +1,4 @@
-class RemoveVersionFromDependencies < ActiveRecord::Migration
+class RemoveVersionFromDependencies < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :dependencies, :version_id
   end

--- a/db/migrate/20090611123606_add_versions_count_to_rubygems.rb
+++ b/db/migrate/20090611123606_add_versions_count_to_rubygems.rb
@@ -1,4 +1,4 @@
-class AddVersionsCountToRubygems < ActiveRecord::Migration
+class AddVersionsCountToRubygems < ActiveRecord::Migration[4.2]
   def self.up
     add_column :rubygems, :versions_count, :integer, default: 0
   end

--- a/db/migrate/20090612020811_add_missing_indicies.rb
+++ b/db/migrate/20090612020811_add_missing_indicies.rb
@@ -1,4 +1,4 @@
-class AddMissingIndicies < ActiveRecord::Migration
+class AddMissingIndicies < ActiveRecord::Migration[4.2]
   def self.up
     add_index 'rubygems', 'name'
     add_index 'linksets', 'rubygem_id'

--- a/db/migrate/20090616121836_add_summary_and_rubyforge_project_to_versions.rb
+++ b/db/migrate/20090616121836_add_summary_and_rubyforge_project_to_versions.rb
@@ -1,4 +1,4 @@
-class AddSummaryAndRubyforgeProjectToVersions < ActiveRecord::Migration
+class AddSummaryAndRubyforgeProjectToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :summary, :string
     add_column :versions, :rubyforge_project, :string

--- a/db/migrate/20090808034224_create_delayed_jobs.rb
+++ b/db/migrate/20090808034224_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0      # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20090820185410_drop_requirements_table.rb
+++ b/db/migrate/20090820185410_drop_requirements_table.rb
@@ -1,4 +1,4 @@
-class DropRequirementsTable < ActiveRecord::Migration
+class DropRequirementsTable < ActiveRecord::Migration[4.2]
   def self.up
     add_column :dependencies, :version_id, :integer
     rename_column :dependencies, :name, :requirements

--- a/db/migrate/20090821044418_add_scope_to_dependencies.rb
+++ b/db/migrate/20090821044418_add_scope_to_dependencies.rb
@@ -1,4 +1,4 @@
-class AddScopeToDependencies < ActiveRecord::Migration
+class AddScopeToDependencies < ActiveRecord::Migration[4.2]
   def self.up
     add_column :dependencies, :scope, :string
     Dependency.update_all(scope: 'runtime')

--- a/db/migrate/20090825121145_textify_summaries.rb
+++ b/db/migrate/20090825121145_textify_summaries.rb
@@ -1,4 +1,4 @@
-class TextifySummaries < ActiveRecord::Migration
+class TextifySummaries < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :versions, :summary
     add_column :versions, :summary, :text

--- a/db/migrate/20090825125958_add_platforms_to_versions.rb
+++ b/db/migrate/20090825125958_add_platforms_to_versions.rb
@@ -1,4 +1,4 @@
-class AddPlatformsToVersions < ActiveRecord::Migration
+class AddPlatformsToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :platform, :string
   end

--- a/db/migrate/20090825173917_create_subscriptions.rb
+++ b/db/migrate/20090825173917_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :subscriptions do |t|
       t.references :rubygem

--- a/db/migrate/20090826035230_fix_version_dates.rb
+++ b/db/migrate/20090826035230_fix_version_dates.rb
@@ -1,4 +1,4 @@
-class FixVersionDates < ActiveRecord::Migration
+class FixVersionDates < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :versions, :created_at, :built_at
     add_column :versions, :created_at, :datetime

--- a/db/migrate/20090826043208_add_indexed_to_versions.rb
+++ b/db/migrate/20090826043208_add_indexed_to_versions.rb
@@ -1,4 +1,4 @@
-class AddIndexedToVersions < ActiveRecord::Migration
+class AddIndexedToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :indexed, :boolean, default: true
   end

--- a/db/migrate/20090901141418_add_more_missing_indexes.rb
+++ b/db/migrate/20090901141418_add_more_missing_indexes.rb
@@ -1,4 +1,4 @@
-class AddMoreMissingIndexes < ActiveRecord::Migration
+class AddMoreMissingIndexes < ActiveRecord::Migration[4.2]
   def self.up
     add_index 'subscriptions', 'rubygem_id'
     add_index 'subscriptions', 'user_id'

--- a/db/migrate/20090910143608_clearance_update_users.rb
+++ b/db/migrate/20090910143608_clearance_update_users.rb
@@ -1,4 +1,4 @@
-class ClearanceUpdateUsers < ActiveRecord::Migration
+class ClearanceUpdateUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table(:users) do |t|
       t.string :confirmation_token, limit: 128

--- a/db/migrate/20090917035818_add_prerelease_to_versions.rb
+++ b/db/migrate/20090917035818_add_prerelease_to_versions.rb
@@ -1,4 +1,4 @@
-class AddPrereleaseToVersions < ActiveRecord::Migration
+class AddPrereleaseToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :prerelease, :boolean
     Version.update_all(prerelease: false)

--- a/db/migrate/20090929211655_add_more_indexes_to_versions.rb
+++ b/db/migrate/20090929211655_add_more_indexes_to_versions.rb
@@ -1,4 +1,4 @@
-class AddMoreIndexesToVersions < ActiveRecord::Migration
+class AddMoreIndexesToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_index :versions, :number
     add_index :versions, :built_at

--- a/db/migrate/20090929212722_add_even_more_indexes_to_versions.rb
+++ b/db/migrate/20090929212722_add_even_more_indexes_to_versions.rb
@@ -1,4 +1,4 @@
-class AddEvenMoreIndexesToVersions < ActiveRecord::Migration
+class AddEvenMoreIndexesToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_index :versions, :prerelease
     add_index :versions, :indexed

--- a/db/migrate/20090930181320_add_position_to_versions.rb
+++ b/db/migrate/20090930181320_add_position_to_versions.rb
@@ -1,4 +1,4 @@
-class AddPositionToVersions < ActiveRecord::Migration
+class AddPositionToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :position, :integer
 

--- a/db/migrate/20091001153907_add_position_index_to_versions.rb
+++ b/db/migrate/20091001153907_add_position_index_to_versions.rb
@@ -1,4 +1,4 @@
-class AddPositionIndexToVersions < ActiveRecord::Migration
+class AddPositionIndexToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_index :versions, :position
   end

--- a/db/migrate/20091007163843_create_downloads.rb
+++ b/db/migrate/20091007163843_create_downloads.rb
@@ -1,4 +1,4 @@
-class CreateDownloads < ActiveRecord::Migration
+class CreateDownloads < ActiveRecord::Migration[4.2]
   def self.up
     create_table :downloads do |table|
       table.string :raw

--- a/db/migrate/20091007170153_add_downloads_to_versions.rb
+++ b/db/migrate/20091007170153_add_downloads_to_versions.rb
@@ -1,4 +1,4 @@
-class AddDownloadsToVersions < ActiveRecord::Migration
+class AddDownloadsToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :downloads_count, :integer, default: 0
   end

--- a/db/migrate/20091007173253_remove_raw_from_downloads.rb
+++ b/db/migrate/20091007173253_remove_raw_from_downloads.rb
@@ -1,4 +1,4 @@
-class RemoveRawFromDownloads < ActiveRecord::Migration
+class RemoveRawFromDownloads < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :downloads, :raw
   end

--- a/db/migrate/20091007183410_zero_out_version_downloads.rb
+++ b/db/migrate/20091007183410_zero_out_version_downloads.rb
@@ -1,4 +1,4 @@
-class ZeroOutVersionDownloads < ActiveRecord::Migration
+class ZeroOutVersionDownloads < ActiveRecord::Migration[4.2]
   def self.up
     # Version.update_all(:downloads_count => 0)
   end

--- a/db/migrate/20091008132519_add_time_stamps_to_users.rb
+++ b/db/migrate/20091008132519_add_time_stamps_to_users.rb
@@ -1,4 +1,4 @@
-class AddTimeStampsToUsers < ActiveRecord::Migration
+class AddTimeStampsToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :created_at, :datetime
     add_column :users, :updated_at, :datetime

--- a/db/migrate/20091009213456_reorder_versions_again.rb
+++ b/db/migrate/20091009213456_reorder_versions_again.rb
@@ -1,4 +1,4 @@
-class ReorderVersionsAgain < ActiveRecord::Migration
+class ReorderVersionsAgain < ActiveRecord::Migration[4.2]
   def self.up
     Rubygem.all.each(&:reorder_versions)
   end

--- a/db/migrate/20091021203534_add_latest_to_version.rb
+++ b/db/migrate/20091021203534_add_latest_to_version.rb
@@ -1,4 +1,4 @@
-class AddLatestToVersion < ActiveRecord::Migration
+class AddLatestToVersion < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :latest, :boolean
 

--- a/db/migrate/20091026124711_create_rubyforgers.rb
+++ b/db/migrate/20091026124711_create_rubyforgers.rb
@@ -1,4 +1,4 @@
-class CreateRubyforgers < ActiveRecord::Migration
+class CreateRubyforgers < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rubyforgers do |t|
       t.string :email

--- a/db/migrate/20091026234707_fix_dependencies.rb
+++ b/db/migrate/20091026234707_fix_dependencies.rb
@@ -1,4 +1,4 @@
-class FixDependencies < ActiveRecord::Migration
+class FixDependencies < ActiveRecord::Migration[4.2]
   def self.up
     # fix bad version reqs
     Dependency.all.each do |dep|

--- a/db/migrate/20091109203935_add_full_name_to_versions.rb
+++ b/db/migrate/20091109203935_add_full_name_to_versions.rb
@@ -1,4 +1,4 @@
-class AddFullNameToVersions < ActiveRecord::Migration
+class AddFullNameToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :full_name, :string
     add_index 'versions', 'full_name'

--- a/db/migrate/20091125213227_create_web_hooks.rb
+++ b/db/migrate/20091125213227_create_web_hooks.rb
@@ -1,4 +1,4 @@
-class CreateWebHooks < ActiveRecord::Migration
+class CreateWebHooks < ActiveRecord::Migration[4.2]
   def self.up
     create_table :web_hooks do |table|
       table.string :gem_name

--- a/db/migrate/20091206165910_add_email_changed_to_users.rb
+++ b/db/migrate/20091206165910_add_email_changed_to_users.rb
@@ -1,4 +1,4 @@
-class AddEmailChangedToUsers < ActiveRecord::Migration
+class AddEmailChangedToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :email_changed, :boolean
   end

--- a/db/migrate/20091207185619_add_handle_to_users.rb
+++ b/db/migrate/20091207185619_add_handle_to_users.rb
@@ -1,4 +1,4 @@
-class AddHandleToUsers < ActiveRecord::Migration
+class AddHandleToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :handle, :string
     add_index :users, :handle

--- a/db/migrate/20091229014120_link_web_hook_to_rubygems.rb
+++ b/db/migrate/20091229014120_link_web_hook_to_rubygems.rb
@@ -1,4 +1,4 @@
-class LinkWebHookToRubygems < ActiveRecord::Migration
+class LinkWebHookToRubygems < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :web_hooks, :gem_name
     add_column :web_hooks, :rubygem_id, :integer

--- a/db/migrate/20100220111111_remove_versions_count_from_rubygems.rb
+++ b/db/migrate/20100220111111_remove_versions_count_from_rubygems.rb
@@ -1,4 +1,4 @@
-class RemoveVersionsCountFromRubygems < ActiveRecord::Migration
+class RemoveVersionsCountFromRubygems < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :rubygems, :versions_count
   end

--- a/db/migrate/20100627193405_rename_email_changed_on_users.rb
+++ b/db/migrate/20100627193405_rename_email_changed_on_users.rb
@@ -1,4 +1,4 @@
-class RenameEmailChangedOnUsers < ActiveRecord::Migration
+class RenameEmailChangedOnUsers < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :users, :email_changed, :email_reset
   end

--- a/db/migrate/20100731230852_change_versions_author_to_text.rb
+++ b/db/migrate/20100731230852_change_versions_author_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeVersionsAuthorToText < ActiveRecord::Migration
+class ChangeVersionsAuthorToText < ActiveRecord::Migration[4.2]
   def self.up
     change_column :versions, :authors, :text
   end

--- a/db/migrate/20100817182653_add_version_hash_and_deps_list_to_redis.rb
+++ b/db/migrate/20100817182653_add_version_hash_and_deps_list_to_redis.rb
@@ -1,4 +1,4 @@
-class AddVersionHashAndDepsListToRedis < ActiveRecord::Migration
+class AddVersionHashAndDepsListToRedis < ActiveRecord::Migration[4.2]
   def self.up
     # NOOP because we removed redis
   end

--- a/db/migrate/20101013135725_create_announcements.rb
+++ b/db/migrate/20101013135725_create_announcements.rb
@@ -1,4 +1,4 @@
-class CreateAnnouncements < ActiveRecord::Migration
+class CreateAnnouncements < ActiveRecord::Migration[4.2]
   def self.up
     create_table :announcements do |t|
       t.text :body

--- a/db/migrate/20110318162103_add_unique_indexes.rb
+++ b/db/migrate/20110318162103_add_unique_indexes.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexes < ActiveRecord::Migration
+class AddUniqueIndexes < ActiveRecord::Migration[4.2]
   def self.up
     remove_index :rubygems, column: [:name]
     add_index :rubygems, [:name], unique: true

--- a/db/migrate/20110601153518_regenerate_runtime_dependencies_list.rb
+++ b/db/migrate/20110601153518_regenerate_runtime_dependencies_list.rb
@@ -1,4 +1,4 @@
-class RegenerateRuntimeDependenciesList < ActiveRecord::Migration
+class RegenerateRuntimeDependenciesList < ActiveRecord::Migration[4.2]
   def self.up
   end
 

--- a/db/migrate/20110601153519_really_regenerate_runtime_dependencies_list.rb
+++ b/db/migrate/20110601153519_really_regenerate_runtime_dependencies_list.rb
@@ -1,4 +1,4 @@
-class ReallyRegenerateRuntimeDependenciesList < ActiveRecord::Migration
+class ReallyRegenerateRuntimeDependenciesList < ActiveRecord::Migration[4.2]
   def self.up
     # NOOP because we removed redis
   end

--- a/db/migrate/20110710054014_add_size_to_version.rb
+++ b/db/migrate/20110710054014_add_size_to_version.rb
@@ -1,4 +1,4 @@
-class AddSizeToVersion < ActiveRecord::Migration
+class AddSizeToVersion < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :size, :integer
   end

--- a/db/migrate/20110805014415_remove_improperly_embedded_yaml_data.rb
+++ b/db/migrate/20110805014415_remove_improperly_embedded_yaml_data.rb
@@ -1,4 +1,4 @@
-class RemoveImproperlyEmbeddedYamlData < ActiveRecord::Migration
+class RemoveImproperlyEmbeddedYamlData < ActiveRecord::Migration[4.2]
   def self.up
     Dependency.where("requirements like '%YAML::Syck::DefaultKey%'").each do |d|
       d.requirements = d.clean_requirements

--- a/db/migrate/20110907000456_drop_unused_database_columns.rb
+++ b/db/migrate/20110907000456_drop_unused_database_columns.rb
@@ -1,4 +1,4 @@
-class DropUnusedDatabaseColumns < ActiveRecord::Migration
+class DropUnusedDatabaseColumns < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :ownerships, :approved
     remove_column :versions, :downloads_count

--- a/db/migrate/20120118192925_add_unresolved_name_to_dependencies.rb
+++ b/db/migrate/20120118192925_add_unresolved_name_to_dependencies.rb
@@ -1,4 +1,4 @@
-class AddUnresolvedNameToDependencies < ActiveRecord::Migration
+class AddUnresolvedNameToDependencies < ActiveRecord::Migration[4.2]
   def self.up
     add_column :dependencies, :unresolved_name, :string
   end

--- a/db/migrate/20120118194729_create_index_on_unresolved_name.rb
+++ b/db/migrate/20120118194729_create_index_on_unresolved_name.rb
@@ -1,4 +1,4 @@
-class CreateIndexOnUnresolvedName < ActiveRecord::Migration
+class CreateIndexOnUnresolvedName < ActiveRecord::Migration[4.2]
   def self.up
     add_index :dependencies, :unresolved_name
   end

--- a/db/migrate/20120904155203_add_license_to_versions.rb
+++ b/db/migrate/20120904155203_add_license_to_versions.rb
@@ -1,4 +1,4 @@
-class AddLicenseToVersions < ActiveRecord::Migration
+class AddLicenseToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :licenses, :string
   end

--- a/db/migrate/20120915055838_create_version_histories.rb
+++ b/db/migrate/20120915055838_create_version_histories.rb
@@ -1,4 +1,4 @@
-class CreateVersionHistories < ActiveRecord::Migration
+class CreateVersionHistories < ActiveRecord::Migration[4.2]
   def change
     create_table :version_histories do |t|
       t.integer :version_id

--- a/db/migrate/20120915212528_add_version_history_indexes.rb
+++ b/db/migrate/20120915212528_add_version_history_indexes.rb
@@ -1,4 +1,4 @@
-class AddVersionHistoryIndexes < ActiveRecord::Migration
+class AddVersionHistoryIndexes < ActiveRecord::Migration[4.2]
   def up
     add_index :version_histories, [:version_id, :day], unique: true
   end

--- a/db/migrate/20120916165331_remove_timestamps_on_version_history.rb
+++ b/db/migrate/20120916165331_remove_timestamps_on_version_history.rb
@@ -1,4 +1,4 @@
-class RemoveTimestampsOnVersionHistory < ActiveRecord::Migration
+class RemoveTimestampsOnVersionHistory < ActiveRecord::Migration[4.2]
   def up
     remove_column :version_histories, :created_at
     remove_column :version_histories, :updated_at

--- a/db/migrate/20121124000000_add_queue_to_delayed_jobs.rb
+++ b/db/migrate/20121124000000_add_queue_to_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class AddQueueToDelayedJobs < ActiveRecord::Migration
+class AddQueueToDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     add_column :delayed_jobs, :queue, :string
   end

--- a/db/migrate/20121220014214_add_requirements_to_versions.rb
+++ b/db/migrate/20121220014214_add_requirements_to_versions.rb
@@ -1,4 +1,4 @@
-class AddRequirementsToVersions < ActiveRecord::Migration
+class AddRequirementsToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :requirements, :string
   end

--- a/db/migrate/20130110064832_add_gittip_username_to_profile.rb
+++ b/db/migrate/20130110064832_add_gittip_username_to_profile.rb
@@ -1,4 +1,4 @@
-class AddGittipUsernameToProfile < ActiveRecord::Migration
+class AddGittipUsernameToProfile < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :gittip_username, :string
   end

--- a/db/migrate/20130829225823_change_requirements_to_text.rb
+++ b/db/migrate/20130829225823_change_requirements_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeRequirementsToText < ActiveRecord::Migration
+class ChangeRequirementsToText < ActiveRecord::Migration[4.2]
   def up
     change_column :versions, :requirements, :text
   end

--- a/db/migrate/20130910013917_add_option_to_hide_email.rb
+++ b/db/migrate/20130910013917_add_option_to_hide_email.rb
@@ -1,4 +1,4 @@
-class AddOptionToHideEmail < ActiveRecord::Migration
+class AddOptionToHideEmail < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :hide_email, :boolean
   end

--- a/db/migrate/20131110192552_add_ruby_version_to_versions.rb
+++ b/db/migrate/20131110192552_add_ruby_version_to_versions.rb
@@ -1,4 +1,4 @@
-class AddRubyVersionToVersions < ActiveRecord::Migration
+class AddRubyVersionToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :ruby_version, :string
   end

--- a/db/migrate/20140809000000_add_sha256_to_versions.rb
+++ b/db/migrate/20140809000000_add_sha256_to_versions.rb
@@ -1,4 +1,4 @@
-class AddSha256ToVersions < ActiveRecord::Migration
+class AddSha256ToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :sha256, :string, null: true
   end

--- a/db/migrate/20141009120000_add_rubygems_name_index.rb
+++ b/db/migrate/20141009120000_add_rubygems_name_index.rb
@@ -1,4 +1,4 @@
-class AddRubygemsNameIndex < ActiveRecord::Migration
+class AddRubygemsNameIndex < ActiveRecord::Migration[4.2]
   def up
     # add_index :rubygems, 'upper(name) varchar_pattern_ops', :name => :rubygems_name_upcase
     execute "CREATE INDEX index_rubygems_upcase ON rubygems (upper(name) varchar_pattern_ops)"

--- a/db/migrate/20150124074536_add_metadata_to_versions.rb
+++ b/db/migrate/20150124074536_add_metadata_to_versions.rb
@@ -1,4 +1,4 @@
-class AddMetadataToVersions < ActiveRecord::Migration
+class AddMetadataToVersions < ActiveRecord::Migration[4.2]
   def change
     enable_extension 'hstore'
 

--- a/db/migrate/20150209074817_remove_gittip.rb
+++ b/db/migrate/20150209074817_remove_gittip.rb
@@ -1,4 +1,4 @@
-class RemoveGittip < ActiveRecord::Migration
+class RemoveGittip < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :gittip_username
   end

--- a/db/migrate/20150407012331_create_deletions.rb
+++ b/db/migrate/20150407012331_create_deletions.rb
@@ -1,4 +1,4 @@
-class CreateDeletions < ActiveRecord::Migration
+class CreateDeletions < ActiveRecord::Migration[4.2]
   def change
     create_table :deletions do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20150709170542_create_doorkeeper_tables.rb
+++ b/db/migrate/20150709170542_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false

--- a/db/migrate/20151123153040_add_yanked_at_to_versions.rb
+++ b/db/migrate/20151123153040_add_yanked_at_to_versions.rb
@@ -1,4 +1,4 @@
-class AddYankedAtToVersions < ActiveRecord::Migration
+class AddYankedAtToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :yanked_at, :datetime
   end

--- a/db/migrate/20160227194735_create_log_tickets.rb
+++ b/db/migrate/20160227194735_create_log_tickets.rb
@@ -1,4 +1,4 @@
-class CreateLogTickets < ActiveRecord::Migration
+class CreateLogTickets < ActiveRecord::Migration[4.2]
   def change
     create_table :log_tickets do |t|
       t.string :key

--- a/db/migrate/20160308201614_add_processed_count_to_log_ticket.rb
+++ b/db/migrate/20160308201614_add_processed_count_to_log_ticket.rb
@@ -1,4 +1,4 @@
-class AddProcessedCountToLogTicket < ActiveRecord::Migration
+class AddProcessedCountToLogTicket < ActiveRecord::Migration[4.2]
   def change
     add_column :log_tickets, :processed_count, :integer
   end

--- a/db/migrate/20160318213755_create_gem_download.rb
+++ b/db/migrate/20160318213755_create_gem_download.rb
@@ -1,4 +1,4 @@
-class CreateGemDownload < ActiveRecord::Migration
+class CreateGemDownload < ActiveRecord::Migration[4.2]
   def change
     create_table :gem_downloads do |t|
       t.integer :rubygem_id, null: false

--- a/db/migrate/20160329184508_create_gem_download_count_index.rb
+++ b/db/migrate/20160329184508_create_gem_download_count_index.rb
@@ -1,4 +1,4 @@
-class CreateGemDownloadCountIndex < ActiveRecord::Migration
+class CreateGemDownloadCountIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :gem_downloads, [:version_id, :rubygem_id, :count]
   end

--- a/db/migrate/20160516141824_remove_version_history.rb
+++ b/db/migrate/20160516141824_remove_version_history.rb
@@ -1,4 +1,4 @@
-class RemoveVersionHistory < ActiveRecord::Migration
+class RemoveVersionHistory < ActiveRecord::Migration[4.2]
   def up
     drop_table :version_histories, force: :cascade
   end

--- a/db/migrate/20160516144704_remove_rubyforger.rb
+++ b/db/migrate/20160516144704_remove_rubyforger.rb
@@ -1,4 +1,4 @@
-class RemoveRubyforger < ActiveRecord::Migration
+class RemoveRubyforger < ActiveRecord::Migration[4.2]
   def up
     drop_table :rubyforgers
     remove_column :versions, :rubyforge_project

--- a/db/migrate/20160517061033_add_rubygems_version.rb
+++ b/db/migrate/20160517061033_add_rubygems_version.rb
@@ -1,4 +1,4 @@
-class AddRubygemsVersion < ActiveRecord::Migration
+class AddRubygemsVersion < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :rubygems_version, :string
   end

--- a/db/migrate/20160527171228_add_required_rubygems_version.rb
+++ b/db/migrate/20160527171228_add_required_rubygems_version.rb
@@ -1,4 +1,4 @@
-class AddRequiredRubygemsVersion < ActiveRecord::Migration
+class AddRequiredRubygemsVersion < ActiveRecord::Migration[4.2]
   def change
     remove_column :versions, :rubygems_version, :string
     add_column :versions, :required_rubygems_version, :string

--- a/db/migrate/20160527190738_rename_ruby_version.rb
+++ b/db/migrate/20160527190738_rename_ruby_version.rb
@@ -1,4 +1,4 @@
-class RenameRubyVersion < ActiveRecord::Migration
+class RenameRubyVersion < ActiveRecord::Migration[4.2]
   def change
     rename_column :versions, :ruby_version, :required_ruby_version
   end

--- a/db/migrate/20160528065150_remove_rubygems_downloads.rb
+++ b/db/migrate/20160528065150_remove_rubygems_downloads.rb
@@ -1,4 +1,4 @@
-class RemoveRubygemsDownloads < ActiveRecord::Migration
+class RemoveRubygemsDownloads < ActiveRecord::Migration[4.2]
   def change
     remove_column :rubygems, :downloads, :integer
   end

--- a/db/migrate/20160530084904_add_info_checksum_to_versions.rb
+++ b/db/migrate/20160530084904_add_info_checksum_to_versions.rb
@@ -1,4 +1,4 @@
-class AddInfoChecksumToVersions < ActiveRecord::Migration
+class AddInfoChecksumToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :info_checksum, :string
   end

--- a/db/migrate/20160702034732_add_twitter_handle_to_users.rb
+++ b/db/migrate/20160702034732_add_twitter_handle_to_users.rb
@@ -1,4 +1,4 @@
-class AddTwitterHandleToUsers < ActiveRecord::Migration
+class AddTwitterHandleToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :twitter_username, :string
   end

--- a/db/migrate/20160810082821_add_yanked_info_checksum_to_versions.rb
+++ b/db/migrate/20160810082821_add_yanked_info_checksum_to_versions.rb
@@ -1,4 +1,4 @@
-class AddYankedInfoChecksumToVersions < ActiveRecord::Migration
+class AddYankedInfoChecksumToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :yanked_info_checksum, :string, default: nil
   end

--- a/db/migrate/20160929104437_remove_doorkeeper_tables.rb
+++ b/db/migrate/20160929104437_remove_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class RemoveDoorkeeperTables < ActiveRecord::Migration
+class RemoveDoorkeeperTables < ActiveRecord::Migration[4.2]
   def up
     drop_table :oauth_applications
     drop_table :oauth_access_grants

--- a/db/migrate/20161231080902_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20161231080902_add_unconfirmed_email_to_users.rb
@@ -1,4 +1,4 @@
-class AddUnconfirmedEmailToUsers < ActiveRecord::Migration
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :unconfirmed_email, :string
   end


### PR DESCRIPTION
rails 5.1 would error with:
StandardError: An error has occurred, all later migrations canceled.
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
class CreateBaseline < ActiveRecord::Migration[4.2]