### PR TITLE
Fix moar deprecations

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -78,15 +78,13 @@ class Dependency < ActiveRecord::Base
 
     if gem_dependency.class != Gem::Dependency
       errors.add :rubygem, "Please use Gem::Dependency to specify dependencies."
-      return false
+      throw :abort
     end
 
     if gem_dependency.name.empty?
       errors.add :rubygem, "Blank is not a valid dependency name"
-      return false
+      throw :abort
     end
-
-    true
   end
 
   def use_existing_rubygem
@@ -95,8 +93,6 @@ class Dependency < ActiveRecord::Base
     self.rubygem = Rubygem.find_by_name(gem_dependency.name)
 
     self.unresolved_name = gem_dependency.name unless rubygem
-
-    true
   end
 
   def parse_gem_dependency

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -83,8 +83,10 @@ class Dependency < ActiveRecord::Base
 
     if gem_dependency.name.empty?
       errors.add :rubygem, "Blank is not a valid dependency name"
-      throw :abort
+      return :abort
     end
+
+    true
   end
 
   def use_existing_rubygem

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -308,12 +308,9 @@ class Rubygem < ActiveRecord::Base
     Dependency.where(unresolved_name: name).find_each do |dependency|
       dependency.update_resolved(self)
     end
-
-    true
   end
 
   def mark_unresolved
     Dependency.mark_unresolved_for(self)
-    true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,12 +17,10 @@ module Gemcutter
     config.i18n.fallbacks = true
 
     config.middleware.insert 0, Rack::UTF8Sanitizer
-    config.middleware.use "Redirector" unless Rails.env.development?
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
 
     config.active_record.include_root_in_json = false
-    config.active_record.raise_in_transactional_callbacks = true
 
     config.after_initialize do
       RubygemFs.s3! ENV['S3_PROXY'] if ENV['S3_PROXY']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,4 +98,6 @@ Rails.application.configure do
     compress: true,
     compression_min_size: 524_288
   }
+
+  config.middleware.use Redirector
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -89,4 +89,6 @@ Rails.application.configure do
     compress: true,
     compression_min_size: 524_288
   }
+
+  config.middleware.use Redirector
 end


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1. To explicitly halt the callback chain, please use `throw :abort` instead.
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:
  "Redirector" => Redirector
DEPRECATION WARNING: ActiveRecord::Base.raise_in_transactional_callbacks= is deprecated, has no effect and will be removed without replacement