### PR TITLE
Update rubocop from 0.47.1 to 0.48.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     nio4r (2.0.0)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
-    parser (2.3.3.1)
+    parser (2.4.0.0)
       ast (~> 2.2)
     paul_revere (2.1.0)
       rails (>= 5.0, < 5.2)
@@ -232,7 +232,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     raindrops (0.18.0)
     rake (12.0.0)
     rbtrace (0.4.8)
@@ -244,7 +245,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rubocop (0.47.1)
+    rubocop (0.48.1)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -286,7 +287,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.2.1)
     unicorn (5.3.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)

--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,4 @@ require File.expand_path('../config/application', __FILE__)
 Gemcutter::Application.load_tasks
 
 desc "Run weekly at 00:00 UTC"
-task weekly_cron: %w(gemcutter:rubygems:update_download_counts)
+task weekly_cron: %w[gemcutter:rubygems:update_download_counts]

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::DeletionsController < Api::BaseController
-  skip_before_action :verify_authenticity_token, only: [:create, :destroy]
+  skip_before_action :verify_authenticity_token, only: %i[create destroy]
 
-  before_action :authenticate_with_api_key, only: [:create, :destroy]
-  before_action :verify_authenticated_user, only: [:create, :destroy]
-  before_action :find_rubygem_by_name,      only: [:create, :destroy]
-  before_action :validate_gem_and_version,  only: [:create]
+  before_action :authenticate_with_api_key, only: %i[create destroy]
+  before_action :verify_authenticated_user, only: %i[create destroy]
+  before_action :find_rubygem_by_name,      only: %i[create destroy]
+  before_action :validate_gem_and_version,  only: %i[create]
 
   def create
     @deletion = current_user.deletions.build(version: @version)

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::DependenciesController < Api::BaseController
 
     expires_in 30, public: true
     fastly_expires_in 60
-    set_surrogate_key 'dependencyapi', gem_names.map { |name| "gem/#{name}" }
+    set_surrogate_key('dependencyapi', gem_names.map { |name| "gem/#{name}" })
 
     respond_to do |format|
       format.json { render json: deps }

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::OwnersController < Api::BaseController
-  skip_before_action :verify_authenticity_token, only: [:create, :destroy]
-  before_action :authenticate_with_api_key, except: [:show, :gems]
-  before_action :verify_authenticated_user, except: [:show, :gems]
+  skip_before_action :verify_authenticity_token, only: %i[create destroy]
+  before_action :authenticate_with_api_key, except: %i[show gems]
+  before_action :verify_authenticated_user, except: %i[show gems]
   before_action :find_rubygem, except: :gems
-  before_action :verify_gem_ownership, except: [:show, :gems]
+  before_action :verify_gem_ownership, except: %i[show gems]
 
   def show
     respond_to do |format|

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::RubygemsController < Api::BaseController
-  skip_before_action :verify_authenticity_token, only: [:create]
+  skip_before_action :verify_authenticity_token, only: %i[create]
 
-  before_action :authenticate_with_api_key, only: [:index, :create]
-  before_action :verify_authenticated_user, only: [:index, :create]
-  before_action :find_rubygem,              only: [:show, :reverse_dependencies]
+  before_action :authenticate_with_api_key, only: %i[index create]
+  before_action :verify_authenticated_user, only: %i[index create]
+  before_action :find_rubygem,              only: %i[show reverse_dependencies]
 
   before_action :cors_preflight_check, only: :show
   after_action  :cors_set_access_control_headers, only: :show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   helper :announcements
   helper ActiveSupport::NumberHelper
 
-  protect_from_forgery only: [:create, :update, :destroy], with: :exception
+  protect_from_forgery only: %i[create update destroy], with: :exception
 
   before_action :set_locale
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_root, unless: :signed_in?, except: :show
-  before_action :verify_password, only: [:update, :destroy]
+  before_action :verify_password, only: %i[update destroy]
 
   def edit
     @user = current_user

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -1,11 +1,11 @@
 class RubygemsController < ApplicationController
   include LatestVersion
-  before_action :redirect_to_root, only: [:edit, :update], unless: :signed_in?
-  before_action :set_blacklisted_gem, only: [:show], if: :blacklisted?
-  before_action :find_rubygem, only: [:edit, :update, :show], unless: :blacklisted?
-  before_action :latest_version, only: [:show], unless: :blacklisted?
-  before_action :find_versioned_links, only: [:show], unless: :blacklisted?
-  before_action :load_gem, only: [:edit, :update]
+  before_action :redirect_to_root, only: %i[edit update], unless: :signed_in?
+  before_action :set_blacklisted_gem, only: %i[show], if: :blacklisted?
+  before_action :find_rubygem, only: %i[edit update show], unless: :blacklisted?
+  before_action :latest_version, only: %i[show], unless: :blacklisted?
+  before_action :find_versioned_links, only: %i[show], unless: :blacklisted?
+  before_action :load_gem, only: %i[edit update]
   before_action :set_page, only: :index
 
   def index

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -3,8 +3,8 @@ module SearchesHelper
     return false if gems.size >= 1
     return false unless gems.respond_to?(:response)
     suggestions = gems.response['suggest']
-    return false unless suggestions.present?
-    return false unless suggestions['suggest_name'].present?
+    return false if suggestions.blank?
+    return false if suggestions['suggest_name'].blank?
     return false if suggestions['suggest_name'][0]['options'].empty?
     suggestions.map { |_k, v| v.first['options'] }.flatten.map { |v| v['text'] }.uniq
   end

--- a/app/middleware/hostess.rb
+++ b/app/middleware/hostess.rb
@@ -2,7 +2,7 @@ class Hostess < Rack::Static
   def initialize(app, options = {})
     options[:root] = RubygemFs.instance.base_dir
 
-    options[:urls] = %w(
+    options[:urls] = %w[
       /specs.4.8.gz
       /latest_specs.4.8.gz
       /prerelease_specs.4.8.gz
@@ -19,7 +19,7 @@ class Hostess < Rack::Static
       /prerelease_specs.4.8
       /quick/index
       /quick/latest_index
-    )
+    ]
 
     super(app, options)
   end

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -14,7 +14,7 @@ module RubygemSearchable
       most_recent_version = versions.most_recent
       {
         name:                  name,
-        yanked:                !versions.any?(&:indexed?),
+        yanked:                versions.none?(&:indexed?),
         summary:               most_recent_version.try(:summary),
         description:           most_recent_version.try(:description),
         downloads:             downloads,
@@ -101,10 +101,10 @@ module RubygemSearchable
           end
         end
 
-        source %w(name summary description downloads latest_version_number)
+        source %w[name summary description downloads latest_version_number]
 
         # Return suggestions unless there's no query from the user
-        unless q.blank?
+        if q.present?
           suggest :suggest_name, text: q, term: { field: 'name.suggest', suggest_mode: 'always' }
         end
       end

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -7,7 +7,7 @@ class Dependency < ActiveRecord::Base
     :parse_gem_dependency
 
   validates :requirements, presence: true
-  validates :scope,        inclusion: { in: %w(development runtime) }
+  validates :scope,        inclusion: { in: %w[development runtime] }
 
   attr_accessor :gem_dependency
 

--- a/app/models/gem_download.rb
+++ b/app/models/gem_download.rb
@@ -2,7 +2,7 @@ class GemDownload < ActiveRecord::Base
   belongs_to :rubygem
   belongs_to :version
 
-  scope :most_downloaded_gems, -> { where("version_id != 0").includes(:version).order(count: :desc) }
+  scope(:most_downloaded_gems, -> { where("version_id != 0").includes(:version).order(count: :desc) })
 
   class << self
     def count_for_version(id)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -46,7 +46,7 @@ class GemInfo
                     v.yanked_at > ?)
               ORDER BY date, number, platform, name", date, date]
 
-    map_gem_versions execute_raw_sql(query).map { |v| [v['name'], [v]] }
+    map_gem_versions(execute_raw_sql(query).map { |v| [v['name'], [v]] })
   end
 
   def self.compact_index_public_versions

--- a/app/models/linkset.rb
+++ b/app/models/linkset.rb
@@ -1,7 +1,7 @@
 class Linkset < ActiveRecord::Base
   belongs_to :rubygem
 
-  LINKS = %w(home code docs wiki mail bugs).freeze
+  LINKS = %w[home code docs wiki mail bugs].freeze
 
   LINKS.each do |url|
     validates_formatting_of url.to_sym,

--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -1,7 +1,7 @@
 class LogTicket < ActiveRecord::Base
-  enum backend: [:s3, :local]
+  enum backend: %i[s3 local]
 
-  scope :pending, -> { limit(1).lock(true).select("id").where(status: "pending").order("id ASC") }
+  scope(:pending, -> { limit(1).lock(true).select("id").where(status: "pending").order("id ASC") })
 
   def self.pop(key: nil, directory: nil)
     scope = pending

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -89,7 +89,7 @@ class Pusher
 
   # Overridden so we don't get megabytes of the raw data printing out
   def inspect
-    attrs = [:@rubygem, :@user, :@message, :@code].map do |attr|
+    attrs = %i[@rubygem @user @message @code].map do |attr|
       "#{attr}=#{instance_variable_get(attr).inspect}"
     end
     "<Pusher #{attrs.join(' ')}>"

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -10,7 +10,7 @@ class Rubygem < ActiveRecord::Base
   has_one :latest_version, -> { where(latest: true).order(:position) }, class_name: "Version"
   has_many :web_hooks, dependent: :destroy
   has_one :linkset, dependent: :destroy
-  has_one :gem_download, -> { where(version_id: 0) }
+  has_one(:gem_download, -> { where(version_id: 0) })
 
   validate :ensure_name_format, if: :needs_name_validation?
   validates :name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,15 +3,15 @@ class User < ActiveRecord::Base
   include Gravtastic
   is_gravtastic default: "retro"
 
-  PERMITTED_ATTRS = [
-    :bio,
-    :email,
-    :handle,
-    :hide_email,
-    :location,
-    :password,
-    :website,
-    :twitter_username
+  PERMITTED_ATTRS = %i[
+    bio
+    email
+    handle
+    hide_email
+    location
+    password
+    website
+    twitter_username
   ].freeze
 
   before_destroy :yank_gems

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -3,7 +3,7 @@ require 'digest/sha2'
 class Version < ActiveRecord::Base
   belongs_to :rubygem, touch: true
   has_many :dependencies, -> { order('rubygems.name ASC').includes(:rubygem) }, dependent: :destroy, inverse_of: "version"
-  has_one :gem_download, proc { |m| where(rubygem_id: m.rubygem_id) }
+  has_one(:gem_download, proc { |m| where(rubygem_id: m.rubygem_id) })
 
   before_save :update_prerelease
   before_validation :full_nameify!

--- a/app/views/versions/_versions_feed.atom.builder
+++ b/app/views/versions/_versions_feed.atom.builder
@@ -1,15 +1,14 @@
 builder.instruct!
 
 builder.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-
   builder.title   title
-  builder.link    "rel" => "self",      "href" => rubygems_url(:format => :atom)
+  builder.link    "rel" => "self",      "href" => rubygems_url(format: :atom)
   builder.link    "rel" => "alternate", "href" => rubygems_url
   builder.id      rubygems_url
 
   builder.updated(versions.first.rubygem.updated_at.iso8601) if versions.any?
 
-  builder.author {xml.name "Rubygems"}
+  builder.author { xml.name "Rubygems" }
 
   versions.each do |version|
     builder.entry do
@@ -17,7 +16,7 @@ builder.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       builder.link      "rel" => "alternate", "href" => rubygem_version_url(version.rubygem, version.slug)
       builder.id        rubygem_version_url(version.rubygem, version.slug)
       builder.updated   version.created_at.iso8601
-      builder.author    {|author| author.name h(version.authors)}
+      builder.author    { |author| author.name h(version.authors) }
       builder.summary   version.summary if version.summary?
       builder.content   "type" => "html" do
         builder.text!   h(version.description)

--- a/app/views/versions/feed.atom.builder
+++ b/app/views/versions/feed.atom.builder
@@ -4,4 +4,5 @@ render(
     builder: xml,
     versions: @versions,
     title: "Rubygems | Latest Gems"
-})
+  }
+)

--- a/app/views/versions/index.atom.builder
+++ b/app/views/versions/index.atom.builder
@@ -4,4 +4,5 @@ render(
     builder: xml,
     versions: @versions,
     title: "Rubygems | Latest Versions for #{@rubygem.name}"
-})
+  }
+)

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,7 +1,7 @@
-server 'app01.production.rubygems.org', user: 'deploy', roles: %w(app), primary: true
-server 'app02.production.rubygems.org', user: 'deploy', roles: %w(app db)
-server 'app03.production.rubygems.org', user: 'deploy', roles: %w(app)
-server 'app04.production.rubygems.org', user: 'deploy', roles: %w(app)
-server 'jobs01.production.rubygems.org', user: 'deploy', roles: %w(jobs)
-server 'jobs02.production.rubygems.org', user: 'deploy', roles: %w(jobs)
-server 'lb03.production.rubygems.org', user: 'deploy', roles: %w(lb), no_release: true
+server 'app01.production.rubygems.org', user: 'deploy', roles: %w[app], primary: true
+server 'app02.production.rubygems.org', user: 'deploy', roles: %w[app db]
+server 'app03.production.rubygems.org', user: 'deploy', roles: %w[app]
+server 'app04.production.rubygems.org', user: 'deploy', roles: %w[app]
+server 'jobs01.production.rubygems.org', user: 'deploy', roles: %w[jobs]
+server 'jobs02.production.rubygems.org', user: 'deploy', roles: %w[jobs]
+server 'lb03.production.rubygems.org', user: 'deploy', roles: %w[lb], no_release: true

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
-server 'app01.staging.rubygems.org', user: 'deploy', roles: %w(app jobs db), primary: true
-server 'lb01.staging.rubygems.org', user: 'deploy', roles: %w(lb), no_release: true
+server 'app01.staging.rubygems.org', user: 'deploy', roles: %w[app jobs db], primary: true
+server 'lb01.staging.rubygems.org', user: 'deploy', roles: %w[lb], no_release: true
 set :bundle_flags, ''
 
 namespace :deploy do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
 
       resources :rubygems,
         path: 'gems',
-        only: [:create, :show, :index],
+        only: %i[create show index],
         id: Patterns::LAZY_ROUTE_PATTERN,
         format: /json|yaml/ do
         member do
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
           put :unyank, to: "deletions#destroy"
         end
         constraints rubygem_id: Patterns::ROUTE_PATTERN do
-          resource :owners, only: [:show, :create, :destroy]
+          resource :owners, only: %i[show create destroy]
         end
       end
 
@@ -89,7 +89,7 @@ Rails.application.routes.draw do
 
       resource :search, only: :show
 
-      resources :web_hooks, only: [:create, :index] do
+      resources :web_hooks, only: %i[create index] do
         collection do
           delete :remove
           post :fire
@@ -129,7 +129,7 @@ Rails.application.routes.draw do
     end
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
-    resource :profile, only: [:edit, :update] do
+    resource :profile, only: %i[edit update] do
       member do
         get :delete
         delete :destroy, as: :destroy
@@ -138,32 +138,32 @@ Rails.application.routes.draw do
     resources :stats, only: :index
 
     resources :rubygems,
-      only: [:index, :show, :edit, :update],
+      only: %i[index show edit update],
       path: 'gems',
       constraints: { id: Patterns::ROUTE_PATTERN, format: /html|atom/ } do
       resource :subscription,
-        only: [:create, :destroy],
+        only: %i[create destroy],
         constraints: { format: :js },
         defaults: { format: :js }
-      resources :versions, only: [:show, :index]
-      resources :reverse_dependencies, only: [:index]
+      resources :versions, only: %i[show index]
+      resources :reverse_dependencies, only: %i[index]
     end
   end
 
   ################################################################################
   # Clearance Overrides and Additions
 
-  resource :email_confirmations, only: [:new, :create] do
+  resource :email_confirmations, only: %i[new create] do
     get 'confirm/:token', to: 'email_confirmations#update', as: :update
     patch 'unconfirmed'
   end
 
-  resource :session, only: [:create, :destroy]
+  resource :session, only: %i[create destroy]
 
-  resources :passwords, only: [:new, :create]
+  resources :passwords, only: %i[new create]
 
-  resources :users, only: [:new, :create] do
-    resource :password, only: [:create, :edit, :update]
+  resources :users, only: %i[new create] do
+    resource :password, only: %i[create edit update]
   end
 
   ################################################################################

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -7,7 +7,7 @@ module Patterns
   LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/
   NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/
   URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
-  GEM_NAME_BLACKLIST    = %w(
+  GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64
     benchmark
@@ -90,5 +90,5 @@ module Patterns
     win32ole
     yaml
     ubygems
-  ).freeze
+  ].freeze
 end

--- a/script/restore_version
+++ b/script/restore_version
@@ -11,7 +11,7 @@ require_relative '../config/environment'
 
 rubygem = Rubygem.find_by_name!(gem_name)
 slug = version_number
-slug << "-#{platform}" unless platform.blank?
+slug << "-#{platform}" if platform.present?
 version = Version.find_from_slug!(rubygem, slug)
 raise "Version #{slug} for #{gem_name} was not found" unless version
 

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -18,7 +18,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
     send("to_#{@format}", @response.body)
   end
 
-  [:json, :yaml].each do |format|
+  %i[json yaml].each do |format|
     context "when using #{format}" do
       setup do
         @format = format

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -179,7 +179,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
       should "only return my gems" do
         gem_names = yield(@response.body).map { |rubygem| rubygem['name'] }.sort
-        assert_equal %w(AnotherGem SomeGem), gem_names
+        assert_equal %w[AnotherGem SomeGem], gem_names
       end
     end
   end
@@ -345,7 +345,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
     end
 
-    %w(json xml yaml).each do |format|
+    %w[json xml yaml].each do |format|
       context "on GET to show for an unknown gem with #{format} format" do
         setup do
           get :show, params: { id: "rials" }, format: format

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -60,7 +60,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     expected_body = "---\ngemA\ngemA1\ngemA2\ngemB\n"
     assert_equal expected_body, @response.body
     assert_equal etag(expected_body), @response.headers['ETag']
-    assert_equal %w(gemA gemA1 gemA2 gemB), Rails.cache.read('names')
+    assert_equal %w[gemA gemA1 gemA2 gemB], Rails.cache.read('names')
   end
 
   test "/names partial response" do
@@ -99,14 +99,14 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
 
   test "/versions updates on gem yank" do
     Deletion.create!(version: @version, user: create(:user))
-    expected = <<-eos
-gemB 1.0.0 qw2dwe
-gemA 1.0.0 013we2
-gemA 2.0.0 1cf94r
-gemA 1.2.0 13q4es
-gemA 2.1.0 e217fz
-gemB -1.0.0 6105347ebb9825ac754615ca55ff3b0c
-eos
+    expected = <<~eos
+      gemB 1.0.0 qw2dwe
+      gemA 1.0.0 013we2
+      gemA 2.0.0 1cf94r
+      gemA 1.2.0 13q4es
+      gemA 2.1.0 e217fz
+      gemB -1.0.0 6105347ebb9825ac754615ca55ff3b0c
+    eos
 
     get versions_path
     full_response_body = @response.body
@@ -116,13 +116,13 @@ eos
   end
 
   test "/info with existing gem" do
-    expected = <<-eos
----
-1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-eos
+    expected = <<~eos
+      ---
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
+      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
+      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
+      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
+    eos
 
     get info_path(gem_name: 'gemA')
 
@@ -138,13 +138,13 @@ eos
   end
 
   test "/info partial response" do
-    expected = <<-eos
----
-1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-eos
+    expected = <<~eos
+      ---
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
+      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
+      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
+      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
+    eos
 
     get info_path(gem_name: 'gemA'), env: { range: "bytes=159-" }
 
@@ -156,10 +156,10 @@ eos
     rubygem = create(:rubygem, name: 'gemC')
     version = create(:version, rubygem: rubygem, number: '1.0.0', info_checksum: '65ea0d')
     create(:dependency, :development, version: version, rubygem: @rubygem2)
-    expected = <<-END
----
-1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-END
+    expected = <<~END
+      ---
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+    END
 
     get info_path(gem_name: 'gemC')
 

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -18,7 +18,7 @@ class DependencyTest < ActiveSupport::TestCase
       @dependency.save
       json = JSON.load(@dependency.to_json)
 
-      assert_equal %w(name requirements), json.keys.sort
+      assert_equal %w[name requirements], json.keys.sort
       assert_equal @dependency.rubygem.name, json["name"]
       assert_equal @dependency.requirements, json["requirements"]
     end
@@ -28,7 +28,7 @@ class DependencyTest < ActiveSupport::TestCase
       xml = Nokogiri.parse(@dependency.to_xml)
 
       assert_equal "dependency", xml.root.name
-      assert_equal %w(name requirements), xml.root.children.select(&:element?).map(&:name).sort
+      assert_equal %w[name requirements], xml.root.children.select(&:element?).map(&:name).sort
       assert_equal @dependency.rubygem.name, xml.at_css("name").content
       assert_equal @dependency.requirements, xml.at_css("requirements").content
     end
@@ -37,7 +37,7 @@ class DependencyTest < ActiveSupport::TestCase
       @dependency.save
       yaml = YAML.safe_load(@dependency.to_yaml)
 
-      assert_equal %w(name requirements), yaml.keys.sort
+      assert_equal %w[name requirements], yaml.keys.sort
       assert_equal @dependency.rubygem.name, yaml["name"]
       assert_equal @dependency.requirements, yaml["requirements"]
     end

--- a/test/unit/gem_dependent_test.rb
+++ b/test/unit/gem_dependent_test.rb
@@ -64,7 +64,7 @@ class GemDependentTest < ActiveSupport::TestCase
         devise = create(:rubygem, name: "devise")
         version = create(:version, number: "1.0.0", rubygem: devise)
 
-        %w(foo bar).map do |gem_name|
+        %w[foo bar].map do |gem_name|
           create(:rubygem, name: gem_name).tap do |rubygem|
             gem_dependency = Gem::Dependency.new(rubygem.name, ['>= 0.0.0'])
             create(:dependency, rubygem: rubygem, version: version, gem_dependency: gem_dependency)

--- a/test/unit/gem_info_test.rb
+++ b/test/unit/gem_info_test.rb
@@ -45,12 +45,12 @@ class GemInfoTest < ActiveSupport::TestCase
 
   context '.ordered_names' do
     setup do
-      %w(abc bcd abd).each { |name| create(:rubygem, name: name) }
+      %w[abc bcd abd].each { |name| create(:rubygem, name: name) }
     end
 
     should 'order rubygems by name' do
       names = GemInfo.ordered_names
-      assert_equal %w(abc abd bcd), names
+      assert_equal %w[abc abd bcd], names
     end
 
     should 'write cache' do
@@ -64,7 +64,7 @@ class GemInfoTest < ActiveSupport::TestCase
       Rails.cache.stubs(:read)
       names = GemInfo.ordered_names
       assert_received(Rails.cache, :read) { |cache| cache.with("names") }
-      assert_equal %w(abc abd bcd), names
+      assert_equal %w[abc abd bcd], names
     end
   end
 

--- a/test/unit/hostess_test.rb
+++ b/test/unit/hostess_test.rb
@@ -15,7 +15,7 @@ class HostessTest < ActiveSupport::TestCase
     RubygemFs.instance.store(path, '')
   end
 
-  %w(/prerelease_specs.4.8.gz
+  %w[/prerelease_specs.4.8.gz
      /latest_specs.4.8.gz
      /specs.4.8.gz
      /Marshal.4.8.Z
@@ -30,7 +30,7 @@ class HostessTest < ActiveSupport::TestCase
      /quick/rubygems-update-1.3.6.gemspec.rz
      /yaml
      /yaml.Z
-     /yaml.z).each do |index|
+     /yaml.z].each do |index|
     should "serve up #{index} locally" do
       touch index
       get index

--- a/test/unit/redirector_test.rb
+++ b/test/unit/redirector_test.rb
@@ -40,13 +40,13 @@ class RedirectorTest < ActiveSupport::TestCase
     assert last_response.ok?
   end
 
-  %w(/book
+  %w[/book
      /book/42
      /chapter/58
      /read/book/2
      /export
      /shelf/9000
-     /syndicate.xml).each do |uri|
+     /syndicate.xml].each do |uri|
     should "redirect to docs.rubygems.org when #{uri} is hit" do
       get uri, {}, "HTTP_HOST" => Gemcutter::HOST
 

--- a/test/unit/rubygem_fs_test.rb
+++ b/test/unit/rubygem_fs_test.rb
@@ -17,7 +17,7 @@ class RubygemFsTest < ActiveSupport::TestCase
       def fs.s3
         [@config[:access_key_id], @config[:secret_access_key]]
       end
-      assert_equal %w(foo bar), fs.s3
+      assert_equal %w[foo bar], fs.s3
     end
   end
 

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -50,7 +50,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
     should 'find all gems with matching tokens' do
       response = Rubygem.elastic_search "example"
       assert_equal 3, response.results.size
-      results = %w(example-gem example_1 example.rb)
+      results = %w[example-gem example_1 example.rb]
       assert_equal results, response.results.map(&:name)
     end
   end
@@ -85,7 +85,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
 
     should "look for keyword in name, summary and description and order them in same priority order" do
       response = Rubygem.elastic_search "keyword"
-      names_order = %w(keyword example_gem3 example_gem2)
+      names_order = %w[keyword example_gem3 example_gem2]
       assert_equal names_order, response.results.map(&:name)
     end
   end
@@ -101,7 +101,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
 
     should "boost score of result by downloads count" do
       response = Rubygem.elastic_search "gem"
-      names_order = %w(gem_30 gem_20 gem_10)
+      names_order = %w[gem_30 gem_20 gem_10]
       assert_equal names_order, response.results.map(&:name)
     end
   end
@@ -139,7 +139,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
 
     should "suggest names of possible gems" do
       response = Rubygem.elastic_search "keywor"
-      suggestions = %w(keyword keywo keywordo)
+      suggestions = %w[keyword keywo keywordo]
       assert_equal suggestions, response.suggestions.terms
     end
   end
@@ -254,7 +254,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
 
     context "query order" do
       setup do
-        %w(rails-async async-rails).each do |gem_name|
+        %w[rails-async async-rails].each do |gem_name|
           rubygem = create(:rubygem, name: gem_name, downloads: 10)
           create(:version, rubygem: rubygem)
         end

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -150,13 +150,13 @@ class UpdateVersionsFileTest < ActiveSupport::TestCase
     end
 
     should "put each gem on new line" do
-      expected_output = <<-eos
-created_at: #{Time.now.iso8601}
----
-rubygem0 0.0.1 13q4e0
-rubygem1 0.0.1 13q4e1
-rubygem2 0.0.1 13q4e2
-eos
+      expected_output = <<~eos
+        created_at: #{Time.now.iso8601}
+        ---
+        rubygem0 0.0.1 13q4e0
+        rubygem1 0.0.1 13q4e1
+        rubygem2 0.0.1 13q4e2
+      eos
       assert_equal expected_output, @tmp_versions_file.read
     end
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -128,7 +128,7 @@ class UserTest < ActiveSupport::TestCase
     should "have email and handle on XML" do
       xml = Nokogiri.parse(@user.to_xml)
       assert_equal "user", xml.root.name
-      assert_equal %w(id handle email), xml.root.children.select(&:element?).map(&:name)
+      assert_equal %w[id handle email], xml.root.children.select(&:element?).map(&:name)
       assert_equal @user.email, xml.at_css("email").content
     end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -11,9 +11,9 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       json = @version.as_json
-      fields = %w(number built_at summary description authors platform
+      fields = %w[number built_at summary description authors platform
                   ruby_version rubygems_version prerelease downloads_count licenses
-                  requirements sha metadata created_at)
+                  requirements sha metadata created_at]
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
@@ -39,9 +39,9 @@ class VersionTest < ActiveSupport::TestCase
 
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
-      fields = %w(number built-at summary description authors platform
+      fields = %w[number built-at summary description authors platform
                   ruby-version rubygems-version prerelease downloads-count licenses
-                  requirements sha metadata created-at)
+                  requirements sha metadata created-at]
       assert_equal fields.map(&:to_s).sort,
         xml.root.children.map(&:name).reject { |t| t == "text" }.sort
       assert_equal @version.authors, xml.at_css("authors").content
@@ -273,7 +273,7 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
-    %w(x86_64-linux java mswin x86-mswin32-60).each do |platform|
+    %w[x86_64-linux java mswin x86-mswin32-60].each do |platform|
       should "be able to find with platform of #{platform}" do
         version = create(:version, platform: platform)
         slug = "#{version.number}-#{platform}"
@@ -529,7 +529,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "be in the proper order" do
-      assert_equal %w(0.7 0.5 0.3 0.2), @gem.versions.by_position.map(&:number)
+      assert_equal %w[0.7 0.5 0.3 0.2], @gem.versions.by_position.map(&:number)
     end
 
     should "know its latest version" do
@@ -558,14 +558,14 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a few versions" do
     setup do
-      @thin = create(:version, authors: %w(thin), built_at: 1.year.ago)
-      @rake = create(:version, authors: %w(rake), built_at: 1.month.ago)
-      @json = create(:version, authors: %w(json), built_at: 1.week.ago)
-      @thor = create(:version, authors: %w(thor), built_at: 2.days.ago)
-      @rack = create(:version, authors: %w(rack), built_at: 1.day.ago)
-      @haml = create(:version, authors: %w(haml), built_at: 1.hour.ago)
-      @dust = create(:version, authors: %w(dust), built_at: 1.day.from_now)
-      @fake = create(:version, authors: %w(fake), indexed: false, built_at: 1.minute.ago)
+      @thin = create(:version, authors: %w[thin], built_at: 1.year.ago)
+      @rake = create(:version, authors: %w[rake], built_at: 1.month.ago)
+      @json = create(:version, authors: %w[json], built_at: 1.week.ago)
+      @thor = create(:version, authors: %w[thor], built_at: 2.days.ago)
+      @rack = create(:version, authors: %w[rack], built_at: 1.day.ago)
+      @haml = create(:version, authors: %w[haml], built_at: 1.hour.ago)
+      @dust = create(:version, authors: %w[dust], built_at: 1.day.from_now)
+      @fake = create(:version, authors: %w[fake], indexed: false, built_at: 1.minute.ago)
     end
 
     should "get the latest versions" do
@@ -743,7 +743,7 @@ class VersionTest < ActiveSupport::TestCase
 
   should "validate authors the same twice" do
     g = Rubygem.new(name: 'test-gem')
-    v = Version.new(authors:  %w(arthurnn dwradcliffe), number: 1, platform: 'ruby', rubygem: g)
+    v = Version.new(authors:  %w[arthurnn dwradcliffe], number: 1, platform: 'ruby', rubygem: g)
     assert_equal "arthurnn, dwradcliffe", v.authors
     assert v.valid?
     assert_equal "arthurnn, dwradcliffe", v.authors
@@ -752,9 +752,9 @@ class VersionTest < ActiveSupport::TestCase
 
   should "not allow full name collision" do
     g1 = Rubygem.create(name: 'test-gem-733.t')
-    Version.create(authors:  %w(arthurnn dwradcliffe), number: '0.0.1', platform: 'ruby', rubygem: g1)
+    Version.create(authors:  %w[arthurnn dwradcliffe], number: '0.0.1', platform: 'ruby', rubygem: g1)
     g2 = Rubygem.create(name: 'test-gem')
-    v2 = Version.new(authors:  %w(arthurnn dwradcliffe), number: '733.t-0.0.1', platform: 'ruby', rubygem: g2)
+    v2 = Version.new(authors:  %w[arthurnn dwradcliffe], number: '733.t-0.0.1', platform: 'ruby', rubygem: g2)
     refute v2.valid?
     assert_equal [:full_name], v2.errors.keys
   end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -79,7 +79,7 @@ class WebHookTest < ActiveSupport::TestCase
       xml = Nokogiri.parse(@webhook.to_xml)
 
       assert_equal "web-hook", xml.root.name
-      assert_equal %w(failure-count url), xml.root.children.select(&:element?).map(&:name).sort
+      assert_equal %w[failure-count url], xml.root.children.select(&:element?).map(&:name).sort
       assert_equal @webhook.url, xml.at_css("url").content
       assert_equal @webhook.failure_count, xml.at_css("failure-count").content.to_i
     end
@@ -136,7 +136,7 @@ class WebHookTest < ActiveSupport::TestCase
       @version = create(:version,
         rubygem: @rubygem,
         number: "3.2.1",
-        authors: %w(AUTHORS),
+        authors: %w[AUTHORS],
         description: "DESC")
       @hook    = create(:web_hook, rubygem: @rubygem)
       @job     = Notifier.new(@hook.url, 'http', 'localhost:1234', @rubygem, @version)


### PR DESCRIPTION
fixes:
* Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ]. (https://github.com/bbatsov/ruby-style-guide#percent-literal-braces)
* Style/SymbolArray: Use %i or %I for an array of symbols. (https://github.com/bbatsov/ruby-style-guide#percent-i)
* Rails/Present: Use if platform.present? instead of unless platform.blank?
* Style/IndentHeredoc: Use 2 spaces for indentation in a heredoc by using <<~ instead of <<-. (https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs)
* Lint/AmbiguousBlockAssociation: Parenthesize the param execute_raw_sql(query).map { |v| [v['name'], [v]] } to make sure that the block will be associated with the execute_raw_sql(query).map method call. (https://github.com/bbatsov/ruby-style-guide#syntax)
* Style/InverseMethods: Use none? instead of inverting any?.
* Rails/Blank: Use if suggestions.blank? instead of unless suggestions.present?