### PR TITLE
Add api endpoint for gem metrics

### DIFF
--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -1,0 +1,39 @@
+class Api::V1::MetricsController < Api::BaseController
+  METRIC_KEYS = %i[
+    bundler
+    rubygems
+    ruby
+    arch
+    command
+  ].freeze
+
+  def create
+    head :ok && return if known_id?(params[:id])
+
+    METRIC_KEYS.each do |metric|
+      StatsD.increment "#{metric}.#{params[metric]}" if params[metric]
+    end
+
+    StatsD.increment ruby_engine_metric if params[:ruby_engine]
+    split_increment("option", params[:options]) if params[:options]
+    split_increment("ci", params[:ci]) if params[:ci]
+    head :ok
+  end
+
+  private
+
+  def split_increment(type, comma_string)
+    comma_string.split(",").each { |k| StatsD.increment("#{type}.#{k}") }
+  end
+
+  def ruby_engine_metric
+    "ruby_engine.#{params[:ruby_engine]}.#{params[:ruby_engine_version]}"
+  end
+
+  def known_id?(id)
+    return true if Rails.cache.read(id)
+
+    Rails.cache.write(id, true, expires_in: 120)
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
         end
       end
 
+      resource :metrics, only: :create
       resources :timeframe_versions, only: :index
     end
   end

--- a/test/functional/api/v1/metrics_controller_test.rb
+++ b/test/functional/api/v1/metrics_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Api::V1::MetricsControllerTest < ActionController::TestCase
+  setup do
+    StatsD.stubs(:increment)
+    @id = "9d16bd9809d392ca"
+    @metric = { bundler:  "1.10.4.beta.1",
+                rubygems: "2.4.1",
+                ruby:     "2.1.2",
+                arch:     "x86_64-apple-darwin13.2.0",
+                command:  "update",
+                options:  "jobs,without,build.mysql",
+                ci:       "jenkins,ci",
+                id:        @id }
+  end
+
+  context "reporting metrics first time" do
+    should "increment the right values" do
+      StatsD.expects(:increment) { |metric| metric.with("bundler.1.10.4.beta.1") }
+      StatsD.expects(:increment) { |metric| metric.with("rubygems.2.4.1") }
+      StatsD.expects(:increment) { |metric| metric.with("ruby.2.1.2") }
+      StatsD.expects(:increment) { |metric| metric.with("command.update") }
+      StatsD.expects(:increment) { |metric| metric.with("arch.x86_64-apple-darwin13.2.0") }
+      StatsD.expects(:increment) { |metric| metric.with("option.jobs") }
+      StatsD.expects(:increment) { |metric| metric.with("option.without") }
+      StatsD.expects(:increment) { |metric| metric.with("option.build.mysql") }
+      StatsD.expects(:increment) { |metric| metric.with("ci.jenkins") }
+      StatsD.expects(:increment) { |metric| metric.with("ci.ci") }
+      post :create, params: @metric
+    end
+  end
+
+  context "reporting metrics second time" do
+    setup do
+      Rails.cache.stubs(:read).with(@id).returns(true)
+    end
+
+    should "not increment metric" do
+      StatsD.expects(:increment) { |metric| metric.with("bundler.1.10.4.beta.1") }.never
+      post :create, params: @metric
+    end
+  end
+end


### PR DESCRIPTION
~~Uses `ENV["HTTP_USER_AGENT']` set by bundler[[1](https://github.com/bundler/bundler/blob/master/lib/bundler/fetcher.rb#L170-L195)].
I am not sure why was the [previously proposed implementation](https://github.com/rubygems/rubygems.org/pull/1390) trying to read values of `params` when `ENV` is being set by bundler.~~

It is based on the bundler-api implementation[[2](https://github.com/bundler/bundler-api/blob/02c2633278edc81bf2e58bf9d7022b8607fd02e5/lib/bundler_api/agent_reporting.rb)][[3](https://github.com/bundler/bundler-api/blob/02c2633278edc81bf2e58bf9d7022b8607fd02e5/spec/agent_reporting_spec.rb)].

cc: @indirect 