### PR TITLE
Throttle patch and delete profile requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -27,6 +27,11 @@ class Rack::Attack
     req.ip if req.path =~ /\A#{Regexp.escape('/api/v1/api_key')}/ && req.get?
   end
 
+  # Throttle PATCH and DELETE profile requests
+  throttle("clearance/remember_token", limit: 100, period: 10.minutes) do |req|
+    req.ip if req.path == "/profile" && (req.patch? || req.delete?)
+  end
+
   # Throttle POST requests to /login by email param
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -85,5 +85,23 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         assert_equal 429, @response.status if i > @limit
       end
     end
+
+    should "throttle profile update" do
+      cookies[:remember_token] = @user.remember_token
+
+      (@limit + 1).times do |i|
+        patch "/profile"
+        assert_equal 429, @response.status if i == @limit
+      end
+    end
+
+    should "throttle profile delete" do
+      cookies[:remember_token] = @user.remember_token
+
+      (@limit + 1).times do |i|
+        delete "/profile"
+        assert_equal 429, @response.status if i == @limit
+      end
+    end
   end
 end


### PR DESCRIPTION
Attacker could brute force password validation on profile update
or delete page if they have access to a compromised session
(XSS or stolen cookie).

Resolves: https://hackerone.com/reports/225396