### PR TITLE
Return 304 not modified when ETag matches on CompactIndex versions requests

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -32,6 +32,10 @@ class Api::CompactIndexController < Api::BaseController
   def render_range(response_body)
     headers['ETag'] = '"' << Digest::MD5.hexdigest(response_body) << '"'
 
+    if headers['ETag'] == request.env['HTTP_IF_NONE_MATCH']
+      return head :not_modified
+    end
+
     ranges = Rack::Utils.byte_ranges(request.env, response_body.bytesize)
     if ranges
       ranged_response = ranges.map { |range| response_body.byteslice(range) }.join

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -97,6 +97,19 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(full_response_body), @response.headers['ETag']
   end
 
+  test "/versions not modified response" do
+    get versions_path
+    full_response_body = @response.body
+
+    get versions_path, headers: {
+      "HTTP_RANGE" => "bytes=229-",
+      "HTTP_IF_NONE_MATCH" => @response.headers['ETag']
+    }
+
+    assert_response 304
+    assert_equal etag(full_response_body), @response.headers['ETag']
+  end
+
   test "/versions updates on gem yank" do
     Deletion.create!(version: @version, user: create(:user))
     expected = <<~eos


### PR DESCRIPTION
Previously, there was no ETag checking for calls to `https://index.rubygems.org/versions`. That was particularly sad for Bundler, as it caused the following flow:
1. Bundler requests `https://index.rubygems.org/versions`, gets the latest `versions` file, and caches it
2. Bundler wants to check for updates to the `versions` file. It submits another request to `https://index.rubygems.org/versions` with the correct ETag, asking only for bytes after the final byte of its current `versions` file
3. EITHER the `version` file had changed, and bundler received the extra bytes successfully (happy case)
4. OR the `version` file had not changed. In this case the ETag was ignored and a range response was still requested. But as the file hadn't changed, the content of this range response would be empty, and would trigger a `416` response. Bundler would treat this as a `Bundler::HTTPError` and give up fetching the CompactIndex, opting for the dependencies index instead.

I'll put a PR in to Bundler to handle 416 errors more sensibly, too.