### PR TITLE
removed 'main-search' and 'search-submit' duplicate ids

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
-  <%= form_tag search_url, :id => "main-search", :method => :get do %>
+  <%= form_tag search_url, :method => :get do %>
     <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem').html_safe, autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t('layouts.application.header.search_gem').html_safe %></span>
@@ -11,7 +11,7 @@
         <%= link_to t("advanced_search"), advanced_search_path, class: "home__advanced__search t-link--has-arrow"%>
       </center>
     <% end %>
-    <%= submit_tag '⌕', :id => 'search_submit', :name => nil, :class => "home__search__icon" %>
+    <%= submit_tag '⌕', :name => nil, :class => "home__search__icon" %>
   <% end %>
 </div>
 <div class="home__cta-wrap">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
         </a>
 
         <div class="header__nav-links-wrap">
-          <%= form_tag search_url, id: "main-search", class: search_form_class, method: :get do %>
+          <%= form_tag search_url, class: search_form_class, method: :get do %>
             <%= search_field_tag :query, params[:query], placeholder: t('.header.search_gem').html_safe, class: "header__search" %>
             <%= label_tag :query do %>
               <span class="t-hidden"><%= t(".header.search_gem").html_safe %></span>

--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -6,7 +6,7 @@
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t("layouts.application.header.search_gem").html_safe %></span>
     <% end %>
-    <%= submit_tag "⌕", id: "search_submit", name: nil, class: "home__search__icon" %>
+    <%= submit_tag "⌕", name: nil, class: "home__search__icon" %>
   <% end %>
 
   <dl id="search-fields">


### PR DESCRIPTION
Removes multiple html elements with the same id. See issue [#1650](https://github.com/rubygems/rubygems.org/issues/1650)