### PR TITLE
Add erubis dependency to brakeman script

### DIFF
--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -7,4 +7,4 @@
 :output_files:
 - reports/brakeman.json
 - reports/brakeman.html
-:rails4: true
+:rails5: true

--- a/script/brakeman
+++ b/script/brakeman
@@ -6,6 +6,8 @@ gem install terminal-table --conservative --no-rdoc --no-ri
 # remove references to multi_json when https://github.com/presidentbeef/brakeman/pull/830
 # is merged and released.
 gem install multi_json --conservative --no-rdoc --no-ri
+gem install erubis --conservative --no-rdoc --no-ri
+
 # Only the output configurations are specified below. The remaining configuration
 # is in config/brakeman.yml and any ignored warnings in config/brakeman.ignore
 # see https://github.com/presidentbeef/brakeman/blob/master/OPTIONS.md


### PR DESCRIPTION
We are using brakeman-min which doesn't have erubis.
erubis is used in template rendering (fixed in brakeman 3.7.0).

See: https://github.com/presidentbeef/brakeman/issues/1068#issuecomment-312437957