### PR TITLE
Remove ipaddr from the blacklist

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -31,7 +31,6 @@ module Patterns
     install
     io-nonblock
     io-wait
-    ipaddr
     irb
     jruby
     logger


### PR DESCRIPTION
It is going to be a default gem in Ruby 2.5: https://github.com/ruby/ipaddr