### PR TITLE
Add lock around save in pusher to avoid race condition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,4 +366,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -27,21 +27,44 @@ class Pusher
   end
 
   def save
-    # Restructured so that if we fail to write the gem (ie, s3 is down)
-    # can clean things up well.
+    with_lock do
+      begin
+        # Restructured so that if we fail to write the gem (ie, s3 is down)
+        # can clean things up well.
 
-    @indexer.write_gem @body, @spec
-  rescue StandardError => e
-    @version.destroy
-    Honeybadger.notify(e)
-    notify("There was a problem saving your gem. Please try again.", 500)
-  else
-    if update
-      after_write
-      notify("Successfully registered gem: #{version.to_title}", 200)
-    else
-      notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403)
+        @indexer.write_gem @body, @spec
+      rescue StandardError => e
+        @version.destroy
+        Honeybadger.notify(e)
+        notify("There was a problem saving your gem. Please try again.", 500)
+      else
+        if update
+          after_write
+          notify("Successfully registered gem: #{version.to_title}", 200)
+        else
+          notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403)
+        end
+      end
     end
+  end
+
+  def with_lock
+    return false unless lock_key
+
+    if Rails.cache.exist?(lock_key)
+      notify("We are already processing this gem with the specified version.", 409)
+      return false
+    end
+
+    Rails.cache.write(lock_key, true, expires_in: 10.minutes)
+
+    begin
+      yield if block_given?
+    ensure
+      Rails.cache.delete(lock_key)
+    end
+
+    lock_key
   end
 
   def pull_spec
@@ -63,7 +86,7 @@ class Pusher
     unless @rubygem.new_record?
       if @rubygem.find_version_from_spec(spec)
         notify("Repushing of gem versions is not allowed.\n" \
-               "Please use `gem yank` to remove bad gem releases.", 409)
+               "Please push a new version.", 409)
 
         return false
       end
@@ -96,6 +119,11 @@ class Pusher
   end
 
   private
+
+  def lock_key
+    return nil unless spec
+    ['pusher', 'lock', spec.name, spec.version.to_s].join('-')
+  end
 
   def after_write
     @version_id = version.id

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -86,7 +86,7 @@ class Pusher
     unless @rubygem.new_record?
       if @rubygem.find_version_from_spec(spec)
         notify("Repushing of gem versions is not allowed.\n" \
-               "Please push a new version.", 409)
+               "Please use `gem yank` to remove bad gem releases.", 409)
 
         return false
       end


### PR DESCRIPTION
The problem
---
When gems are pushed at approximately the same time, 2 simultaneous request will happen. These requests end up both pushing an identical version to Rubygems. When Bundler tries to validate the version, things go :boom: and the SHA256 checksum fails.

This often happens in matrix builds in Travis

How this fixes it
---
A lock around the functionality was discussed in the linked issues. I chose to take this path.
I did not use an active record lock as we do not want to prevent other changes to the gem (like download stats, edits, etc) while something is uploading. Instead, we lock the `save` functionality directly.

This means that a call to `save` must first be able to get a lock and will 409 CONFLICT otherwise.

Should the system crash during a save, the lock will expire automatically in 10 minutes as a backup method.

Questions
---
- Is there a locking library I should use instead?
- `Rails.cache` locking is supposedly not the best, I have little experience with it. Maybe it gives us enough benefit without additional overhead?

Issues this solves
---
Fixes https://github.com/rubygems/rubygems.org/issues/1564
Fixes https://github.com/rubygems/rubygems.org/issues/1551

cc @indirect @dwradcliffe 