### PR TITLE
Relative urls and more zh-CN translate

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -51,7 +51,7 @@ class RubygemsController < ApplicationController
   def load_gem
     unless @rubygem.owned_by?(current_user)
       flash[:warning] = "You do not have permission to edit this gem."
-      redirect_to root_url
+      redirect_to root_path
     end
 
     @linkset = @rubygem.linkset

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,6 +24,6 @@ class SessionsController < Clearance::SessionsController
   end
 
   def url_after_create
-    dashboard_url
+    dashboard_path
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -5,7 +5,7 @@
     <h3 class="gems__gem__name">
       <%= t '.latest' %>:
     </h3>
-    <%= link_to dashboard_url(:api_key => current_user.api_key, :format => :atom), :id => 'feed', :title => t('.latest_title'), :class => 'gem__link t-list__item', 'data-icon' => '#' do %>
+    <%= link_to dashboard_path(:api_key => current_user.api_key, :format => :atom), :id => 'feed', :title => t('.latest_title'), :class => 'gem__link t-list__item', 'data-icon' => '#' do %>
       <span class="t-hidden">RSS</span>
     <% end %>
     </a>
@@ -18,7 +18,7 @@
         <ol>
           <% @latest_updates.each do |version| %>
             <li>
-              <a href="<%= rubygem_url(version.rubygem) %>" class="dashboard__gem">
+              <a href="<%= rubygem_path(version.rubygem) %>" class="dashboard__gem">
                 <div class="dashboard__gem__info">
                   <strong class="dashboard__gem__name"><%= version.to_title %></strong>
                   <i class="dashboard__gem__version"><%= t 'time_ago', :duration => time_ago_in_words(version.created_at) %></i>
@@ -39,7 +39,7 @@
         <div class="t-body push--bottom">
           <p>
             <%= t('.no_owned', :creating_link => link_to(t('.creating_link_text'), "http://guides.rubygems.org/make-your-own-gem/").html_safe,
-                               :migrating_link => link_to(t('.migrating_link_text'), page_url("migrate"))).html_safe %>
+                               :migrating_link => link_to(t('.migrating_link_text'), page_path("migrate"))).html_safe %>
           </p>
         </div>
       <% else %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
-  <%= form_tag search_url, :method => :get do %>
+  <%= form_tag search_path, :method => :get do %>
     <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem').html_safe, autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t('layouts.application.header.search_gem').html_safe %></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
         </a>
 
         <div class="header__nav-links-wrap">
-          <%= form_tag search_url, class: search_form_class, method: :get do %>
+          <%= form_tag search_path, class: search_form_class, method: :get do %>
             <%= search_field_tag :query, params[:query], placeholder: t('.header.search_gem').html_safe, class: "header__search" %>
             <%= label_tag :query do %>
               <span class="t-hidden"><%= t(".header.search_gem").html_safe %></span>
@@ -53,9 +53,9 @@
             <%= link_to "News", news_url, class: "header__nav-link #{active?(news_path)}" %>
 
             <%- if request.path_info == '/gems' %>
-              <%= link_to "Gems", rubygems_url, class: "header__nav-link is-active" %>
+              <%= link_to "Gems", rubygems_path, class: "header__nav-link is-active" %>
             <%- else %>
-              <%= link_to "Gems", rubygems_url, class: "header__nav-link" %>
+              <%= link_to "Gems", rubygems_path, class: "header__nav-link" %>
             <%- end %>
 
             <%= link_to t('.footer.guides'), "http://guides.rubygems.org", class: "header__nav-link" %>
@@ -70,7 +70,7 @@
                 <span class="t-hidden">More items</span>
               </a>
               <div class="header__popup__nav-links">
-                <%= link_to t('.header.dashboard'), dashboard_url, class: "header__nav-link" %>
+                <%= link_to t('.header.dashboard'), dashboard_path, class: "header__nav-link" %>
                 <%= link_to t('.header.sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
               </div>
             <% else %>
@@ -127,21 +127,21 @@
             <%= link_to t('.footer.status'), "https://status.rubygems.org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.uptime'), "http://uptime.rubygems.org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.source_code'), "https://github.com/rubygems/rubygems.org", class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.data'), page_url("data"), class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.data'), page_path("data"), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.discussion_forum'), "https://groups.google.com/group/rubygems-org", class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.statistics'), stats_url, class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.statistics'), stats_path, class: "nav--v__link--footer" %>
             <%= link_to t('.footer.blog'), "http://blog.rubygems.org", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/about' %>
-              <%= link_to t('.footer.about'), page_url("about"), class: "nav--v__link--footer is-active" %>
+              <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer is-active" %>
             <%- else %>
-              <%= link_to t('.footer.about'), page_url("about"), class: "nav--v__link--footer" %>
+              <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer" %>
             <%- end %>
             <%= link_to t('.footer.help'), t(:help_url), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.api'), "http://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/security' %>
-              <%= link_to t('.footer.security'), page_url("security"), class: "nav--v__link--footer is-active" %>
+              <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer is-active" %>
             <%- else %>
-              <%= link_to t('.footer.security'), page_url("security"), class: "nav--v__link--footer" %>
+              <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer" %>
             <%- end %>
           </div>
           <div class="l-colspan--l colspan--l--has-border">
@@ -151,7 +151,7 @@
                   publish_docs: "http://guides.rubygems.org/publishing/",
                   install_docs: "http://guides.rubygems.org/command-reference/#gem-install",
                   api_docs: "http://guides.rubygems.org/rubygems-org-api/",
-                  gem_list: rubygems_url,
+                  gem_list: rubygems_path,
                   contributing_docs: "http://guides.rubygems.org/contributing/"
                 ) %>
               </p>
@@ -216,7 +216,7 @@
       <div class="footer__language_selector">
         <% I18n.available_locales.each do |language| %>
           <div class="footer__language">
-            <%= link_to I18n.t(:locale_name, locale: language), url_for(locale: language), class: "nav--v__link--footer" %>
+            <%= link_to I18n.t(:locale_name, locale: language), url_for(locale: language, only_path: true), class: "nav--v__link--footer" %>
           </div>
         <% end %>
       </div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -10,7 +10,7 @@
   <p>
     <%= t('.founding', :founder => link_to('Nick Quaranto', 'https://twitter.com/qrush'),
                        :contributors => link_to("291 Rubyists", "https://github.com/rubygems/rubygems.org/graphs/contributors"),
-                       :downloads => link_to("millions of gem downloads", stats_url),
+                       :downloads => link_to("millions of gem downloads", stats_path),
                        :title => t('title')).html_safe %>
   </p>
   <p>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -69,7 +69,7 @@
 
   <div class="t-body">
     <h2><%= t '.reset_password.title' %></h2>
-    <p><%= t('.reset_password.text', :link => link_to(t('.reset_password.link_text'), new_password_url)).html_safe %></p>
+    <p><%= t('.reset_password.text', :link => link_to(t('.reset_password.link_text'), new_password_path)).html_safe %></p>
 
     <h2><%= t '.api_access.title' %></h2>
     <p>
@@ -77,7 +77,7 @@
     </p>
     <p>
       <%= t('.api_access.credentials', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
-                                       :gem_commands_link => link_to(t('.api_access.link_text'), page_url('gem_docs'))).html_safe %>
+                                       :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))).html_safe %>
     </p>
     <pre><code>curl -u <%= current_user.name %> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials</code></pre>
   </div>

--- a/app/views/rubygems/edit.html.erb
+++ b/app/views/rubygems/edit.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <%= error_messages_for :linkset, :object_name => "gem" %>
-<%= form_for @rubygem.linkset, :url => rubygem_url(@rubygem), :method => :put do |form| %>
+<%= form_for @rubygem.linkset, :url => rubygem_path(@rubygem), :method => :put do |form| %>
   <div class="url_field">
     <%= form.label :code, :class => 'form__label' %>
     <%= form.text_field :code, :class => 'form__input' %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="t-body">
   <p>
-    <%= link_to t('.forgot_password'), new_password_url, class: 't-list__item' %>
+    <%= link_to t('.forgot_password'), new_password_path, class: 't-list__item' %>
     <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: 't-list__item' %>
   </p>
 </div>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -1,5 +1,5 @@
 <li class="gem__version-wrap">
-  <%= link_to version.number, rubygem_version_url(version.rubygem, version.slug), :class => 't-list__item' %>
+  <%= link_to version.number, rubygem_version_path(version.rubygem, version.slug), :class => 't-list__item' %>
   <small class="gem__version__date">- <%= nice_date_for(version.built_at) %></small>
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -83,6 +83,6 @@ class DashboardsControllerTest < ActionController::TestCase
   context "On GET to show without being signed in" do
     setup { get :show }
     should respond_with :redirect
-    should redirect_to('the homepage') { root_url }
+    should redirect_to('the homepage') { root_path }
   end
 end

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -207,6 +207,6 @@ class ProfilesControllerTest < ActionController::TestCase
   context "On GET to edit without being signed in" do
     setup { get :edit }
     should respond_with :redirect
-    should redirect_to('the homepage') { root_url }
+    should redirect_to('the homepage') { root_path }
   end
 end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -114,7 +114,7 @@ class RubygemsControllerTest < ActionController::TestCase
         get :edit, params: { id: @rubygem.to_param }
       end
       should respond_with :redirect
-      should redirect_to('the homepage') { root_url }
+      should redirect_to('the homepage') { root_path }
       should set_flash.to("You do not have permission to edit this gem.")
     end
 
@@ -501,7 +501,7 @@ class RubygemsControllerTest < ActionController::TestCase
         get :edit, params: { id: @rubygem.to_param }
       end
       should respond_with :redirect
-      should redirect_to('the homepage') { root_url }
+      should redirect_to('the homepage') { root_path }
     end
 
     context "On PUT to update" do
@@ -510,7 +510,7 @@ class RubygemsControllerTest < ActionController::TestCase
         put :update, params: { id: @rubygem.to_param, linkset: {} }
       end
       should respond_with :redirect
-      should redirect_to('the homepage') { root_url }
+      should redirect_to('the homepage') { root_path }
     end
   end
 end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -10,7 +10,7 @@ class SessionsControllerTest < ActionController::TestCase
       end
 
       should respond_with :redirect
-      should redirect_to('the dashboard') { dashboard_url }
+      should redirect_to('the dashboard') { dashboard_path }
 
       should "sign in the user" do
         assert @controller.request.env[:clearance].signed_in?
@@ -53,7 +53,7 @@ class SessionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :redirect
-    should redirect_to('login page') { sign_in_url }
+    should redirect_to('login page') { sign_in_path }
 
     should "sign out the user" do
       refute @controller.request.env[:clearance].signed_in?

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -6,7 +6,7 @@ class UsersControllerTest < ActionController::TestCase
       get :new
     end
 
-    should redirect_to("sign up page") { sign_up_url }
+    should redirect_to("sign up page") { sign_up_path }
   end
 
   context "on POST to create" do


### PR DESCRIPTION
Why need relative urls?

https://gems.ruby-china.org/gems/rails

I builded a mirror sites (a CDN), for help Chinese users visit RubyGems (It's slow or can not connect in some times), but source page have a lot of absolute URLs, links will go to https://rubygems.org