### PR TITLE
Blacklist "MRI" and "MRuby" Gem Names

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -37,6 +37,8 @@ module Patterns
     matrix
     mkmf
     monitor
+    mri
+    mruby
     mutex_m
     net-ftp
     net-http


### PR DESCRIPTION
Since `jruby` is blacklisted, I thought `mri` and `mruby` should be blacklisted too, especially since there are no gems with those names (at least at the time of the PR).

Other names that could be good to blacklist, but are already taken:

- cruby
- gem

There's also a number of other Ruby implementation/interpreter names that could be blacklisted.