### PR TITLE
Add locking around the rubygem while uploading a new version

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -13,7 +13,11 @@ class Pusher
   end
 
   def process
-    pull_spec && find && authorize && validate && save
+    return false unless pull_spec && find
+
+    rubygem.with_lock do
+      validate_gem_version && authorize && validate && save
+    end
   end
 
   def authorize
@@ -61,12 +65,7 @@ class Pusher
     @rubygem = Rubygem.name_is(name).first || Rubygem.new(name: name)
 
     unless @rubygem.new_record?
-      if @rubygem.find_version_from_spec(spec)
-        notify("Repushing of gem versions is not allowed.\n" \
-               "Please use `gem yank` to remove bad gem releases.", 409)
-
-        return false
-      end
+      return false unless validate_gem_version
 
       if @rubygem.name != name && @rubygem.indexed_versions?
         return notify("Unable to change case of gem name with indexed versions\n" \
@@ -85,6 +84,13 @@ class Pusher
                                      sha256: sha256
 
     true
+  end
+
+  def validate_gem_version
+    return true unless rubygem.find_version_from_spec(spec)
+    notify("Repushing of gem versions is not allowed.\n" \
+           "Please use `gem yank` to remove bad gem releases.", 409)
+    false
   end
 
   # Overridden so we don't get megabytes of the raw data printing out

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -29,9 +29,13 @@ class PusherTest < ActiveSupport::TestCase
       should "work normally when things go well" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
+        @cutter.stubs(:validate_gem_version).returns true
         @cutter.stubs(:authorize).returns true
         @cutter.stubs(:validate).returns true
         @cutter.stubs(:save)
+
+        legit_gem = create(:rubygem, name: 'legit-gem')
+        @cutter.stubs(:rubygem).returns(legit_gem)
 
         @cutter.process
       end
@@ -56,9 +60,13 @@ class PusherTest < ActiveSupport::TestCase
       should "not attempt to validate if not authorized" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
+        @cutter.stubs(:validate_gem_version).returns true
         @cutter.stubs(:authorize).returns false
         @cutter.stubs(:validate).never
         @cutter.stubs(:save).never
+
+        legit_gem = create(:rubygem, name: 'legit-gem')
+        @cutter.stubs(:rubygem).returns(legit_gem)
 
         @cutter.process
       end
@@ -66,9 +74,27 @@ class PusherTest < ActiveSupport::TestCase
       should "not attempt to save if not validated" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
+        @cutter.stubs(:validate_gem_version).returns true
         @cutter.stubs(:authorize).returns true
         @cutter.stubs(:validate).returns false
         @cutter.stubs(:save).never
+
+        legit_gem = create(:rubygem, name: 'legit-gem')
+        @cutter.stubs(:rubygem).returns(legit_gem)
+
+        @cutter.process
+      end
+
+      should "not attempt to save if duplicate gem version" do
+        @cutter.stubs(:pull_spec).returns true
+        @cutter.stubs(:find).returns true
+        @cutter.stubs(:validate_gem_version).returns(false)
+        @cutter.stubs(:authorize).returns false
+        @cutter.stubs(:validate).returns false
+        @cutter.stubs(:save).never
+
+        legit_gem = create(:rubygem, name: 'legit-gem')
+        @cutter.stubs(:rubygem).returns(legit_gem)
 
         @cutter.process
       end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -22,7 +22,7 @@ class PusherTest < ActiveSupport::TestCase
       @cutter.process
     end
 
-    should "not attempt to find rubygem if spec can't be pulled" do
+    should "not attempt to find gem if spec can't be pulled" do
       @cutter.stubs(:pull_spec).returns false
       @cutter.stubs(:find).never
       @cutter.stubs(:authorize).never


### PR DESCRIPTION
The problem
---
When gems are pushed at approximately the same time, 2 simultaneous request will happen. These requests end up both pushing an identical version to Rubygems. When Bundler tries to validate the version, things go :boom: and the SHA256 checksum fails.

This often happens in matrix builds in Travis

How this fixes it
---
By locking the rubygem, we cause the entire gem to be locked - but nothing else. This means that we cannot update the versions at the same time.

When we retrieve the lock, we validate the version again and 409 conflict.

Issues this solves
---
Fixes https://github.com/rubygems/rubygems.org/issues/1564
Fixes https://github.com/rubygems/rubygems.org/issues/1551

cc @indirect @dwradcliffe @arthurnn 