### PR TITLE
Disable Honeybadger in development

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -2,3 +2,7 @@
 Honeybadger.exception_filter do |notice|
   ActionDispatch::ExceptionWrapper.rescue_responses.keys.include? notice[:error_class]
 end
+
+Honeybadger.configure do |config|
+  config.disabled = true if Rails.env.development?
+end


### PR DESCRIPTION
When i'm working on the rails app i noticed that I get this error from Honeybadger whenever an uncaught error/exception is raised in Rails:
 
    ** [Honeybadger] Unable to send error report: API key is missing. id=f0e57af1-e1d4-41ee-9ed3-8a8ba20cfde0 level=3 pid=421

Honeybadger seems to be an error reporting service that defiantly should be enabled for staging/production but probably not for development because the ENV vars are not available/setup.