### PR TITLE
Use bootsnap in development to speed up rails load times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bootsnap', require: false
   gem 'rails-erd'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       aws-sdk-core (= 2.10.21)
     aws-sigv4 (1.0.1)
     bcrypt (3.1.11)
+    bootsnap (1.1.5)
+      msgpack (~> 1.0)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.2.3)
@@ -309,6 +311,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   aws-sdk (~> 2.2)
+  bootsnap
   bourne
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,8 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
+dev_mode = ['', nil, 'development'].include? env
+
+require 'bootsnap/setup' if dev_mode && !ENV['NO_BOOTSNAP']


### PR DESCRIPTION
[Bootsnap](https://github.com/Shopify/bootsnap) is a library that caches the ruby VM bytecode in `require` calls to help speed up boot time in Rails. This helps in development by not having to wait a ~6ish seconds for rails to boot when i start the rails server.

I've limited Bootsnap to only load in development _only_ for now until we're comfortable using this in production some time in the future.