### PR TITLE
Add graphql-pro to blacklist (like sidekiq-pro)

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -92,5 +92,6 @@ module Patterns
     yaml
     ubygems
     sidekiq-pro
+    graphql-pro
   ].freeze
 end


### PR DESCRIPTION
Hi,

Thanks for your work on Rubygems.org! I've been trying to find a good solution for preventing naming conflicts with privately-distributed gems, and I'd like to take a page out of `sidekiq-pro`'s book, does this look OK?

I distribute a gem called `graphql-pro` from a private server, but I want to prevent naming conflicts for a few reasons:

- A malicious coder could put destructive code on Rubygems.org with the same name and attack users who forget the proper `source` in their Gemfile 
- I tried putting a dummy gem on Rubygems.org to prevent the naming ambiguity, but the problem is that `source` is not supported in `.gemspec` files. Some `graphql-pro` users want to add `graphql-pro` to internal gems, but it results in "Gem found in multiple sources" issues. So, blocking the namespace will support its use in `.gemspec` files. 

I see that `sidekiq-pro` was recently added without comment (7b363e19fbe901c59dc3ecc4e98a5a7a066795ee) so I hope this addition is OK too. I already control the (empty) graphql-pro gem, so reserving this namespace is no problem in that regard. 

Thanks again, and let me know if I can do something to improve this change!