### PR TITLE
Removed reserved gem name for Ruby 2.5

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -17,7 +17,6 @@ module Patterns
     continuation
     coverage
     delegate
-    digest
     drb
     e2mmap
     english
@@ -72,8 +71,6 @@ module Patterns
     shellwords
     singleton
     socket
-    stringio
-    strscan
     sync
     syslog
     tempfile

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -17,6 +17,7 @@ module Patterns
     continuation
     coverage
     delegate
+    digest
     drb
     e2mmap
     english


### PR DESCRIPTION
It's a final request for Ruby 2.5 releasing. ref. https://github.com/rubygems/rubygems.org/pull/1608

But `digest` name has already reserved. I requested to transfer it to me. Please wait a few days.

