### PR TITLE
add a docker-compose file to easily spin up the required services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,15 @@ gem server, please consider checking out
 provide pass-through caching for RubyGems.org, as well as host private
 gems for your organization..**
 
+#### Environment (Docker)
+There is a `docker-compose.yml` file inside the project that easily lets you spin up
+services that the application depends on such as: postgresql, memcached & elasticsearch.
+
+* Install Docker. See instructions at https://docs.docker.com/engine/installation/ 
+* run `docker-compose up` to start the required services.
+
+Follow the instructions below on how to install Bundler and setup the database.
+
 #### Environment (OS X)
 
 * Use Ruby 2.3.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  db:
+    image: postgres:9
+    ports:
+      - "5432:5432"
+  cache:
+    image: memcached
+    ports:
+      - "11211:11211"
+  search:
+    image: elasticsearch:5
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"


### PR DESCRIPTION
This PR adds a `docker-compose.yml` file to the project. This lets us easily spin up the services in development that the project depends on. Namely postgresql, elasticsearch and memcached.