### PR TITLE
display version number on rubygem webpage

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -90,13 +90,13 @@ a.page__heading {
     outline: none; }
 
 .page__subheading {
-  color: #a6aab2; }
+  color: #e9573f; }
   @media (max-width: 929px) {
     .page__subheading {
-      font-size: 18px; } }
+      font-size: 20px; } }
   @media (min-width: 930px) {
     .page__subheading {
-      font-size: 24px; } }
+      font-size: 30px; } }
 
 .page__heading__info {
   font-weight: 200;

--- a/app/assets/stylesheets/type.css
+++ b/app/assets/stylesheets/type.css
@@ -44,7 +44,7 @@ label.t-hidden {
   font-weight: 800;
   font-size: 12px;
   text-transform: uppercase;
-  color: #a6aab2; }
+  color: #e9573f; }
   .t-list__heading:not(:first-child) {
     margin-top: 25px; }
 


### PR DESCRIPTION
I fixed a display issue (#1699) raised by users concerning the version number not been visible. 
**The current state looks like this:**
https://imgur.com/CWGZ5OG
![cwgz5og](https://user-images.githubusercontent.com/28534124/35676683-fe70d17c-074c-11e8-9ccf-799818b1532c.png)

 **My proposed state looks like this:**
![screen shot 2018-01-26 at 4 14 21 pm](https://user-images.githubusercontent.com/28534124/35676660-e78a5096-074c-11e8-8e03-64b1efe7d5d7.png)
I believe this will look great from the UI/UX stand point.  @colby-swandale 