### PR TITLE
Enable HSTS in prod and set max age to 5 minutes

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,8 +39,8 @@ Rails.application.configure do
   # Force all access to the app over SSL and use secure cookies.
   config.force_ssl = true
 
-  # Set HSTS max-age to 2 years
-  config.ssl_options = { hsts: { expires: 730.days } }
+  # Set HSTS max-age to 5 minutes
+  config.ssl_options = { hsts: { expires: 5.minutes } }
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,9 @@ Rails.application.configure do
 
   # Force all access to the app over SSL and use secure cookies.
   config.force_ssl = true
-  config.ssl_options = { hsts: false }
+
+  # Set HSTS max-age to 2 years
+  config.ssl_options = { hsts: { expires: 730.days } }
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
This changes the current HSTS value of 0 (effectively disabled) in the production environment and ensures secure transport for users visiting rubygems.org using a browser.  We already 302 HTTP web content to HTTPS by default.  I believe we do allow HTTP API calls, but this shouldn't be respected by programmatic API clients such that it would prevent those HTTP transport clients from getting what they need (I would love a second opinion on that before this lands as not to negatively affect users who are using HTTP as a fallback means if they have a borked OpenSSL or something like that).

This follows recommendations from the Mozilla Web Security guidelines here:

https://infosec.mozilla.org/guidelines/web_security.html#http-strict-transport-security