### PR TITLE
Add documenation about confirmation email and fix broken badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,13 @@ Follow the instructions below on how to install Bundler and setup the database.
 * Start memcached: `memcached`
 * Run the tests: `bundle exec rake`
 
+#### Confirmation emails
+
+* Start rails: `rails s`
+* Sign up for a new user: http://localhost:3000/sign_up
+* Account confirmation email: http://localhost:3000/rails/mailers/mailer/email_confirmation
+  A list of all email previews is available at http://localhost:3000/rails/mailers.
+
 #### Running RuboCop
 
 We use RuboCop to enforce a consistent coding style throughout the project.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Ruby community's gem host.
 * [IRC][]: #rubygems on Freenode
 * [Travis][]: [![Build Status](https://img.shields.io/travis/rubygems/rubygems.org/master.svg)][travis]
 * [Gemnasium][]: [![Dependency Status](https://img.shields.io/gemnasium/rubygems/rubygems.org.svg)][gemnasium]
-* [Code Climate][]: [![Code Climate](https://img.shields.io/codeclimate/github/rubygems/rubygems.org.svg)][code climate]
+* [Code Climate][]: [![Maintainability](https://api.codeclimate.com/v1/badges/7110bb3f9b765042d604/maintainability)](https://codeclimate.com/github/rubygems/rubygems.org/maintainability)
 * [Trello Board][]
 
 [mailing list]: https://groups.google.com/group/rubygems-org


### PR DESCRIPTION
Changing codeclimate badge to what is said [here](https://codeclimate.com/github/rubygems/rubygems.org/badges#maintainability-markdown). One provided on https://shields.io/ for codeclimate is not working.
![Code Climate](https://img.shields.io/codeclimate/maintainability/rubygems/rubygems.org.svg)
