### PR TITLE
Grammar fix from @DillonHeins

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   failure_when_forbidden: Please double check the URL or try submitting it again.
   feed_latest: RubyGems.org | Latest Gems
   feed_subscribed: RubyGems.org | Subscribed Gems
-  footer_about: RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
+  footer_about: RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> to find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
   form_disable_with: Please wait...
   help_url: http://help.rubygems.org
   locale_name: English


### PR DESCRIPTION
Hi All,

Saw this in the mailing list [[ref]] and thought I'd post it:

>I believe the following line is a grammatical error:
"Use the API find out more about available gems."
I think it should rather read:
"Use the API to find out more about available gems."
> -- @DillonHeins

--K

[ref]: https://groups.google.com/forum/#!topic/rubygems-org/QAX-3FNhHvk