### PR TITLE
[WIP] push gem with the correct platform

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -7,17 +7,18 @@ class Indexer
     purge_cdn
     log "Finished updating the index"
   end
+
   statsd_count_success :perform, 'Indexer.perform'
   statsd_measure :perform, 'Indexer.perform'
 
   def write_gem(body, spec)
-    RubygemFs.instance.store("gems/#{spec.original_name}.gem", body.string)
+    RubygemFs.instance.store("gems/#{spec.full_name}.gem", body.string)
 
     spec.abbreviate
     spec.sanitize
 
     RubygemFs.instance.store(
-      "quick/Marshal.4.8/#{spec.original_name}.gemspec.rz",
+      "quick/Marshal.4.8/#{spec.full_name}.gemspec.rz",
       Gem.deflate(Marshal.dump(spec))
     )
   end


### PR DESCRIPTION
closes https://github.com/rubygems/rubygems.org/issues/1700

Ensure a gem is stored with the correct platform in its name

Still working on a test case for this...