### PR TITLE
Upgrade lograge dependency in preparation for Rails 5.1 upgrade.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,10 +162,11 @@ GEM
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    lograge (0.4.1)
-      actionpack (>= 4, < 5.1)
-      activesupport (>= 4, < 5.1)
-      railties (>= 4, < 5.1)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     logstash-event (1.2.02)
     loofah (2.2.2)
       crass (~> 1.0.2)
@@ -246,6 +247,8 @@ GEM
       msgpack (>= 0.4.3)
       trollop (>= 1.16.2)
     rdoc (5.1.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -371,4 +374,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
lograge 0.4 depends on Rails < 5.1.

Latest version of lograge (0.10) can be used with any version of Rails greater than 4.0 so this can be upgraded before of handling another changes required for Rails upgrade.