### PR TITLE
Associations should be defined before of being used in `:through`

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -2,10 +2,10 @@ class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
 
-  has_many :owners, through: :ownerships, source: :user
   has_many :ownerships, dependent: :destroy
-  has_many :subscribers, through: :subscriptions, source: :user
+  has_many :owners, through: :ownerships, source: :user
   has_many :subscriptions, dependent: :destroy
+  has_many :subscribers, through: :subscriptions, source: :user
   has_many :versions, dependent: :destroy, validate: false
   has_one :latest_version, -> { where(latest: true).order(:position) }, class_name: "Version"
   has_many :web_hooks, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,13 +15,14 @@ class User < ApplicationRecord
   ].freeze
 
   before_destroy :yank_gems
+
+  has_many :ownerships, dependent: :destroy
   has_many :rubygems, through: :ownerships
 
+  has_many :subscriptions, dependent: :destroy
   has_many :subscribed_gems, -> { order("name ASC") }, through: :subscriptions, source: :rubygem
 
   has_many :deletions
-  has_many :ownerships, dependent: :destroy
-  has_many :subscriptions, dependent: :destroy
   has_many :web_hooks, dependent: :destroy
 
   after_validation :set_unconfirmed_email, if: :email_changed?, on: :update


### PR DESCRIPTION
As part of Rails 5.1 upgrade, we should change some existing models.

In Active Record 5.1+ isn't possible to use an association in the `:through`
option before of defining it, e.g:

```ruby
has_many :rubygems, through: :ownerships
has_many :ownerships, dependent: :destroy
```

will raise an error because the `ownerships` association is being used
in the first association before of being defined, to fix it the order of
the associations need to be changed:

```ruby
has_many :ownerships, dependent: :destroy
has_many :rubygems, through: :ownerships
```