### PR TITLE
Update Support Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ The Ruby community's gem host.
 <a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a>
 <a href="https://rubycentral.org/"><img src="http://rubycentral.org/images/logo.png" width=200></a><br/>
 
-http://rubycentral.org/images/logo.png
+[RubyGems.org](https://rubygems.org) is managed by [Ruby Central](http://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](https://railsconf.org) and [RubyConf](https://rubyconf.org) through tickets and sponsorships.
 
-[RubyGems.org](RubyGems.org) is managed by [Ruby Central](http://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](railsconf.org) and [RubyConf](rubyconf.org) through tickets and sponsorships.
+Hosting fees are paid by Ruby Central and CDN fees are generously donated by [Fastly](https://fastly.com).
 
-[RubyTogether](rubytogether.org) sponsors individuals to work on development and operations work of RubyGems.org to augment the work of many volunteers. If you are interested in joining, you can do so as a [developer](https://rubytogether.org/developers) or as a [company](https://rubytogether.org/companies). The availability of RubyGems.org is not dependent on these paid contributors and is the sole responsibility of Ruby Central.
+Additionally, [RubyTogether](https://rubytogether.org) sponsors individuals to work on development and operations work for RubyGems.org which augments volunteer efforts from the Ruby community. 
 
-Hosting fees are paid by Ruby Central and CDN fees are generously donated by [Fastly](fastly.com).
+[Learn more about our sponsors and how they work together.](https://rubygems.org/pages/sponsors)
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@ The Ruby community's gem host.
 * Create more transparent and accessible project pages
 * Enable the community to improve and enhance the site
 
-## Supporting
+## Support
 
-<a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a><br/>
-  RubyGems.org is maintained by <a href="https://rubytogether.org/">Ruby Together</a>, a grassroots initiative committed to supporting the critical Ruby infrastructure you rely on. Contribute today <a href="https://rubytogether.org/developers">as an individual</a> or even better, <a href="https://rubytogether.org/companies">as a company</a>, and ensure that RubyGems.org, Bundler, and other shared tooling is around for years to come.
+<a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a>
+<a href="https://rubycentral.org/"><img src="http://rubycentral.org/images/logo.png" width=200></a><br/>
+
+
+http://rubycentral.org/images/logo.png
+
+> [RubyGems.org](RubyGems.org) is managed by [Ruby Central](http://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](railsconf.org) and [RubyConf](rubyconf.org) through tickets and sponsorships.
+>
+> [RubyTogether](rubytogether.org) sponsors individuals to work on development and operations work of RubyGems.org to augment the work of many volunteers. If you are interested in joining, you can do so as a [developer](https://rubytogether.org/developers) or as a [company](https://rubytogether.org/companies). The availability of RubyGems.org is not dependent on these paid contributors and is the sole responsibility of Ruby Central.
+>
+> Hosting fees are paid by Ruby Central and CDN fees are generously donated by [Fastly](fastly.com).
 
 ## Links
 


### PR DESCRIPTION
Reason for Change
=================
* As a result of some confusion about how RubyGems.org is supported, the folks at [Ruby Together](rubytogether.org) and @evanphx worked on some language we can use broadly to help clarify things.

Changes
=======
* Add the same paragraph from [our RT discussion](https://github.com/rubytogether/board/issues/5) here in this `README.md`.

Minor
-----
* Rename `Supporting` section heading to `Support` to move from a "how you could support this project" to "how it's currently being supported". Interested in feedback on this angle.
* Add the Ruby Central logo.