### PR TITLE
updates to rubygems.org footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -156,10 +156,11 @@
                 ) %>
               </p>
               <p>
-                RubyGems.org is made possible by
-                <%= link_to "many sponsors", page_path("sponsors") %>,
-                with development funded by the Ruby trade association,
-                <%= link_to "Ruby Together", "https://rubytogether.org/?source=rubygems" %>.
+                 RubyGems.org is made possible through a partnership with the greater Ruby community.
+                <%= link_to "Fastly" "https://www.fastly.com/") %> provides bandwidth and CDN support,
+                <%= link_to "Ruby Central" "http://www.rubycentral.org/") %> covers infrastructure costs, and
+                <%= link_to "Ruby Together" "https://rubytogether.org/?source=rubygems" %> funds ongoing development and ops work.
+                <%= link_to "Learn more about our sponsors and how they work together." page_path("sponsors") %>
               </p>
               <p>
                 We need your help to fund the developer time that keeps RubyGems.org running smoothly for everyone.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -157,10 +157,10 @@
               </p>
               <p>
                  RubyGems.org is made possible through a partnership with the greater Ruby community.
-                <%= link_to "Fastly" "https://www.fastly.com/") %> provides bandwidth and CDN support,
-                <%= link_to "Ruby Central" "http://www.rubycentral.org/") %> covers infrastructure costs, and
-                <%= link_to "Ruby Together" "https://rubytogether.org/?source=rubygems" %> funds ongoing development and ops work.
-                <%= link_to "Learn more about our sponsors and how they work together." page_path("sponsors") %>
+                <%= link_to "Fastly", "https://www.fastly.com/" %> provides bandwidth and CDN support,
+                <%= link_to "Ruby Central", "http://www.rubycentral.org/" %> covers infrastructure costs, and
+                <%= link_to "Ruby Together", "https://rubytogether.org/?source=rubygems" %> funds ongoing development and ops work.
+                <%= link_to "Learn more about our sponsors and how they work together", page_path("sponsors") %>.
               </p>
               <p>
                 We need your help to fund the developer time that keeps RubyGems.org running smoothly for everyone.


### PR DESCRIPTION
Hey team,

Per https://github.com/rubytogether/board/issues/5 (and as seen in https://github.com/rubygems/rubygems.org/pull/1721), here are some copy updates to the RubyGems.org footer. It details the partnership between Ruby Central, Fastly, and Ruby Together.