### PR TITLE
Allow editing of homepage link

### DIFF
--- a/app/views/rubygems/edit.html.erb
+++ b/app/views/rubygems/edit.html.erb
@@ -8,6 +8,10 @@
 <%= error_messages_for :linkset, :object_name => "gem" %>
 <%= form_for @rubygem.linkset, :url => rubygem_path(@rubygem), :method => :put do |form| %>
   <div class="url_field">
+    <%= form.label :home, :class => 'form__label' %>
+    <%= form.text_field :home, :class => 'form__input' %>
+  </div>
+  <div class="url_field">
     <%= form.label :code, :class => 'form__label' %>
     <%= form.text_field :code, :class => 'form__input' %>
   </div>


### PR DESCRIPTION
At the moment, the homepage link for a gem isn't editable. As far as I can tell there's no reason why this should be the case - `home` is included in the allowed linksets for a gem, so updating it in the normal way should work fine.

Will allow a proper fix of https://github.com/rails/sprockets/issues/557#issuecomment-398481683.