### PR TITLE
Update linkset only for latest version

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -215,7 +215,7 @@ class Rubygem < ApplicationRecord
       save!
       update_versions! version, spec
       update_dependencies! version, spec
-      update_linkset! spec
+      update_linkset! spec if version.reload.latest?
     end
   end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -771,6 +771,20 @@ class RubygemTest < ActiveSupport::TestCase
         assert Rubygem.exists?(name: 'rake')
       end
     end
+
+    context "from a Gem:Specification of older version" do
+      setup do
+        linkset  = create(:linkset, home: "http://latest.com")
+        @rubygem = create(:rubygem, name: "test", number: "1.0.0", linkset: linkset)
+        gemspec  = new_gemspec("test", "0.0.1", "test", "ruby") { |spec| spec.homepage = "http://test.com" }
+        version  = @rubygem.find_or_initialize_version_from_spec(gemspec)
+        @rubygem.update_attributes_from_gem_specification!(version, gemspec)
+      end
+
+      should "not update linkset" do
+        assert_equal "http://latest.com", @rubygem.linkset.home
+      end
+    end
   end
 
   context "downloads" do


### PR DESCRIPTION
This should have always been as such. It can be futher improved if we
update linkset only when `most_recent` version and updated version are
the same.
closes #1734