### PR TITLE
Exactly matching gem displays twice in search

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -147,7 +147,7 @@ a.page__heading {
       border-right-color: rgba(255, 255, 255, 0.1); } }
 
 .push {
-  margin-top: 60px; }
+  margin-top: 30px; }
 
 .push--bottom {
   margin-bottom: 60px; }

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -8,6 +8,7 @@ class SearchesController < ApplicationController
     @error_msg, @gems = Rubygem.search(params[:query], es: es_enabled?, page: @page)
     limit_total_entries if @gems.total_entries > MAX_PAGE * Rubygem.per_page
 
+    @all_gems =  @gems.reject { |gem| gem == @gems.first }
     @exact_match = Rubygem.name_is(params[:query]).with_versions.first
     redirect_to rubygem_path(@exact_match) if @exact_match && @gems.size == 1
   end

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -37,7 +37,7 @@
   <% end %>
 
   <% if @gems.present? %>
-    <%= render partial: 'rubygems/rubygem', collection: @gems %>
+    <%= render partial: 'rubygems/rubygem', collection: @all_gems %>
     <%= will_paginate @gems %>
   <% end %>
 <% end %>


### PR DESCRIPTION
I fixed the issue (#1709 ): Exactly matching gem is displayed twice in search.

**Previous State:**
![image](https://user-images.githubusercontent.com/29783644/42003522-cabf9c48-7a63-11e8-9625-4243f6395799.png)

**Current State:**
![image](https://user-images.githubusercontent.com/29783644/42003535-d41764c4-7a63-11e8-91fc-f877d8ebd184.png)

@m1kit @segiddins @sonalkr132 please can you review this PR. Thank you.