### PR TITLE
Fix deprecation for halt_callback_chains_on_return_false

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -81,12 +81,9 @@ class Dependency < ApplicationRecord
       throw :abort
     end
 
-    if gem_dependency.name.empty?
-      errors.add :rubygem, "Blank is not a valid dependency name"
-      return :abort
-    end
-
-    true
+    return unless gem_dependency.name.empty?
+    errors.add :rubygem, "Blank is not a valid dependency name"
+    throw :abort
   end
 
   def use_existing_rubygem

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -349,7 +349,6 @@ class Version < ApplicationRecord
 
   def update_prerelease
     self[:prerelease] = !!to_gem_version.prerelease? # rubocop:disable Style/DoubleNegation
-    true
   end
 
   def full_nameify!

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2
We don't need to explicitly return true, callback chain will be halted only on `throw :abort`.
Related: https://github.com/rubygems/rubygems.org/pull/1627/commits/289483285da16cea86dc7f30493e9d0d1f73af11