### PR TITLE
Don't set csp headers in development env

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  before_action :set_csp
+  before_action :set_csp unless Rails.env.development?
 
   def set_csp
     response.headers['Content-Security-Policy'] = "default-src 'self'; "\


### PR DESCRIPTION
In dev external resources are requested over http
Fixes:
![screenshot from 2018-06-30 16-43-20](https://user-images.githubusercontent.com/7680662/42124745-2356dfc8-7c86-11e8-82f6-fc22748a2227.png)
