### PR TITLE
Whitelist https://www.fastly-insights.com in csp header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   def set_csp
     response.headers['Content-Security-Policy'] = "default-src 'self'; "\
-      "script-src 'self' https://secure.gaug.es; "\
+      "script-src 'self' https://secure.gaug.es https://www.fastly-insights.com; "\
       "style-src 'self' https://fonts.googleapis.com; "\
       "img-src 'self' https://secure.gaug.es https://gravatar.com https://secure.gravatar.com; "\
       "font-src 'self' https://fonts.gstatic.com; "\


### PR DESCRIPTION
Fixes: Refused to load the script 'https://www.fastly-insights.com/insights.js?k=3e63c3cd-fc37-4b19-80b9-65ce64af060a' because it violates the following Content Security Policy directive: "script-src 'self' https://secure.gaug.es".
Related: #1744