### PR TITLE
 Add platform to v2 versions api

### DIFF
--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -4,7 +4,7 @@ class Api::V2::VersionsController < Api::BaseController
   def show
     return unless stale?(@rubygem)
 
-    version = @rubygem.public_version_payload(params[:number])
+    version = @rubygem.public_version_payload(params[:number], params[:platform])
     if version
       respond_to do |format|
         format.json { render json: version }

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -106,8 +106,13 @@ class Rubygem < ApplicationRecord
     versions.uniq.sort_by(&:position)
   end
 
-  def public_version_payload(number)
-    version = public_versions.find_by(number: number)
+  def public_version_payload(number, platform = nil)
+    version =
+      if platform
+        public_versions.find_by(number: number, platform: platform)
+      else
+        public_versions.find_by(number: number)
+      end
     payload(version).merge!(version.as_json) if version
   end
 

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -77,6 +77,26 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       get_show(@rubygem, '2.0.0')
       assert_response :not_found
     end
+
+    context "same version with mulitple platform" do
+      setup do
+        create(:version, rubygem: @rubygem, number: '2.0.0', platform: 'jruby')
+      end
+
+      should "return version by position without platform param" do
+        get_show(@rubygem, '2.0.0')
+        assert_response :success
+        response = JSON.load(@response.body)
+        assert_equal 'jruby', response["platform"]
+      end
+
+      should "return platform version with platform param" do
+        get :show, params: { rubygem_name: @rubygem.name, number: '2.0.0', platform: 'ruby', format: 'json' }
+        assert_response :success
+        response = JSON.load(@response.body)
+        assert_equal 'ruby', response["platform"]
+      end
+    end
   end
 
   context "on GET to show for an unknown gem" do
@@ -128,11 +148,6 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       get_show(@rubygem, '4.0.0')
       assert_kind_of Hash, JSON.load(@response.body)
       assert_equal "4.0.0", JSON.load(@response.body)["number"]
-    end
-
-    context "expected attributes by compact index" do
-      setup do
-      end
     end
   end
 


### PR DESCRIPTION
Release with multiple platform can have same version number.
without platform this endpoint shows version by position (sort by platform name)
ideally, it should use ruby platform as default but it won't be wise
to change it now.
This endpoint is not used in our clients. params can be passed as `/api/v2/rubygems/:rubygem_name/versions/:number(.:format)?platform=<platform>`
closes: #1692
api added in #980