### PR TITLE
fixes dashboard#show when using ?api_key and being logged out

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,6 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_with_api_key, unless: :signed_in?
-  before_action :redirect_to_root, unless: :signed_in?
+  before_action :redirect_to_root, unless: ->() { signed_in? || @api_user }
 
   def show
     respond_to do |format|
@@ -10,9 +10,15 @@ class DashboardsController < ApplicationController
         @subscribed_gems = current_user.subscribed_gems.with_versions
       end
       format.atom do
-        @versions = Version.subscribed_to_by(current_user).published(Gemcutter::DEFAULT_PAGINATION)
+        @versions = Version.subscribed_to_by(api_or_logged_in_user).published(Gemcutter::DEFAULT_PAGINATION)
         render 'versions/feed'
       end
     end
+  end
+
+  private
+
+  def api_or_logged_in_user
+    @api_user || current_user
   end
 end

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
 class DashboardsControllerTest < ActionController::TestCase
-
   context "When not logged in" do
     setup do
       user = create(:user)
-      @subscribed_version = create(:version, created_at: 1.hours.ago)
+      @subscribed_version = create(:version, created_at: 1.hour.ago)
       create(:subscription, rubygem: @subscribed_version.rubygem, user: user)
 
       get :show, params: { api_key: user.api_key }, format: "atom"

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -1,6 +1,25 @@
 require 'test_helper'
 
 class DashboardsControllerTest < ActionController::TestCase
+
+  context "When not logged in" do
+    setup do
+      user = create(:user)
+      @subscribed_version = create(:version, created_at: 1.hours.ago)
+      create(:subscription, rubygem: @subscribed_version.rubygem, user: user)
+
+      get :show, params: { api_key: user.api_key }, format: "atom"
+    end
+
+    context "On GET to show as an atom feed with a working api_key" do
+      should respond_with :success
+
+      should "render an XML feed with subscribed items" do
+        assert_select "entry > title", text: /#{@subscribed_version.rubygem.name}/
+      end
+    end
+  end
+
   context "When logged in" do
     setup do
       @user = create(:user)


### PR DESCRIPTION
Requesting /dashboard.atom?api_key=<key> currently results in being redirected to /
because the `redirect_to_root` before_action triggers.

I think this has been introduced with commit `11309ae7650a6cebac2acdfbbb0df47c857ef677`.

This commit fixes this behaviour by allowing the `@api_user` to be set or the current user to be logged in.

Thanks for your great work!

Frank