### PR TITLE
Whitelist img- and connect-src for fastly insights

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,9 +16,9 @@ class ApplicationController < ActionController::Base
     response.headers['Content-Security-Policy'] = "default-src 'self'; "\
       "script-src 'self' https://secure.gaug.es https://www.fastly-insights.com; "\
       "style-src 'self' https://fonts.googleapis.com; "\
-      "img-src 'self' https://secure.gaug.es https://gravatar.com https://secure.gravatar.com; "\
+      "img-src 'self' https://secure.gaug.es https://gravatar.com https://secure.gravatar.com https://*.fastly-insights.com; "\
       "font-src 'self' https://fonts.gstatic.com; "\
-      "connect-src https://s3-us-west-2.amazonaws.com/rubygems-dumps/; "\
+      "connect-src https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com; "\
       "frame-src https://ghbtns.com"
   end
 


### PR DESCRIPTION
The script only makes requests to the `fastly-insights.com` domain,
however we use DNS to route test requests to specific POPs such as
`iad.pops.fastly-insights.com`, therefore the policy needs to be a
wildcard *.fastly-insights.com. It then fetches small image objects to
different nearby POPS to get timing information and one fetch request
to get the resolver information.

With guidance from @phamann

See also #1746, #1744 