### PR TITLE
Expiry time for multifactor auth QR-code.

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -3,6 +3,7 @@ class MultifactorAuthsController < ApplicationController
   before_action :redirect_to_root, unless: :signed_in?
   before_action :require_mfa_disabled, only: %i[new create]
   before_action :require_mfa_enabled, only: :destroy
+  before_action :seed_and_expire, only: :create
   helper_method :issuer
 
   def new
@@ -14,24 +15,13 @@ class MultifactorAuthsController < ApplicationController
   end
 
   def create
-    seed = session[:mfa_seed]
-    expire = Time.at(session[:mfa_seed_expire] || 0).utc
-    %i[mfa_seed mfa_seed_expire].each do |key|
-      session.delete(key)
-    end
-
-    totp = ROTP::TOTP.new(seed, issuer: issuer)
-    if Time.now.utc > expire
-      flash[:error] = t('.qrcode_expired')
+    current_user.verify_and_enable_mfa!(@seed, :mfa_login_only, params[:otp], @expire)
+    if current_user.errors.any?
+      flash[:error] = current_user.errors[:base].join
       redirect_to edit_profile_url
-    elsif totp.verify(params[:otp])
-      current_user.enable_mfa!(seed, :mfa_login_only)
-      current_user.update!(last_otp_at: Time.current)
+    else
       flash[:success] = t('.success')
       render :recovery
-    else
-      flash[:error] = t('multifactor_auths.incorrect_otp')
-      redirect_to edit_profile_url
     end
   end
 
@@ -61,6 +51,14 @@ class MultifactorAuthsController < ApplicationController
     return if current_user.mfa_enabled?
     flash[:error] = t('multifactor_auths.require_mfa_enabled')
     redirect_to edit_profile_path
+  end
+
+  def seed_and_expire
+    @seed = session[:mfa_seed]
+    @expire = Time.at(session[:mfa_seed_expire] || 0).utc
+    %i[mfa_seed mfa_seed_expire].each do |key|
+      session.delete(key)
+    end
   end
 
   def check_feature_flag

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -8,7 +8,7 @@ class MultifactorAuthsController < ApplicationController
   def new
     @seed = ROTP::Base32.random_base32
     session[:mfa_seed] = @seed
-    session[:mfa_seed_expire] = (Time.now.utc + 30.minutes).to_i
+    session[:mfa_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
     text = ROTP::TOTP.new(@seed, issuer: issuer).provisioning_uri(current_user.email)
     @qrcode_svg = RQRCode::QRCode.new(text, level: :l).as_svg
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,4 +39,5 @@ module Gemcutter
   HOST = config['host']
   DEFAULT_PAGINATION = 20
   REMEMBER_FOR = 2.weeks
+  MFA_KEY_EXPIRY = 30.minutes
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -151,6 +151,7 @@ de:
       key:
       time_based:
     create:
+      qrcode_expired:
       success:
     recovery:
       continue:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
       key: "Key: %{key}"
       time_based: "Time based: Yes"
     create:
+      qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
       success: You have successfully enabled multifactor authentication.
     recovery:
       continue: Continue

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -151,6 +151,7 @@ es:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -151,6 +151,7 @@ fr:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -151,6 +151,7 @@ nl:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -151,6 +151,7 @@ pt-BR:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -151,6 +151,7 @@ zh-CN:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -151,6 +151,7 @@ zh-TW:
       key:
       time_based:
     create:
+      qrcode_expired:      
       success:
     recovery:
       continue:

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -105,7 +105,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         context 'when qr-code is expired' do
           setup do
-            @controller.session[:mfa_seed_expire] = 0
+            @controller.session[:mfa_seed_expire] = 1.minute.ago
             post :create, params: { otp: ROTP::TOTP.new(@seed).now }
           end
 

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -88,7 +88,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         context 'when qr-code is not expired' do
           setup do
-            @controller.session[:mfa_seed_expire] = (Time.now.utc + 30.minutes).to_i
+            @controller.session[:mfa_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
             post :create, params: { otp: ROTP::TOTP.new(@seed).now }
           end
 


### PR DESCRIPTION
Currently, the QR-code in multifactor auth enabling page is forever active unless it's deleted in enabling process or replaced by another request to the page. This PR will add expiry time to the QR-code, default is 30 minutes.

Implementation here is just storing the time in session. That seems simple but really helps when testing. We just fill different expiry time to session in testing so that we can test different cases when the code expires or not, without any need of time-mocking gems like 'timecop'.