### PR TITLE
Set "postgres" as the default username inside database.yml.example

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,6 +1,7 @@
 development: &DEVELOPMENT
   adapter: postgresql
   database: gemcutter_development
+  username: postgres
   host: localhost
   pool: 5
   timeout: 5000


### PR DESCRIPTION
Related to https://github.com/rubygems/rubygems.org/pull/1751 which I'll close.

Adds the default user "postgres" to the example database.yml file so that
the connection can be easily established when using the docker setup.