### PR TITLE
[FEATURE]: Enable a new versions endpoint which allows querying by creation time

### DIFF
--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
       render plain: 'timeframe parameters must be iso8601 formatted',
              status: :bad_request
     else
-      render_rubygems(version_timeframe_query)
+      render_rubygems(Version.created_between(from_time..to_time).paginate(page: @page))
     end
   end
 
@@ -23,13 +23,6 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
     @to_time ||= params[:to].blank? ? Time.zone.now : Time.iso8601(params[:to])
   rescue ArgumentError
     return
-  end
-
-  def version_timeframe_query
-    Version
-      .where(created_at: from_time..to_time)
-      .order(:created_at)
-      .paginate(page: @page)
   end
 
   def render_rubygems(versions)

--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -1,0 +1,45 @@
+class Api::V1::TimeframeVersionsController < Api::BaseController
+  skip_before_action :verify_authenticity_token
+  before_action :set_page, only: :index
+
+  def index
+    if from_time.nil? || to_time.nil?
+      render plain: 'timeframe parameters must be iso8601 formatted',
+             status: :bad_request
+    else
+      render_rubygems(version_timeframe_query)
+    end
+  end
+
+  private
+
+  def from_time
+    @parse_from_time ||= Time.iso8601(params.require(:from))
+  rescue ArgumentError
+    return
+  end
+
+  def to_time
+    @to_time ||= params[:to].blank? ? Time.now : Time.iso8601(params[:to])
+  rescue ArgumentError
+    return
+  end
+
+  def version_timeframe_query
+    Version
+      .where(created_at: from_time..to_time)
+      .order(:created_at)
+      .paginate(page: @page)
+  end
+
+  def render_rubygems(versions)
+    rubygems = versions.includes(:dependencies, rubygem: :linkset).map do |version|
+      version.rubygem.payload(version)
+    end
+
+    respond_to do |format|
+      format.json { render json: rubygems }
+      format.yaml { render yaml: rubygems }
+    end
+  end
+end

--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -2,27 +2,33 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
   skip_before_action :verify_authenticity_token
   before_action :set_page, only: :index
 
+  MAXIMUM_TIMEFRAME_QUERY_IN_DAYS = 7
+  class InvalidTimeframeParameterError < StandardError ; end
+
   def index
-    if from_time.nil? || to_time.nil?
-      render plain: 'timeframe parameters must be iso8601 formatted',
-             status: :bad_request
-    else
-      render_rubygems(Version.created_between(from_time..to_time).paginate(page: @page))
-    end
+    render_rubygems(Version.created_between(query_time_range).paginate(page: @page))
+  rescue InvalidTimeframeParameterError => ex
+    render plain: ex.message, status: :bad_request
   end
 
   private
 
-  def from_time
-    @parse_from_time ||= Time.iso8601(params.require(:from))
-  rescue ArgumentError
-    return
+  def query_time_range
+    parse_time_range_from_params.tap do |range|
+      if (range.max - range.min).to_i > MAXIMUM_TIMEFRAME_QUERY_IN_DAYS.days
+        raise InvalidTimeframeParameterError,
+              "the supplied query time range cannot exceed #{MAXIMUM_TIMEFRAME_QUERY_IN_DAYS} days"
+      end
+    end
   end
 
-  def to_time
-    @to_time ||= params[:to].blank? ? Time.zone.now : Time.iso8601(params[:to])
+  def parse_time_range_from_params
+    from = Time.iso8601(params.require(:from))
+    to = params[:to].blank? ? Time.zone.now : Time.iso8601(params[:to])
+
+    from..to
   rescue ArgumentError
-    return
+    raise InvalidTimeframeParameterError, "timeframe parameters must be iso8601 formatted"
   end
 
   def render_rubygems(versions)

--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
   end
 
   def to_time
-    @to_time ||= params[:to].blank? ? Time.now : Time.iso8601(params[:to])
+    @to_time ||= params[:to].blank? ? Time.zone.now : Time.iso8601(params[:to])
   rescue ArgumentError
     return
   end

--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
   before_action :set_page, only: :index
 
   MAXIMUM_TIMEFRAME_QUERY_IN_DAYS = 7
-  class InvalidTimeframeParameterError < StandardError ; end
+  class InvalidTimeframeParameterError < StandardError; end
 
   def index
     render_rubygems(Version.created_between(query_time_range).paginate(page: @page))
@@ -17,7 +17,7 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
     parse_time_range_from_params.tap do |range|
       if (range.max - range.min).to_i > MAXIMUM_TIMEFRAME_QUERY_IN_DAYS.days
         raise InvalidTimeframeParameterError,
-              "the supplied query time range cannot exceed #{MAXIMUM_TIMEFRAME_QUERY_IN_DAYS} days"
+          "the supplied query time range cannot exceed #{MAXIMUM_TIMEFRAME_QUERY_IN_DAYS} days"
       end
     end
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -167,10 +167,8 @@ class Version < ApplicationRecord
     find_by(full_name: full_name).try(:rubygem).try(:name)
   end
 
-  def self.created_between(range)
-    raise ArgumentError unless range.is_a?(Range)
-
-    where(created_at: range).order(:created_at)
+  def self.created_between(start_time, end_time)
+    where(created_at: start_time..end_time).order(:created_at)
   end
 
   def platformed?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -167,6 +167,12 @@ class Version < ApplicationRecord
     find_by(full_name: full_name).try(:rubygem).try(:name)
   end
 
+  def self.created_between(range)
+    raise ArgumentError unless range.is_a?(Range)
+
+    where(created_at: range).order(:created_at)
+  end
+
   def platformed?
     platform != "ruby"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
           post :fire
         end
       end
+      
+      resources :timeframe_versions, only: :index
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
           post :fire
         end
       end
-      
+
       resources :timeframe_versions, only: :index
     end
   end

--- a/test/functional/api/v1/timeframe_versions_controller_test.rb
+++ b/test/functional/api/v1/timeframe_versions_controller_test.rb
@@ -61,11 +61,21 @@ class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
       should 'return a bad request with message when the range exceeds the max allowed' do
         get :index, format: :json, params: {
           from: Time.zone.parse('2017-11-09').iso8601,
-          to: Time.zone.parse('2017-11-17').iso8601
+          to: Time.zone.parse('2017-11-30').iso8601
         }
 
         assert_equal 400, response.status
         assert response.body.include?('query time range cannot exceed')
+      end
+
+      should 'return a bad request with message if from is after to' do
+        get :index, format: :json, params: {
+          from: Time.zone.parse('2017-11-11').iso8601,
+          to: Time.zone.parse('2017-11-09').iso8601
+        }
+
+        assert_equal 400, response.status
+        assert response.body.include?('must be before the ending time parameter')
       end
     end
 

--- a/test/functional/api/v1/timeframe_versions_controller_test.rb
+++ b/test/functional/api/v1/timeframe_versions_controller_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
   setup do
     @rails = create(:rubygem, name: 'rails')
-    @rails_version_1 = create(:version, rubygem: @rails, created_at: Time.parse('2017-10-10'))
-    @rails_version_2 = create(:version, rubygem: @rails, created_at: Time.parse('2017-11-10'))
+    @rails_version1 = create(:version, rubygem: @rails, created_at: Time.zone.parse('2017-10-10'))
+    @rails_version2 = create(:version, rubygem: @rails, created_at: Time.zone.parse('2017-11-10'))
 
     @sinatra = create(:rubygem, name: 'sinatra')
-    @sinatra_version = create(:version, rubygem: @sinatra, created_at: Time.parse('2017-11-11'))
+    @sinatra_version = create(:version, rubygem: @sinatra, created_at: Time.zone.parse('2017-11-11'))
   end
 
   context 'GET to index' do
@@ -18,21 +18,21 @@ class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
           to: Time.parse('2017-11-12').iso8601
         }
 
-        gems = JSON.load @response.body
+        gems = JSON.parse @response.body
         assert_equal 2, gems.length
         assert_equal 'rails', gems[0]['name']
-        assert_equal @rails_version_2.number, gems[0]['version']
+        assert_equal @rails_version2.number, gems[0]['version']
         assert_equal 'sinatra', gems[1]['name']
       end
 
       should 'allow paging through results' do
         get :index, format: :json, params: {
-          from: Time.parse('2017-11-09').iso8601,
+          from: Time.zone.parse('2017-11-09').iso8601,
           to: Time.parse('2017-11-12').iso8601,
           page: 2
         }
 
-        gems = JSON.load @response.body
+        gems = JSON.parse @response.body
         assert_equal [], gems
       end
     end
@@ -40,7 +40,7 @@ class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
     context 'with invalid timeframe params' do
       should 'return a bad request with message when "to" is invalid' do
         get :index, format: :json, params: {
-          from: Time.parse('2017-11-09').iso8601,
+          from: Time.zone.parse('2017-11-09').iso8601,
           to: '2017-11-12'
         }
 
@@ -51,7 +51,7 @@ class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
       should 'return a bad request with message when "from" is invalid' do
         get :index, format: :json, params: {
           from: '2017-11-09',
-          to: Time.parse('2017-11-12').iso8601
+          to: Time.zone.parse('2017-11-12').iso8601
         }
 
         assert_equal 400, response.status
@@ -61,15 +61,15 @@ class Api::V1::TimeframeVersionsControllerTest < ActionController::TestCase
 
     context 'with missing params' do
       should 'return a bad request when "from" is missing' do
-        get :index, format: :json, params: { to: Time.parse('2017-11-12').iso8601 }
+        get :index, format: :json, params: { to: Time.zone.parse('2017-11-12').iso8601 }
 
         assert_equal 400, response.status
         assert response.body.include?('missing')
       end
 
       should 'default to the current time if "to" is missing' do
-        get :index, format: :json, params: { from: Time.parse('2017-9-9').iso8601 }
-        gems = JSON.load @response.body
+        get :index, format: :json, params: { from: Time.zone.parse('2017-9-9').iso8601 }
+        gems = JSON.parse @response.body
         assert_equal 3, gems.length
       end
     end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -783,31 +783,26 @@ class VersionTest < ActiveSupport::TestCase
   context "created_between" do
     setup do
       @version = create(:version)
-      @range = Time.zone.parse('2017-10-10')..Time.zone.parse('2017-11-10')
+      @start_time = Time.zone.parse('2017-10-10')
+      @end_time = Time.zone.parse('2017-11-10')
     end
 
     should "return versions created in the given range" do
       @version.created_at = Time.zone.parse('2017-10-20')
       @version.save!
-      assert_contains Version.created_between(@range), @version
+      assert_contains Version.created_between(@start_time, @end_time), @version
     end
 
     should "NOT return versions created before the range begins" do
       @version.created_at = Time.zone.parse('2017-10-09')
       @version.save!
-      assert_does_not_contain Version.created_between(@range), @version
+      assert_does_not_contain Version.created_between(@start_time, @end_time), @version
     end
 
     should "NOT return versions after the range begins" do
       @version.created_at = Time.zone.parse('2017-11-11')
       @version.save!
-      assert_does_not_contain Version.created_between(@range), @version
-    end
-
-    should "raise an ArgumentError if something other than a range is passed" do
-      assert_raises ArgumentError do
-        Version.created_between(Time.zone.now)
-      end
+      assert_does_not_contain Version.created_between(@start_time, @end_time), @version
     end
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -779,4 +779,35 @@ class VersionTest < ActiveSupport::TestCase
       assert_nil version.sha256_hex
     end
   end
+
+  context "created_between" do
+    setup do
+      @version = create(:version)
+      @range = Time.zone.parse('2017-10-10')..Time.zone.parse('2017-11-10')
+    end
+
+    should "return versions created in the given range" do
+      @version.created_at = Time.zone.parse('2017-10-20')
+      @version.save!
+      assert_contains Version.created_between(@range), @version
+    end
+
+    should "NOT return versions created before the range begins" do
+      @version.created_at = Time.zone.parse('2017-10-09')
+      @version.save!
+      assert_does_not_contain Version.created_between(@range), @version
+    end
+
+    should "NOT return versions after the range begins" do
+      @version.created_at = Time.zone.parse('2017-11-11')
+      @version.save!
+      assert_does_not_contain Version.created_between(@range), @version
+    end
+
+    should "raise an ArgumentError if something other than a range is passed" do
+      assert_raises ArgumentError do
+        Version.created_between(Time.zone.now)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In #1266 , the request was made to extend the `just_updated` activities endpoint. I have a similar use-case in that I'd like to keep a system up to date with new version information as it becomes available periodically. In my case, the update client needs to be tolerant of outages/downtime with the ability to catch back up from around the time of outage. I checked out the webhooks api as was suggested in #1266 for this purpose, and while very cool, I think there's a legitimate use-case for an endpoint that allows getting versions that were created within a given timeframe.

An endpoint like this allows the client to skip dealing with tokens/auth, running a service to consume inbound webhooks, and dealing with webhook failure/retry scenarios.

Happy to elaborate or clarify if needed, thanks for considering this! API docs updated in https://github.com/rubygems/guides/pull/217.