### PR TITLE
Remove check against otp code reuse

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,10 +205,9 @@ class User < ApplicationRecord
 
   def verify_digit_otp(seed, otp)
     totp = ROTP::TOTP.new(seed)
-    last_success = totp.verify_with_drift_and_prior(otp, 30, last_otp_at)
-    return false unless last_success
+    return false unless totp.verify_with_drift_and_prior(otp, 30)
 
-    self.last_otp_at = Time.at(last_success).utc.to_datetime
+    self.last_otp_at = Time.now.utc.to_datetime
     save!(validate: false)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,7 +172,6 @@ class User < ApplicationRecord
     no_mfa!
     self.mfa_seed = ''
     self.mfa_recovery_codes = []
-    self.last_otp_at = nil
     save!(validate: false)
   end
 
@@ -207,7 +206,6 @@ class User < ApplicationRecord
     totp = ROTP::TOTP.new(seed)
     return false unless totp.verify_with_drift_and_prior(otp, 30)
 
-    self.last_otp_at = Time.now.utc.to_datetime
     save!(validate: false)
   end
 

--- a/db/migrate/20181020173922_remove_users_last_otp_at.rb
+++ b/db/migrate/20181020173922_remove_users_last_otp_at.rb
@@ -1,0 +1,5 @@
+class RemoveUsersLastOtpAt < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :last_otp_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180525160703) do
+ActiveRecord::Schema.define(version: 20181020173922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,7 +140,6 @@ ActiveRecord::Schema.define(version: 20180525160703) do
     t.string   "mfa_seed"
     t.integer  "mfa_level",                             default: 0
     t.string   "mfa_recovery_codes",                    default: [],                 array: true
-    t.datetime "last_otp_at"
     t.index ["email"], name: "index_users_on_email", using: :btree
     t.index ["handle"], name: "index_users_on_handle", using: :btree
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token", using: :btree

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -277,12 +277,6 @@ class UserTest < ActiveSupport::TestCase
           next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
           assert @user.otp_verified?(next_otp)
         end
-
-        should "return false for second attempt for the same otp" do
-          otp = ROTP::TOTP.new(@user.mfa_seed).now
-          assert @user.otp_verified?(otp)
-          refute @user.otp_verified?(otp)
-        end
       end
 
       context "when disabled" do


### PR DESCRIPTION
# Why

In current implementation of multifactor authentication of RubyGems.org, there's a check of reuse of digit codes (OTP), see [homepage of rotp](https://github.com/mdp/rotp#preventing-reuse-of-time-based-otps). This may improve security, but in some occasions we may check digit codes more than once in an interval (30 seconds), so that will make authentication failed and break the workflow.

Also, many multifactor authentication providers do not check reuse of digital codes (GitHub, npm, etc.). We can temporarily disable it until finding a better solution.

# What

* No more send `last_otp_at` to `rotp`.
* A related unit test has been removed.