### PR TITLE
Blacklist derivative spellings of Rails deps

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -91,5 +91,29 @@ module Patterns
     ubygems
     sidekiq-pro
     graphql-pro
+
+    # Blacklisted internal Rails dependency misspellings
+    # which could be used for malicious purposes.
+    action-cable
+    action_cable
+    action-mailer
+    action_mailer
+    action-pack
+    action_pack
+    action-view
+    action_view
+    active-job
+    active_job
+    active-model
+    active_model
+    active-record
+    active_record
+    active-storage
+    active_storage
+    active-support
+    active_support
+    sprockets_rails
+    rail-ties
+    rail_ties
   ].freeze
 end


### PR DESCRIPTION
Related to https://github.com/rubysec/ruby-advisory-db/commit/b27b9586c46ca189780ffde7ea8dfaab9f6e125c

There's surely a smarter way to blacklist close Levenshtein matches of 
popular gems but this seems like a good manual first step to ensure no one 
can easily spoof misspellings of internal Rails gem names.