### PR TITLE
load-pg-dump should not dump/create database

### DIFF
--- a/script/load-pg-dump
+++ b/script/load-pg-dump
@@ -78,12 +78,6 @@ fi
 
 printf 'Loading "%s" into database "%s" as user "%s"\n', "$public_tar", "$pg_database", "$pg_user"
 
-echo "Droppping database $pg_database"
-dropdb -U $pg_user $pg_database
-
-echo "Creating database $pg_database"
-createdb -U $pg_user $pg_database
-
 echo "Adding hstore extension"
 psql -q -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
 


### PR DESCRIPTION
Newer database dumps only contain certain tables. Dumping/recreating the DB leaves you with a DB that you cannot use since it only contains part of the schema.