### PR TITLE
Change Elasticsearch initializer port setting

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,16 +1,15 @@
-if Rails.env.test? || Rails.env.development?
-  port = Toxiproxy.running? ? 22_221 : 9200
-  if Toxiproxy.running?
-    Toxiproxy.populate(
-      [
-        {
-          name: 'elasticsearch',
-          listen: "127.0.0.1:#{port}",
-          upstream: '127.0.0.1:9200'
-        }
-      ]
-    )
-  end
+port = 9200
+if (Rails.env.test? || Rails.env.development?) && Toxiproxy.running?
+  port = 22_221
+  Toxiproxy.populate(
+    [
+      {
+        name: 'elasticsearch',
+        listen: "127.0.0.1:#{port}",
+        upstream: '127.0.0.1:9200'
+      }
+    ]
+  )
 end
 
 url = ENV['ELASTICSEARCH_URL'] || "http://localhost:#{port}"


### PR DESCRIPTION
When profiling applications locally, I use the production Rails environment. Prior to this commit, I would have to set ELASTICSEARCH_URL. Now, it should Just Work.