### PR TITLE
Rubygems#show 2x faster for gems with many versions

### DIFF
--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, rubygem_versions_path(@rubygem, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
-  <% if @rubygem.versions.present? && @latest_version.indexed %>
+  <% if @rubygem.versions.any? && @latest_version.indexed %>
     <link rel="canonical" href="<%= rubygem_version_url(@rubygem, @latest_version.slug) %>" />
   <% else %>
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
This turns this query:

```SQL
SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1
```

...into this:

```SQL
SELECT  1 AS one FROM "versions" WHERE "versions"."rubygem_id" = $1 LIMIT $2
```

I noticed that most of the code in Rubygems#show tries very hard not to load all of the versions at once. This makes sense, since this page only actually displays 5 versions, here:

<img width="274" alt="screen shot 2018-08-23 at 10 05 12 am" src="https://user-images.githubusercontent.com/845662/44537440-0e5f7700-a6bc-11e8-904a-56baaee9e4f6.png">

However, calling `present?` on an association which has not been loaded will cause the entire association to load, because `present?` is defined on `Object` rather than anywhere on `ActiveRecord::Relation`. 

[`any?`, however, *is* defined on ActiveRecord::Relation.](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-any-3F). It ends up calling `!empty`, which is defined like:

```ruby
# File activerecord/lib/active_record/relation.rb, line 215
def empty?
  return @records.empty? if loaded?
  !exists?
end
```

And, crucially, `exists?` causes a `SELECT 1`, so we only check to see if *a* version record actually exists rather than loading the entire association.

**On my machine, the gem with the most versions (`cookbooks`) goes from a ~300ms load to ~150ms**. That gem has almost 1000 versions.  Gems with less than ~100 versions have too small an effect to really notice locally.

