### PR TITLE
Remove unnecessary dependencies count

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -243,14 +243,6 @@ class Version < ApplicationRecord
     gem_download.try(:count) || 0
   end
 
-  def runtime_dependencies_count
-    dependencies.runtime.length
-  end
-
-  def development_dependencies_count
-    dependencies.development.length
-  end
-
   def payload
     {
       'authors'                    => authors,

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -1,7 +1,7 @@
 <% if dependencies.present? && @latest_version.indexed %>
   <div class="l-half--l">
     <div class="dependencies" id="<%= dependencies.first.scope %>_dependencies">
-      <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies_count %>):</h3>
+      <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies.size %>):</h3>
       <div class="t-list__items">
         <% dependencies.each do |dependency| %>
           <% if rubygem = dependency.rubygem %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -39,8 +39,8 @@
       </div>
     <% end %>
 
-    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime, :dependencies_count => @latest_version.runtime_dependencies_count } %>
-    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development, :dependencies_count => @latest_version.development_dependencies_count } %>
+    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.runtime } %>
+    <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development } %>
 
     <% if @latest_version.requirements.present? %>
       <div class="l-half--l">

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -402,8 +402,8 @@ class RubygemsControllerTest < ActionController::TestCase
       assert page.has_content?(@development.rubygem.name)
     end
     should "show runtime and development dependencies count" do
-      assert page.has_content?(@version.runtime_dependencies_count)
-      assert page.has_content?(@version.development_dependencies_count)
+      assert page.has_content?(@version.dependencies.runtime.count)
+      assert page.has_content?(@version.dependencies.development.count)
     end
   end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -288,14 +288,6 @@ class VersionTest < ActiveSupport::TestCase
       assert @version.downloads_count.zero?
     end
 
-    should "have runtime dependencies count" do
-      assert_equal @version.runtime_dependencies_count, Version.find_by(rubygem: @version.rubygem).dependencies.runtime.count
-    end
-
-    should "have development dependencies count" do
-      assert_equal @version.development_dependencies_count, Version.find_by(rubygem: @version.rubygem).dependencies.development.count
-    end
-
     should "give no version flag for the latest version" do
       new_version = create(:version, rubygem: @version.rubygem, built_at: 1.day.from_now)
 


### PR DESCRIPTION
A count of dependencies was being passed into the dependencies partial. This is unnecessary because the method call directly preceding that loads the entire association into memory. 

This also eliminates an AR::Cache entry. Before:

```
D, [2018-08-23T10:14:24.917833 #44687] DEBUG -- :   SQL (1.7ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "runtime"]]
D, [2018-08-23T10:14:24.919967 #44687] DEBUG -- :   CACHE SQL (0.0ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "runtime"]]
I, [2018-08-23T10:14:24.920683 #44687]  INFO -- :   Rendered rubygems/_dependencies.html.erb (2.3ms)
D, [2018-08-23T10:14:24.923711 #44687] DEBUG -- :   SQL (1.6ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "development"]]
D, [2018-08-23T10:14:24.925590 #44687] DEBUG -- :   CACHE SQL (0.0ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "development"]]
I, [2018-08-23T10:14:24.927623 #44687]  INFO -- :   Rendered rubygems/_dependencies.html.erb (2.9ms)
```

After:

```
D, [2018-08-23T10:31:33.559006 #45062] DEBUG -- :   SQL (1.7ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "runtime"]]
I, [2018-08-23T10:31:33.559488 #45062]  INFO -- :   Rendered rubygems/_dependencies.html.erb (2.3ms)
D, [2018-08-23T10:31:33.564816 #45062] DEBUG -- :   SQL (1.6ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."slug" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = $1 AND "dependencies"."scope" = $2 ORDER BY rubygems.name ASC  [["version_id", 630401], ["scope", "development"]]
I, [2018-08-23T10:31:33.566697 #45062]  INFO -- :   Rendered rubygems/_dependencies.html.erb (2.8ms)
```

Also eliminated the now-unused method + tests.