### PR TITLE
Remove unnecessary COUNT on Versions#show

### DIFF
--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -1,5 +1,5 @@
 <% @title = t('.title', :name => @rubygem.name) %>
-<% if @versions.size.zero? %>
+<% if @versions.load.size.zero? %>
   <div class="t-body">
     <p><%= t('.not_hosted_notice') %></p>
   </div>


### PR DESCRIPTION
Loading the association before `size` is called means that a `COUNT` is not run.

`@versions` is loaded anyway on line 10, so may as well load it early to avoid the `COUNT`.

Before:

```
D, [2018-08-23T15:52:51.325389 #52485] DEBUG -- :   Rubygem Load (1.2ms)  SELECT  "rubygems".* FROM "rubygems" WHERE "rubygems"."name" = $1 LIMIT $2  [["name", "rspec"], ["LIMIT", 1]]
I, [2018-08-23T15:52:51.326870 #52485]  INFO -- :   Rendering versions/index.html.erb within layouts/application
D, [2018-08-23T15:52:51.329150 #52485] DEBUG -- :    (1.4ms)  SELECT COUNT(*) FROM "versions" WHERE "versions"."rubygem_id" = $1  [["rubygem_id", 15076]]
D, [2018-08-23T15:52:51.329828 #52485] DEBUG -- :   CACHE  (0.0ms)  SELECT COUNT(*) FROM "versions" WHERE "versions"."rubygem_id" = $1  [["rubygem_id", 15076]]
D, [2018-08-23T15:52:51.332457 #52485] DEBUG -- :   Version Load (1.7ms)  SELECT  "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."built_at" ASC LIMIT $2  [["rubygem_id", 15076], ["LIMIT", 1]]
D, [2018-08-23T15:52:51.335688 #52485] DEBUG -- :   Version Load (2.3ms)  SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."position" ASC  [["rubygem_id", 15076]]
```

After:

```
D, [2018-08-23T15:55:49.254371 #52555] DEBUG -- :   Rubygem Load (0.9ms)  SELECT  "rubygems".* FROM "rubygems" WHERE "rubygems"."name" = $1 LIMIT $2  [["name", "rspec"], ["LIMIT", 1]]
I, [2018-08-23T15:55:49.255887 #52555]  INFO -- :   Rendering versions/index.html.erb within layouts/application
D, [2018-08-23T15:55:49.260245 #52555] DEBUG -- :   Version Load (3.5ms)  SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."position" ASC  [["rubygem_id", 15076]]
D, [2018-08-23T15:55:49.269156 #52555] DEBUG -- :   Version Load (1.4ms)  SELECT  "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."built_at" ASC LIMIT $2  [["rubygem_id", 15076], ["LIMIT", 1]]
```