### PR TITLE
Sort versions first built in memory, not in the DB.

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -260,10 +260,6 @@ class Rubygem < ApplicationRecord
     version
   end
 
-  def first_built_date
-    versions.by_earliest_built_at.limit(1).last.built_at
-  end
-
   # returns days left before the reserved namespace will be released
   # 100 + 1 days are added so that last_protected_day / 1.day = 1
   def protected_days

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -4,7 +4,7 @@
     <p><%= t('.not_hosted_notice') %></p>
   </div>
 <% else %>
-  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@rubygem.first_built_date)) %>:</h3>
+  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@versions.sort_by(&:built_at).first.built_at)) %>:</h3>
   <div class="versions">
     <ul class="t-list__items">
       <%= render @versions %>

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -118,17 +118,6 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.versions.most_recent
     end
 
-    should "can find when the first built date was" do
-      travel_to Time.zone.now do
-        create(:version, rubygem: @rubygem, number: "3.0.0", built_at: 1.day.ago)
-        create(:version, rubygem: @rubygem, number: "2.0.0", built_at: 2.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0", built_at: 3.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0.beta", built_at: 4.days.ago)
-
-        assert_equal 4.days.ago.to_date, @rubygem.first_built_date.to_date
-      end
-    end
-
     should "have a most_recent version if only a platform version exists" do
       version1 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "linux")
 


### PR DESCRIPTION
This improves Versions#show by almost 2x for me on Rubygems which have 500+ versions.

For reasons beyond my database-fu, this query is very slow:

```
D, [2018-08-23T16:05:05.701808 #52751] DEBUG -- :   Version Load (1119.3ms)  SELECT  "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."built_at" ASC LIMIT $2  [["rubygem_id", 77133], ["LIMIT", 1]]
```

This particular rubygem, `cookbooks`, has over 1000 versions. But just loading every version is 10x faster:

```
D, [2018-08-23T16:05:04.540701 #52751] DEBUG -- :   Version Load (101.5ms)  SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = $1 ORDER BY "versions"."position" ASC  [["rubygem_id", 77133]]
```

Maybe someone with more database-fu than I can figure out how to do this in the database faster. But sorting 1000 records isn't really all that slow in Ruby either, and all of them are loaded anyway.