### PR TITLE
Removed default-gems from blacklist for releasing Ruby 2.6.

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -70,6 +70,7 @@ module Patterns
     time
     timeout
     tmpdir
+    tracer
     tsort
     un
     unicode_normalize

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -48,6 +48,7 @@ module Patterns
     pathname
     pp
     prettyprint
+    prime
     profile
     profiler
     pstore

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -30,7 +30,6 @@ module Patterns
     io-nonblock
     io-wait
     jruby
-    logger
     mkmf
     monitor
     mri

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -47,6 +47,7 @@ module Patterns
     open3
     optparse
     pathname
+    pp
     prettyprint
     profile
     profiler
@@ -55,6 +56,7 @@ module Patterns
     rational
     rbconfig
     resolv
+    resolv-replace
     rinda
     ruby
     rubygems

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -19,27 +19,22 @@ module Patterns
     delegate
     digest
     drb
-    e2mmap
     english
     enumerator
     erb
     expect
     fiber
     find
-    forwardable
     getoptlong
     install
     io-nonblock
     io-wait
-    irb
     jruby
     logger
-    matrix
     mkmf
     monitor
     mri
     mruby
-    mutex_m
     net-ftp
     net-http
     net-imap
@@ -51,10 +46,8 @@ module Patterns
     open-uri
     open3
     optparse
-    ostruct
     pathname
     prettyprint
-    prime
     profile
     profiler
     pstore
@@ -62,9 +55,7 @@ module Patterns
     rational
     rbconfig
     resolv
-    rexml
     rinda
-    rss
     ruby
     rubygems
     securerandom
@@ -72,11 +63,9 @@ module Patterns
     shellwords
     singleton
     socket
-    sync
     syslog
     tempfile
     thread
-    thwait
     time
     timeout
     tmpdir


### PR DESCRIPTION
This pull-request is work-in-progress because I need to contact owners of registered gems like shell, matrix and others.

### not yet registered gems

* thwait
* rss
* rexml
* ostruct
* mutex_m
* irb
* forwardable
* e2mmap

### registered gems

* [x] sync
* [ ] prime
* [x] matrix
* [x] shell
* [ ] tracer
* [ ] digest