### PR TITLE
Simplify and speed up rack-attack integration tests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,7 @@
 class Rack::Attack
+  REQUEST_LIMIT = 100
+  LIMIT_PERIOD = 10.minutes
+
   ### Prevent Brute-Force Login Attacks ###
 
   # The most common brute-force login attack is a brute-force password
@@ -18,17 +21,17 @@ class Rack::Attack
   ]
   paths_regex = Regexp.union(protected_paths.map { |path| /\A#{Regexp.escape(path)}\z/ })
 
-  throttle('clearance/ip', limit: 100, period: 10.minutes) do |req|
+  throttle('clearance/ip', limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
     req.ip if req.path =~ paths_regex && req.post?
   end
 
   # Throttle GET request for api_key by IP address
-  throttle('api_key/ip', limit: 100, period: 10.minutes) do |req|
+  throttle('api_key/ip', limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
     req.ip if req.path =~ /\A#{Regexp.escape('/api/v1/api_key')}/ && req.get?
   end
 
   # Throttle PATCH and DELETE profile requests
-  throttle("clearance/remember_token", limit: 100, period: 10.minutes) do |req|
+  throttle("clearance/remember_token", limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
     req.ip if req.path == "/profile" && (req.patch? || req.delete?)
   end
 
@@ -40,7 +43,7 @@ class Rack::Attack
   # throttle logins for another user and force their login requests to be
   # denied, but that's not very common and shouldn't happen to you. (Knock
   # on wood!)
-  throttle("logins/handler", limit: 100, period: 10.minutes) do |req|
+  throttle("logins/handler", limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
     if req.path == "/session" && req.post?
       # return the handler if present, nil otherwise
       req.params['session']['who'].presence if req.params['session']

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,107 +1,158 @@
 require 'test_helper'
 
-## SLOW TESTS ##
 class RackAttackTest < ActionDispatch::IntegrationTest
   setup do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+
+    @ip_address = "1.2.3.4"
     @user = create(:user, email: "nick@example.com", password: "secret12345")
-    @limit = 100
+  end
+
+  def exceeding_limit
+    (Rack::Attack::REQUEST_LIMIT * 1.25).to_i
+  end
+
+  def under_limit
+    (Rack::Attack::REQUEST_LIMIT * 0.5).to_i
+  end
+
+  def limit_period
+    Rack::Attack::LIMIT_PERIOD
+  end
+
+  def exceed_limit_for(scope)
+    exceeding_limit.times do
+      Rack::Attack.cache.count("#{scope}:#{@ip_address}", limit_period)
+    end
+  end
+
+  def stay_under_limit_for(scope)
+    under_limit.times do
+      Rack::Attack.cache.count("#{scope}:#{@ip_address}", limit_period)
+    end
   end
 
   def encode(username, password)
-    ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+    ActionController::HttpAuthentication::Basic
+      .encode_credentials(username, password)
   end
 
   context 'requests is lower than limit' do
     should 'allow sign in' do
-      10.times do
-        post '/session', params: { session: { who: @user.email, password: @user.password } }
-        follow_redirect!
-        assert_equal 200, @response.status
-      end
+      stay_under_limit_for("clearance/ip")
+
+      post '/session',
+        params: { session: { who: @user.email, password: @user.password } }
+      follow_redirect!
+
+      assert_response :success
     end
 
     should 'allow sign up' do
-      10.times do
-        user = build(:user)
-        post '/users', params: { user: { email: user.email, password: user.password } }
-        follow_redirect!
-        assert_equal 200, @response.status
-      end
+      stay_under_limit_for("clearance/ip")
+
+      user = build(:user)
+      post '/users',
+        params: { user: { email: user.email, password: user.password } }
+      follow_redirect!
+
+      assert_response :success
     end
 
     should 'allow forgot password' do
-      10.times do
-        post '/passwords', params: { password: { email: @user.email } }
-        assert_equal 200, @response.status
-      end
+      stay_under_limit_for("clearance/ip")
+
+      post '/passwords',
+        params: { password: { email: @user.email } }
+
+      assert_response :success
     end
 
     should 'allow api_key show' do
-      10.times do
-        get '/api/v1/api_key.json', env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
-        assert_equal 200, @response.status
-      end
+      stay_under_limit_for("api_key/ip")
+
+      get '/api/v1/api_key.json',
+        env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
+
+      assert_response :success
     end
 
     context 'params' do
       should 'return 400 for bad request' do
         post '/session'
-        assert_equal 400, @response.status
+
+        assert_response :bad_request
       end
 
       should 'return 401 for unauthorized request' do
         post '/session', params: { session: { password: @user.password } }
-        assert_equal 401, @response.status
+
+        assert_response :unauthorized
       end
     end
   end
 
   context 'requests is higher than limit' do
     should 'throttle sign in' do
-      (@limit + 1).times do |i|
-        post '/session', params: { session: { who: @user.email, password: @user.password } }
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("clearance/ip")
+
+      post '/session',
+        params: { session: { who: @user.email, password: @user.password } },
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
 
     should 'throttle sign up' do
-      (@limit + 1).times do |i|
-        user = build(:user)
-        post '/users', params: { user: { email: user.email, password: user.password } }
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("clearance/ip")
+
+      user = build(:user)
+      post '/users',
+        params: { user: { email: user.email, password: user.password } },
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
 
     should 'throttle forgot password' do
-      (@limit + 1).times do |i|
-        post '/passwords', params: { password: { email: @user.email } }
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("clearance/ip")
+
+      post '/passwords',
+        params: { password: { email: @user.email } },
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
 
     should 'throttle api_key show' do
-      (@limit + 1).times do |i|
-        get '/api/v1/api_key.json', env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("api_key/ip")
+
+      get '/api/v1/api_key.json',
+        env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) },
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
 
     should "throttle profile update" do
       cookies[:remember_token] = @user.remember_token
 
-      (@limit + 1).times do |i|
-        patch "/profile"
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("clearance/remember_token")
+      patch "/profile",
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
 
     should "throttle profile delete" do
       cookies[:remember_token] = @user.remember_token
 
-      (@limit + 1).times do |i|
-        delete "/profile"
-        assert_equal 429, @response.status if i == @limit
-      end
+      exceed_limit_for("clearance/remember_token")
+      delete "/profile",
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
     end
   end
 end


### PR DESCRIPTION
Instead of running hundreds of requests here, we can put the cache in a
condition where rack-attack will believe that the requests have happened and
then block the subsequent request made in the test.

This should reduce intermittent failures, and also speed up the test.

For me locally, this reduced the `rack_attack` test about ~10x (from ~6s to ~0.6s) when run by itself.

Resolves https://github.com/rubygems/rubygems.org/issues/1713