### PR TITLE
Add index to web_hooks(user_id, rubygem_id)

### DIFF
--- a/db/migrate/20181022172318_add_index_to_web_hooks.rb
+++ b/db/migrate/20181022172318_add_index_to_web_hooks.rb
@@ -1,0 +1,5 @@
+class AddIndexToWebHooks < ActiveRecord::Migration[5.2]
+  def change
+    add_index :web_hooks, [:user_id, :rubygem_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_20_173922) do
+ActiveRecord::Schema.define(version: 2018_10_22_172318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -191,6 +191,7 @@ ActiveRecord::Schema.define(version: 2018_10_20_173922) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "rubygem_id"
+    t.index ["user_id", "rubygem_id"], name: "index_web_hooks_on_user_id_and_rubygem_id"
   end
 
 end


### PR DESCRIPTION
This index will speed up a few queries in the web hooks API. Without knowning
how many total rows there are in the web_hooks table, it's hard to know what the
magnitude of improvement here will be.