### PR TITLE
Update mime-types to version 3.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-# https://github.com/mime-types/ruby-mime-types/issues/94
-# This can be removed once all gems depend on > 3.0
-gem 'mime-types', '~> 2.99', require: 'mime/types/columnar'
-
 gem 'rails', '~> 5.2.1'
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,9 @@ GEM
     memoist (0.16.0)
     metaclass (0.0.4)
     method_source (0.9.0)
-    mime-types (2.99.3)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
@@ -429,7 +431,6 @@ DEPENDENCIES
   lograge
   logstash-event
   mail (= 2.6.6)
-  mime-types (~> 2.99)
   minitest
   mocha
   newrelic_rpm


### PR DESCRIPTION
This gem was previously locked to `~> 2.99` while waiting for gems which depend
on it to be able to support the newer version.

At this point the gems being used which rely on mime-types (mail and
rest-client) both support 3.x versions, so we can upgrade mime-types.