### PR TITLE
Fix Rubocop todo for Style/GuardClause rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,14 +103,6 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'lib/rubygem_fs.rb'
 
-# Offense count: 5
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'app/controllers/api/v1/rubygems_controller.rb'
-    - 'app/helpers/searches_helper.rb'
-    - 'app/jobs/indexer.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedOctalStyle, SupportedOctalStyles.

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -67,11 +67,10 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def cors_preflight_check
-    if request.method == 'OPTIONS'
-      cors_set_access_control_headers
-      headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version'
+    return unless request.method == 'OPTIONS'
 
-      render plain: ''
-    end
+    cors_set_access_control_headers
+    headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version'
+    render plain: ''
   end
 end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -11,27 +11,27 @@ module SearchesHelper
 
   def aggregation_match_count(aggregration, field)
     count = aggregration['buckets'][field]['doc_count']
-    if count > 0
-      path = search_path(params: { query: "#{field}:#{params[:query]}" })
-      link_to "#{field.capitalize} (#{count})", path, class: 't-link--black'
-    end
+    return unless count > 0
+
+    path = search_path(params: { query: "#{field}:#{params[:query]}" })
+    link_to "#{field.capitalize} (#{count})", path, class: 't-link--black'
   end
 
   def aggregation_week_count(aggregration)
     count = aggregration['buckets'][1]['doc_count']
-    if count > 0
-      week_ago = (Time.zone.today - 7.days).to_s(:db)
-      path = search_path(params: { query: "#{params[:query]} AND updated:[#{week_ago} TO *}" })
-      link_to "Updated last week (#{count})", path, class: 't-link--black'
-    end
+    return unless count > 0
+
+    week_ago = (Time.zone.today - 7.days).to_s(:db)
+    path = search_path(params: { query: "#{params[:query]} AND updated:[#{week_ago} TO *}" })
+    link_to "Updated last week (#{count})", path, class: 't-link--black'
   end
 
   def aggregation_month_count(aggregration)
     count = aggregration['buckets'][0]['doc_count']
-    if count > 0
-      month_ago = (Time.zone.today - 30.days).to_s(:db)
-      path = search_path(params: { query: "#{params[:query]} AND updated:[#{month_ago} TO *}" })
-      link_to "Updated last month (#{count})", path, class: 't-link--black'
-    end
+    return unless count > 0
+
+    month_ago = (Time.zone.today - 30.days).to_s(:db)
+    path = search_path(params: { query: "#{params[:query]} AND updated:[#{month_ago} TO *}" })
+    link_to "Updated last month (#{count})", path, class: 't-link--black'
   end
 end

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -47,10 +47,10 @@ class Indexer
   end
 
   def purge_cdn
-    if ENV['FASTLY_SERVICE_ID'] && ENV['FASTLY_API_KEY']
-      Fastly.purge_key('full-index')
-      log 'Purged index urls from fastly'
-    end
+    return unless ENV['FASTLY_SERVICE_ID'] && ENV['FASTLY_API_KEY']
+
+    Fastly.purge_key('full-index')
+    log 'Purged index urls from fastly'
   end
 
   def minimize_specs(data)


### PR DESCRIPTION
In `rubocop_todo.yml` there is a disabled rule for Style/GuardClause:
```
  Exclude:
    - 'app/controllers/api/v1/rubygems_controller.rb'
    - 'app/helpers/searches_helper.rb'
    - 'app/jobs/indexer.rb'
```
It is a relatively easy fix which should not cause any new bugs