### PR TITLE
Restrict special chars from prefixing new gem names

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -299,7 +299,7 @@ class Rubygem < ApplicationRecord
       errors.add :name, "must include at least one letter"
     elsif name !~ NAME_PATTERN
       errors.add :name, "can only include letters, numbers, dashes, and underscores"
-    elsif name =~ /^[#{Regexp.escape(Patterns::SPECIAL_CHARACTERS)}]+/
+    elsif name =~ /\A[#{Regexp.escape(Patterns::SPECIAL_CHARACTERS)}]+/
       errors.add :name, "can not begin with a period, dash, or underscore"
     end
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -299,6 +299,8 @@ class Rubygem < ApplicationRecord
       errors.add :name, "must include at least one letter"
     elsif name !~ NAME_PATTERN
       errors.add :name, "can only include letters, numbers, dashes, and underscores"
+    elsif name =~ /^[#{Regexp.escape(Patterns::SPECIAL_CHARACTERS)}]+/
+      errors.add :name, "can not begin with a period, dash, or underscore"
     end
   end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -23,6 +23,9 @@ class RubygemTest < ActiveSupport::TestCase
     should_not allow_value("\342\230\203").for(:name)
     should_not allow_value("2.2").for(:name)
     should_not allow_value("Ruby").for(:name)
+    should_not allow_value(".omghi").for(:name)
+    should_not allow_value("-omghi").for(:name)
+    should_not allow_value("_omghi").for(:name)
 
     context "that has an invalid name already persisted" do
       setup do


### PR DESCRIPTION
There is an interesting problem when creating and publishing a gem that
is prefixed with a period (`.`), creating a sort of "hidden gem" that
you can create, publish, and install, but can't uninstall. Reported by
@JoshCheek in rubygems/rubygems#2430

This is a quick patch for Rubygems.org; there may be deeper issues.