### PR TITLE
Update nokogiri to version 1.8.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (5.4.0.347)
     nio4r (2.3.1)
-    nokogiri (1.8.3)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     optimist (3.0.0)
     parallel (1.12.1)


### PR DESCRIPTION
Resolves CVE described here: https://github.com/sparklemotion/nokogiri/issues/1785