### PR TITLE
Add webhook for yanked versions

### DIFF
--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::DeletionsController < Api::BaseController
     @deletion = @api_user.deletions.build(version: @version)
     if @deletion.save
       StatsD.increment 'yank.success'
-      enqueue_web_hook_jobs
+      enqueue_web_hook_jobs(@version)
       render plain: "Successfully deleted gem: #{@version.to_title}"
     else
       StatsD.increment 'yank.failure'
@@ -46,18 +46,6 @@ class Api::V1::DeletionsController < Api::BaseController
         render plain: "The version #{params[:version]} does not exist.",
                status: :not_found
       end
-    end
-  end
-
-  def enqueue_web_hook_jobs
-    jobs = @version.rubygem.web_hooks + WebHook.global
-    jobs.each do |job|
-      job.fire(
-        request.protocol.delete("://"),
-        request.host_with_port,
-        @version.rubygem,
-        @version
-      )
     end
   end
 end

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::DeletionsController < Api::BaseController
     @deletion = @api_user.deletions.build(version: @version)
     if @deletion.save
       StatsD.increment 'yank.success'
+      enqueue_web_hook_jobs
       render plain: "Successfully deleted gem: #{@version.to_title}"
     else
       StatsD.increment 'yank.failure'
@@ -45,6 +46,18 @@ class Api::V1::DeletionsController < Api::BaseController
         render plain: "The version #{params[:version]} does not exist.",
                status: :not_found
       end
+    end
+  end
+
+  def enqueue_web_hook_jobs
+    jobs = @version.rubygem.web_hooks + WebHook.global
+    jobs.each do |job|
+      job.fire(
+        request.protocol.delete("://"),
+        request.host_with_port,
+        @version.rubygem,
+        @version
+      )
     end
   end
 end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -36,6 +36,7 @@ class Api::V1::RubygemsController < Api::BaseController
       request.host_with_port
     )
     gemcutter.process
+    enqueue_web_hook_jobs(gemcutter.version) if gemcutter.version
     render plain: gemcutter.message, status: gemcutter.code
   rescue => e
     Honeybadger.notify(e)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,4 +141,16 @@ class ApplicationController < ActionController::Base
   def reject_null_char_param
     render plain: "bad request", status: :bad_request if params.to_s.include?("\\u0000")
   end
+
+  def enqueue_web_hook_jobs(version)
+    jobs = version.rubygem.web_hooks + WebHook.global
+    jobs.each do |job|
+      job.fire(
+        request.protocol.delete("://"),
+        request.host_with_port,
+        version.rubygem,
+        version
+      )
+    end
+  end
 end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -102,7 +102,6 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     GemCachePurger.call(rubygem.name)
-    enqueue_web_hook_jobs
     StatsD.increment 'push.success'
   end
 
@@ -121,13 +120,6 @@ class Pusher
     true
   rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique
     false
-  end
-
-  def enqueue_web_hook_jobs
-    jobs = rubygem.web_hooks + WebHook.global
-    jobs.each do |job|
-      job.fire(@protocol, @host_with_port, rubygem, version)
-    end
   end
 
   def set_info_checksum

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -153,6 +153,7 @@ class Rubygem < ApplicationRecord
       'info'              => version.info,
       'licenses'          => version.licenses,
       'metadata'          => version.metadata,
+      'yanked'            => version.yanked?,
       'sha'               => version.sha256_hex,
       'project_uri'       => "#{protocol}://#{host_with_port}/gems/#{name}",
       'gem_uri'           => "#{protocol}://#{host_with_port}/gems/#{version.full_name}.gem",

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -55,6 +55,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "ON DELETE to create for existing gem version" do
         setup do
+          create(:global_web_hook, user: @user, url: "http://example.org")
           delete :create, params: { gem_name: @rubygem.to_param, version: @v1.number }
         end
         should respond_with :success
@@ -66,6 +67,9 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
           assert_not_nil Deletion.where(user: @user,
                                         rubygem: @rubygem.name,
                                         number: @v1.number).first
+        end
+        should "have enqueued a webhook" do
+          assert_instance_of Notifier, Delayed::Job.last.payload_object
         end
       end
 


### PR DESCRIPTION
Rubygems' webhooks are awesome. We use them to trigger dependency updates with Dependabot.

Sometimes, gems get yanked. Currently, rubygems doesn't send a webhook when this happens.

This PR changes that - it adds a `yanked` attribute to the payload serialized in webhooks for a given version, and adds a trigger to send webhooks when a gem is yanked. The webhook sent is the same as the one sent when a new version is pushed (except the new yanked attribute will be true).

I'd like to use this at Dependabot to automatically close any PRs that we've open to yanked versions, and downgrade people if necessary.