### PR TITLE
Increase email confirmation token expires after time

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,7 +141,7 @@ class User < ApplicationRecord
 
   def generate_confirmation_token
     self.confirmation_token = Clearance::Token.new
-    self.token_expires_at = Time.zone.now + 15.minutes
+    self.token_expires_at = Time.zone.now + Gemcutter::EMAIL_TOKEN_EXPRIES_AFTER
   end
 
   def unconfirmed?

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,4 +46,5 @@ module Gemcutter
   POPULAR_DAYS_LIMIT = 70.days
   # Limit max page as ES result window is upper bounded by 10_000 records
   SEARCH_MAX_PAGES = 100
+  EMAIL_TOKEN_EXPRIES_AFTER = 3.hours
 end


### PR DESCRIPTION
We have too many tickets on help site complaining that they have either not received the confirmation mail or that confirmation link was invalid when they clicked on it.