### PR TITLE
Remove iframe used in github stars

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require clipboard
+//= require github_buttons
 //= require_tree .
 
 function handleClick(event, nav, removeNavExpandedClass, addNavExpandedClass) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,5 +3,6 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require_self
+ *= require github_buttons
  *= require_tree .
 */

--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -157,3 +157,10 @@ a.page__heading {
 
 .push--s {
   margin-top: 20px; }
+
+/* style used to be applied on iframe of github_buttons */
+span#github-btn {
+  display: block;
+  margin-bottom: 15px;
+  margin-top: 5px;
+}

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -107,4 +107,8 @@ module RubygemsHelper
     return rubygem.latest_version_number if rubygem.respond_to?(:latest_version_number)
     (rubygem.latest_version || rubygem.versions.last).try(:number)
   end
+
+  def github_params(link)
+    "user=#{link.path.split('/').second}&repo=#{link.path.split('/').third}&type=star&count=true&size=large"
+  end
 end

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -1,6 +1,6 @@
 <div class="gem__aside l-col--r--pad">
   <% if @rubygem.linkset.present? && github_link = link_to_github(@rubygem) %>
-    <iframe class="gem__ghbtn" src="https://ghbtns.com/github-btn.html?user=<%= github_link.path.split('/').second %>&repo=<%= github_link.path.split('/').third %>&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+    <%= render partial: "rubygems/github_button", locals: { github_link: github_link } %>
   <% end %>
 
   <% if @latest_version.indexed %>

--- a/app/views/rubygems/_github_button.html.erb
+++ b/app/views/rubygems/_github_button.html.erb
@@ -1,0 +1,7 @@
+<span class="github-btn" id="github-btn" data-params=<%= github_params(github_link) %> %>
+  <a class="gh-btn" id="gh-btn" href="#" target="_blank" aria-label="">
+    <span class="gh-ico" aria-hidden="true"></span>
+    <span class="gh-text" id="gh-text"></span>
+  </a>
+  <a class="gh-count" id="gh-count" href="#" target="_blank" aria-label=""></a>
+</span>

--- a/vendor/assets/javascripts/github_buttons.js
+++ b/vendor/assets/javascripts/github_buttons.js
@@ -2,129 +2,135 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this work except in compliance with the License.
  * You may obtain a copy of the License in the LICENSE file, or at:
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * Soure repo: https://github.com/mdo/github-buttons
+ * Modification: Changed params to read attributes from data-params
+ *               Changed jsonp to get callback directly
+ *               Execute only when #github-btn exists
 */
+
 // Read a page's GET URL variables and return them as an associative array.
 // Source: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
-var params = (function () {
-  var vars = [],
-      hash;
-  var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-  for (var i = 0; i < hashes.length; i++) {
-    hash = hashes[i].split('=');
-    vars.push(hash[0]);
-    vars[hash[0]] = hash[1];
-  }
-  return vars;
-}());
-
-var user = params.user,
-    repo = params.repo,
-    type = params.type,
-    count = params.count,
-    size = params.size,
-    v = params.v,
-    head = document.getElementsByTagName('head')[0],
-    button = document.getElementById('gh-btn'),
-    mainButton = document.getElementById('github-btn'),
-    text = document.getElementById('gh-text'),
-    counter = document.getElementById('gh-count'),
-    labelSuffix = ' on GitHub';
-
-// Add commas to numbers
-function addCommas(n) {
-  return String(n).replace(/(\d)(?=(\d{3})+$)/g, '$1,');
-}
-
-function jsonp(path, cbName) {
-  var el = document.createElement('script');
-  el.src = path + '?callback=' + (cbName ? cbName : 'callback');
-  head.insertBefore(el, head.firstChild);
-}
-
-function callback(obj) {
-  switch (type) {
-    case 'watch':
-      if (v === '2') {
-        counter.innerHTML = addCommas(obj.data.subscribers_count);
-        counter.setAttribute('aria-label', counter.innerHTML + ' watchers' + labelSuffix);
-      } else {
-        counter.innerHTML = addCommas(obj.data.stargazers_count);
-        counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+if ($("#github-btn").length) {
+  $("document").ready(function() {
+    var params = (function () {
+      var vars = [],
+          hash;
+      var hashes = $('.github-btn').attr('data-params').split('&');
+      for (var i = 0; i < hashes.length; i++) {
+        hash = hashes[i].split('=');
+        vars.push(hash[0]);
+        vars[hash[0]] = hash[1];
       }
-      break;
-    case 'star':
-      counter.innerHTML = addCommas(obj.data.stargazers_count);
-      counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
-      break;
-    case 'fork':
-      counter.innerHTML = addCommas(obj.data.network_count);
-      counter.setAttribute('aria-label', counter.innerHTML + ' forks' + labelSuffix);
-      break;
-    case 'follow':
-      counter.innerHTML = addCommas(obj.data.followers);
-      counter.setAttribute('aria-label', counter.innerHTML + ' followers' + labelSuffix);
-      break;
-  }
+      return vars;
+    }());
 
-  // Show the count if asked
-  if (count === 'true' && counter.innerHTML !== 'undefined') {
-    counter.style.display = 'block';
-  }
-}
+    var user = params.user,
+        repo = params.repo,
+        type = params.type,
+        count = params.count,
+        size = params.size,
+        v = params.v,
+        head = document.getElementsByTagName('head')[0],
+        button = document.getElementById('gh-btn'),
+        mainButton = document.getElementById('github-btn'),
+        text = document.getElementById('gh-text'),
+        counter = document.getElementById('gh-count'),
+        labelSuffix = ' on GitHub';
 
-// Set href to be URL for repo
-button.href = 'https://github.com/' + user + '/' + repo + '/';
-
-// Add the class, change the text label, set count link href
-switch (type) {
-  case 'watch':
-    if (v === '2') {
-      mainButton.className += ' github-watchers';
-      text.innerHTML = 'Watch';
-      counter.href = 'https://github.com/' + user + '/' + repo + '/watchers';
-    } else {
-      mainButton.className += ' github-stargazers';
-      text.innerHTML = 'Star';
-      counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+    // Add commas to numbers
+    function addCommas(n) {
+      return String(n).replace(/(\d)(?=(\d{3})+$)/g, '$1,');
     }
-    break;
-  case 'star':
-    mainButton.className += ' github-stargazers';
-    text.innerHTML = 'Star';
-    counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
-    break;
-  case 'fork':
-    mainButton.className += ' github-forks';
-    text.innerHTML = 'Fork';
-    button.href = 'https://github.com/' + user + '/' + repo + '/fork';
-    counter.href = 'https://github.com/' + user + '/' + repo + '/network';
-    break;
-  case 'follow':
-    mainButton.className += ' github-me';
-    text.innerHTML = 'Follow @' + user;
-    button.href = 'https://github.com/' + user;
-    counter.href = 'https://github.com/' + user + '/followers';
-    break;
-}
-button.setAttribute('aria-label', text.innerHTML + labelSuffix);
 
-// Change the size
-if (size === 'large') {
-  mainButton.className += ' github-btn-large';
-}
+    function jsonp(path) {
+      jQuery.getJSON(path + '?callback=?', callback)
+    }
 
-if (type === 'follow') {
-  jsonp('https://api.github.com/users/' + user);
-} else {
-  jsonp('https://api.github.com/repos/' + user + '/' + repo);
+    function callback(obj) {
+      switch (type) {
+        case 'watch':
+          if (v === '2') {
+            counter.innerHTML = addCommas(obj.data.subscribers_count);
+            counter.setAttribute('aria-label', counter.innerHTML + ' watchers' + labelSuffix);
+          } else {
+            counter.innerHTML = addCommas(obj.data.stargazers_count);
+            counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+          }
+          break;
+        case 'star':
+          counter.innerHTML = addCommas(obj.data.stargazers_count);
+          counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+          break;
+        case 'fork':
+          counter.innerHTML = addCommas(obj.data.network_count);
+          counter.setAttribute('aria-label', counter.innerHTML + ' forks' + labelSuffix);
+          break;
+        case 'follow':
+          counter.innerHTML = addCommas(obj.data.followers);
+          counter.setAttribute('aria-label', counter.innerHTML + ' followers' + labelSuffix);
+          break;
+      }
+
+      // Show the count if asked
+      if (count === 'true' && counter.innerHTML !== 'undefined') {
+        counter.style.display = 'block';
+      }
+    }
+
+    // Set href to be URL for repo
+    button.href = 'https://github.com/' + user + '/' + repo + '/';
+
+    // Add the class, change the text label, set count link href
+    switch (type) {
+      case 'watch':
+        if (v === '2') {
+          mainButton.className += ' github-watchers';
+          text.innerHTML = 'Watch';
+          counter.href = 'https://github.com/' + user + '/' + repo + '/watchers';
+        } else {
+          mainButton.className += ' github-stargazers';
+          text.innerHTML = 'Star';
+          counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+        }
+        break;
+      case 'star':
+        mainButton.className += ' github-stargazers';
+        text.innerHTML = 'Star';
+        counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+        break;
+      case 'fork':
+        mainButton.className += ' github-forks';
+        text.innerHTML = 'Fork';
+        button.href = 'https://github.com/' + user + '/' + repo + '/fork';
+        counter.href = 'https://github.com/' + user + '/' + repo + '/network';
+        break;
+      case 'follow':
+        mainButton.className += ' github-me';
+        text.innerHTML = 'Follow @' + user;
+        button.href = 'https://github.com/' + user;
+        counter.href = 'https://github.com/' + user + '/followers';
+        break;
+    }
+    button.setAttribute('aria-label', text.innerHTML + labelSuffix);
+
+    // Change the size
+    if (size === 'large') {
+      mainButton.className += ' github-btn-large';
+    }
+
+    if (type === 'follow') {
+      jsonp('https://api.github.com/users/' + user);
+    } else {
+      jsonp('https://api.github.com/repos/' + user + '/' + repo);
+    }
+  });
 }

--- a/vendor/assets/javascripts/github_buttons.js
+++ b/vendor/assets/javascripts/github_buttons.js
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this work except in compliance with the License.
+ * You may obtain a copy of the License in the LICENSE file, or at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Soure repo: https://github.com/mdo/github-buttons
+*/
+// Read a page's GET URL variables and return them as an associative array.
+// Source: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
+var params = (function () {
+  var vars = [],
+      hash;
+  var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+  for (var i = 0; i < hashes.length; i++) {
+    hash = hashes[i].split('=');
+    vars.push(hash[0]);
+    vars[hash[0]] = hash[1];
+  }
+  return vars;
+}());
+
+var user = params.user,
+    repo = params.repo,
+    type = params.type,
+    count = params.count,
+    size = params.size,
+    v = params.v,
+    head = document.getElementsByTagName('head')[0],
+    button = document.getElementById('gh-btn'),
+    mainButton = document.getElementById('github-btn'),
+    text = document.getElementById('gh-text'),
+    counter = document.getElementById('gh-count'),
+    labelSuffix = ' on GitHub';
+
+// Add commas to numbers
+function addCommas(n) {
+  return String(n).replace(/(\d)(?=(\d{3})+$)/g, '$1,');
+}
+
+function jsonp(path, cbName) {
+  var el = document.createElement('script');
+  el.src = path + '?callback=' + (cbName ? cbName : 'callback');
+  head.insertBefore(el, head.firstChild);
+}
+
+function callback(obj) {
+  switch (type) {
+    case 'watch':
+      if (v === '2') {
+        counter.innerHTML = addCommas(obj.data.subscribers_count);
+        counter.setAttribute('aria-label', counter.innerHTML + ' watchers' + labelSuffix);
+      } else {
+        counter.innerHTML = addCommas(obj.data.stargazers_count);
+        counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+      }
+      break;
+    case 'star':
+      counter.innerHTML = addCommas(obj.data.stargazers_count);
+      counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+      break;
+    case 'fork':
+      counter.innerHTML = addCommas(obj.data.network_count);
+      counter.setAttribute('aria-label', counter.innerHTML + ' forks' + labelSuffix);
+      break;
+    case 'follow':
+      counter.innerHTML = addCommas(obj.data.followers);
+      counter.setAttribute('aria-label', counter.innerHTML + ' followers' + labelSuffix);
+      break;
+  }
+
+  // Show the count if asked
+  if (count === 'true' && counter.innerHTML !== 'undefined') {
+    counter.style.display = 'block';
+  }
+}
+
+// Set href to be URL for repo
+button.href = 'https://github.com/' + user + '/' + repo + '/';
+
+// Add the class, change the text label, set count link href
+switch (type) {
+  case 'watch':
+    if (v === '2') {
+      mainButton.className += ' github-watchers';
+      text.innerHTML = 'Watch';
+      counter.href = 'https://github.com/' + user + '/' + repo + '/watchers';
+    } else {
+      mainButton.className += ' github-stargazers';
+      text.innerHTML = 'Star';
+      counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+    }
+    break;
+  case 'star':
+    mainButton.className += ' github-stargazers';
+    text.innerHTML = 'Star';
+    counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+    break;
+  case 'fork':
+    mainButton.className += ' github-forks';
+    text.innerHTML = 'Fork';
+    button.href = 'https://github.com/' + user + '/' + repo + '/fork';
+    counter.href = 'https://github.com/' + user + '/' + repo + '/network';
+    break;
+  case 'follow':
+    mainButton.className += ' github-me';
+    text.innerHTML = 'Follow @' + user;
+    button.href = 'https://github.com/' + user;
+    counter.href = 'https://github.com/' + user + '/followers';
+    break;
+}
+button.setAttribute('aria-label', text.innerHTML + labelSuffix);
+
+// Change the size
+if (size === 'large') {
+  mainButton.className += ' github-btn-large';
+}
+
+if (type === 'follow') {
+  jsonp('https://api.github.com/users/' + user);
+} else {
+  jsonp('https://api.github.com/repos/' + user + '/' + repo);
+}

--- a/vendor/assets/stylesheets/github_buttons.css
+++ b/vendor/assets/stylesheets/github_buttons.css
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this work except in compliance with the License.
+ * You may obtain a copy of the License in the LICENSE file, or at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Soure repo: https://github.com/mdo/github-buttons
+*/
+
+body {
+  padding: 0;
+  margin: 0;
+  font: bold 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  overflow: hidden;
+}
+
+.github-btn {
+  font: bold 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  height: 20px;
+  overflow: hidden;
+}
+.gh-btn,
+.gh-count,
+.gh-ico {
+  float: left;
+}
+.gh-btn,
+.gh-count {
+  padding: 2px 5px 2px 4px;
+  color: #333;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border-radius: 3px;
+}
+.gh-btn {
+  background-color: #eee;
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #fcfcfc), color-stop(100%, #eee));
+  background-image: -webkit-linear-gradient(top, #fcfcfc 0, #eee 100%);
+  background-image: -moz-linear-gradient(top, #fcfcfc 0, #eee 100%);
+  background-image: -ms-linear-gradient(top, #fcfcfc 0, #eee 100%);
+  background-image: -o-linear-gradient(top, #fcfcfc 0, #eee 100%);
+  background-image: linear-gradient(to bottom, #fcfcfc 0, #eee 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#eeeeee', GradientType=0);
+  background-repeat: no-repeat;
+  border: 1px solid #d5d5d5;
+}
+.gh-btn:hover,
+.gh-btn:focus {
+  text-decoration: none;
+  background-color: #ddd;
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #eee), color-stop(100%, #ddd));
+  background-image: -webkit-linear-gradient(top, #eee 0, #ddd 100%);
+  background-image: -moz-linear-gradient(top, #eee 0, #ddd 100%);
+  background-image: -ms-linear-gradient(top, #eee 0, #ddd 100%);
+  background-image: -o-linear-gradient(top, #eee 0, #ddd 100%);
+  background-image: linear-gradient(to bottom, #eee 0, #ddd 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eeeeee', endColorstr='#dddddd', GradientType=0);
+  border-color: #ccc;
+}
+.gh-btn:active {
+  background-image: none;
+  background-color: #dcdcdc;
+  border-color: #b5b5b5;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+.gh-ico {
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjQwcHgiIGhlaWdodD0iNDBweCIgdmlld0JveD0iMTIgMTIgNDAgNDAiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMTIgMTIgNDAgNDAiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwYXRoIGZpbGw9IiMzMzMzMzMiIGQ9Ik0zMiAxMy40Yy0xMC41IDAtMTkgOC41LTE5IDE5YzAgOC40IDUuNSAxNS41IDEzIDE4YzEgMC4yIDEuMy0wLjQgMS4zLTAuOWMwLTAuNSAwLTEuNyAwLTMuMiBjLTUuMyAxLjEtNi40LTIuNi02LjQtMi42QzIwIDQxLjYgMTguOCA0MSAxOC44IDQxYy0xLjctMS4yIDAuMS0xLjEgMC4xLTEuMWMxLjkgMC4xIDIuOSAyIDIuOSAyYzEuNyAyLjkgNC41IDIuMSA1LjUgMS42IGMwLjItMS4yIDAuNy0yLjEgMS4yLTIuNmMtNC4yLTAuNS04LjctMi4xLTguNy05LjRjMC0yLjEgMC43LTMuNyAyLTUuMWMtMC4yLTAuNS0wLjgtMi40IDAuMi01YzAgMCAxLjYtMC41IDUuMiAyIGMxLjUtMC40IDMuMS0wLjcgNC44LTAuN2MxLjYgMCAzLjMgMC4yIDQuNyAwLjdjMy42LTIuNCA1LjItMiA1LjItMmMxIDIuNiAwLjQgNC42IDAuMiA1YzEuMiAxLjMgMiAzIDIgNS4xYzAgNy4zLTQuNSA4LjktOC43IDkuNCBjMC43IDAuNiAxLjMgMS43IDEuMyAzLjVjMCAyLjYgMCA0LjYgMCA1LjJjMCAwLjUgMC40IDEuMSAxLjMgMC45YzcuNS0yLjYgMTMtOS43IDEzLTE4LjFDNTEgMjEuOSA0Mi41IDEzLjQgMzIgMTMuNHoiLz48L3N2Zz4=');
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+}
+.gh-count {
+  position: relative;
+  display: none; /* hidden to start */
+  margin-left: 4px;
+  background-color: #fafafa;
+  border: 1px solid #d4d4d4;
+}
+.gh-count:hover,
+.gh-count:focus {
+  color: #4183C4;
+}
+.gh-count:before,
+.gh-count:after {
+  content: '';
+  position: absolute;
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.gh-count:before {
+  top: 50%;
+  left: -3px;
+  margin-top: -4px;
+  border-width: 4px 4px 4px 0;
+  border-right-color: #fafafa;
+}
+.gh-count:after {
+  top: 50%;
+  left: -4px;
+  z-index: -1;
+  margin-top: -5px;
+  border-width: 5px 5px 5px 0;
+  border-right-color: #d4d4d4;
+}
+.github-btn-large {
+  height: 30px;
+}
+.github-btn-large .gh-btn,
+.github-btn-large .gh-count {
+  padding: 3px 10px 3px 8px;
+  font-size: 16px;
+  line-height: 22px;
+  border-radius: 4px;
+}
+.github-btn-large .gh-ico {
+  width: 20px;
+  height: 20px;
+}
+.github-btn-large .gh-count {
+  margin-left: 6px;
+}
+.github-btn-large .gh-count:before {
+  left: -5px;
+  margin-top: -6px;
+  border-width: 6px 6px 6px 0;
+}
+.github-btn-large .gh-count:after {
+  left: -6px;
+  margin-top: -7px;
+  border-width: 7px 7px 7px 0;
+}

--- a/vendor/assets/stylesheets/github_buttons.css
+++ b/vendor/assets/stylesheets/github_buttons.css
@@ -12,14 +12,8 @@
  * limitations under the License.
  * 
  * Soure repo: https://github.com/mdo/github-buttons
-*/
-
-body {
-  padding: 0;
-  margin: 0;
-  font: bold 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  overflow: hidden;
-}
+ * Modification - Removed style on body tag
+ */
 
 .github-btn {
   font: bold 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
![me-after-staying-in-one-night-drinking-a-green-drink-31272695](https://user-images.githubusercontent.com/7680662/47959636-e8851580-e00e-11e8-980c-a27decd4d212.png)

http://www.rwblackburn.com/iframe-evil/
github-buttons repo had its last commit 3 years ago, it should be too much hassle to keep their code upto date. For some reason, importing assets fixes following mobile view gotcha:
![screenshot from 2018-11-04 08-19-56](https://user-images.githubusercontent.com/7680662/47959650-621d0380-e00f-11e8-9905-a41521d030be.png)
