### PR TITLE
Update i18n strings with new link timeout values

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
       welcome_message: Welcome to RubyGems.org! Click the link below to verify your email.
     email_reset:
       visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
-      link_expiration_explanation: Please keep in mind that this link is only valid for 15 minutes.
+      link_expiration_explanation: Please keep in mind that this link is only valid for 3 hours.
     deletion_complete:
       subject: Your account has been deleted from rubygems.org
       body: Your request for account deletion on rubygems.org has been processed. You can always create a new account using our %{sign_up} page.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -104,7 +104,7 @@ fr:
       welcome_message: Bienvenue sur RubyGems.org! Veuillez cliquer sur le lien ci-dessous pour vérifier votre adresse email.
     email_reset:
       visit_link_instructions: Vous avez changé d'adresse email sur RubyGems.org. Veuillez suivre l'URL suivant pour réactiver votre compte.
-      link_expiration_explanation: Veuillez noter que ce lien n'est valide que pendant 15 minutes.
+      link_expiration_explanation: Veuillez noter que ce lien n'est valide que pendant 3 heures.
     deletion_complete:
       subject: Votre compte a bien été supprimé de RubyGems.org
       body: "Votre demande de suppression de compte sur RubyGems.org a bien été prise en compte. Vous pouvez toujours créer un nouveau compte sur la page %{sign_up}"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -104,7 +104,7 @@ nl:
       welcome_message:
     email_reset:
       visit_link_instructions:
-      link_expiration_explanation: Deze link is 15 minuten geldig.
+      link_expiration_explanation: Deze link is 3 uur geldig.
     deletion_complete:
       subject:
       body:


### PR DESCRIPTION
In rubygems/rubygems.org#1823 we changed the timeout of the confirmation token from 15 minutes
to 3 hours, to hopefully help a constant support issue around timely
delivery of the validation emails. This change updates this value in a
string included the email sent to users.