### PR TITLE
fix click events on the nav's in Firefox

### DIFF
--- a/app/assets/javascripts/mobile-nav.js
+++ b/app/assets/javascripts/mobile-nav.js
@@ -42,9 +42,9 @@ $(function() {
     }
   }
 
-  sandwichIcon.click(function(){
+  sandwichIcon.click(function(e){
     var nav = {expandedClass: navExpandedClass, popUp: header}
-    handleClick(event, nav, removeNavExpandedClass, addNavExpandedClass);
+    handleClick(e, nav, removeNavExpandedClass, addNavExpandedClass);
   });
 
   sandwichIcon.on('focusin', handleFocusIn);

--- a/app/assets/javascripts/popup-nav.js
+++ b/app/assets/javascripts/popup-nav.js
@@ -12,9 +12,9 @@ $(function() {
     popupNav.addClass(navExpandedClass);
   }
 
-  arrowIcon.click(function(){
+  arrowIcon.click(function(e){
     var nav = {expandedClass: navExpandedClass, popUp: popupNav}
-    handleClick(event, nav, removeNavExpandedClass, addNavExpandedClass);
+    handleClick(e, nav, removeNavExpandedClass, addNavExpandedClass);
   });
 });
 


### PR DESCRIPTION
- the global event object is non-standard (and not implemented in Firefox)
- use the first parameter to the event callback instead (as this is the standard)