### PR TITLE
For gem edit pages, build a new linkset if gem is missing one

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -36,6 +36,8 @@ class RubygemsController < ApplicationController
 
   def edit
     flash[:warning] = t('.deprecation_message').html_safe # rubocop:disable Rails/OutputSafety
+
+    @linkset = @rubygem.linkset || @rubygem.build_linkset
   end
 
   def update

--- a/app/views/rubygems/edit.html.erb
+++ b/app/views/rubygems/edit.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <%= error_messages_for :linkset, :object_name => "gem" %>
-<%= form_for @rubygem.linkset, :url => rubygem_path(@rubygem), :method => :put do |form| %>
+<%= form_for @linkset, :url => rubygem_path(@rubygem), :method => :put do |form| %>
   <div class="url_field">
     <%= form.label :code, :class => 'form__label' %>
     <%= form.text_field :code, :class => 'form__input' %>

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -107,6 +107,26 @@ class RubygemsControllerTest < ActionController::TestCase
       end
     end
 
+    context "On GET to edit for this user's gem that is missing a linkset" do
+      setup do
+        @rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
+        @rubygem.linkset = nil
+
+        get :edit, params: { id: @rubygem.to_param }
+      end
+
+      should respond_with :success
+      should "render form" do
+        assert page.has_selector?("form")
+        assert page.has_selector?("input#linkset_code")
+        assert page.has_selector?("input#linkset_docs")
+        assert page.has_selector?("input#linkset_wiki")
+        assert page.has_selector?("input#linkset_mail")
+        assert page.has_selector?("input#linkset_bugs")
+        assert page.has_selector?("input[type='submit']")
+      end
+    end
+
     context "On GET to edit for another user's gem" do
       setup do
         @other_user = create(:user)


### PR DESCRIPTION
We have a few places where we work around the issue of a gem not having
an associated linkset record, so this at least is in that genre of
change.

This was reported to us via the support site; something about that
user's gemspec is funky, and a linkset isn't being created. The unusual
thing is that this user attempted to edit via the web UI, and I wouldn't
be surprised if this is a low-traffic action, which would explain why we
wouldn't have seen this error crop up previously.

http://help.rubygems.org/discussions/problems/34216-unable-to-edit-newly-published-gem-server-error