### PR TITLE
Fix app crash on unknown format

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,4 +1,6 @@
 class EmailConfirmationsController < ApplicationController
+  before_action :redirect_to_root, unless: :signed_in?, only: :unconfirmed
+
   def update
     user = User.find_by(confirmation_token: params[:token])
 
@@ -15,7 +17,7 @@ class EmailConfirmationsController < ApplicationController
 
   # used to resend confirmation mail for email validation
   def create
-    user = User.find_by(email: confirmation_params[:email])
+    user = User.find_by(email: email_params)
 
     if user
       user.generate_confirmation_token
@@ -37,7 +39,7 @@ class EmailConfirmationsController < ApplicationController
 
   private
 
-  def confirmation_params
-    params[:email_confirmation]
+  def email_params
+    params.require(:email_confirmation).permit(:email).fetch(:email, "")
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,11 +3,6 @@ class UsersController < Clearance::UsersController
     redirect_to sign_up_path
   end
 
-  def disabled_signup
-    flash[:notice] = "Sign up is temporarily disabled."
-    redirect_to root_path
-  end
-
   def create
     @user = user_from_params
     if @user.save

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -3,5 +3,5 @@
   <%= t('.welcome_message') %>
   <br />
   <%= link_to t('.confirmation_link'),
-    update_email_confirmations_url(@user, token: @user.confirmation_token.html_safe) %>
+    update_email_confirmations_url(token: @user.confirmation_token.html_safe) %>
 </p>

--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -3,6 +3,6 @@
   <%= t('.visit_link_instructions') %>
   <br />
   <%= link_to t('.confirmation_link'),
-    update_email_confirmations_url(@user, token: @user.confirmation_token.html_safe) %>
+    update_email_confirmations_url(token: @user.confirmation_token.html_safe) %>
 </p>
 <p><%= t('.link_expiration_explanation') %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,13 @@
 require_relative 'boot'
 
-require 'rails/all'
+
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+require 'rails/test_unit/railtie'
+require 'sprockets/railtie'
 require 'elasticsearch/rails/instrumentation'
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,5 @@
 require_relative 'boot'
 
-
 require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,9 +29,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,9 +28,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
-
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -6,6 +6,7 @@ Clearance.configure do |config|
   config.sign_in_guards = [ConfirmedUserGuard]
   config.rotate_csrf_on_sign_in = true
   config.cookie_expiration = ->(_cookies) { 2.weeks.from_now.utc }
+  config.routes = false
 end
 
 class Clearance::Session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,11 @@ Rails.application.routes.draw do
     ################################################################################
     # Clearance Overrides and Additions
 
+    resource :email_confirmations, only: %i[new create] do
+      get 'confirm/:token', to: 'email_confirmations#update', as: :update
+      patch 'unconfirmed'
+    end
+
     resources :passwords, only: %i[new create]
 
     resource :session, only: %i[create destroy] do
@@ -173,12 +178,6 @@ Rails.application.routes.draw do
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
     get '/sign_up' => 'clearance/users#new', as: 'sign_up' if Clearance.configuration.allow_sign_up?
-  end
-
-  # TODO: Move to UI routes (will apply format constrains)
-  resource :email_confirmations, only: %i[new create] do
-    get 'confirm/:token', to: 'email_confirmations#update', as: :update
-    patch 'unconfirmed'
   end
 
   ################################################################################

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RoutingTest < ActionDispatch::IntegrationTest
   def contoller_in_ui?(controller)
-    !controller.nil? && controller !~ /^api|internal|email_confirmations.*$/
+    !controller.nil? && controller !~ /^api|internal.*$/
   end
 
   setup do
@@ -23,6 +23,7 @@ class RoutingTest < ActionDispatch::IntegrationTest
       next if path == "/" # adding random format after root (/) gives 404
 
       assert_raises(ActionController::RoutingError) do
+        # ex: get(/password/new.json)
         send(verb.downcase, path.gsub("(.:format)", ".something"))
       end
     end
@@ -30,7 +31,7 @@ class RoutingTest < ActionDispatch::IntegrationTest
 
   test "adding format param to UI routes doesn't break the app" do
     @ui_paths_verb.each do |path, verb|
-      next if path == "/" # adding random format after root (/) gives 404
+      next if path == "/"
 
       format_path = path.gsub("(.:format)", "?format=something")
       format_path.gsub!(":rubygem_id", "someid")
@@ -38,6 +39,7 @@ class RoutingTest < ActionDispatch::IntegrationTest
       format_path.gsub!("*id", "about") # used in high voltage route
 
       assert_nothing_raised do
+        # ex: get(/password/new?format=json)
         send(verb.downcase, format_path)
       end
     end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class RoutingTest < ActionDispatch::IntegrationTest
+  def contoller_in_ui?(controller)
+    !controller.nil? && controller !~ /^api|internal|email_confirmations.*$/
+  end
+
+  setup do
+    @prev_env = ENV["RAILS_ENV"]
+    ENV["RAILS_ENV"] = "production"
+    routes = Rails.application.routes.routes
+    @ui_paths_verb = routes.map { |r| [r.path.spec.to_s, r.verb] if contoller_in_ui? r.defaults[:controller] }.compact.to_h
+  end
+
+  test "active storate routes don't exist" do
+    assert_raises(ActionController::RoutingError) do
+      post "/rails/active_storage/direct_uploads"
+    end
+  end
+
+  test "non html format route don't exist for UI" do
+    @ui_paths_verb.each do |path, verb|
+      next if path == "/" # adding random format after root (/) gives 404
+
+      assert_raises(ActionController::RoutingError) do
+        send(verb.downcase, path.gsub("(.:format)", ".something"))
+      end
+    end
+  end
+
+  test "adding format param to UI routes doesn't break the app" do
+    @ui_paths_verb.each do |path, verb|
+      next if path == "/" # adding random format after root (/) gives 404
+
+      format_path = path.gsub("(.:format)", "?format=something")
+      format_path.gsub!(":rubygem_id", "someid")
+      format_path.gsub!(":id", "someid")
+      format_path.gsub!("*id", "about") # used in high voltage route
+
+      assert_nothing_raised do
+        send(verb.downcase, format_path)
+      end
+    end
+  end
+
+  teardown do
+    ENV["RAILS_ENV"] = @prev_env
+  end
+end

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -51,9 +51,9 @@ class SignUpTest < SystemTest
 
     visit root_path
     refute page.has_content? "Sign up"
-    visit sign_up_path
-    assert_equal current_path, "/"
-    assert page.has_content? "Sign up is temporarily disabled."
+    assert_raises(ActionController::RoutingError) do
+      visit '/sign_up'
+    end
   end
 
   test "email confirmation" do


### PR DESCRIPTION
Unsupported formats were previously raising:
ActionView::MissingTemplate: Missing template passwords/new with
{:locale=>[:en], :formats=>[:json], :variants=>[], :handlers=>[:raw,
:erb, :html, :builder, :ruby]}.

UI routes will only allow html format (unless explicitly whitelisted)
Removed disabled sign up action, it was unnecessary. when disabled, sign_up will give 404.
Also, removed active storage and action cable routes. we are not using it.

Fixed url in email confirmation.

Related: https://github.com/thoughtbot/clearance/issues/807