### PR TITLE
Set max limit on page param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,10 @@ class ApplicationController < ActionController::Base
   end
 
   def set_page
-    @page = params[:page].respond_to?(:to_i) ? [1, params[:page].to_i].max : 1
+    @page = Gemcutter::DEFAULT_PAGE && return unless params.key?(:page)
+    redirect_to url_for(page: Gemcutter::DEFAULT_PAGE) unless valid_page_param?
+
+    @page = params[:page].to_i
   end
 
   def user_locale
@@ -128,5 +131,9 @@ class ApplicationController < ActionController::Base
 
   def limit_page(max_page)
     render_404 if @page > max_page
+  end
+
+  def valid_page_param?
+    params[:page].respond_to?(:to_i) && params[:page].to_i.between?(Gemcutter::DEFAULT_PAGE, Gemcutter::MAX_PAGES)
   end
 end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,6 +1,5 @@
 class NewsController < ApplicationController
-  before_action :set_page
-  before_action -> { limit_page Gemcutter::NEWS_MAX_PAGES }
+  before_action -> { set_page Gemcutter::NEWS_MAX_PAGES }
 
   def show
     @rubygems = Rubygem.news(Gemcutter::NEWS_DAYS_LIMIT).page(@page).per(Gemcutter::NEWS_PER_PAGE)

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,5 @@
 class SearchesController < ApplicationController
-  before_action :set_page, only: :show
-  before_action -> { limit_page Gemcutter::SEARCH_MAX_PAGES }, only: :show
+  before_action -> { set_page Gemcutter::SEARCH_MAX_PAGES }, only: :show
 
   def show
     return unless params[:query]&.is_a?(String)

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,4 +47,6 @@ module Gemcutter
   # Limit max page as ES result window is upper bounded by 10_000 records
   SEARCH_MAX_PAGES = 100
   EMAIL_TOKEN_EXPRIES_AFTER = 3.hours
+  MAX_PAGES = 1000
+  DEFAULT_PAGE = 1
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -6,6 +6,7 @@ de:
   footer_about:
   form_disable_with: Bitte warten...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: Deutsch
   none:
   not_found:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
   footer_about: RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> to find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
   form_disable_with: Please wait...
   help_url: http://help.rubygems.org
+  invalid_page: Page number is out of range. Redirected to default page.
   locale_name: English
   none: None
   not_found: Not Found

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,6 +6,7 @@ es:
   footer_about: RubyGems.org es el servicio de alojamiento de gemas de la comunidad de Ruby. Publica tus gemas de manera instantánea e instalalas. Usa la API para interactuar y buscar información de las gemas disponibles. Conviértete en contribuidor y mejora este sitio con tus cambios.
   form_disable_with: Un momento por favor...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: Español
   none:
   not_found:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -6,6 +6,7 @@ fr:
   footer_about: RubyGems.org est le service d&rsquo;hébergement de la communauté Ruby. Publiez vos gems instantanément et utilisez-les. Utilisez l'API pour interagir et trouver des informations sur les gems disponibles. Contribuez et améliorez ce site avec nous !
   form_disable_with: Veuillez patienter...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: Français
   none:
   not_found: Introuvable

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -6,6 +6,7 @@ nl:
   footer_about: RubyGems.org is de gem hosting service van de Ruby community. <a href="%{publish_docs}">Publiceer</a> en <a href="%{install_docs}">installeer</a> je gems direct. Gebruik <a href="%{api_docs}">de API</a> om meer informatie over beschikbare gems te vinden. <a href="%{contributing_docs}">Word een deelnemer</a> en verbeter de site met jouw aanpassingen.
   form_disable_with: Een moment geduld...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: Nederlands
   none: Geen
   not_found: Niet gevonden

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -6,6 +6,7 @@ pt-BR:
   footer_about: RubyGems.org é o serviço de hospedagem de gems da comunidade Ruby. Publique e instale suas gems instantaneamente. Use a API para interagir e encontrar mais informações sobre gems disponíveis. Torne-se um contribuidor e melhore o site com suas mudanças.
   form_disable_with: Atualizando...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: Português do Brasil
   none:
   not_found:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -6,6 +6,7 @@ zh-CN:
   footer_about: RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。
   form_disable_with: 请稍后...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: 简体中文
   none: 无
   not_found: 未找到

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -6,6 +6,7 @@ zh-TW:
   footer_about: RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。
   form_disable_with: 請稍候...
   help_url: http://help.rubygems.org
+  invalid_page:
   locale_name: 正體中文
   none:
   not_found:

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -46,26 +46,4 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
       YAML.safe_load body
     end
   end
-
-  context "on GET passing a page" do
-    setup do
-      @match = create(:rubygem, name: "match")
-      create(:version, rubygem: @match)
-    end
-
-    should "default to first page when page is 0" do
-      get :show, params: { query: "match", page: 0 }, format: :json
-      refute JSON.parse(response.body).empty?
-    end
-
-    should "default to first page when page is not a number" do
-      get :show, params: { query: "match", page: "foo" }, format: :json
-      refute JSON.parse(response.body).empty?
-    end
-
-    should "default to first page when page cannot be converted to a number" do
-      get :show, params: { query: "match", page: { "$acunetix" => "1" } }, format: :json
-      refute JSON.parse(response.body).empty?
-    end
-  end
 end

--- a/test/functional/news_controller_test.rb
+++ b/test/functional/news_controller_test.rb
@@ -1,20 +1,6 @@
 require 'test_helper'
 
 class NewsControllerTest < ActionController::TestCase
-  def self.should_paginate(action)
-    should "display entries and total in page info" do
-      assert_select "header > p.gems__meter", text: /.*10 of 100 in total/
-    end
-
-    context "with page greater than 10" do
-      setup { get action, params: { page: 11 } }
-
-      should "render 404 page" do
-        assert_response :not_found
-      end
-    end
-  end
-
   setup do
     @rubygem1 = create(:rubygem, downloads: 10)
     @rubygem2 = create(:rubygem, downloads: 20)
@@ -41,7 +27,9 @@ class NewsControllerTest < ActionController::TestCase
       end
     end
 
-    should_paginate :show
+    should "display entries and total in page info" do
+      assert_select "header > p.gems__meter", text: /.*10 of 100 in total/
+    end
   end
 
   context "on GET to popular" do
@@ -63,6 +51,8 @@ class NewsControllerTest < ActionController::TestCase
       end
     end
 
-    should_paginate :popular
+    should "display entries and total in page info" do
+      assert_select "header > p.gems__meter", text: /.*10 of 100 in total/
+    end
   end
 end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -153,12 +153,4 @@ class SearchesControllerTest < ActionController::TestCase
       end
     end
   end
-
-  context "with page greater than 100" do
-    setup { get :show, params: { page: 204 } }
-
-    should "render 404 page" do
-      assert_response :not_found
-    end
-  end
 end

--- a/test/integration/page_params_test.rb
+++ b/test/integration/page_params_test.rb
@@ -1,13 +1,58 @@
 require 'test_helper'
 
 class PageParamsTest < SystemTest
-  test "page params is not integer" do
+  test "stats page params is not integer" do
     visit stats_path(page: "3\"")
+    assert redirect_to(stats_path(page: "1"))
     assert page.has_content? "Stats"
   end
 
-  test "page param is more than 1000" do
+  test "stats with page param more than 1000" do
     visit stats_path(page: "553402322211286548480")
+    assert redirect_to(stats_path(page: "1"))
     assert page.has_content? "Stats"
+    assert page.has_content? "Page number is out of range. Redirected to default page."
+  end
+
+  test "search with page more than 100" do
+    visit search_path(page: "102")
+    assert redirect_to(search_path(page: "1"))
+    assert page.has_content? "search"
+    assert page.has_content? "Page number is out of range. Redirected to default page."
+  end
+
+  test "news with page more than 10" do
+    visit news_path(page: "12")
+    assert redirect_to(news_path(page: "1"))
+    assert page.has_content? "New Releases — All Gems"
+    assert page.has_content? "Page number is out of range. Redirected to default page."
+  end
+
+  test "popular news with page more than 10" do
+    visit popular_news_path(page: "12")
+    assert redirect_to(popular_news_path(page: "1"))
+    assert page.has_content? "New Releases — Popular Gems"
+    assert page.has_content? "Page number is out of range. Redirected to default page."
+  end
+
+  test "api search with page smaller than 1" do
+    create(:rubygem, name: "some", number: "1.0.0")
+    visit api_v1_search_path(page: "0", query: "some", format: :json)
+    assert redirect_to(api_v1_search_path(page: "1", query: "some", format: :json))
+    refute JSON.parse(page.body).empty?
+  end
+
+  test "api search with page is not a numer" do
+    create(:rubygem, name: "some", number: "1.0.0")
+    visit api_v1_search_path(page: "foo", query: "some", format: :json)
+    assert redirect_to(api_v1_search_path(page: "1", query: "some", format: :json))
+    refute JSON.parse(page.body).empty?
+  end
+
+  test "api search with page that can't be converted to a number" do
+    create(:rubygem, name: "some", number: "1.0.0")
+    visit api_v1_search_path(page: "foo", query: "some", format: :json)
+    assert redirect_to(api_v1_search_path(page: "1", query: "some", format: :json))
+    refute JSON.parse(page.body).empty?
   end
 end

--- a/test/integration/page_params_test.rb
+++ b/test/integration/page_params_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class PageParamsTest < SystemTest
+  test "page params is not integer" do
+    visit stats_path(page: "3\"")
+    assert page.has_content? "Stats"
+  end
+
+  test "page param is more than 1000" do
+    visit stats_path(page: "553402322211286548480")
+    assert page.has_content? "Stats"
+  end
+end

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class StatsTest < SystemTest
-  test "page params is not integer" do
-    visit stats_path(page: "3\"")
-    assert page.has_content? "Stats"
-  end
-end


### PR DESCRIPTION
Max page value currently in use is
https://rubygems.org/gems?letter=S&page=524

Fixes:
PageParamsTest#test_page_param_is_more_than_1000:
ActionView::Template::Error: PG::NumericValueOutOfRange: ERROR:  value
"5534023222112865484790" is out of range for type bigint
: SELECT COUNT(count_column) FROM (SELECT  DISTINCT "rubygems"."id" AS
count_column FROM "rubygems" INNER JOIN "gem_downloads" ON
"gem_downloads"."rubygem_id" = "rubyg
ems"."id" AND "gem_downloads"."version_id" = $1 LIMIT $2 OFFSET $3)
subquery_for_count
    app/views/stats/index.html.erb:23:in
`_app_views_stats_index_html_erb___1883205568873874677_47399701305320'
    lib/clearance_backdoor.rb:9:in `call'
    test/integration/page_params_test.rb:10:in `block in
<class:PageParamsTest>'


gem page count by first char in name:
https://gist.github.com/sonalkr132/976223056926c70a093051c1b2e64c00