### PR TITLE
Add 1Password to sponsor page

### DIFF
--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -5,7 +5,7 @@
     RubyGems.org is made possible by support from the Ruby community. These companies provide the servers and developers that create the public infrastructure of the Ruby programming language.
   </p>
 
-  <h2>Ruby Central</h2>
+  <h2><a href="https://rubycentral.org">Ruby Central</a></h2>
 
   <p>
     Ruby Central, Inc. is a nonprofit 501(c)3 organization dedicated to the support and advocacy of the worldwide Ruby community. They organize the annual RubyConf and RailsConf as opportunities for Rubyists to collaborate and network. As part of those conferences, Ruby Central also operates the Opportunity Scholarship program to consistently bring new people into the tech community and to provide them with a comfortable, welcoming environment to explore our community and its events.
@@ -13,7 +13,7 @@
     They also fund and operate the Ruby Central Community Grant, underwriting events or open source projects that benefit the Ruby community, and they fund the ongoing server costs associated with running RubyGems.org.
   </p>
 
-  <h2>Ruby Together</h2>
+  <h2><a href="https://rubytogether.org">Ruby Together</a></h2>
 
   <p>
     Ruby Together is a grassroots initiative committed to supporting the critical Ruby infrastructure you rely on: Bundler, RubyGems, and other shared tools. No more waiting around until someone has free time to apply security patches. Instead, Ruby Together pays developers for dedicated time maintaining and improving shared Ruby tools. Help us keep RubyGems.org running smoothly and free for everyone to use by <a href="https://rubytogether.org/developers?source=rubygems">joining as a developer today</a>.

--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -21,11 +21,17 @@
     Companies count on robust tools, but the volunteers who maintain critical Ruby infrastructure can't keep up in their free time. All too often, individual companies end up paying full-time engineers to privately work around issues shared by the entire Ruby community. You shouldn't pay full price for private solutions to shared issues. Spend more time building great apps, and less time on the tools that make those apps possible: <%= link_to "join Ruby Together", "https://rubytogether.org/companies?source=rubygems" %>.
   </p>
 
-  <h2>Fastly</h2>
+  <h2><a href="https://fastly.com">Fastly</a></h2>
 
   <p>
     Fastly is the future of content delivery, giving businesses complete control over how they serve content, unprecedented access to real-time performance analytics, and the ability to cache frequently changing content at the edge.
   <br><br>
     Fastly provides the RubyGems.org content delivery network, allowing Ruby developers all over the world to download gems from nearby servers around the world.
   </p>
+
+  <hr>
+
+  <h3><a href="https://1password.com">1Password</a></h3>
+
+  <p>A password manager, digital vault, form filler and secure digital wallet. 1Password remembers all your passwords for you to help keep account information safe.</p>
 </div>


### PR DESCRIPTION
1Password has given us a free team account to use for the RubyGems.org, RubyGems, Bundler, and other associated projects. Thanks, 1Password <3