### PR TITLE
Using safe html translations

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="t-display page__heading">Dashboard</h1>
+<% @title = t('.title') %>
 
 <div class="l-overflow">
   <div class="subscribed l-colspan--l colspan--l--has-border">
@@ -12,7 +12,7 @@
     <div class="push--bottom">
       <% if @latest_updates.empty? %>
         <div class="t-body push--s">
-          <i class="t-text"><%= t('.no_subscriptions', :gem_link => link_to(t('.gem_link_text'), rubygem_path("rake"))).html_safe %></i>
+          <i class="t-text"><%= t('.no_subscriptions_html', :gem_link => link_to(t('.gem_link_text'), rubygem_path("rake"))) %></i>
         </div>
       <% else %>
         <ol>
@@ -38,8 +38,8 @@
       <% if @my_gems.empty? %>
         <div class="t-body push--bottom">
           <p>
-            <%= t('.no_owned', :creating_link => link_to(t('.creating_link_text'), "http://guides.rubygems.org/make-your-own-gem/").html_safe,
-                               :migrating_link => link_to(t('.migrating_link_text'), page_path("migrate"))).html_safe %>
+            <%= t('.no_owned_html', :creating_link => link_to(t('.creating_link_text'), "http://guides.rubygems.org/make-your-own-gem/"),
+                                    :migrating_link => link_to(t('.migrating_link_text'), page_path("migrate"))) %>
           </p>
         </div>
       <% else %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,9 +4,9 @@
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>
-    <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem').html_safe, autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
+    <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem_html'), autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
     <%= label_tag :home_query do %>
-      <span class="t-hidden"><%= t('layouts.application.header.search_gem').html_safe %></span>
+      <span class="t-hidden"><%= t('layouts.application.header.search_gem_html') %></span>
       <center>
         <%= link_to t("advanced_search"), advanced_search_path, class: "home__advanced__search t-link--has-arrow"%>
       </center>
@@ -18,12 +18,12 @@
   <% if @downloads_count %>
     <h2 class="home__downloads">
       <p><%= number_with_delimiter(@downloads_count) %></p>
-      <span class="home__downloads__desc"><%= raw t('.downloads_counting') %></span>
+      <span class="home__downloads__desc"><%= t('.downloads_counting_html') %></span>
     </h2>
   <% end %>
   <%= link_to t('.learn.install_rubygems'), page_url("download"), :class => "home__join #{@downloads_count.nil? ? 'no-download-count' : ''}", "data-icon" => ">" %>
 </div>
 <div class="home__links">
-  <%= link_to t('.footer.status'), "https://status.rubygems.org", class: "home__link", "data-icon" => "⌁" %>
-  <%= link_to t('.footer.uptime'), "http://uptime.rubygems.org", class: "home__link", "data-icon" => "⧖" %>
+  <%= link_to t('layouts.application.footer.status'), "https://status.rubygems.org", class: "home__link", "data-icon" => "⌁" %>
+  <%= link_to t('layouts.application.footer.uptime'), "http://uptime.rubygems.org", class: "home__link", "data-icon" => "⧖" %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,9 +35,9 @@
 
         <div class="header__nav-links-wrap">
           <%= form_tag search_path, class: search_form_class, method: :get do %>
-            <%= search_field_tag :query, params[:query], placeholder: t('.header.search_gem').html_safe, class: "header__search" %>
+            <%= search_field_tag :query, params[:query], placeholder: t('.header.search_gem_html'), class: "header__search" %>
             <%= label_tag :query do %>
-              <span class="t-hidden"><%= t(".header.search_gem").html_safe %></span>
+              <span class="t-hidden"><%= t(".header.search_gem_html") %></span>
             <% end %>
             <%= submit_tag "⌕", id: "search_submit", name: nil, class: "header__search__icon" %>
           <% end %>
@@ -147,24 +147,19 @@
           <div class="l-colspan--l colspan--l--has-border">
             <div class="footer__about">
               <p>
-                <%= raw t('footer_about',
+                <%= t('footer_about_html',
                   publish_docs: "http://guides.rubygems.org/publishing/",
                   install_docs: "http://guides.rubygems.org/command-reference/#gem-install",
                   api_docs: "http://guides.rubygems.org/rubygems-org-api/",
                   gem_list: rubygems_path,
                   contributing_docs: "http://guides.rubygems.org/contributing/"
-                ) %>
+                  ) %>
               </p>
               <p>
-                 RubyGems.org is made possible through a partnership with the greater Ruby community.
-                <%= link_to "Fastly", "https://www.fastly.com/" %> provides bandwidth and CDN support,
-                <%= link_to "Ruby Central", "http://www.rubycentral.org/" %> covers infrastructure costs, and
-                <%= link_to "Ruby Together", "https://rubytogether.org/?source=rubygems" %> funds ongoing development and ops work.
-                <%= link_to "Learn more about our sponsors and how they work together", page_path("sponsors") %>.
+                <%= t('footer_sponsors_html', sponsors_page: page_path("sponsors")) %>
               </p>
               <p>
-                We need your help to fund the developer time that keeps RubyGems.org running smoothly for everyone.
-                <%= link_to "Join Ruby Together today", "https://rubytogether.org/join?source=rubygems" %>.
+                <%= t('footer_join_rt_html') %>
               </p>
             </div>
           </div>

--- a/app/views/mailer/deletion_complete.html.erb
+++ b/app/views/mailer/deletion_complete.html.erb
@@ -1,4 +1,4 @@
 <p>Hi </p>
 <p>
-  <%= t('.body', sign_up: link_to(t('sign_up'), sign_up_url)).html_safe %>
+  <%= t('.body_html', sign_up: link_to(t('sign_up'), sign_up_url)) %>
 </p>

--- a/app/views/mailer/deletion_failed.html.erb
+++ b/app/views/mailer/deletion_failed.html.erb
@@ -1,4 +1,4 @@
 <p>Hi </p>
 <p>
-  <%= t('.body', contact: link_to('contact', "http://help.rubygems.org")).html_safe %>
+  <%= t('.body_html', contact: link_to('contact', "http://help.rubygems.org")) %>
 </p>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -8,24 +8,24 @@
     <li class="t-numbered-item"><%= t '.purpose.enable_community' %></li>
   </ol>
   <p>
-    <%= t('.founding', :founder => link_to('Nick Quaranto', 'https://twitter.com/qrush'),
-                       :contributors => link_to("291 Rubyists", "https://github.com/rubygems/rubygems.org/graphs/contributors"),
-                       :downloads => link_to("millions of gem downloads", stats_path),
-                       :title => t('title')).html_safe %>
+    <%= t('.founding_html', :founder => link_to('Nick Quaranto', 'https://twitter.com/qrush'),
+                            :contributors => link_to("291 Rubyists", "https://github.com/rubygems/rubygems.org/graphs/contributors"),
+                            :downloads => link_to("millions of gem downloads", stats_path),
+                            :title => t('title')) %>
   </p>
   <p>
-    <%= t('.support', :dockyard => link_to("DockYard", "https://www.dockyard.com/"),
-                      :github => link_to("GitHub", "https://github.com"),
-                      :heroku => link_to("Heroku", "https://heroku.com"),
-                      :aws => link_to("AWS", "https://aws.amazon.com")).html_safe %>
+    <%= t('.support_html', :dockyard => link_to("DockYard", "https://www.dockyard.com/"),
+                           :github => link_to("GitHub", "https://github.com"),
+                           :heroku => link_to("Heroku", "https://heroku.com"),
+                           :aws => link_to("AWS", "https://aws.amazon.com")) %>
   </p>
   <p>
-    <%= t('.technical', :rails => link_to("Rails", "http://rubyonrails.org"),
-                        :s3 => link_to("Amazon S3", "https://aws.amazon.com/s3/"),
-                        :fastly => link_to("Fastly", "https://www.fastly.com"),
-                        :source_code => link_to("please check out the code", "https://github.com/rubygems/rubygems.org"),
-                        :license => link_to("MIT licensed", "http://www.opensource.org/licenses/mit-license.php")
-                        ).html_safe %>
+    <%= t('.technical_html', :rails => link_to("Rails", "http://rubyonrails.org"),
+                             :s3 => link_to("Amazon S3", "https://aws.amazon.com/s3/"),
+                             :fastly => link_to("Fastly", "https://www.fastly.com"),
+                             :source_code => link_to("please check out the code", "https://github.com/rubygems/rubygems.org"),
+                             :license => link_to("MIT licensed", "http://www.opensource.org/licenses/mit-license.php")
+                             ) %>
   </p>
 
   <div class="hide-assets">

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -1,4 +1,4 @@
-<% @title = "RubyGems.org Data Dumps" %>
+<% @title = t('.title') %>
 
 <div class="t-body">
   <p>We provide weekly dumps of the RubyGems.org PostgreSQL data. This dump is sanitized, removing all user information.</p>

--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Download RubyGems" %>
+<% @title = t('.title') %>
 <% @subtitle = subtitle %>
 
 <div class="l-colspan t-body">

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -1,4 +1,4 @@
-<% @title = "FAQ" %>
+<% @title = t('.title') %>
 
 <div class="t-body">
   <p>

--- a/app/views/pages/migrate.html.erb
+++ b/app/views/pages/migrate.html.erb
@@ -1,4 +1,4 @@
-<% @title = "migrate gems" %>
+<% @title = t('.title') %>
 
 <div class="l-colspan t-body">
   <p>

--- a/app/views/pages/security.html.erb
+++ b/app/views/pages/security.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Security" %>
+<% @title = t('.title') %>
 
 <div class="l-colspan t-body">
   <p>

--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Sponsors" %>
+<% @title = t('.title') %>
 
 <div class="l-colspan t-body">
   <p>

--- a/app/views/profiles/delete.html.erb
+++ b/app/views/profiles/delete.html.erb
@@ -2,7 +2,7 @@
 
 <% if @only_owner_gems.any? %>
   <div class="t-body">
-    <p class="page__subheading"><%= (t '.list_only_owner', command_link: link_to('gem owner', 'http://guides.rubygems.org/command-reference/#gem-owner')).html_safe %></p>
+    <p class="page__subheading"><%= (t '.list_only_owner_html', command_link: link_to('gem owner', 'http://guides.rubygems.org/command-reference/#gem-owner')) %></p>
   </div>
   <div id="profile">
     <div class="profile-list">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -69,15 +69,15 @@
 
   <div class="t-body">
     <h2><%= t '.reset_password.title' %></h2>
-    <p><%= t('.reset_password.text', :link => link_to(t('.reset_password.link_text'), new_password_path)).html_safe %></p>
+    <p><%= t('.reset_password.text_html', :link => link_to(t('.reset_password.link_text'), new_password_path)) %></p>
 
     <h2><%= t '.api_access.title' %></h2>
     <p>
-      <%= t('.api_access.key_is', :key => content_tag(:strong, current_user.api_key)).html_safe %>
+      <%= t('.api_access.key_is_html', :key => content_tag(:strong, current_user.api_key)) %>
     </p>
     <p>
-      <%= t('.api_access.credentials', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
-                                       :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))).html_safe %>
+      <%= t('.api_access.credentials_html', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
+                                            :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))) %>
     </p>
     <pre><code>curl -u <%= current_user.name %> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials</code></pre>
   </div>

--- a/app/views/reverse_dependencies/_search.html.erb
+++ b/app/views/reverse_dependencies/_search.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag rubygem_reverse_dependencies_path(rubygem),
   id: "rdeps-search", class: "header__search-wrap", method: :get do %>
-  <%= search_field_tag :rdeps_query, params[:rdeps_query], placeholder: t('.search_reverse_dependencies').html_safe, class: "header__search" %>
+  <%= search_field_tag :rdeps_query, params[:rdeps_query], placeholder: t('.search_reverse_dependencies_html'), class: "header__search" %>
   <%= label_tag :rdeps_query do %>
-    <span class="t-hidden"><%= t('.search_reverse_dependencies').html_safe %></span>
+    <span class="t-hidden"><%= t('.search_reverse_dependencies_html') %></span>
   <% end %>
   <%= submit_tag '⌕', id: 'rdeps_search_submit', name: nil, class: "header__search__icon" %>
 <% end %>

--- a/app/views/rubygems/show_yanked.html.erb
+++ b/app/views/rubygems/show_yanked.html.erb
@@ -10,7 +10,7 @@
       <% if @rubygem.pushable? %>
         <%= t '.not_hosted_notice' %>
       <% else %>
-        <%= t('.reserved_namespace', count: @rubygem.protected_days).html_safe %>
+        <%= t('.reserved_namespace_html', count: @rubygem.protected_days) %>
       <% end %>
       <%= unsubscribe_link(@rubygem) %>
     </div>

--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -2,9 +2,9 @@
 
 <div class="home__search-wrap">
   <%= form_tag search_url, id: "advanced-search", method: :get do %>
-    <%= search_field_tag :query, params[:query], placeholder: t("layouts.application.header.search_gem").html_safe, autofocus: current_page?(root_url), id: "home_query", class: "home__search" %>
+    <%= search_field_tag :query, params[:query], placeholder: t("layouts.application.header.search_gem_html"), autofocus: current_page?(root_url), id: "home_query", class: "home__search" %>
     <%= label_tag :home_query do %>
-      <span class="t-hidden"><%= t("layouts.application.header.search_gem").html_safe %></span>
+      <span class="t-hidden"><%= t("layouts.application.header.search_gem_html") %></span>
     <% end %>
     <%= submit_tag "⌕", name: nil, class: "home__search__icon" %>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module Gemcutter
     config.time_zone = "UTC"
     config.encoding  = "utf-8"
     config.i18n.available_locales = [:en, :nl, 'zh-CN', 'zh-TW', 'pt-BR', :fr, :es, :de]
-    config.i18n.fallbacks = true
+    config.i18n.fallbacks = [:en]
 
     config.middleware.insert 0, Rack::UTF8Sanitizer
     config.middleware.use Rack::Attack

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3,7 +3,9 @@ de:
   failure_when_forbidden:
   feed_latest: RubyGems.org | Neueste Gems
   feed_subscribed: RubyGems.org | Abonnierte Gems
-  footer_about:
+  footer_about_html:
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: Bitte warten...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ de:
       migrating_link_text: Migrieren
       mine: Meine Gems
       my_subscriptions: Abonnements
-      no_owned: Du hast noch keine Gems gepusht. Schau doch vielleicht die Dokumentation auf %{creating_link} an und %{migrating_link} ein Gem from RubyForge.
-      no_subscriptions: Du hast noch keine Gems abonniert. Besuche %{gem_link} um das Gem zu abonnieren!
+      no_owned_html: Du hast noch keine Gems gepusht. Schau doch vielleicht die Dokumentation auf %{creating_link} an und %{migrating_link} ein Gem from RubyForge.
+      no_subscriptions_html: Du hast noch keine Gems abonniert. Besuche %{gem_link} um das Gem zu abonnieren!
+      title: Dashboard
   email_confirmations:
     create:
       promise_resend:
@@ -62,7 +65,7 @@ de:
       confirmed_email:
   home:
     index:
-      downloads_counting: Gezählte Downloads
+      downloads_counting_html: Gezählte Downloads
       find_blurb: Finde, installiere und veröffentliche RubyGems.
       learn:
         install_rubygems: Installiere RubyGems
@@ -93,7 +96,7 @@ de:
         uptime: Betriebszeit
       header:
         dashboard: Dashboard
-        search_gem: Suche Gems&hellip;
+        search_gem_html: Suche Gems&hellip;
         sign_in: Anmelden
         sign_out: Abmelden
         sign_up: Registrieren
@@ -108,10 +111,10 @@ de:
       link_expiration_explanation:
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title:
@@ -121,15 +124,27 @@ de:
       title:
   pages:
     about:
-      founding: Das Projekt wurde im April 2009 von %{founder} gestartet und hat seitdem über %{contributors} und %{downloads}. Ab dem Release von RubyGems 1.3.6 wurde die Website von Gemcutter zu %{title} umbenannt, um eine zentrale Rolle in der Ruby-Community zu verfestigen.
-      support: Obwohl RubyGems.org nicht von einem bestimmten Unternehmen ausgeführt wird, haben viele Unternehmen uns bereits unterstützt. Das aktuelle Design, die Illustrationen und die Front-End-Entwicklung für dieser Webseite wurden von %{dockyard} erstellt. %{github} hat auch von unschätzbarem Wert uns geholfen den Code mit anderen Entwicklern zuteilen, um an dem Code leichter zusammenarbeiten. Die Website wurde mit %{heroku} gestartet, dessen großen Dienst uns geholfen, RubyGems als eine praktikable Lösung zu erweisen, wo die ganze Gemeinschaft darauf verlassen kann. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Einige Einblicke in die technischen Aspekte dieser Webseite: Es ist 100% in Ruby geschrieben. Die Hauptseite ist verwendet die %{rails}-Software. Die Gems werden in %{s3}, served by %{fastly}, gehostet und die Zeit zwischen der Veröffentlichung eines neuen Gems und nachdem er bereit zur Installation freigegeben ist, ist minimal. Für mehr Informationen siehe %{source_code} (%{license}) auf GitHub.'
+      founding_html: Das Projekt wurde im April 2009 von %{founder} gestartet und hat seitdem über %{contributors} und %{downloads}. Ab dem Release von RubyGems 1.3.6 wurde die Website von Gemcutter zu %{title} umbenannt, um eine zentrale Rolle in der Ruby-Community zu verfestigen.
+      support_html: Obwohl RubyGems.org nicht von einem bestimmten Unternehmen ausgeführt wird, haben viele Unternehmen uns bereits unterstützt. Das aktuelle Design, die Illustrationen und die Front-End-Entwicklung für dieser Webseite wurden von %{dockyard} erstellt. %{github} hat auch von unschätzbarem Wert uns geholfen den Code mit anderen Entwicklern zuteilen, um an dem Code leichter zusammenarbeiten. Die Website wurde mit %{heroku} gestartet, dessen großen Dienst uns geholfen, RubyGems als eine praktikable Lösung zu erweisen, wo die ganze Gemeinschaft darauf verlassen kann. Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Einige Einblicke in die technischen Aspekte dieser Webseite: Es ist 100% in Ruby geschrieben. Die Hauptseite ist verwendet die %{rails}-Software. Die Gems werden in %{s3}, served by %{fastly}, gehostet und die Zeit zwischen der Veröffentlichung eines neuen Gems und nachdem er bereit zur Installation freigegeben ist, ist minimal. Für mehr Informationen siehe %{source_code} (%{license}) auf GitHub.'
       title: Über uns
       purpose:
         better_api: Bereitstellen eines besseren APIs für den Umgang mit Gems
         enable_community: Der Gemeinschaft ermöglichen, die Webseite zu verbessern und zu erweitern
         header: 'Willkommen in %{site}, die Community für Ruby Gem-Hostingservice. Die Gründe sind vielfältig:'
         transparent_pages: Erstellen transparenter und zugänglicher Projektseiten
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: Speichern dieses Passworts
@@ -172,14 +187,14 @@ de:
       title: Bearbeite Profil
       api_access:
         confirm_reset: Sind Sie sicher? Das kann nicht rückgängig gemacht werden.
-        credentials: 'Wenn du %{gem_commands_link} über das Terminal oder über die Kommandozeile verwenden möchtest, dann brauchst du die %{gem_credentials_file}-Datei, die du mit dem folgenden Befehl erzeugen kannst:'
-        key_is: Dein API-Schlüssel ist %{key}.
+        credentials_html: 'Wenn du %{gem_commands_link} über das Terminal oder über die Kommandozeile verwenden möchtest, dann brauchst du die %{gem_credentials_file}-Datei, die du mit dem folgenden Befehl erzeugen kannst:'
+        key_is_html: Dein API-Schlüssel ist %{key}.
         link_text: Gem-Befehle
         reset: Zurücksetzen meines API-Schlüssels
         title: API-Zugang
       reset_password:
         link_text: Jetzt ein neues Passwort zuschicken lassen.
-        text: Brauchst du ein neues Passwort? Kein Problem. %{link}
+        text_html: Brauchst du ein neues Passwort? Kein Problem. %{link}
         title: Zurücksetzen des Passworts
       delete:
         delete:
@@ -200,7 +215,7 @@ de:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ de:
       yanked_notice:
     show_yanked:
       not_hosted_notice: Dieses Gem wird aktuell nicht auf RubyGems.org gehostet.
-      reserved_namespace:
+      reserved_namespace_html:
         one:
         other:
   reverse_dependencies:
     index:
       title:
     search:
-      search_reverse_dependencies:
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,17 @@ en:
   failure_when_forbidden: Please double check the URL or try submitting it again.
   feed_latest: RubyGems.org | Latest Gems
   feed_subscribed: RubyGems.org | Subscribed Gems
-  footer_about: RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>. Use <a href="%{api_docs}">the API</a> to find out more about <a href="%{gem_list}">available gems</a>. <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
+  footer_about_html: RubyGems.org is the Ruby community&rsquo;s gem hosting service.
+    Instantly <a href="%{publish_docs}">publish your gems</a> and then <a href="%{install_docs}">install them</a>.
+    Use <a href="%{api_docs}">the API</a> to find out more about <a href="%{gem_list}">available gems</a>.
+    <a href="%{contributing_docs}">Become a contributor</a> and improve the site yourself.
+  footer_sponsors_html: RubyGems.org is made possible through a partnership with the greater Ruby community.
+    <a href="https://www.fastly.com/">Fastly</a> provides bandwidth and CDN support,
+    <a href="http://www.rubycentral.org/">Ruby Central</a> covers infrastructure costs, and
+    <a href="https://rubytogether.org/?source=rubygems">Ruby Together</a> funds ongoing development and ops work.
+    <a href="%{sponsors_page}">Learn more about our sponsors and how they work together</a>.
+  footer_join_rt_html: We need your help to fund the developer time that keeps RubyGems.org running smoothly for everyone.
+    <a href="https://rubytogether.org/join?source=rubygems">Join Ruby Together today</a>.
   form_disable_with: Please wait...
   help_url: http://help.rubygems.org
   invalid_page: Page number is out of range. Redirected to default page.
@@ -49,8 +59,9 @@ en:
       migrating_link_text: migrating
       mine: My Gems
       my_subscriptions: Subscriptions
-      no_owned: You haven't pushed any gems yet. Perhaps check out the guides on %{creating_link} a gem or %{migrating_link} a gem from RubyForge.
-      no_subscriptions: You're not subscribed to any gems yet. Visit a %{gem_link} to subscribe to one!
+      no_owned_html: You haven't pushed any gems yet. Perhaps check out the guides on %{creating_link} a gem or %{migrating_link} a gem from RubyForge.
+      no_subscriptions_html: You're not subscribed to any gems yet. Visit a %{gem_link} to subscribe to one!
+      title: Dashboard
   email_confirmations:
     create:
       promise_resend: We will email you confirmation link to activate your account if one exists.
@@ -62,7 +73,7 @@ en:
       confirmed_email: Your email address has been verified.
   home:
     index:
-      downloads_counting: downloads &amp; counting
+      downloads_counting_html: downloads &amp; counting
       find_blurb: Find, install, and publish RubyGems.
       learn:
         install_rubygems: Install RubyGems
@@ -93,7 +104,7 @@ en:
         uptime: Uptime
       header:
         dashboard: Dashboard
-        search_gem: Search Gems&hellip;
+        search_gem_html: Search Gems&hellip;
         sign_in: Sign in
         sign_out: Sign out
         sign_up: Sign up
@@ -108,10 +119,10 @@ en:
       link_expiration_explanation: Please keep in mind that this link is only valid for 3 hours.
     deletion_complete:
       subject: Your account has been deleted from rubygems.org
-      body: Your request for account deletion on rubygems.org has been processed. You can always create a new account using our %{sign_up} page.
+      body_html: Your request for account deletion on rubygems.org has been processed. You can always create a new account using our %{sign_up} page.
     deletion_failed:
       subject: Your account deletion request on rubygems.org has failed
-      body: You had request for account deletion on rubygems.org. Unfortunately, we were not able to process your request. Please try again after some time or %{contact} us if problem persists.
+      body_html: You had request for account deletion on rubygems.org. Unfortunately, we were not able to process your request. Please try again after some time or %{contact} us if problem persists.
   news:
     show:
       title: New Releases — All Gems
@@ -121,15 +132,27 @@ en:
       title: New Releases — Popular Gems
   pages:
     about:
-      founding: The project was started in April 2009 by %{founder}, and has since grown to include the contributions of over %{contributors} and %{downloads}. As of the RubyGems 1.3.6 release, the site has been renamed to %{title} from Gemcutter to solidify the site's central role in the Ruby community.
-      support: Although RubyGems.org is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove RubyGems as a viable solution that the whole community could rely on. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Some insights into the technical aspects of the site: It''s 100% Ruby. The main site is a %{rails} application. Gems are hosted on %{s3}, served by %{fastly}, and the time between publishing a new gem and having it ready for installation is usually just a few seconds. For more info, %{source_code}, which is %{license} over at GitHub.'
+      founding_html: The project was started in April 2009 by %{founder}, and has since grown to include the contributions of over %{contributors} and %{downloads}. As of the RubyGems 1.3.6 release, the site has been renamed to %{title} from Gemcutter to solidify the site's central role in the Ruby community.
+      support_html: Although RubyGems.org is not run by one specific company, plenty have helped us out so far. The current design, illustrations, and front-end development of this site were created by %{dockyard}. %{github} has also been invaluable for helping us collaborate and share code easily. The site started on %{heroku}, whose great service helped prove RubyGems as a viable solution that the whole community could rely on. Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Some insights into the technical aspects of the site: It''s 100% Ruby. The main site is a %{rails} application. Gems are hosted on %{s3}, served by %{fastly}, and the time between publishing a new gem and having it ready for installation is usually just a few seconds. For more info, %{source_code}, which is %{license} over at GitHub.'
       title: About
       purpose:
         better_api: Provide a better API for dealing with gems
         enable_community: Enable the community to improve and enhance the site
         header: 'Welcome to %{site}, the Ruby community''s gem hosting service. The purpose of this project is three-fold:'
         transparent_pages: Create more transparent and accessible project pages
+    data:
+      title: RubyGems.org Data Dumps
+    download:
+      title: Download RubyGems
+    faq:
+      title: FAQ
+    migrate:
+      title: Migrate gems
+    security:
+      title: Security
+    sponsors:
+      title: Sponsors
   passwords:
     edit:
       submit: Save this password
@@ -172,14 +195,14 @@ en:
       title: Edit profile
       api_access:
         confirm_reset: Are you sure? This cannot be undone.
-        credentials: 'If you want to use %{gem_commands_link} from the command line, you''ll need a %{gem_credentials_file} file, which you can generate using the following command:'
-        key_is: Your API key is %{key}.
+        credentials_html: 'If you want to use %{gem_commands_link} from the command line, you''ll need a %{gem_credentials_file} file, which you can generate using the following command:'
+        key_is_html: Your API key is %{key}.
         link_text: gem commands
         reset: Reset my API key
         title: API Access
       reset_password:
         link_text: Request a new one here.
-        text: Need a new password? No problem. %{link}
+        text_html: Need a new password? No problem. %{link}
         title: Reset password
       delete:
         delete: Delete
@@ -200,7 +223,7 @@ en:
       title: Delete profile
       confirm: Confirm
       instructions: We are sorry to see you go. Type your password in the field below and confirm.
-      list_only_owner: These gems will be yanked when you delete your profile. If you would like to add owners before you delete your profile, you can use %{command_link} command.
+      list_only_owner_html: These gems will be yanked when you delete your profile. If you would like to add owners before you delete your profile, you can use %{command_link} command.
       list_multi_owner: You will lose access to these gem but other owners of the gem will continue to have access.
     rubygem:
       owners_header: Owners
@@ -255,14 +278,14 @@ en:
       yanked_notice: This version has been yanked, and it is not available for download directly or for other gems that may have depended on it.
     show_yanked:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
-      reserved_namespace:
+      reserved_namespace_html:
         one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
         other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"
     search:
-      search_reverse_dependencies: "Search reverse dependencies Gems&hellip;"
+      search_reverse_dependencies_html: "Search reverse dependencies Gems&hellip;"
   searches:
     advanced:
       name: Name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,7 +3,9 @@ es:
   failure_when_forbidden:
   feed_latest: RubyGems.org | Gemas Nuevas
   feed_subscribed: RubyGems.org | Subscripciones de Gemas
-  footer_about: RubyGems.org es el servicio de alojamiento de gemas de la comunidad de Ruby. Publica tus gemas de manera instantánea e instalalas. Usa la API para interactuar y buscar información de las gemas disponibles. Conviértete en contribuidor y mejora este sitio con tus cambios.
+  footer_about_html: RubyGems.org es el servicio de alojamiento de gemas de la comunidad de Ruby. Publica tus gemas de manera instantánea e instalalas. Usa la API para interactuar y buscar información de las gemas disponibles. Conviértete en contribuidor y mejora este sitio con tus cambios.
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: Un momento por favor...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ es:
       migrating_link_text: migrar
       mine: Mis Gemas
       my_subscriptions: Subscripciones
-      no_owned: Aún no has registrado ninguna gema. Tal vez puedes revisar las guías para %{creating_link} una gema o %{migrating_link} una gema de RubyForge.
-      no_subscriptions: Aún no te has subscrito a ningua gema. ¡Visita la %{gem_link} para subscribirte!
+      no_owned_html: Aún no has registrado ninguna gema. Tal vez puedes revisar las guías para %{creating_link} una gema o %{migrating_link} una gema de RubyForge.
+      no_subscriptions_html: Aún no te has subscrito a ningua gema. ¡Visita la %{gem_link} para subscribirte!
+      title: Dashboard
   email_confirmations:
     create:
       promise_resend:
@@ -62,7 +65,7 @@ es:
       confirmed_email:
   home:
     index:
-      downloads_counting: descargas y contando
+      downloads_counting_html: descargas y contando
       find_blurb: Encuentra, instala, y publica RubyGems.
       learn:
         install_rubygems: Instalar RubyGems
@@ -93,7 +96,7 @@ es:
         uptime: Uptime
       header:
         dashboard: Dashboard
-        search_gem: Buscar gemas&hellip;
+        search_gem_html: Buscar gemas&hellip;
         sign_in: Ingresar
         sign_out: Cerrar sesión
         sign_up: Registro
@@ -108,10 +111,10 @@ es:
       link_expiration_explanation:
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title:
@@ -121,15 +124,27 @@ es:
       title:
   pages:
     about:
-      founding: El proyecto comenzó en Abril del 2009 por %{founder}, y desde entonces ha crecido para incluir las contribuciones de %{contributors} y %{downloads}. A partir de RubyGems 1.3.6 el sitio se renombró de Gemcutter a %{title} para hacer más claro el rol del mismo en la comunidad de Ruby.
-      support: A pesar de que Gemcutter no es mantenido por una compañía en específico, muchas de ellas nos han ayudado. El diseño actual, las ilustraciones y el desarrollo de front-end del sitio fue cortesía de %{dockyard}. %{github} también ha sido invaluable por ayudarnos a colaborar y compartir código de manera sencilla. El sitio comenzó en %{heroku}, cuyo excelente servicio ayudó a probar que Gemcutter es una solución viable en la que toda la comunidad puede confiar. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Algunos aspectos técnicos del sitio: Es 100% Ruby. El sitio principal es una aplicación de %{rails}. Las gemas se almacenan en %{s3}, served by %{fastly}, y el tiempo entre que se publica una gema y que está lista para instalarse es mínimo. Para más información, %{source_code}, cuya licencia es %{license} en GitHub.'
+      founding_html: El proyecto comenzó en Abril del 2009 por %{founder}, y desde entonces ha crecido para incluir las contribuciones de %{contributors} y %{downloads}. A partir de RubyGems 1.3.6 el sitio se renombró de Gemcutter a %{title} para hacer más claro el rol del mismo en la comunidad de Ruby.
+      support_html: A pesar de que Gemcutter no es mantenido por una compañía en específico, muchas de ellas nos han ayudado. El diseño actual, las ilustraciones y el desarrollo de front-end del sitio fue cortesía de %{dockyard}. %{github} también ha sido invaluable por ayudarnos a colaborar y compartir código de manera sencilla. El sitio comenzó en %{heroku}, cuyo excelente servicio ayudó a probar que Gemcutter es una solución viable en la que toda la comunidad puede confiar. Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Algunos aspectos técnicos del sitio: Es 100% Ruby. El sitio principal es una aplicación de %{rails}. Las gemas se almacenan en %{s3}, served by %{fastly}, y el tiempo entre que se publica una gema y que está lista para instalarse es mínimo. Para más información, %{source_code}, cuya licencia es %{license} en GitHub.'
       title: Acerca de
       purpose:
         better_api: Otorgar una mejor API para manejar las gemas
         enable_community: Permitirle a la comunidad contribuir para mejorar este sitio
         header: 'Bienvenido a %{site}, el servicio de alojamiento de gemas para la comunidad de Ruby. Este proyecto tiene 3 objetivos:'
         transparent_pages: Crear páginas de proyecto más accesibles y transparentes
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: Guardar esta contraseña
@@ -172,14 +187,14 @@ es:
       title: Editar perfil
       api_access:
         confirm_reset: "¿Estás seguro? Este cambio no puede deshacerse."
-        credentials: 'Si quieres usar %{gem_commands_link} desde la línea de comandos, vas a necesitar un archivo llamado %{gem_credentials_file}, el cual puedes generar usando el siguiente comando:'
-        key_is: Tu llave de API es %{key}.
+        credentials_html: 'Si quieres usar %{gem_commands_link} desde la línea de comandos, vas a necesitar un archivo llamado %{gem_credentials_file}, el cual puedes generar usando el siguiente comando:'
+        key_is_html: Tu llave de API es %{key}.
         link_text: comandos de gem
         reset: Reestablecer llave API
         title: Acceso a API
       reset_password:
         link_text: Pide una nueva aquí.
-        text: "¿Necesitas otra contraseña? No hay problema. %{link}"
+        text_html: "¿Necesitas otra contraseña? No hay problema. %{link}"
         title: Reestablecer contraseña
       delete:
         delete:
@@ -200,7 +215,7 @@ es:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ es:
       yanked_notice: Esta gema ya no está disponible para descarga directa o para otras gemas que dependan de ella.
     show_yanked:
       not_hosted_notice: Esta gema no se encuentra alojada en Gemcutter.
-      reserved_namespace:
+      reserved_namespace_html:
         one:
         other:
   reverse_dependencies:
     index:
       title:
     search:
-      search_reverse_dependencies:
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,7 +3,9 @@ fr:
   failure_when_forbidden: Veuillez vérifier l'URL ou réessayer.
   feed_latest: RubyGems.org | Derniers Gems
   feed_subscribed: RubyGems.org | Gems abonnés
-  footer_about: RubyGems.org est le service d&rsquo;hébergement de la communauté Ruby. Publiez vos gems instantanément et utilisez-les. Utilisez l'API pour interagir et trouver des informations sur les gems disponibles. Contribuez et améliorez ce site avec nous !
+  footer_about_html: RubyGems.org est le service d&rsquo;hébergement de la communauté Ruby. Publiez vos gems instantanément et utilisez-les. Utilisez l'API pour interagir et trouver des informations sur les gems disponibles. Contribuez et améliorez ce site avec nous !
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: Veuillez patienter...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ fr:
       migrating_link_text: migration
       mine: Mes Gems
       my_subscriptions: Abonnements
-      no_owned: Vous n'avez pas encore publié de gem. Vous pouvez vérifier les guides de %{creating_link} ou de %{migrating_link} de gems depuis RubyForge.
-      no_subscriptions: Vous n'avez pas encore d'abonnements. Visitez %{gem_link} pour vous y abonner !
+      no_owned_html: Vous n'avez pas encore publié de gem. Vous pouvez vérifier les guides de %{creating_link} ou de %{migrating_link} de gems depuis RubyForge.
+      no_subscriptions_html: Vous n'avez pas encore d'abonnements. Visitez %{gem_link} pour vous y abonner !
+      title: Dashboard
   email_confirmations:
     create:
       promise_resend: Si ce compte existe, vous recevrez un email avec un lien de confirmation pour l'activer.
@@ -62,7 +65,7 @@ fr:
       confirmed_email: Votre adresse email a été vérifiée.
   home:
     index:
-      downloads_counting: téléchargements à ce jour
+      downloads_counting_html: téléchargements à ce jour
       find_blurb: Trouvez, installez et publiez des RubyGems.
       learn:
         install_rubygems: Installez RubyGems
@@ -93,7 +96,7 @@ fr:
         uptime: Uptime
       header:
         dashboard: Dashboard
-        search_gem: Recherche de Gems&hellip;
+        search_gem_html: Recherche de Gems&hellip;
         sign_in: Connexion
         sign_out: Déconnexion
         sign_up: Inscription
@@ -108,10 +111,10 @@ fr:
       link_expiration_explanation: Veuillez noter que ce lien n'est valide que pendant 3 heures.
     deletion_complete:
       subject: Votre compte a bien été supprimé de RubyGems.org
-      body: "Votre demande de suppression de compte sur RubyGems.org a bien été prise en compte. Vous pouvez toujours créer un nouveau compte sur la page %{sign_up}"
+      body_html: "Votre demande de suppression de compte sur RubyGems.org a bien été prise en compte. Vous pouvez toujours créer un nouveau compte sur la page %{sign_up}"
     deletion_failed:
       subject: Votre demande de suppression de compte sur RubyGems.org a échoué
-      body: "Vous avez effectué une demande de suppression de compte sur RubyGems.org. Malheureusement, votre demande n'a pu aboutir. Veuillez réessayer plus tard ou nous %{contact} si le problème subsiste."
+      body_html: "Vous avez effectué une demande de suppression de compte sur RubyGems.org. Malheureusement, votre demande n'a pu aboutir. Veuillez réessayer plus tard ou nous %{contact} si le problème subsiste."
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems
@@ -121,15 +124,27 @@ fr:
       title: Nouvelles Versions - Gems populaires
   pages:
     about:
-      founding: Le projet a commencé en avril 2009 par %{founder}, et a grandi avec les contribution de %{contributors} et %{downloads}. À la sortie de RubyGems 1.3.6, ce site a été renommé de Gemcutter à %{title} pour ancrer son rôle central dans la communauté Ruby.
-      support: Bien que Gemcutter n'appartienne à aucune entreprise en particulier, il a reçu l'aide de nombreuses d'entre elles. Le design actuel, les illustrations, et développement front-end de ce site nous ont été offerts par %{dockyard}. Nous n'aurions pas pu collaborer et partager de code facilement sans %{github}. Ce site s'est lancé sur %{heroku}, dont l'excellent service a fait de Gemcutter une solution viable pour que la communauté s'y appuie en toute confiance. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Quelques informations sur les aspects techniques de ce site : il est en Ruby à 100%. Le site principal est une application %{rails}. Les Gems sont hébergés sur %{s3}, served by %{fastly}, permettant un record de vitesse entre le moment de publication et de mise à disposition de gems. Pour davantage d''informations, le %{source_code} est disponible sous licence %{license} sur GitHub.'
+      founding_html: Le projet a commencé en avril 2009 par %{founder}, et a grandi avec les contribution de %{contributors} et %{downloads}. À la sortie de RubyGems 1.3.6, ce site a été renommé de Gemcutter à %{title} pour ancrer son rôle central dans la communauté Ruby.
+      support_html: Bien que Gemcutter n'appartienne à aucune entreprise en particulier, il a reçu l'aide de nombreuses d'entre elles. Le design actuel, les illustrations, et développement front-end de ce site nous ont été offerts par %{dockyard}. Nous n'aurions pas pu collaborer et partager de code facilement sans %{github}. Ce site s'est lancé sur %{heroku}, dont l'excellent service a fait de Gemcutter une solution viable pour que la communauté s'y appuie en toute confiance. Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Quelques informations sur les aspects techniques de ce site : il est en Ruby à 100%. Le site principal est une application %{rails}. Les Gems sont hébergés sur %{s3}, served by %{fastly}, permettant un record de vitesse entre le moment de publication et de mise à disposition de gems. Pour davantage d''informations, le %{source_code} est disponible sous licence %{license} sur GitHub.'
       title: À propos
       purpose:
         better_api: Fournir une meilleure API pour gérer les gems
         enable_community: Permettre à la communauté d'améliorer ce site
         header: 'Bienvenue sur %{site}, le service d''hébergement des gems de la communauté Ruby. Ce projet a trois objectifs :'
         transparent_pages: Créer des pages de projet plus accessibles et transparentes
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: Enregistrer ce mot de passe
@@ -172,14 +187,14 @@ fr:
       title: Modification de profil
       api_access:
         confirm_reset: Êtes-vous sûr ? Cette action ne peut être annulée.
-        credentials: 'Si vous voulez utiliser %{gem_commands_link} de la ligne de commande, vous aurez besoin d''un fichier %{gem_credentials_file}, que vous pouvez générer avec la commande suivante :'
-        key_is: Votre clé API est %{key}.
+        credentials_html: 'Si vous voulez utiliser %{gem_commands_link} de la ligne de commande, vous aurez besoin d''un fichier %{gem_credentials_file}, que vous pouvez générer avec la commande suivante :'
+        key_is_html: Votre clé API est %{key}.
         link_text: des commandes gems
         reset: Remise à zéro de votre clé API
         title: Accès API
       reset_password:
         link_text: Demandez un nouveau mot de passe ici.
-        text: Besoin d'un nouveau mot de passe ? Pas de problème. %{link}
+        text_html: Besoin d'un nouveau mot de passe ? Pas de problème. %{link}
         title: Renvoi de mot de passe
       delete:
         delete: Supprimer
@@ -200,7 +215,7 @@ fr:
       title: Supprimer le profil
       confirm: Confirmer
       instructions: Nous sommes désolés de vous voir partir. Veuillez entrer votre mot de passe dans le champ et confirmer.
-      list_only_owner: Ces gems seront effacées quand vous effacerez votre profil. Si vous désirez ajouter des propriétaires avant de supprimer votre profil, vous pouvez utiliser la commande %{command_link}.
+      list_only_owner_html: Ces gems seront effacées quand vous effacerez votre profil. Si vous désirez ajouter des propriétaires avant de supprimer votre profil, vous pouvez utiliser la commande %{command_link}.
       list_multi_owner: Vous allez perdre l'accès à ces gems mais d'autres propriétaires de ces gems y ont toujours accès.
     rubygem:
       owners_header: Propriétaires
@@ -255,14 +270,14 @@ fr:
       yanked_notice: 'Retrait de Gem : disponible ni directement, ni pour les gems qui en dépendraient.'
     show_yanked:
       not_hosted_notice: Gem non hébergé sur Rubygems pour le moment.
-      reserved_namespace:
+      reserved_namespace_html:
         one: Cette gem existait, mais a été supprimée par son propriétaire. L'équipe RubyGems.org a réservé ce nom de gem pour un jour supplémentaire. Une fois ce temps écoulé, quiconque pourra utiliser ce nom de gem en utilisant gem push. <br/> Si vous êtes le propriétaire précédent de cette gem, vous pouvez modifier la propriété de cette gem en utilisant la commande de gem owner. Vous pouvez également créer de nouvelles versions de cette gem avec gem push.
         other: Cette gem existait, mais a été supprimée par son propriétaire. L'équipe RubyGems.org a réservé ce nom de gem pour %{count} jours supplémentaires. Une fois ce temps écoulé, quiconque pourra utiliser ce nom de gem en utilisant gem push. <br/> Si vous êtes le propriétaire précédent de cette gem, vous pouvez modifier la propriété de cette gem en utilisant la commande de gem owner. Vous pouvez également créer de nouvelles versions de cette gem avec gem push.
   reverse_dependencies:
     index:
       title: "Dépendances inversées pour %{name}"
     search:
-      search_reverse_dependencies: "Chercher des dépendances inversées Gems&hellip;"
+      search_reverse_dependencies_html: "Chercher des dépendances inversées Gems&hellip;"
   searches:
     advanced:
       name: Nom

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -3,7 +3,9 @@ nl:
   failure_when_forbidden: Controleer het webadres, en probeer het opnieuw.
   feed_latest: RubyGems.org | Nieuwste Gems
   feed_subscribed: RubyGems.org | Geabonneerde Gems
-  footer_about: RubyGems.org is de gem hosting service van de Ruby community. <a href="%{publish_docs}">Publiceer</a> en <a href="%{install_docs}">installeer</a> je gems direct. Gebruik <a href="%{api_docs}">de API</a> om meer informatie over beschikbare gems te vinden. <a href="%{contributing_docs}">Word een deelnemer</a> en verbeter de site met jouw aanpassingen.
+  footer_about_html: RubyGems.org is de gem hosting service van de Ruby community. <a href="%{publish_docs}">Publiceer</a> en <a href="%{install_docs}">installeer</a> je gems direct. Gebruik <a href="%{api_docs}">de API</a> om meer informatie over beschikbare gems te vinden. <a href="%{contributing_docs}">Word een deelnemer</a> en verbeter de site met jouw aanpassingen.
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: Een moment geduld...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ nl:
       migrating_link_text: migreren
       mine: Mijn Gems
       my_subscriptions: Mijn abonnementen
-      no_owned: Je hebt nog geen gems gepubliceerd. Bekijk de instructies voor het %{creating_link} van een gem of het  %{migrating_link} van een gem vanaf RubyForge.
-      no_subscriptions: Je bent nog niet geabonneerd op een of meerdere gems. Bezoek een %{gem_link} en abonneer je erop.
+      no_owned_html: Je hebt nog geen gems gepubliceerd. Bekijk de instructies voor het %{creating_link} van een gem of het  %{migrating_link} van een gem vanaf RubyForge.
+      no_subscriptions_html: Je bent nog niet geabonneerd op een of meerdere gems. Bezoek een %{gem_link} en abonneer je erop.
+      title: Dashboard
   email_confirmations:
     create:
       promise_resend: Als het opgegeven account bestaat, wordt er een activatielink naar je e-mail gestuurd.
@@ -62,7 +65,7 @@ nl:
       confirmed_email:
   home:
     index:
-      downloads_counting:
+      downloads_counting_html:
       find_blurb: Vind je gems makkelijker en publiceer ze sneller.
       learn:
         install_rubygems: Installeer RubyGems
@@ -93,7 +96,7 @@ nl:
         uptime: Uptime
       header:
         dashboard: Dashboard
-        search_gem: Gems Zoeken&hellip;
+        search_gem_html: Gems Zoeken&hellip;
         sign_in: Inloggen
         sign_out: Uitloggen
         sign_up: Registreren
@@ -108,10 +111,10 @@ nl:
       link_expiration_explanation: Deze link is 3 uur geldig.
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title:
@@ -121,15 +124,27 @@ nl:
       title:
   pages:
     about:
-      founding: Het project is gestart in april 2009 door %{founder} en is sindsdien uitgegroeid tot een dienst met bijdragen van meer dan %{contributors} en %{downloads}. Sinds de RubyGems 1.3.6 release, is de site hernoemd van Gemcutter naar %{title} om de centrale rol in de Ruby community te verstevigen.
-      support: Hoewel rubygems.org niet wordt gerund door één specifiek bedrijf, zijn er vele die ons tot hier geholpen hebben. Het huidige design van de site is gesponsord door %{dockyard}. %{github} is van onschatbare waarde geweest om code te delen en er samen aan te werken. De site is begonnen op  %{heroku}, waarvan de geweldige service heeft geholpen om te bewijzen dat rubygems.org een oplossing is waar de hele community op kan bouwen. Our infrastructure is currently hosted on %{aws}.
-      technical: 'Een klein inkijkje in de technische aspecten van de site: Het is 100% Ruby. The main site is a %{rails}-applicatie. Gems worden gehost op %{s3}, served by %{fastly}, en de tijd tussen het publiceren van een nieuwe gem en het beschikbaar zijn voor installatie is minimaal. Voor meer informatie, %{source_code} op GitHub. De code is %{license}'
+      founding_html: Het project is gestart in april 2009 door %{founder} en is sindsdien uitgegroeid tot een dienst met bijdragen van meer dan %{contributors} en %{downloads}. Sinds de RubyGems 1.3.6 release, is de site hernoemd van Gemcutter naar %{title} om de centrale rol in de Ruby community te verstevigen.
+      support_html: Hoewel rubygems.org niet wordt gerund door één specifiek bedrijf, zijn er vele die ons tot hier geholpen hebben. Het huidige design van de site is gesponsord door %{dockyard}. %{github} is van onschatbare waarde geweest om code te delen en er samen aan te werken. De site is begonnen op  %{heroku}, waarvan de geweldige service heeft geholpen om te bewijzen dat rubygems.org een oplossing is waar de hele community op kan bouwen. Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Een klein inkijkje in de technische aspecten van de site: Het is 100% Ruby. The main site is a %{rails}-applicatie. Gems worden gehost op %{s3}, served by %{fastly}, en de tijd tussen het publiceren van een nieuwe gem en het beschikbaar zijn voor installatie is minimaal. Voor meer informatie, %{source_code} op GitHub. De code is %{license}'
       title: Over
       purpose:
         better_api: Een betere API ter beschikking te stellen voor het beheren van gems.
         enable_community: De community in staat te stellen de site te verbeteren en uit te breiden.
         header: 'Welkom bij %{site}, dé hosting service voor de Ruby community. Het doel van dit poroject is drieledig:'
         transparent_pages: Het maken van meer transparante en toegankelijke projectpagina's.
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: Sla dit wachtwoord op
@@ -172,14 +187,14 @@ nl:
       title: Wijzig profiel
       api_access:
         confirm_reset: Weet je het zeker? Dit kan niet ongedaan worden gemaakt.
-        credentials: 'Als je de %{gem_commands_link} vanaf de command-line wilt gebruiken, heb je een %{gem_credentials_file} bestand nodig. Je kunt deze genereren met het volgende commando:'
-        key_is: Je API key is %{key}
+        credentials_html: 'Als je de %{gem_commands_link} vanaf de command-line wilt gebruiken, heb je een %{gem_credentials_file} bestand nodig. Je kunt deze genereren met het volgende commando:'
+        key_is_html: Je API key is %{key}
         link_text: gem commando’s
         reset: Reset mijn API key
         title: API toegang
       reset_password:
         link_text: Vraag hier een nieuwe aan.
-        text: Nieuw wachtwoord nodig? Geen probleem. %{link}
+        text_html: Nieuw wachtwoord nodig? Geen probleem. %{link}
         title: Reset wachtwoord
       delete:
         delete:
@@ -200,7 +215,7 @@ nl:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ nl:
       yanked_notice:
     show_yanked:
       not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org.
-      reserved_namespace:
+      reserved_namespace_html:
         one:
         other:
   reverse_dependencies:
     index:
       title:
     search:
-      search_reverse_dependencies:
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -3,7 +3,9 @@ pt-BR:
   failure_when_forbidden:
   feed_latest: RubyGems.org | Últimas Gems
   feed_subscribed: RubyGems.org | Gems do seu Feed
-  footer_about: RubyGems.org é o serviço de hospedagem de gems da comunidade Ruby. Publique e instale suas gems instantaneamente. Use a API para interagir e encontrar mais informações sobre gems disponíveis. Torne-se um contribuidor e melhore o site com suas mudanças.
+  footer_about_html: RubyGems.org é o serviço de hospedagem de gems da comunidade Ruby. Publique e instale suas gems instantaneamente. Use a API para interagir e encontrar mais informações sobre gems disponíveis. Torne-se um contribuidor e melhore o site com suas mudanças.
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: Atualizando...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ pt-BR:
       migrating_link_text: migrar
       mine: Minhas Gems
       my_subscriptions: Observando
-      no_owned: Você ainda não enviou nenhuma gem. Verifique os guias sobre %{creating_link} uma gem ou %{migrating_link} uma gem do RubyForge.
-      no_subscriptions: Você ainda não está observando nenhuma gem. Visite uma %{gem_link} para poder observá-la!
+      no_owned_html: Você ainda não enviou nenhuma gem. Verifique os guias sobre %{creating_link} uma gem ou %{migrating_link} uma gem do RubyForge.
+      no_subscriptions_html: Você ainda não está observando nenhuma gem. Visite uma %{gem_link} para poder observá-la!
+      title: Painel de Controle
   email_confirmations:
     create:
       promise_resend:
@@ -62,7 +65,7 @@ pt-BR:
       confirmed_email:
   home:
     index:
-      downloads_counting: downloads
+      downloads_counting_html: downloads
       find_blurb: Encontre, instale e publique RubyGems.
       learn:
         install_rubygems: Instalar o RubyGems
@@ -93,7 +96,7 @@ pt-BR:
         uptime: Uptime
       header:
         dashboard: Painel de Controle
-        search_gem: Buscar Gems&hellip;
+        search_gem_html: Buscar Gems&hellip;
         sign_in: Fazer Login
         sign_out: Sair
         sign_up: Cadastrar
@@ -108,10 +111,10 @@ pt-BR:
       link_expiration_explanation:
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title:
@@ -121,15 +124,27 @@ pt-BR:
       title:
   pages:
     about:
-      founding: Este projeto foi iniciado em Abril de 2009 por %{founder}, e desde então tem crescido para incluir as contribuições de %{contributors} e %{downloads}. A partir do lançamento do RubyGems 1.3.6 o site foi renomeado de Gemcutter para %{title} para solidificar o papel centra do site na comunidade Ruby.
-      support: Pelo Gemcutter não ser mantido por uma empresa específica, o projeto contou e conta com a contribuição de muitas pessoas. O design atual, ilustrações e o frontend do site foram criados pela %{dockyard}. Nós também contamos com ajuda do %{github} por nos ajudar a compartilhar código facilmente. Este site foi inicialmente hospedado no %{heroku}, que nos ajudaram a validar o Gemcutter como uma solução viável para toda a comunidade Ruby.  Our infrastructure is currently hosted on %{aws}.
-      technical: 'Alguns aspectos técnicos sobre este site: 100% Ruby. A parte principal é um aplicativo %{rails}. As gems são hospedadas no %{s3}, served by %{fastly}, e o tempo de espera entre publicar uma nova gem e disponibilidade para instalação é mínimo. Para mais informações, verifique o %{source_code}, com a licença %{license} no GitHub.'
+      founding_html: Este projeto foi iniciado em Abril de 2009 por %{founder}, e desde então tem crescido para incluir as contribuições de %{contributors} e %{downloads}. A partir do lançamento do RubyGems 1.3.6 o site foi renomeado de Gemcutter para %{title} para solidificar o papel centra do site na comunidade Ruby.
+      support_html: Pelo Gemcutter não ser mantido por uma empresa específica, o projeto contou e conta com a contribuição de muitas pessoas. O design atual, ilustrações e o frontend do site foram criados pela %{dockyard}. Nós também contamos com ajuda do %{github} por nos ajudar a compartilhar código facilmente. Este site foi inicialmente hospedado no %{heroku}, que nos ajudaram a validar o Gemcutter como uma solução viável para toda a comunidade Ruby.  Our infrastructure is currently hosted on %{aws}.
+      technical_html: 'Alguns aspectos técnicos sobre este site: 100% Ruby. A parte principal é um aplicativo %{rails}. As gems são hospedadas no %{s3}, served by %{fastly}, e o tempo de espera entre publicar uma nova gem e disponibilidade para instalação é mínimo. Para mais informações, verifique o %{source_code}, com a licença %{license} no GitHub.'
       title: Sobre o Rubygems
       purpose:
         better_api: Prover uma API melhor para lidar com gems
         enable_community: Empoderar a comunidade para melhorar o site
         header: 'Bem vindo ao %{site}, o serviço de hospedagem de gems da comunidade Ruby. Este projeto tem três propósitos:'
         transparent_pages: Criar páginas mais acessíveis e transparentes para os projetos
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: Salvar senha
@@ -172,14 +187,14 @@ pt-BR:
       title: Editar Perfil
       api_access:
         confirm_reset: Tem certeza?
-        credentials: 'Se você quiser usar %{gem_commands_link} pela linha comando, você vai precisar de um arquivo %{gem_credentials_file}. Para gerar este arquivo rode o seguinte comando:'
-        key_is: A chave da sua API é %{key}.
+        credentials_html: 'Se você quiser usar %{gem_commands_link} pela linha comando, você vai precisar de um arquivo %{gem_credentials_file}. Para gerar este arquivo rode o seguinte comando:'
+        key_is_html: A chave da sua API é %{key}.
         link_text: gems
         reset: Resetar minha chave da API
         title: Acesso à API
       reset_password:
         link_text: Solicitar uma nova senha.
-        text: Esqueceu sua senha? Sem problema. %{link}
+        text_html: Esqueceu sua senha? Sem problema. %{link}
         title: Resetar senha
       delete:
         delete:
@@ -200,7 +215,7 @@ pt-BR:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ pt-BR:
       yanked_notice: Esta gem foi removida, e não está mais disponível para download.
     show_yanked:
       not_hosted_notice: Esta gem não está hospedada no Gemcutter.
-      reserved_namespace:
+      reserved_namespace_html:
         one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
         other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"
     search:
-      search_reverse_dependencies:
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -3,7 +3,9 @@ zh-CN:
   failure_when_forbidden: 请确认 URL 或再次提交
   feed_latest: RubyGems.org | 最新 Gems
   feed_subscribed: RubyGems.org | 订阅 Gems
-  footer_about: RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。
+  footer_about_html: RubyGems.org 是 Ruby 社区的 Gem 托管服务。<br />让你能便捷、快速的发布、管理你的 Gem 以及安装它们。提供 API 查阅可用 Gem 的详细资料。<br />参与进来成为一个贡献者，用你的能力推动社区进步。
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: 请稍后...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ zh-CN:
       migrating_link_text: 迁移
       mine: 我的 Gems
       my_subscriptions: 我的订阅
-      no_owned: 你没有发布过任何一个 Gem。可以尝试阅读 %{creating_link} 教程，或看看 %{migrating_link} 教程。
-      no_subscriptions: 你目前没有订阅任何 Gem，访问 %{gem_link} 可以订阅一个！
+      no_owned_html: 你没有发布过任何一个 Gem。可以尝试阅读 %{creating_link} 教程，或看看 %{migrating_link} 教程。
+      no_subscriptions_html: 你目前没有订阅任何 Gem，访问 %{gem_link} 可以订阅一个！
+      title: 控制台
   email_confirmations:
     create:
       promise_resend:
@@ -62,7 +65,7 @@ zh-CN:
       confirmed_email: 邮箱地址验证成功。
   home:
     index:
-      downloads_counting: 总下载次数
+      downloads_counting_html: 总下载次数
       find_blurb: 寻找、安装以及发布 RubyGems
       learn:
         install_rubygems: 安装 RubyGems
@@ -93,7 +96,7 @@ zh-CN:
         uptime: 服务状况
       header:
         dashboard: 控制台
-        search_gem: 搜索 Gems&hellip;
+        search_gem_html: 搜索 Gems&hellip;
         sign_in: 登录
         sign_out: 退出
         sign_up: 注册
@@ -108,10 +111,10 @@ zh-CN:
       link_expiration_explanation:
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title: 全部新发布 Gems
@@ -121,15 +124,27 @@ zh-CN:
       title: 热门新发布 Gems
   pages:
     about:
-      founding: 此项目创立由 %{founder} 于2009年4月，发展过程中有超过 %{contributors} 贡献者以及 %{downloads}。自从 RubyGems 1.3.6 发布以后，本站名称由 Gemcutter 改名为 %{title}，从而巩固在 Ruby 社区网站中和核心作用。
-      support: 虽然 Gemcutter 不是由一个具体的公司来运作，但也有很多的帮助让我们走出了这么远。目前的设计、插画、以及网站的前端开发都是由 %{dockyard} 提供支持。%{github} 帮助我们轻松的协助和共享代码。本站最初部署在 %{heroku}，其一流的服务，有助于证明 Gemcutter 是可以依赖、可行的解决方案。Our infrastructure is currently hosted on %{aws}.
-      technical: 关于本站的一些技术方案：100% Ruby。主站基于 %{rails}。Gems 文件放在 %{s3}, served by %{fastly}, 上面，它能缩短在 Gem 提交到可以下载之间的耗时。更多的信息可以在 GitHub 上阅读 %{source_code}，基于 %{license} 协议。
+      founding_html: 此项目创立由 %{founder} 于2009年4月，发展过程中有超过 %{contributors} 贡献者以及 %{downloads}。自从 RubyGems 1.3.6 发布以后，本站名称由 Gemcutter 改名为 %{title}，从而巩固在 Ruby 社区网站中和核心作用。
+      support_html: 虽然 Gemcutter 不是由一个具体的公司来运作，但也有很多的帮助让我们走出了这么远。目前的设计、插画、以及网站的前端开发都是由 %{dockyard} 提供支持。%{github} 帮助我们轻松的协助和共享代码。本站最初部署在 %{heroku}，其一流的服务，有助于证明 Gemcutter 是可以依赖、可行的解决方案。Our infrastructure is currently hosted on %{aws}.
+      technical_html: 关于本站的一些技术方案：100% Ruby。主站基于 %{rails}。Gems 文件放在 %{s3}, served by %{fastly}, 上面，它能缩短在 Gem 提交到可以下载之间的耗时。更多的信息可以在 GitHub 上阅读 %{source_code}，基于 %{license} 协议。
       title: 关于
       purpose:
         better_api: 提供更好的 API 来为 Gems 服务
         enable_community: 可以让社区来改善本站
         header: 欢迎来到 %{site}, 这是 Ruby 社区的 Gem 托管服务。此项目有三个目的：
         transparent_pages: 构建更透明以及便于浏览的项目页面
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: 更新密码
@@ -172,14 +187,14 @@ zh-CN:
       title: 修改个人资料
       api_access:
         confirm_reset: 确定要重置吗？此动作执行后将无法撤销
-        credentials: 如果你希望在命令行中使用 %{gem_commands_link}，你需要一个 %{gem_credentials_file} 文件，可用下面的命令生成：
-        key_is: 你的 API Key：%{key}。
+        credentials_html: 如果你希望在命令行中使用 %{gem_commands_link}，你需要一个 %{gem_credentials_file} 文件，可用下面的命令生成：
+        key_is_html: 你的 API Key：%{key}。
         link_text: Gem 命令
         reset: 重置 API Key
         title: API 访问
       reset_password:
         link_text: 这里找回密码
-        text: 需要一个新密码？没问题，访问 %{link}
+        text_html: 需要一个新密码？没问题，访问 %{link}
         title: 重置密码
       delete:
         delete: 删除
@@ -200,7 +215,7 @@ zh-CN:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ zh-CN:
       yanked_notice: 这个 Gem 版本已经 yanked（废弃了），他无法提供下载，也无法被其他的 Gem 依赖。
     show_yanked:
       not_hosted_notice: 这个 Gem 目前没有托管在 Gemcutter。
-      reserved_namespace:
+      reserved_namespace_html:
         one:
         other:
   reverse_dependencies:
     index:
       title: "%{name} 的反向依赖"
     search:
-      search_reverse_dependencies: 搜索反向依赖
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name: 名称

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -3,7 +3,9 @@ zh-TW:
   failure_when_forbidden:
   feed_latest: RubyGems.org | 最新 Gems
   feed_subscribed: RubyGems.org | 訂閱 Gems
-  footer_about: RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。
+  footer_about_html: RubyGems.org 是 Ruby 社群的 Gem 套件管理服務，讓你能立即地發佈及安裝你的 Gem 套件，並且利用 API 查詢及操作可用 Gem 的詳細資訊。<br />現在就成為貢獻者，貢獻一己之力來改善本站。
+  footer_sponsors_html:
+  footer_join_rt_html:
   form_disable_with: 請稍候...
   help_url: http://help.rubygems.org
   invalid_page:
@@ -49,8 +51,9 @@ zh-TW:
       migrating_link_text: Gem 轉移
       mine: 我的 Gems
       my_subscriptions: 我的訂閱
-      no_owned: 你尚未發佈任何 Gem。可以閱讀 %{creating_link} 教學，或參考 %{migrating_link} 教學來將你的 Gem 從 RubyForge 遷移過來。
-      no_subscriptions: 你還沒有訂閱過 Gem，前往 %{gem_link} 來訂閱！
+      no_owned_html: 你尚未發佈任何 Gem。可以閱讀 %{creating_link} 教學，或參考 %{migrating_link} 教學來將你的 Gem 從 RubyForge 遷移過來。
+      no_subscriptions_html: 你還沒有訂閱過 Gem，前往 %{gem_link} 來訂閱！
+      title: 控制台
   email_confirmations:
     create:
       promise_resend:
@@ -62,7 +65,7 @@ zh-TW:
       confirmed_email:
   home:
     index:
-      downloads_counting: 總下載次數
+      downloads_counting_html: 總下載次數
       find_blurb: 搜尋、安裝以及發佈 RubyGems
       learn:
         install_rubygems: 安裝 RubyGems
@@ -93,7 +96,7 @@ zh-TW:
         uptime: 上線時間
       header:
         dashboard: 控制台
-        search_gem:
+        search_gem_html:
         sign_in: 登入
         sign_out: 登出
         sign_up: 註冊
@@ -108,10 +111,10 @@ zh-TW:
       link_expiration_explanation:
     deletion_complete:
       subject:
-      body:
+      body_html:
     deletion_failed:
       subject:
-      body:
+      body_html:
   news:
     show:
       title:
@@ -121,15 +124,27 @@ zh-TW:
       title:
   pages:
     about:
-      founding: 本專案由 %{founder} 於 2009 年 4 月創立，發展過程中有超過 %{contributors} 貢獻者以及 %{downloads}。自 RubyGems 1.3.6 發佈以來，本站名稱由 Gemcutter 更名為 %{title}，本站自此之後成為 Ruby 社群的核心網站。
-      support: 雖然 Gemcutter 並不是由一個特定的公司運作，但在發展過程中接受了許多來源的幫助。目前的設計、圖像以及網站的前端開發是由 %{dockyard} 提供。%{github} 也幫助我們能更容易地協作和分享原始碼。本站部署在 %{heroku} 上，其一流的服務，更有助於證明 Gemcutter 是一個可以穩定、可行的解決方案。Our infrastructure is currently hosted on %{aws}.
-      technical: 關於本站的技術資訊：100% Ruby。主站是一個 %{rails} 應用程式。Gems 架設在 %{s3} 上, served by %{fastly}, 使得 Gem 從發佈到提供下載的時間大幅縮短。詳細資訊可從 GitHub 上的 %{source_code} 查看（遵守 %{license} 協議）。
+      founding_html: 本專案由 %{founder} 於 2009 年 4 月創立，發展過程中有超過 %{contributors} 貢獻者以及 %{downloads}。自 RubyGems 1.3.6 發佈以來，本站名稱由 Gemcutter 更名為 %{title}，本站自此之後成為 Ruby 社群的核心網站。
+      support_html: 雖然 Gemcutter 並不是由一個特定的公司運作，但在發展過程中接受了許多來源的幫助。目前的設計、圖像以及網站的前端開發是由 %{dockyard} 提供。%{github} 也幫助我們能更容易地協作和分享原始碼。本站部署在 %{heroku} 上，其一流的服務，更有助於證明 Gemcutter 是一個可以穩定、可行的解決方案。Our infrastructure is currently hosted on %{aws}.
+      technical_html: 關於本站的技術資訊：100% Ruby。主站是一個 %{rails} 應用程式。Gems 架設在 %{s3} 上, served by %{fastly}, 使得 Gem 從發佈到提供下載的時間大幅縮短。詳細資訊可從 GitHub 上的 %{source_code} 查看（遵守 %{license} 協議）。
       title: 關於
       purpose:
         better_api: 提供更好的 Gem API
         enable_community: 讓社群能透過眾人的力量來改善本站
         header: 歡迎來到 %{site}，這裡是 Ruby 社群 Gem 套件管理服務。此專案的建立有以下三個目的：
         transparent_pages: 建立更透明、更易於瀏覽的 Gem 專案頁面
+    data:
+      title:
+    download:
+      title:
+    faq:
+      title:
+    migrate:
+      title:
+    security:
+      title:
+    sponsors:
+      title:
   passwords:
     edit:
       submit: 更新密碼
@@ -172,14 +187,14 @@ zh-TW:
       title: 編輯個人檔案
       api_access:
         confirm_reset: 確定要重設嗎？此動作無法還原
-        credentials: 如果你需要從 command line 中執行 %{gem_commands_link}，你需要先準備 %{gem_credentials_file} 這個檔案，用以下的指令可以產生：
-        key_is: 你的 API key 是 %{key}。
+        credentials_html: 如果你需要從 command line 中執行 %{gem_commands_link}，你需要先準備 %{gem_credentials_file} 這個檔案，用以下的指令可以產生：
+        key_is_html: 你的 API key 是 %{key}。
         link_text: Gem 指令
         reset: 重設 API key
         title: API 存取
       reset_password:
         link_text: 從這裡設定新密碼
-        text: 需要重設密碼？沒問題。 %{link}
+        text_html: 需要重設密碼？沒問題。 %{link}
         title: 重設密碼
       delete:
         delete:
@@ -200,7 +215,7 @@ zh-TW:
       title:
       confirm:
       instructions:
-      list_only_owner:
+      list_only_owner_html:
       list_multi_owner:
     rubygem:
       owners_header:
@@ -255,14 +270,14 @@ zh-TW:
       yanked_notice: 這個 Gem 版本已被移除，因此無法提供下載，也無法被其他的 Gem 相依。
     show_yanked:
       not_hosted_notice: 這個 Gem 目前沒有在 Gemcutter 上
-      reserved_namespace:
+      reserved_namespace_html:
         one:
         other:
   reverse_dependencies:
     index:
       title:
     search:
-      search_reverse_dependencies:
+      search_reverse_dependencies_html:
   searches:
     advanced:
       name:


### PR DESCRIPTION
Fixes brakeman Cross-Site Scripting warning:
Unescaped model attribute near app/views/rubygems/show_yanked.html.erb:13
`t(".reserved_namespace", :count => Rubygem.find_by_name((params[:rubygem_id] or params[:id])).protected_days).html_safe`
Fixes i18n fallback