### PR TITLE
Add rate limit on email confirmation per ip and per email

### DIFF
--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class RackAttackTest < ActionDispatch::IntegrationTest
   setup do
@@ -13,8 +13,16 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     (Rack::Attack::REQUEST_LIMIT * 1.25).to_i
   end
 
+  def exceeding_email_limit
+    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 1.25).to_i
+  end
+
   def under_limit
     (Rack::Attack::REQUEST_LIMIT * 0.5).to_i
+  end
+
+  def under_email_limit
+    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 0.5).to_i
   end
 
   def limit_period
@@ -22,15 +30,23 @@ class RackAttackTest < ActionDispatch::IntegrationTest
   end
 
   def exceed_limit_for(scope)
-    exceeding_limit.times do
-      Rack::Attack.cache.count("#{scope}:#{@ip_address}", limit_period)
-    end
+    update_limit_for("#{scope}:#{@ip_address}", exceeding_limit)
+  end
+
+  def exceed_email_limit_for(scope)
+    update_limit_for("#{scope}:#{@user.email}", exceeding_email_limit)
   end
 
   def stay_under_limit_for(scope)
-    under_limit.times do
-      Rack::Attack.cache.count("#{scope}:#{@ip_address}", limit_period)
-    end
+    update_limit_for("#{scope}:#{@ip_address}", under_limit)
+  end
+
+  def stay_under_email_limit_for(scope)
+    update_limit_for("#{scope}:#{@user.email}", under_email_limit)
+  end
+
+  def update_limit_for(key, limit)
+    limit.times { Rack::Attack.cache.count(key, limit_period) }
   end
 
   def encode(username, password)
@@ -38,100 +54,114 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       .encode_credentials(username, password)
   end
 
-  context 'requests is lower than limit' do
-    should 'allow sign in' do
+  context "requests is lower than limit" do
+    should "allow sign in" do
       stay_under_limit_for("clearance/ip")
 
-      post '/session',
-        params: { session: { who: @user.email, password: @user.password } }
+      post "/session",
+        params: { session: { who: @user.email, password: @user.password } },
+        headers: { REMOTE_ADDR: @ip_address }
       follow_redirect!
 
       assert_response :success
     end
 
-    should 'allow sign up' do
+    should "allow sign up" do
       stay_under_limit_for("clearance/ip")
 
       user = build(:user)
-      post '/users',
-        params: { user: { email: user.email, password: user.password } }
+      post "/users",
+        params: { user: { email: user.email, password: user.password } },
+        headers: { REMOTE_ADDR: @ip_address }
       follow_redirect!
 
       assert_response :success
     end
 
-    should 'allow forgot password' do
+    should "allow forgot password" do
       stay_under_limit_for("clearance/ip")
-      under_limit = (Rack::Attack::PASSWORD_UPDATE_LIMIT * 0.25).to_i
-      under_limit.times { Rack::Attack.cache.count("password/email:#{@email}", limit_period) }
+      stay_under_email_limit_for("password/email")
 
-      post '/passwords',
-        params: { password: { email: @user.email } }
+      post "/passwords",
+        params: { password: { email: @user.email } },
+        headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :success
     end
 
-    should 'allow api_key show' do
+    should "allow api_key show" do
       stay_under_limit_for("api_key/ip")
 
-      get '/api/v1/api_key.json',
-        env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) }
+      get "/api/v1/api_key.json",
+        env: { "HTTP_AUTHORIZATION" => encode(@user.handle, @user.password) },
+        headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :success
     end
 
-    context 'params' do
-      should 'return 400 for bad request' do
-        post '/session'
+    should "allow email confirmation resend" do
+      stay_under_limit_for("clearance/ip")
+      stay_under_email_limit_for("email_confirmations/email")
+
+      post "/email_confirmations",
+        params: { email_confirmation: { email: @user.email } },
+        headers: { REMOTE_ADDR: @ip_address }
+      follow_redirect!
+      assert_response :success
+    end
+
+    context "params" do
+      should "return 400 for bad request" do
+        post "/session"
 
         assert_response :bad_request
       end
 
-      should 'return 401 for unauthorized request' do
-        post '/session', params: { session: { password: @user.password } }
+      should "return 401 for unauthorized request" do
+        post "/session", params: { session: { password: @user.password } }
 
         assert_response :unauthorized
       end
     end
   end
 
-  context 'requests is higher than limit' do
-    should 'throttle sign in' do
+  context "requests is higher than limit" do
+    should "throttle sign in" do
       exceed_limit_for("clearance/ip")
 
-      post '/session',
+      post "/session",
         params: { session: { who: @user.email, password: @user.password } },
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests
     end
 
-    should 'throttle sign up' do
+    should "throttle sign up" do
       exceed_limit_for("clearance/ip")
 
       user = build(:user)
-      post '/users',
+      post "/users",
         params: { user: { email: user.email, password: user.password } },
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests
     end
 
-    should 'throttle forgot password' do
+    should "throttle forgot password" do
       exceed_limit_for("clearance/ip")
 
-      post '/passwords',
+      post "/passwords",
         params: { password: { email: @user.email } },
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests
     end
 
-    should 'throttle api_key show' do
+    should "throttle api_key show" do
       exceed_limit_for("api_key/ip")
 
-      get '/api/v1/api_key.json',
-        env: { 'HTTP_AUTHORIZATION' => encode(@user.handle, @user.password) },
+      get "/api/v1/api_key.json",
+        env: { "HTTP_AUTHORIZATION" => encode(@user.handle, @user.password) },
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests
@@ -157,11 +187,29 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       assert_response :too_many_requests
     end
 
-    context "password update" do
-      should 'throttle by ip' do
+    context "email confirmation" do
+      should "throttle by ip" do
         exceed_limit_for("clearance/ip")
 
-        post '/passwords',
+        post "/email_confirmations",
+          params: { email_confirmation: { email: @user.email } },
+          headers: { REMOTE_ADDR: @ip_address }
+        assert_response :too_many_requests
+      end
+
+      should "throttle by email" do
+        exceed_email_limit_for("email_confirmations/email")
+
+        post "/email_confirmations", params: { email_confirmation: { email: @user.email } }
+        assert_response :too_many_requests
+      end
+    end
+
+    context "password update" do
+      should "throttle by ip" do
+        exceed_limit_for("clearance/ip")
+
+        post "/passwords",
           params: { password: { email: @user.email } },
           headers: { REMOTE_ADDR: @ip_address }
 
@@ -169,10 +217,9 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       end
 
       should "throttle by email" do
-        exceed_limit = (Rack::Attack::PASSWORD_UPDATE_LIMIT * 1.25).to_i
-        exceed_limit.times { Rack::Attack.cache.count("password/email:#{@user.email}", limit_period) }
-        post '/passwords', params: { password: { email: @user.email } }
+        exceed_email_limit_for("password/email")
 
+        post "/passwords", params: { password: { email: @user.email } }
         assert_response :too_many_requests
       end
     end


### PR DESCRIPTION
This will rate limit resend email confirmation with `100req/10min/client ip` and `10req/10min/email`.
We seem to have missed this endpoint. should have always been in the list.
