### PR TITLE
Distribute pagination links uniformly

### DIFF
--- a/app/assets/stylesheets/modules/nav/nav--paginated.css
+++ b/app/assets/stylesheets/modules/nav/nav--paginated.css
@@ -73,3 +73,5 @@
   .pagination .next_page {
     position: absolute;
     right: 0; }
+  .pagination .current {
+    margin: 0 8px; }


### PR DESCRIPTION
The "current" pagination indicator on the "News" page is at present *narrow* in comparison to its adjacent indicators. This produces a slight visual mismatch as evident from below:

![Narrow current page indicator](https://user-images.githubusercontent.com/12479464/50440826-e4de8280-091d-11e9-9e09-45a5fd9901a0.png)

The proposed change fixes this by mirroring the adjacent links' margins:

![Corrected page indicator](https://user-images.githubusercontent.com/12479464/50440857-08a1c880-091e-11e9-87a7-64c423427150.png)

