### PR TITLE
Use build option instead of method override in test gem helper

### DIFF
--- a/test/helpers/gem_helpers.rb
+++ b/test/helpers/gem_helpers.rb
@@ -9,7 +9,7 @@ module GemHelpers
 
   def build_gemspec(gemspec)
     Gem::DefaultUserInteraction.use_ui(Gem::StreamUI.new(StringIO.new, StringIO.new)) do
-      Gem::Package.build(gemspec)
+      Gem::Package.build(gemspec, true)
     end
   end
 
@@ -20,7 +20,7 @@ module GemHelpers
   def new_gemspec(name, version, summary, platform, extra_args = {})
     ruby_version = extra_args[:ruby_version]
     rubygems_version = extra_args[:rubygems_version]
-    gemspec = Gem::Specification.new do |s|
+    Gem::Specification.new do |s|
       s.name = name
       s.platform = platform
       s.version = version.to_s
@@ -39,11 +39,5 @@ module GemHelpers
       s.metadata = { "foo" => "bar" }
       yield s if block_given?
     end
-
-    gemspec.define_singleton_method(:validate) do
-      "not validating on purpose"
-    end
-
-    gemspec
   end
 end


### PR DESCRIPTION
The `Gem::Package.build` method takes an argument which allows the validation
step to be skipped, but it was not in use here. This helper skips the validation
to suppress noisy output about a (fake) gemspec defined in the test helper. We
were previously suppressing the output via a method override, this change
updates to use an option instead.