### PR TITLE
Update rubocop to version 0.61.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,12 @@ Performance/RedundantMerge:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/AlignHash:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
     optimist (3.0.0)
     os (0.9.6)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     paul_revere (3.0.0)
       rails (>= 5.0, < 6.0)
@@ -317,16 +317,16 @@ GEM
     rotp (3.3.1)
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
-    rubocop (0.58.2)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     ruby-graphviz (1.2.3)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     sass (3.4.24)
     shoryuken (2.1.3)
@@ -363,7 +363,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     unicorn (5.3.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -441,4 +441,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/lib/app_revision.rb
+++ b/lib/app_revision.rb
@@ -1,6 +1,10 @@
 class AppRevision
   def self.version
-    @version ||= begin
+    @version ||= revision_or_fallback
+  end
+
+  def self.revision_or_fallback
+    begin
       revision_file.read
     rescue Errno::ENOENT
       `git rev-parse HEAD`

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -3,10 +3,10 @@ module Patterns
 
   SPECIAL_CHARACTERS    = ".-_".freeze
   ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+".freeze
-  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
-  LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/
-  NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/
-  URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/.freeze
+  LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/.freeze
+  NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/.freeze
+  URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}.freeze
   GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64


### PR DESCRIPTION
Update is required to allow for ruby version 2.6 support. I chose to disable two things:

- Disabled `Layout/AlignHash` because there was a mix of styles within the project and there was no easy path to picking one w/out a lot of churn.
- Disabled `Layout/EmptyLineAfterGuardClause` for similar reasons ... although this one might be simpler/easier to just make the changes because it would be a bunch of new lines.

I'm open to making more changes if there's a different preference on those styles.

The other changes were related to fixes for what had previously been rubocop bugs fixed in the newer version.