### PR TITLE
Fix ActionDispatch::RemoteIp::IpSpoofAttackError

### DIFF
--- a/test/integration/ip_spoofing_test.rb
+++ b/test/integration/ip_spoofing_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class IpSpoofingTest < ActionDispatch::IntegrationTest
+  test "request with Client-IP and X-Forwarded-For header mismatch responds with bad request" do
+    get "/", headers: { HTTP_CLIENT_IP: "172.16.72.122", HTTP_X_FORWARDED_FOR: "8.8.8.8, 8.8.8.8" }
+    assert_response :bad_request
+  end
+end


### PR DESCRIPTION
We don't need to blow the app for logging support. Using `request.remote_ip`
was raising this. existing `rescue_from ActionDispatch::RemoteIp::IpSpoofAttackError`
was not working as rescue_from catches exception only coming from app
code (techinally, request.remote_ip is in our app code!?).
`render` by default would render application layout, so updated that
to use plain text for ip spoofing rescue.
ip spoofing is more of a `bad_request` than authentication failure
(forbidden), hence updated status.

Failing test on master: [Travis](https://travis-ci.org/sonalkr132/rubygems.org/jobs/475236003#L1496)
Related: https://github.com/rubygems/rubygems.org/commit/a34627389e59c01af471b9f31c7aa9b28f9fa057, #1538