### PR TITLE
Fix ArgumentError: string contains null byte

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   before_action :set_csp unless Rails.env.development?
+  before_action :reject_null_char_param
 
   def set_csp
     response.headers['Content-Security-Policy'] = "default-src 'self'; "\
@@ -135,5 +136,9 @@ class ApplicationController < ActionController::Base
 
   def valid_page_param?(max_page)
     params[:page].respond_to?(:to_i) && params[:page].to_i.between?(Gemcutter::DEFAULT_PAGE, max_page)
+  end
+
+  def reject_null_char_param
+    render plain: "bad request", status: :bad_request if params.values.any? { |v| v.to_s.include?("\u0000") }
   end
 end

--- a/test/integration/null_char_param_test.rb
+++ b/test/integration/null_char_param_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class NullCharParamTest < ActionDispatch::IntegrationTest
+  test "params with null character respond with bad request" do
+    get "/search?utf8=%E2%9C%93&query=php://input%00.&search_submit=%E2%8C%95"
+    assert_response :bad_request
+  end
+end


### PR DESCRIPTION
This was getting raised when we try to run a pg query with null chars.
Example req:
https://rubygems.org/search?utf8=%E2%9C%93&query=php://input%00.&search_submit=%E2%8C%95

query param has null char and blows up `Rubygem#name_is`.
Tried to report it to rails/rails ([#26891](https://github.com/rails/rails/issues/26891)) but was not accepted as valid bug,
hence fixing it in app.
Failing test on master: [Travis](https://travis-ci.org/sonalkr132/rubygems.org/jobs/475326554#L1489)