### PR TITLE
Fix broken translation keys

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -23,7 +23,7 @@ module SearchesHelper
 
     time_ago = (Time.zone.today - duration).to_s(:db)
     path = search_path(params: { query: "#{params[:query]} AND updated:[#{time_ago} TO *}" })
-    update_info = (duration == 30.days ? t('.month_update', count: count) : t('.week_update', count: count))
+    update_info = (duration == 30.days ? t('searches.show.month_update', count: count) : t('searches.show.week_update', count: count))
     link_to update_info, path, class: 't-link--black'
   end
 end

--- a/app/views/searches/_aggregations.html.erb
+++ b/app/views/searches/_aggregations.html.erb
@@ -1,6 +1,6 @@
 <% if gems.respond_to?(:response) && aggregations = gems.response['aggregations'] %>
   <div class="aggregations">
-    <%= t('.filter')%>
+    <%= t('searches.show.filter')%>
     <%= aggregation_match_count aggregations['matched_field'], 'name' %>
     <%= aggregation_match_count aggregations['matched_field'], 'description' %>
     <%= aggregation_match_count aggregations['matched_field'], 'summary' %>


### PR DESCRIPTION
This fixes https://github.com/rubygems/rubygems.org/issues/1879.

As the original issue says, translation missing is happening because proper translation keys are not given.

![image](https://user-images.githubusercontent.com/1811616/51084783-f673b700-1772-11e9-9000-97aeb11be040.png)

It seems to try to fetch translation with `"searches.aggregations.week_update"` since the `t` method is called in [`app/views/searches/_aggregations.html.erb`](https://github.com/rubygems/rubygems.org/blob/master/app/views/searches/_aggregations.html.erb) without full path. But there are no translations for `"searches.aggregations.*"`, correct path is [`"searches.show.*"`](https://github.com/rubygems/rubygems.org/blob/f99a7955f51d6e9ce1e43705a1c27980437b71b7/config/locales/en.yml#L299-L301).