### PR TITLE
fix statsd for k8s environment

### DIFF
--- a/config/deploy/db-migrate.yaml.erb
+++ b/config/deploy/db-migrate.yaml.erb
@@ -20,6 +20,13 @@ spec:
         value: "<%= environment %>"
       - name: STATSD_IMPLEMENTATION
         value: "datadog"
+      - name: STATSD_HOST
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: status.hostIP
+      - name: STATSD_ADDR
+        value: $(STATSD_HOST):8125
       - name: RAILS_LOG_TO_STDOUT
         value: "true"
       - name: SECRET_KEY_BASE

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -45,6 +45,13 @@ spec:
             value: "<%= environment %>"
           - name: STATSD_IMPLEMENTATION
             value: "datadog"
+          - name: STATSD_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: STATSD_ADDR
+            value: $(STATSD_HOST):8125
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -45,6 +45,13 @@ spec:
             value: "<%= environment %>"
           - name: STATSD_IMPLEMENTATION
             value: "datadog"
+          - name: STATSD_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: STATSD_ADDR
+            value: $(STATSD_HOST):8125
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -58,6 +58,13 @@ spec:
             value: "<%= environment %>"
           - name: STATSD_IMPLEMENTATION
             value: "datadog"
+          - name: STATSD_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: STATSD_ADDR
+            value: $(STATSD_HOST):8125
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,3 +1,13 @@
+# TODO: add feature to statsd-instrument for default tags
+class StatsD::Instrument::Metric
+  def self.normalize_tags(tags)
+    tags ||= []
+    tags = tags.map { |k, v| k.to_s + ":".freeze + v.to_s } if tags.is_a?(Hash)
+    tags.map { |tag| tag.tr('|,'.freeze, ''.freeze) }
+    tags << "env:#{Rails.env}" # Added to allow default env tag on all metrics
+  end
+end
+
 ActiveSupport::Notifications.subscribe(/process_action.action_controller/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
   event.payload[:format] = event.payload[:format] || 'all'


### PR DESCRIPTION
- fix deployments to have correct env vars to access statsd
- monkeypatch statsd-instrument to provide default `env` tag (this is temporary)