### PR TITLE
stop checking database during healthcheck

### DIFF
--- a/app/controllers/internal/ping_controller.rb
+++ b/app/controllers/internal/ping_controller.rb
@@ -1,7 +1,5 @@
 class Internal::PingController < ApplicationController
   def index
-    ActiveRecord::Base.connection.select_value('SELECT 1') == 1 or \
-      raise StandardError, 'Failed to SELECT 1 from DB server'
     render plain: 'PONG'
   end
 

--- a/test/functional/internal/ping_controller_test.rb
+++ b/test/functional/internal/ping_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class Internal::PingControllerTest < ActionController::TestCase
   context 'on GET to index' do
     setup do
+      ActiveRecord::Base.connection.stubs(:select_value).returns(nil)
       get :index
     end
 
@@ -10,15 +11,6 @@ class Internal::PingControllerTest < ActionController::TestCase
 
     should 'PONG' do
       assert page.has_content?('PONG')
-    end
-  end
-
-  context 'with postgres down' do
-    should 'not PONG' do
-      ActiveRecord::Base.connection.stubs(:select_value).returns(nil)
-      assert_raises StandardError do
-        get :index
-      end
     end
   end
 


### PR DESCRIPTION
We've had several outages recently where the healthchecks were failing. This removed the pods from the service, which resulted in a full outage.
At this point I don't this it's useful to check the health of the database before allowing traffic to hit the unicorn tier. This will also reduce the load on the database.