### PR TITLE
Update linkset model with spec metadata

### DIFF
--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -43,9 +43,8 @@ class Links
   # or if linksets has it defined, use that
   # else, generate one from gem name and version number
   def documentation_uri
-    version.metadata["documentation_uri"].presence ||
-      linkset&.docs&.presence ||
-      "http://www.rubydoc.info/gems/#{rubygem.name}/#{version.number}"
+    return version.metadata["documentation_uri"].presence if version.metadata_uri_set?
+    linkset&.docs&.presence || "http://www.rubydoc.info/gems/#{rubygem.name}/#{version.number}"
   end
 
   # technically this is a path
@@ -59,7 +58,8 @@ class Links
   LINKS.each do |short, long|
     unless method_defined?(long)
       define_method(long) do
-        version.metadata[long].presence || linkset.try(short)
+        return version.metadata[long].presence if version.metadata_uri_set?
+        linkset.try(short)
       end
     end
     alias_method short, long

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -324,6 +324,10 @@ class Version < ApplicationRecord
     raw.unpack("m0").first.unpack("H*").first
   end
 
+  def metadata_uri_set?
+    Links::LINKS.any? { |_, long| metadata.key? long }
+  end
+
   private
 
   def platform_and_number_are_unique

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -35,4 +35,15 @@ class LinksTest < ActiveSupport::TestCase
     refute links.links.key?('home')
     assert links.links.key?('docs')
   end
+
+  should "not use linkset value when any metadta uri attribute is set" do
+    version = build(:version, metadata: { "wiki_uri" => "https://example.wiki" })
+    linkset = build(:linkset, docs: "https://herebe.docs", code: "https://source.code")
+    rubygem = build(:rubygem, linkset: linkset, versions: [version])
+    links = rubygem.links(version)
+
+    refute links.documentation_uri
+    refute links.source_code_uri
+    assert links.wiki_uri
+  end
 end


### PR DESCRIPTION
We fall back to linkset when spec metadata is absent
(`version.metadata["documentation_uri"].presence || linkset&.docs&.presence`).
It keeps *aside* links populated for gems which don't see version updates.
This also meant that gem releases which have not set these links in spec
metadata, will also fallback to old linkset data. Intended behaviour
for not setting these links (for gem releases henceforth) should be that
we do not show the unset/empty links.

Closes: #1899
cc: @kbrock 