### PR TITLE
don't force TLS or domain for healthcheck endpoints

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -8,17 +8,17 @@ class Redirector
 
     allowed_hosts = [Gemcutter::HOST, 'index.rubygems.org', 'fastly.rubygems.org', 'bundler.rubygems.org']
 
-    if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api} && request.host !~ /docs/
+    if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))
       redirect_to(fake_request.url)
     elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)} && request.host !~ /docs/
       redirect_to("https://docs.rubygems.org#{request.path}")
     elsif request.path =~ %r{^/pages/docs$}
-      redirect_to("http://guides.rubygems.org")
+      redirect_to("https://guides.rubygems.org")
     elsif request.path =~ %r{^/pages/gem_docs$}
-      redirect_to("http://guides.rubygems.org/command-reference")
+      redirect_to("https://guides.rubygems.org/command-reference")
     elsif request.path =~ %r{^/pages/api_docs$}
-      redirect_to("http://guides.rubygems.org/rubygems-org-api")
+      redirect_to("https://guides.rubygems.org/rubygems-org-api")
     else
       @app.call(env)
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,12 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.ssl_options = { hsts: false }
+  config.ssl_options = {
+    hsts: false,
+    redirect: {
+      exclude: ->(request) { request.path.start_with?('internal') }
+    }
+  }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -52,7 +52,12 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.ssl_options = { hsts: false }
+  config.ssl_options = {
+    hsts: false,
+    redirect: {
+      exclude: ->(request) { request.path.start_with?('/internal') }
+    }
+  }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/test/unit/redirector_test.rb
+++ b/test/unit/redirector_test.rb
@@ -65,27 +65,32 @@ class RedirectorTest < ActiveSupport::TestCase
     get "/pages/docs", {}, "HTTP_HOST" => Gemcutter::HOST
 
     assert_equal 301, last_response.status
-    assert_equal "http://guides.rubygems.org", last_response.headers["Location"]
+    assert_equal "https://guides.rubygems.org", last_response.headers["Location"]
   end
 
   should "redirect request to gem docs to guides " do
     get "/pages/gem_docs", {}, "HTTP_HOST" => Gemcutter::HOST
 
     assert_equal 301, last_response.status
-    assert_equal "http://guides.rubygems.org/command-reference", last_response.headers["Location"]
+    assert_equal "https://guides.rubygems.org/command-reference", last_response.headers["Location"]
   end
 
   should "redirect request to api docs to guides " do
     get "/pages/api_docs", {}, "HTTP_HOST" => Gemcutter::HOST
 
     assert_equal 301, last_response.status
-    assert_equal "http://guides.rubygems.org/rubygems-org-api", last_response.headers["Location"]
+    assert_equal "https://guides.rubygems.org/rubygems-org-api", last_response.headers["Location"]
   end
 
   should "allow fastly domains" do
     get "/", {}, "HTTP_HOST" => 'index.rubygems.org'
     assert_equal 200, last_response.status
     get "/", {}, "HTTP_HOST" => 'fastly.rubygems.org'
+    assert_equal 200, last_response.status
+  end
+
+  should "allow healthcheck" do
+    get "/internal/ping", {}, "HTTP_HOST" => "localhost"
     assert_equal 200, last_response.status
   end
 end


### PR DESCRIPTION
This PR allows the healthcheck endpoint to be accessed over plain http on any domain (for use by the kubernetes readiness probe). Before, this was causing a cascading failure.

Every ping from the kubelet to the pod was getting a redirect, and following the redirect. This would occasionally timeout, as it was going through the internet and back through the full stack. When it would timeout, the readiness probe would fail, removing the endpoint from service. Once all the endpoints were removed, the probe would fail 100% of the time, and could not recover.

This explains why the only thing that fixed it at this point was removing the readiness probe and adding it back. This allowed the endpoints to be active again and the (re-added) probe would be able to pass.