### PR TITLE
Reorder versions only when indexed column changes

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -7,7 +7,7 @@ class Version < ApplicationRecord
 
   before_save :update_prerelease
   before_validation :full_nameify!
-  after_save :reorder_versions
+  after_save :reorder_versions, if: -> { saved_change_to_indexed? || saved_change_to_id? }
 
   serialize :licenses
   serialize :requirements

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -797,4 +797,26 @@ class VersionTest < ActiveSupport::TestCase
       assert_does_not_contain Version.created_between(@start_time, @end_time), @version
     end
   end
+
+  context "after_save" do
+    context "reorder versions" do
+      setup do
+        @version = create(:version)
+      end
+
+      context "indexed is updated" do
+        should "reorder versions" do
+          @version.expects(:reorder_versions).times(1)
+          @version.update(indexed: false)
+        end
+      end
+
+      context "info checksum is updated" do
+        should "not reorder versions" do
+          @version.expects(:reorder_versions).times(0)
+          @version.update(info_checksum: "lala")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Periously, versions were getting reordered for any change to version
record and causing performance issue where gems have a large set of
released versions.
We need to reorder versions only when a new version is created or when
a version is yanked (indexed column changes).
This reduces versions reordering in gem push from thrice to once and
in gem yank from twice to once.

Related: #1908