### PR TITLE
purge multiple domains

### DIFF
--- a/config/deploy/db-migrate.yaml.erb
+++ b/config/deploy/db-migrate.yaml.erb
@@ -76,11 +76,11 @@ spec:
           secretKeyRef:
             name: <%= environment %>
             key: fastly_service_id
-      - name: FASTLY_DOMAIN
+      - name: FASTLY_DOMAINS
         valueFrom:
           secretKeyRef:
             name: <%= environment %>
-            key: fastly_domain
+            key: fastly_domains
       - name: ELASTICSEARCH_URL
         valueFrom:
           secretKeyRef:

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -101,11 +101,11 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: fastly_service_id
-          - name: FASTLY_DOMAIN
+          - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
                 name: <%= environment %>
-                key: fastly_domain
+                key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:

--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -16,7 +16,7 @@
         "honeybadger_api_key": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:PvoZeAX52WmcFsCSWiVhSF86SNd3j9SF:z5I4XA0St0psAfod3SCcwPMWYl2d330p]",
         "fastly_api_key": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:M98nU0WSNMUuTRzN9y+01NZqgGRXTZPI:bG+dA1ngkleKfENVTvk84PL9BuPunrJlJa9lqMnuBwosD0fC6EKp4k2hhfCxIl7A]",
         "fastly_service_id": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:C4oFJ1efUUzzBp0bHOoD9RfYhksPv9b2:8/aWHX+8FFB3xh5XOPP77/O4feoGI9zPX1cvJuijuRfl9UMxC+4=]",
-        "_fastly_domain": "index.rubygems.org",
+        "_fastly_domains": "index.rubygems.org,api.rubygems.org,rubygems.org",
         "elasticsearch_url": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:L0W35UFL4ENDzCE9zbscqKM+5mIGjvZC:ea/Tiu6HlWBcS58gxaWsXSRMtuUqSbDO8bm5l9WLlq83WXAT+3Pea6XjpSrQUHZuA+ebTRJxur/U5iWzs8isq+/KQINJmbfHLqR7JLSEklFIYvB5WvewfAVl3sJ4lTEPjJ8nL9CkhD2i7g==]",
         "memcached_endpoint": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:FIeGTD+rb3bEUmaY9Bjf/iB2IhstX4wK://dMk+r6yv5mhlG1A2sms1C1RAyGvtb1UBsigE3DCPP7F7t7B4uE6CA6qHQq99VWLE+4NK4eA6bG+SyezG1QWs2yib5ziRx2GQ0qM/5OUw==]",
         "sendgrid_username": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:C8S7bPGPGmgRuD3Fbl4YHaH3kgIRVqZ+:86aooyNFO+v8ZSLPU+rvUTVN5BiezQ==]",

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -101,11 +101,11 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: fastly_service_id
-          - name: FASTLY_DOMAIN
+          - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
                 name: <%= environment %>
-                key: fastly_domain
+                key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -16,7 +16,7 @@
         "honeybadger_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:TD1e42m2hCnraaRigNZZZao9WKF9S9Nf:Myj5m7maDkOC2GbolUskZ2F+zmRscHE8]",
         "fastly_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:Hig6V1MQP4qgUM0ONuSJ1baySFEjBUtv:38lnkxBDiihzxIKy1qRFlNIkFVK6w77KHkrKAFv23Bcn/Z3h13NjXZO/tkr27AcV]",
         "fastly_service_id": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:4PJ8m22sz0fVV514tgOaV+G6Imw2TU2h:4hdG2htqLTOP8ky59J+V1VI5l4FCiTef+ixbnaNJU6nriNh2U6c=]",
-        "_fastly_domain": "staging.rubygems.org",
+        "_fastly_domains": "staging.rubygems.org",
         "elasticsearch_url": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:md53NdJnx5PVn95M4NAotzMGZ06ub5wf:pBIlOJ3GHAe1PFeoUzQ0rLQ/uuT/rkXDpOZuJiltcuE30QIdqfmVhT7BoGKl0TRAO6EihH22u46hUarfZugyHZoJN71AD8YngxFgYTFMCH4VXEKEj6YNow6lG+3gshupYK7V9YIP+Bu9]",
         "memcached_endpoint": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:EMi4FLAdV9tWQ8IevfUfr75o6pTo0GAC:ylZl7qFloCf1iUqtEyDsam2ZsEUYcws56jQiR3mT1quTlNQr38fDz5MjeNhMAQfbdGY8KnC2v50Vs1wb1AuKbRUNwU9bGO9pl3E2]",
         "sendgrid_username": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:SBrWz77BfZ7BECNMAwhSB+MrfezIsjl4:1vc/AeDn3zWbEyseu88JyUc6rHV6yw==]",

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -116,11 +116,11 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: fastly_service_id
-          - name: FASTLY_DOMAIN
+          - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
                 name: <%= environment %>
-                key: fastly_domain
+                key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -8,17 +8,18 @@ end
 
 class Fastly
   def self.purge(path, soft = false)
-    return unless ENV['FASTLY_DOMAIN']
-    domain = "https://#{ENV['FASTLY_DOMAIN']}/"
-    headers = soft ? { 'Fastly-Soft-Purge' => 1 } : {}
+    return unless ENV['FASTLY_DOMAINS']
+    ENV['FASTLY_DOMAINS'].split(",").each do |domain|
+      url = "https://#{domain}/#{path}"
+      headers = soft ? { 'Fastly-Soft-Purge' => 1 } : {}
 
-    response = RestClient::Request.execute(method: :purge,
-                                           url: domain + path,
-                                           timeout: 10,
-                                           headers: headers)
-    json = JSON.parse(response)
-    Rails.logger.debug "Fastly purge url=#{domain + path} status=#{json['status']} id=#{json['id']}"
-    json
+      response = RestClient::Request.execute(method: :purge,
+                                             url: url,
+                                             timeout: 10,
+                                             headers: headers)
+      json = JSON.parse(response)
+      Rails.logger.debug "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}"
+    end
   end
 
   def self.purge_key(key, soft = false)

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class FastlyTest < ActiveSupport::TestCase
+  setup do
+    ENV['FASTLY_DOMAINS'] = "domain1.example.com,domain2.example.com"
+  end
+
+  teardown do
+    ENV['FASTLY_DOMAINS'] = nil
+  end
+
+  context ".purge" do
+    should "purge for each domain" do
+      RestClient::Request.expects(:execute).times(2).returns("{}")
+      Fastly.purge("some-url")
+    end
+  end
+end


### PR DESCRIPTION
Different clients may access the api on different domains. Currently we only purge the CDN on one domain. This change will purge on all 3 domains.

This partially solves https://github.com/rubygems/rubygems.org/issues/1877. Related to https://github.com/rubygems/rubygems.org/issues/1698.