### PR TITLE
Add lower index to versions full name

### DIFF
--- a/db/migrate/20190220164205_add_lower_full_name_index_to_versions.rb
+++ b/db/migrate/20190220164205_add_lower_full_name_index_to_versions.rb
@@ -1,0 +1,5 @@
+class AddLowerFullNameIndexToVersions < ActiveRecord::Migration[5.2]
+  def change
+    add_index :versions, 'lower(full_name)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_22_172318) do
+ActiveRecord::Schema.define(version: 2019_02_20_164205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2018_10_22_172318) do
     t.string "required_rubygems_version"
     t.string "info_checksum"
     t.string "yanked_info_checksum"
+    t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"


### PR DESCRIPTION
`validates :full_name, presence: true, uniqueness: { case_sensitive:
false }` creates sql:
```
SELECT  1 AS one FROM "versions" WHERE LOWER("versions"."full_name") =
LOWER($1) AND "versions"."id" != $2 LIMIT $3
```
it was not hitting index because of `lower` expression:
```sql
gemcutter_development=# explain analyse SELECT  1 AS one FROM "versions" WHERE LOWER("versions"."full_name") = LOWER('nokogiri-1.8.3') AND
"versions"."id" != 1062467 LIMIT 1;
                                                    QUERY PLAN
-------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..13.29 rows=1 width=0) (actual time=681.907..681.907
rows=0 loops=1)
   ->  Seq Scan on versions  (cost=0.00..68408.23 rows=5148 width=0)
(actual time=681.906..681.906 rows=0 loops=1)
         Filter: ((id <> 1062467) AND (lower((full_name)::text) =
'nokogiri-1.8.3'::text))
         Rows Removed by Filter: 1029670
 Planning time: 1.250 ms
 Execution time: 681.960 ms
(6 rows)

gemcutter_development=# create index on "versions" (lower("full_name"));
CREATE INDEX
gemcutter_development=# explain analyse SELECT  1 AS one FROM "versions"
WHERE LOWER("versions"."full_name") = LOWER('nokogiri-1.8.3') AND
"versions"."id" != 1062467 LIMIT 1;
                                                                QUERY
PLAN
------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.42..4.27 rows=1 width=0) (actual time=0.092..0.092
rows=0 loops=1)
   ->  Index Scan using versions_lower_idx on versions
(cost=0.42..19795.38 rows=5148 width=0) (actual time=0.091..0.091 rows=0
loops=1)
         Index Cond: (lower((full_name)::text) = 'nokogiri-1.8.3'::text)
         Filter: (id <> 1062467)
         Rows Removed by Filter: 1
 Planning time: 0.488 ms
 Execution time: 0.137 ms
(7 rows)
```
Closes: #1908