### PR TITLE
Cache bundle install for docker build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/cache"]
-	path = vendor/cache
-	url = https://github.com/rubygems/rubygems.org-vendor.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 cache:
   bundler: true
   directories:
-    - reports
-    - vendor/cache
+    - $HOME/docker
 
 rvm:
   - 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,7 @@ sudo: false
 
 bundler_args: --jobs=3 --retry=3 --without development
 
-git:
-  submodules: true
-
 before_install:
-  - git submodule update --init
   - sh -c "if [ '$RUBYGEMS_VERSION' != 'latest' ]; then gem update --system $RUBYGEMS_VERSION; fi"
   - gem --version
   - script/install_toxiproxy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,19 +19,16 @@ RUN apk add --no-cache \
 RUN mkdir -p /app /app/config
 WORKDIR /app
 
-RUN gem update --system 2.6.10
+ADD Gemfile* /app/
+RUN gem update --system 2.6.10 && gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without deploy
+
+ADD https://github.com/bundler/bundler-api/raw/master/versions.list /app/config/versions.list.bk
 
 COPY . /app
 
-ADD https://github.com/bundler/bundler-api/raw/master/versions.list /app/config/versions.list
-
-RUN mv /app/config/database.yml.example /app/config/database.yml
-
-RUN gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without deploy
+RUN mv /app/config/database.yml.example /app/config/database.yml && mv /app/config/versions.list.bk /app/config/versions.list
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=1234 bin/rails assets:precompile
-
-
 
 
 FROM ruby:2.5-alpine

--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -2,19 +2,23 @@
 
 set -ex
 
-if [ -z "$RUBYGEMS_VERSION" ] || [ $RUBYGEMS_VERSION == 'latest' ]
+if [[ $RUBYGEMS_VERSION == 'latest' ]] || [[ $TRAVIS_RUBY_VERSION == 'ruby-head' ]]
 then
   exit 0
 fi
 
-if [ -z "$TRAVIS_RUBY_VERSION" ] || [ $TRAVIS_RUBY_VERSION == 'ruby-head' ]
+if [[ -f "$HOME/docker/docker-cache.tgz" ]]
 then
-  exit 0
+  docker load -i $HOME/docker/docker-cache.tgz
 fi
 
 echo "$TRAVIS_COMMIT" > REVISION
 
-docker build -t quay.io/$TRAVIS_REPO_SLUG:$TRAVIS_COMMIT .
+docker build --target build --cache-from rubygems-org:build -t rubygems-org:build .
+docker build --cache-from rubygems-org:build -t quay.io/$TRAVIS_REPO_SLUG:$TRAVIS_COMMIT .
+
+mkdir -p $HOME/docker
+docker save -o $HOME/docker/docker-cache.tgz rubygems-org
 
 if [ -z "$DOCKER_USERNAME" ] || [ -z "$DOCKER_PASSWORD" ]
 then


### PR DESCRIPTION
This PR aims to achieve build capability when rubygems.org is down. `docker build ..` will use cache if Gemfile hasn't changed.
Reduces time for `script/build_docker.sh` by ~110 seconds. 
Travis officially [doesn't support docker cache](https://github.com/travis-ci/travis-ci/issues/5358) but we can directory cache along with `docker save` and `docker load`.
[Travis build using cache](https://travis-ci.org/sonalkr132/rubygems.org/jobs/496095123#L1648).
