### PR TITLE
Add mfa to password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,12 +1,29 @@
 class PasswordsController < Clearance::PasswordsController
-  before_action :validate_confirmation_token, only: :edit
+  before_action :validate_confirmation_token, only: %i[edit mfa_edit]
+
+  def edit
+    if @user.mfa_enabled?
+      render template: 'passwords/otp_prompt'
+    else
+      render template: 'passwords/edit'
+    end
+  end
+
+  def mfa_edit
+    if @user.mfa_enabled? && @user.otp_verified?(params[:otp])
+      render template: 'passwords/edit'
+    else
+      flash.now.alert = t('multifactor_auths.incorrect_otp')
+      render template: 'passwords/otp_prompt', status: :unauthorized
+    end
+  end
+
+  private
 
   def find_user_for_create
     Clearance.configuration.user_model
       .find_by_normalized_email password_params[:email]
   end
-
-  private
 
   def url_after_update
     dashboard_path
@@ -17,8 +34,7 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def validate_confirmation_token
-    user = find_user_for_edit
-    return if user&.valid_confirmation_token?
-    redirect_to root_path, alert: t('failure_when_forbidden')
+    @user = find_user_for_edit
+    redirect_to root_path, alert: t('failure_when_forbidden') unless @user&.valid_confirmation_token?
   end
 end

--- a/app/views/passwords/otp_prompt.html.erb
+++ b/app/views/passwords/otp_prompt.html.erb
@@ -1,0 +1,11 @@
+<% @title = t('multifactor_authentication') %>
+
+<%= form_tag mfa_edit_user_password_path(@user, token: @user.confirmation_token), method: :post do %>
+  <div class="text_field">
+    <%= label_tag :otp, t('multifactor_auths.otp_code'), class: 'form__label' %>
+    <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+  </div>
+  <div class="form_bottom">
+    <%= submit_tag t('.authenticate'), data: {disable_with: t('form_disable_with')}, class: 'form__submit' %>
+  </div>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -153,6 +153,8 @@ de:
       submit: Zurücksetzen des Passworts
       title: Ändere dein Passwort
       will_email_notice: Wir senden dir einen Link damit du dein Passwort ändern kannst.
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,8 @@ en:
       submit: Reset password
       title: Change your password
       will_email_notice: We will email you a link to change your password.
+    otp_prompt:
+      authenticate: Authenticate
   multifactor_auths:
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,6 +153,8 @@ es:
       submit: Reestablecer contraseña
       title: Cambiar contraseña
       will_email_notice: Te enviaremos un email con un enlace para cambiar tu contraseña.
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,6 +153,8 @@ fr:
       submit: Réinitialisez votre mot de passe
       title: Changement de mot de passe
       will_email_notice: Nous vous enverrons un email pour changer votre mot de passe.
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp: Votre clé OTP est incorrecte.
     otp_code: clé OTP

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -153,6 +153,8 @@ nl:
       submit: Wachtwoord wijzigen
       title: Wachtwoord wijzigen
       will_email_notice: We sturen een link om je wachtwoord te wijzigen.
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -153,6 +153,8 @@ pt-BR:
       submit: Resetar senha
       title: Alterar senha
       will_email_notice: Você vai receber um email com o link para atualizar sua senha.
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -153,6 +153,8 @@ zh-CN:
       submit: 重置密码
       title: 修改密码
       will_email_notice: 我们将会通过 Email 发送修改密码的链接给你。
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -153,6 +153,8 @@ zh-TW:
       submit: 更新密碼
       title: 修改密碼
       will_email_notice: 系統將會寄一封包含重設密碼連結的電子郵件給你
+    otp_prompt:
+      authenticate:
   multifactor_auths:
     incorrect_otp:
     otp_code:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,7 +171,9 @@ Rails.application.routes.draw do
     end
 
     resources :users, only: %i[new create] do
-      resource :password, only: %i[create edit update]
+      resource :password, only: %i[create edit update] do
+        post 'mfa_edit', to: 'passwords#mfa_edit', as: :mfa_edit
+      end
     end
 
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class PasswordsControllerTest < ActionController::TestCase
   context "on POST to create" do
@@ -33,7 +33,10 @@ class PasswordsControllerTest < ActionController::TestCase
         get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
       end
 
-      should redirect_to("password edit page") { edit_user_password_path }
+      should respond_with :success
+      should "display edit form" do
+        assert page.has_content?("Reset password")
+      end
     end
 
     context "with expired confirmation_token" do
@@ -45,6 +48,51 @@ class PasswordsControllerTest < ActionController::TestCase
       should redirect_to("the home page") { root_path }
       should "warn about invalid url" do
         assert_equal flash[:alert], "Please double check the URL or try submitting it again."
+      end
+    end
+
+    context "with mfa enabled" do
+      setup do
+        @user.mfa_ui_only!
+        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+      end
+
+      should respond_with :success
+      should "display otp form" do
+        assert page.has_content?("Multifactor authentication")
+      end
+    end
+  end
+
+  context "on POST to mfa_edit" do
+    setup do
+      @user = create(:user)
+      @user.forgot_password!
+    end
+
+    context "with mfa enabled" do
+      setup { @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only) }
+
+      context "when OTP is correct" do
+        setup do
+          post :mfa_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.mfa_seed).now }
+        end
+
+        should respond_with :success
+        should "display edit form" do
+          assert page.has_content?("Reset password")
+        end
+      end
+
+      context "when OTP is incorrect" do
+        setup do
+          post :mfa_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: "eatthis" }
+        end
+
+        should respond_with :unauthorized
+        should "alert about otp being incorrect" do
+          assert_equal flash[:alert], "Your OTP code is incorrect."
+        end
       end
     end
   end


### PR DESCRIPTION
Unlike sessions#create, we don't need to use session here as
confirmation_token present in form as hidden field acts as proxy
for user.

Canonical [Clearance::PasswordsController#edit](https://github.com/thoughtbot/clearance/blob/master/app/controllers/clearance/passwords_controller.rb#L34) uses
`session[:password_reset_token]` to prevent leak of token through
HTTP Referer header. We don't need it anymore since rails 5.2 started setting
`Referrer-Policy` to `strict-origin-when-cross-origin` by default. https://github.com/rails/rails/commit/428939be9f954d39b0c41bc53d85d0d106b9d1a1

Integration test of password reset when signed in was changed to
ensure password reset was successful (previously giving password too
short).

I considered using the same action with `before_action` for mfa edit and it looked unnecessarily complex.

cc: @ecnelises 