### PR TITLE
Increase yank rate limit to 10 yank per ip per 10 min

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,7 +39,8 @@ class Rack::Attack
   end
 
   # Throttle yank requests
-  throttle("yank/ip", limit: 1, period: LIMIT_PERIOD) do |req|
+  YANK_LIMIT = 10
+  throttle("yank/ip", limit: YANK_LIMIT, period: LIMIT_PERIOD) do |req|
     req.ip if req.path == "/api/v1/gems/yank"
   end
 

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -14,7 +14,6 @@ class YankTest < SystemTest
   end
 
   test "view yanked gem" do
-    skip "This needs to be rewritten to yank in setup"
     create(:version, rubygem: @rubygem, number: "1.1.1")
     create(:version, rubygem: @rubygem, number: "2.2.2")
 
@@ -37,7 +36,6 @@ class YankTest < SystemTest
   end
 
   test "yanked gem entirely then someone else pushes a new version" do
-    skip "This needs to be rewritten to yank in setup"
     create(:version, rubygem: @rubygem, number: "0.0.0")
 
     visit rubygem_path(@rubygem)
@@ -67,7 +65,6 @@ class YankTest < SystemTest
   end
 
   test "undo a yank is not supported" do
-    skip "This doesn't actually test undoing yank"
     create(:version, rubygem: @rubygem, number: "1.0.0", indexed: true)
     create(:version, rubygem: @rubygem, number: "0.0.0", indexed: false)
 


### PR DESCRIPTION
Except mammoths like
[these](https://rubygems.org/gems/rcfile_generator/versions), yank api
response time is under 300ms.

Removed in: 860f21939f7f5d2c1d04bbc2f7d1ddb72542625f