### PR TITLE
Removed default gems of Ruby 2.7 from reserved names.

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -17,6 +17,7 @@ module Patterns
     continuation
     coverage
     delegate
+    digest
     drb
     english
     enumerator

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -10,10 +10,13 @@ module Patterns
   GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64
+    benchmark
+    cgi
     cgi-session
     complex
     continuation
     coverage
+    delegate
     digest
     drb
     english
@@ -22,6 +25,7 @@ module Patterns
     expect
     fiber
     find
+    getoptlong
     install
     io-nonblock
     io-wait
@@ -32,15 +36,19 @@ module Patterns
     net-ftp
     net-http
     net-imap
+    net-pop
     net-protocol
+    net-smtp
     nkf
     open-uri
+    open3
     optparse
     pathname
     pp
     prettyprint
     profile
     profiler
+    pstore
     pty
     rational
     rbconfig
@@ -51,6 +59,7 @@ module Patterns
     securerandom
     set
     shellwords
+    singleton
     socket
     syslog
     tempfile

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -57,7 +57,6 @@ module Patterns
     resolv
     resolv-replace
     rinda
-    ruby
     rubygems
     securerandom
     set

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -10,13 +10,10 @@ module Patterns
   GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64
-    benchmark
-    cgi
     cgi-session
     complex
     continuation
     coverage
-    delegate
     digest
     drb
     english
@@ -25,32 +22,25 @@ module Patterns
     expect
     fiber
     find
-    getoptlong
     install
     io-nonblock
     io-wait
     jruby
     mkmf
-    monitor
     mri
     mruby
     net-ftp
     net-http
     net-imap
-    net-pop
     net-protocol
-    net-smtp
     nkf
-    observer
     open-uri
-    open3
     optparse
     pathname
     pp
     prettyprint
     profile
     profiler
-    pstore
     pty
     rational
     rbconfig
@@ -61,22 +51,18 @@ module Patterns
     securerandom
     set
     shellwords
-    singleton
     socket
     syslog
     tempfile
     thread
     time
-    timeout
     tmpdir
     tsort
     un
     unicode_normalize
     uninstall
-    uri
     weakref
     win32ole
-    yaml
     ubygems
     sidekiq-pro
     graphql-pro

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -17,7 +17,6 @@ module Patterns
     continuation
     coverage
     delegate
-    digest
     drb
     english
     enumerator
@@ -48,7 +47,6 @@ module Patterns
     pathname
     pp
     prettyprint
-    prime
     profile
     profiler
     pstore
@@ -71,7 +69,6 @@ module Patterns
     time
     timeout
     tmpdir
-    tracer
     tsort
     un
     unicode_normalize


### PR DESCRIPTION
I shipped `prime` and `tracer` as default gems at Ruby 2.6. But there is no response from the current name-holder with a transfer request.

Can we enforce to transfer them to the ruby core team(it's me)?