### PR TITLE
Use limit in subquery for new pushed versions

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ActivitiesController < Api::BaseController
   private
 
   def render_rubygems(versions)
-    rubygems = versions.includes(:dependencies, rubygem: :linkset).map do |version|
+    rubygems = versions.includes(:dependencies, rubygem: %i[linkset gem_download]).map do |version|
       version.rubygem.payload(version)
     end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -127,13 +127,12 @@ class Version < ApplicationRecord
   # This method returns the new versions for brand new rubygems
   def self.new_pushed_versions(limit = 5)
     subquery = <<-SQL
-      versions.id IN (SELECT max(versions.id)
-                                FROM versions
-                            GROUP BY versions.rubygem_id
-                              HAVING COUNT(versions.rubygem_id) = 1)
+      versions.rubygem_id IN (SELECT versions.rubygem_id FROM versions
+        GROUP BY versions.rubygem_id HAVING COUNT(versions.rubygem_id) = 1
+        ORDER BY versions.rubygem_id DESC LIMIT :limit)
     SQL
 
-    Version.where(subquery).by_created_at.limit limit
+    where(subquery, limit: limit).by_created_at
   end
 
   def self.just_updated(limit = 5)


### PR DESCRIPTION
The subquery without limit meant the query as whole has to spend lot
of time in filtering (~110k more). Updated method is 3.45 times faster.
[Benchmarks and query analyze](https://gist.github.com/sonalkr132/2070908d1d036e9916ca1002fa13b6c0)

Verified with following that output didn't change:
```rb
versions = Version.new_pushed_versions(10000).pluck(:id)
new_versions = Version.newer_pushed_versions(10000).pluck(:id)

versions.each_with_index do |v_id, idx|
  puts "#{idx}, #{v_id} - #{new_versions[idx]}" if v_id != new_versions[idx]
end
```

Eager loading gem_downloads removes one n + 1 for downloads per gem.
There is one more for version downloads and problem is explained in https://github.com/rubygems/rubygems.org/issues/1450. will take it up in a different PR.

We have tried limit in subquery previously but it was removed ([commit](https://github.com/rubygems/rubygems.org/commit/3c7eb20de47936d939c45793d446b8ea66f92ada)). Only problem I see there is missing `ORDER by versions.rubygems_id` which is used here.

cc: @arthurnn    