### PR TITLE
Remove broken reference to `Download`

### DIFF
--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -790,29 +790,6 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context "downloads" do
-    setup do
-      @rubygem = create(:rubygem)
-      @version = create(:version, rubygem: @rubygem)
-
-      travel_to Date.parse("2010-10-02") do
-        1.times { Download.incr(@rubygem.name, @version.full_name) }
-      end
-
-      travel_to Date.parse("2010-10-03") do
-        6.times { Download.incr(@rubygem.name, @version.full_name) }
-      end
-
-      travel_to Date.parse("2010-10-16") do
-        4.times { Download.incr(@rubygem.name, @version.full_name) }
-      end
-
-      travel_to Date.parse("2010-11-01") do
-        2.times { Download.incr(@rubygem.name, @version.full_name) }
-      end
-    end
-  end
-
   context "#protected_days" do
     setup do
       @rubygem = create(:rubygem)


### PR DESCRIPTION
As part of open sourcing our Ruby typechecker, Sorbet (https://sorbet.run/) we're using it to check large open source Ruby projects. When I ran it on your project, it reported the error:

```
./test/unit/rubygem_test.rb:799: Unable to resolve constant Download http://go/e/5002
     799 |        1.times { Download.incr(@rubygem.name, @version.full_name) }
                            ^^^^^^^^
    ./app/models/gem_download.rb:1: Did you mean: GemDownload?
     1 |class GemDownload < ApplicationRecord
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It looks like this constant indeed doesn't exist in your codebase:

```
$ rails c
Loading development environment (Rails 5.2.2.1)
irb(main):001:0> Download
Traceback (most recent call last):
        1: from (irb):1
NameError (uninitialized constant Download)
```

This specific code will never run because there are no `should` blocks in it so I think that is why it wasn't caught by your runtime testing.