### PR TITLE
Small refactoring of #link_to_github logic

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -17,9 +17,9 @@ module RubygemsHelper
 
   def link_to_github(rubygem)
     results = [rubygem.linkset.code, rubygem.linkset.home].map do |linkset|
-      if !linkset.nil? && URI(linkset).host == "github.com"
-        URI(linkset)
-      end
+      uri = URI(linkset.to_s)
+
+      uri.host == "github.com" ? uri : nil
     end
 
     results.reject(&:blank?).first

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -16,11 +16,13 @@ module RubygemsHelper
   end
 
   def link_to_github(rubygem)
-    if !rubygem.linkset.code.nil? && URI(rubygem.linkset.code).host == "github.com"
-      URI(@rubygem.linkset.code)
-    elsif !rubygem.linkset.home.nil? && URI(rubygem.linkset.home).host == "github.com"
-      URI(rubygem.linkset.home)
+    results = [rubygem.linkset.code, rubygem.linkset.home].map do |linkset|
+      if !linkset.nil? && URI(linkset).host == "github.com"
+        URI(linkset)
+      end
     end
+
+    results.reject(&:blank?).first
   rescue URI::InvalidURIError
     nil
   end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -16,13 +16,11 @@ module RubygemsHelper
   end
 
   def link_to_github(rubygem)
-    results = [rubygem.linkset.code, rubygem.linkset.home].map do |linkset|
-      uri = URI(linkset.to_s)
-
-      uri.host == "github.com" ? uri : nil
+    result = [rubygem.linkset.code, rubygem.linkset.home].detect do |linkset|
+      URI(linkset.to_s).host == "github.com"
     end
 
-    results.reject(&:blank?).first
+    URI(result.to_s)
   rescue URI::InvalidURIError
     nil
   end


### PR DESCRIPTION
I was writing up a script for a project on code metrics and spotted this method as one of the more complicated ones in the app. It wasn't /bad/ but I thought it could be a bit cleaner. This change drops its flog score from 38 to 16.4, but YMMV on if you think this is cleaner or not.

```
Before:
   158.6: flog total
     9.3: flog/method average

    38.0: RubygemsHelper#link_to_github    app/helpers/rubygems_helper.rb:18-25
    23.2: RubygemsHelper#links_to_owners   app/helpers/rubygems_helper.rb:91-95
    18.0: RubygemsHelper#subscribe_link    app/helpers/rubygems_helper.rb:44-58
    12.9: RubygemsHelper#simple_markup     app/helpers/rubygems_helper.rb:34-40
     9.5: RubygemsHelper#unsubscribe_link  app/helpers/rubygems_helper.rb:61-68

After:
   136.9: flog total
     8.1: flog/method average

    23.2: RubygemsHelper#links_to_owners   app/helpers/rubygems_helper.rb:91-95
    18.0: RubygemsHelper#subscribe_link    app/helpers/rubygems_helper.rb:44-58
    16.4: RubygemsHelper#link_to_github    app/helpers/rubygems_helper.rb:18-25
    12.9: RubygemsHelper#simple_markup     app/helpers/rubygems_helper.rb:34-40
     9.5: RubygemsHelper#unsubscribe_link  app/helpers/rubygems_helper.rb:61-68
     7.5: RubygemsHelper#latest_version_number app/helpers/rubygems_helper.rb:106-108
```