### PR TITLE
Link to title only if title_url set

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -105,7 +105,11 @@
         <div class="l-wrap--b">
           <% if @title %>
             <h1 class="t-display page__heading">
-              <%= link_to @title, @title_url, class: "t-link--black" %>
+              <% if @title_url %>
+                <%= link_to @title, @title_url, class: "t-link--black" %>
+              <% else %>
+                <%= @title %>
+              <% end %>
 
               <% if @subtitle %>
                 <i class="page__subheading"><%= @subtitle.html_safe %></i>


### PR DESCRIPTION
When I setup MFA, I double-clicked `Recovery codes` to start selection.
But it disappeared because it is a link.
And I have to disable MFA and enable again.

So I think title should not be link without title_url explicitly.