### PR TITLE
show downloads and license information for yanked versions too

### DIFF
--- a/app/controllers/api/v1/downloads_controller.rb
+++ b/app/controllers/api/v1/downloads_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::DownloadsController < Api::BaseController
   def show
     full_name = params[:id]
     version = Version.find_by(full_name: full_name)
-    if version && !version.yanked?
+    if version
       data = {
         total_downloads: GemDownload.count_for_rubygem(version.rubygem_id),
         version_downloads: GemDownload.count_for_version(version.id)

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -3,18 +3,16 @@
     <%= render partial: "rubygems/github_button", locals: { github_link: github_link } %>
   <% end %>
 
-  <% if @latest_version.indexed %>
-    <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
-      <h2 class="gem__downloads__heading t-text--s">
-        <%= t('stats.index.total_downloads') %>
-        <span class="gem__downloads"><%= number_with_delimiter(@rubygem.downloads) %></span>
-      </h2>
-      <h2 class="gem__downloads__heading t-text--s">
-        <%= t('.downloads_for_this_version') %>
-        <span class="gem__downloads"><%= number_with_delimiter(@latest_version.downloads_count) %></span>
-      </h2>
-    </div>
-  <% end %>
+  <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
+    <h2 class="gem__downloads__heading t-text--s">
+      <%= t('stats.index.total_downloads') %>
+      <span class="gem__downloads"><%= number_with_delimiter(@rubygem.downloads) %></span>
+    </h2>
+    <h2 class="gem__downloads__heading t-text--s">
+      <%= t('.downloads_for_this_version') %>
+      <span class="gem__downloads"><%= number_with_delimiter(@latest_version.downloads_count) %></span>
+    </h2>
+  </div>
 
   <% if @latest_version.indexed %>
     <h2 class="gem__ruby-version__heading t-list__heading">
@@ -33,13 +31,14 @@
         <span class="gem__code__icon" id="js-gem__code--install" data-clipboard-target="#install_text">=</span>
       </div>
     </h2>
-    <h2 class="gem__ruby-version__heading t-list__heading">
-      <%= pluralized_licenses_header @latest_version %>:
-      <span class="gem__ruby-version">
-        <p><%= formatted_licenses @latest_version.licenses %></p>
-      </span>
-    </h2>
   <% end %>
+
+  <h2 class="gem__ruby-version__heading t-list__heading">
+    <%= pluralized_licenses_header @latest_version %>:
+    <span class="gem__ruby-version">
+      <p><%= formatted_licenses @latest_version.licenses %></p>
+    </span>
+  </h2>
 
   <h2 class="gem__ruby-version__heading t-list__heading">
     <%= t('.required_ruby_version') %>:

--- a/test/functional/api/v1/downloads_controller_test.rb
+++ b/test/functional/api/v1/downloads_controller_test.rb
@@ -97,13 +97,7 @@ class Api::V1::DownloadsControllerTest < ActionController::TestCase
       get_show(@version)
     end
 
-    should "return a 404" do
-      assert_response :not_found
-    end
-
-    should "say gem could not be found" do
-      assert_equal "This rubygem could not be found.", @response.body
-    end
+    should respond_with :success
   end
 
   context "On GET to all" do


### PR DESCRIPTION
I'm not sure why these details were hidden. I can't think of a good reason to hide the download stats and license information for yanked versions.

This will show the downloads and license on the version page, and allow the downloads to be fetched via the API.

(Ref: https://github.com/twbs/bootstrap-sass/issues/1195#issuecomment-479890179)