### PR TITLE
make "Install RubyGems" button for Japanese translation

### DIFF
--- a/app/assets/stylesheets/modules/button.css
+++ b/app/assets/stylesheets/modules/button.css
@@ -37,7 +37,7 @@
 
 .home__join {
   padding-left: 22px;
-  width: 250px;
+  width: 290px;
   background-color: white;
   color: #e9573f; }
   @media (max-width: 519px) {

--- a/app/assets/stylesheets/modules/home.css
+++ b/app/assets/stylesheets/modules/home.css
@@ -50,7 +50,7 @@
   margin-top: 45px;
   position: relative;
   width: 90%;
-  max-width: 460px; }
+  max-width: 500px; }
   @media (max-width: 519px) {
     .home__cta-wrap {
       margin-bottom: 60px; } }


### PR DESCRIPTION
The button was too narrow for Japanese translation.

![image](https://user-images.githubusercontent.com/21557/55632503-6a16e480-57f5-11e9-9a82-408ee7bf3f32.png)

Some letters overlaps the arrow icon.  This PR widens the button width.

![image](https://user-images.githubusercontent.com/21557/55632620-a0546400-57f5-11e9-8769-8c4c57337118.png)