### PR TITLE
Send email to gem owners on push

### DIFF
--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -1,0 +1,19 @@
+class NotifiersController < ApplicationController
+  before_action :redirect_to_signin, unless: :signed_in?
+
+  def update
+    to_enable = []
+    to_disable = []
+    params.require(:ownerships).each do |ownership_id, notifier|
+      (notifier == "off" ? to_disable : to_enable) << ownership_id.to_i
+    end
+
+    current_user.transaction do
+      current_user.ownerships.where(id: to_enable).update_all(notifier: true) if to_enable.any?
+      current_user.ownerships.where(id: to_disable).update_all(notifier: false) if to_disable.any?
+      Mailer.delay.notifiers_changed(current_user.id)
+    end
+
+    redirect_to edit_profile_url, notice: t("notifier.update.success")
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,7 @@ class ProfilesController < ApplicationController
 
   def edit
     @user = current_user
+    @ownerships = @user.ownerships.by_gem_name
   end
 
   def show
@@ -26,6 +27,7 @@ class ProfilesController < ApplicationController
       redirect_to edit_profile_path
     else
       current_user.reload
+      @ownerships = current_user.ownerships.by_gem_name
       render :edit
     end
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -2,6 +2,8 @@ class Mailer < ActionMailer::Base
   layout "mailer"
   include Roadie::Rails::Automatic
 
+  default from: Clearance.configuration.mailer_sender
+
   default_url_options[:host] = Gemcutter::HOST
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
@@ -31,5 +33,26 @@ class Mailer < ActionMailer::Base
     mail from: Clearance.configuration.mailer_sender,
          to: email,
          subject: I18n.t("mailer.deletion_failed.subject")
+  end
+
+  def notifiers_changed(user_id)
+    user = User.find(user_id)
+    @ownerships = user.ownerships.by_gem_name
+
+    mail to: user.email,
+         subject: I18n.t("mailer.notifiers_changed.subject",
+           default: "You changed your RubyGems.org email notification settings")
+  end
+
+  def gem_pushed(pushed_by_user_id, version_id)
+    @version = Version.find(version_id)
+    owners_to_notify = @version.rubygem.owners.where(ownerships: { notifier: true }).pluck(:email)
+    return if owners_to_notify.empty?
+
+    @pushed_by_user = User.find(pushed_by_user_id)
+
+    mail bcc: owners_to_notify,
+         subject: I18n.t("mailer.gem_pushed.subject", gem: @version.to_title,
+           default: "Gem %{gem} pushed to RubyGems.org")
   end
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -4,6 +4,10 @@ class Ownership < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :rubygem_id }
 
+  def self.by_gem_name
+    joins(:rubygem).order("rubygems.name ASC")
+  end
+
   def safe_destroy
     rubygem.owners.many? && destroy
   end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -99,6 +99,7 @@ class Pusher
 
   def after_write
     @version_id = version.id
+    Mailer.delay.gem_pushed(user.id, @version_id) if user
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     GemCachePurger.call(rubygem.name)

--- a/app/views/mailer/gem_pushed.html.erb
+++ b/app/views/mailer/gem_pushed.html.erb
@@ -1,0 +1,33 @@
+<p>
+  A gem you are responsible for was recently pushed to RubyGems.org.
+</p>
+<p>
+  Gem: <strong><%= @version.to_title %></strong>
+  <br>
+  Pushed by user:
+  <strong>
+    <%= @pushed_by_user.handle %> <%= mail_to(@pushed_by_user.email) unless @pushed_by_user.hide_email? %>
+  </strong>
+</p>
+<p>If this push is expected, you do not need to take further action.</p>
+<p>
+  <strong>Only if this push is unexpected</strong>
+  please take immediate steps to secure your account and gems:
+</p>
+<ol>
+  <li>If you suspect your account was compromised:
+    <ol>
+      <li>Change your password: <%= link_to(new_password_url, new_password_url) %></li>
+      <li>Reset your API key: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+      <li>Enable multifactor authentication: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+    </ol>
+  </li>
+  <li>Yank the version of the gem reported in this email</li>
+  <li>Report this incident to RubyGems.org: <%= link_to(page_url("security"), page_url("security")) %></li>
+</ol>
+<p>
+  <em>
+    To stop receiving these messages, update your email notification settings at
+    <%= link_to(edit_profile_url, edit_profile_url) %>.
+  </em>
+</p>

--- a/app/views/mailer/notifiers_changed.html.erb
+++ b/app/views/mailer/notifiers_changed.html.erb
@@ -1,0 +1,31 @@
+<p>
+  This confirms you successfully changed your email notification settings on RubyGems.org.
+</p>
+<p>
+  Here are your email notification settings for each gem you are responsible for:
+</p>
+<ul>
+  <% @ownerships.each do |ownership| %>
+    <li>
+      <%= ownership.rubygem.name %> emails:
+      <%= ownership.notifier? ? 'ON' : '<strong>OFF</strong>'.html_safe %>
+    </li>
+  <% end %>
+</ul>
+<p>If this change to your settings is expected, you do not need to take further action.</p>
+<p>
+  <strong>Only if this change to your settings is unexpected</strong>
+  please take immediate steps to secure your account and gems:
+</p>
+<ol>
+  <li>If you suspect your account was compromised:
+    <ol>
+      <li>Change your password: <%= link_to(new_password_url, new_password_url) %></li>
+      <li>Reset your API key: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+      <li>Enable multifactor authentication: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+      <li>Enable email notifications for all of your gems: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+    </ol>
+  </li>
+  <li>Look out for unexpected changes to your gems on RubyGems.org</li>
+  <li>Report this incident to RubyGems.org: <%= link_to(page_url("security"), page_url("security")) %></li>
+</ol>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -110,6 +110,34 @@
   <% end %>
 </div>
 
+<% if @ownerships.any? %>
+  <div class="t-body">
+    <h2><%= t '.notifier.email_notifications' %></h2>
+    <%= form_tag notifier_path, method: :put do %>
+      <p>
+        To aid detection of unauthorized gem changes, we email you each time a new version of a
+        gem you own is pushed. By receiving and reading these emails, you help protect the Ruby
+        ecosystem.
+      </p>
+      <% @ownerships.each do |ownership| %>
+        <h4><%= ownership.rubygem.name %></h4>
+        <p>
+          <%= label_tag do %>
+            <%= radio_button_tag "ownerships[#{ownership.id}]", :on, ownership.notifier? %>
+            On <em>(recommended)</em>
+          <% end %>
+          <br>
+          <%= label_tag do %>
+            <%= radio_button_tag "ownerships[#{ownership.id}]", :off, !ownership.notifier? %>
+            Off
+          <% end %>
+        </p>
+      <% end %>
+      <%= submit_tag t('.notifier.update'), class: 'form__submit' %>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="t-body">
   <h2><%= t '.delete.delete_profile' %></h2>
   <p><%= t '.delete.warning' %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -128,6 +128,10 @@ de:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title:
@@ -193,6 +197,9 @@ de:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation:
@@ -226,6 +233,9 @@ de:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,10 @@ en:
       subtitle: Sorry!
       subject: Your account deletion request on rubygems.org has failed
       body_html: You had request for account deletion on rubygems.org. Unfortunately, we were not able to process your request. Please try again after some time or %{contact} us if problem persists.
+    notifiers_changed:
+      subject: You changed your RubyGems.org email notification settings
+    gem_pushed:
+      subject: Gem %{gem} pushed to RubyGems.org
   news:
     show:
       title: New Releases — All Gems
@@ -201,6 +205,9 @@ en:
       success: You have successfully disabled multifactor authentication.
     update:
       success: You have successfully updated your MFA level.
+  notifier:
+    update:
+      success: You have successfully updated your email notification settings.
   profiles:
     edit:
       email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
@@ -234,6 +241,9 @@ en:
           disabled: Disabled
           ui_only: UI Only
           ui_and_api: UI and API
+      notifier:
+        email_notifications: Email Notifications
+        update: Update notifications
     delete:
       title: Delete profile
       confirm: Confirm

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -128,6 +128,10 @@ es:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title:
@@ -193,6 +197,9 @@ es:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation:
@@ -226,6 +233,9 @@ es:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -128,6 +128,10 @@ fr:
       subtitle:
       subject: Votre demande de suppression de compte sur RubyGems.org a échoué
       body_html: "Vous avez effectué une demande de suppression de compte sur RubyGems.org. Malheureusement, votre demande n'a pu aboutir. Veuillez réessayer plus tard ou nous %{contact} si le problème subsiste."
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems
@@ -193,6 +197,9 @@ fr:
       success: Vous avez désactivé l'authentification multifacteur.
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation: Veuillez confirmer votre nouvelle adresse email %{unconfirmed_email}
@@ -226,6 +233,9 @@ fr:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title: Supprimer le profil
       confirm: Confirmer

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -128,6 +128,10 @@ ja:
       subtitle:
       subject: あなたのアカウントはrubygems.orgから削除されませんでした
       body_html: あなたのrubygems.orgにおけるアカウント削除申請は処理されませんでした。申し訳ありませんが、現在アカウントを削除することができません。しばらく待ってから再度お試し頂くか、問題が継続するようならば%{contact}をお願いいたします。
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title: 新しくリリースされたGem
@@ -193,6 +197,9 @@ ja:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation: あなたの新しいメールアドレス%{unconfirmed_email}を確認してください。
@@ -226,6 +233,9 @@ ja:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title: アカウント削除
       confirm: 確認

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -128,6 +128,10 @@ nl:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title:
@@ -193,6 +197,9 @@ nl:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation:
@@ -226,6 +233,9 @@ nl:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -128,6 +128,10 @@ pt-BR:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title:
@@ -193,6 +197,9 @@ pt-BR:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation:
@@ -226,6 +233,9 @@ pt-BR:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -128,6 +128,10 @@ zh-CN:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title: 全部新发布 Gems
@@ -193,6 +197,9 @@ zh-CN:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation: 请验证你的新邮箱地址 %{unconfirmed_email}
@@ -226,6 +233,9 @@ zh-CN:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -128,6 +128,10 @@ zh-TW:
       subtitle:
       subject:
       body_html:
+    notifiers_changed:
+      subject:
+    gem_pushed:
+      subject:
   news:
     show:
       title: 最新發佈
@@ -193,6 +197,9 @@ zh-TW:
       success:
     update:
       success:
+  notifier:
+    update:
+      success:
   profiles:
     edit:
       email_awaiting_confirmation: 請驗證你的新 Email %{unconfirmed_email}
@@ -226,6 +233,9 @@ zh-TW:
           disabled:
           ui_only:
           ui_and_api:
+      notifier:
+        email_notifications:
+        update:
     delete:
       title:
       confirm:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Rails.application.routes.draw do
     resource :news, path: 'news', only: [:show] do
       get :popular, on: :collection
     end
+    resource :notifier, only: :update
 
     resources :rubygems,
       only: %i[index show],

--- a/db/migrate/20190419175448_add_notifier_to_ownerships.rb
+++ b/db/migrate/20190419175448_add_notifier_to_ownerships.rb
@@ -1,0 +1,5 @@
+class AddNotifierToOwnerships < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ownerships, :notifier, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_11_065002) do
+ActiveRecord::Schema.define(version: 2019_04_19_175448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_04_11_065002) do
     t.string "token"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "notifier", default: true, null: false
     t.index ["rubygem_id"], name: "index_ownerships_on_rubygem_id"
     t.index ["user_id"], name: "index_ownerships_on_user_id"
   end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -259,7 +259,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           number: "0.0.0",
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
-        assert_difference "Delayed::Job.count", 6 do
+        assert_difference "Delayed::Job.count", 7 do
           post :create, body: gem_file("test-1.0.0.gem").read
         end
       end

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -1,8 +1,16 @@
 module EmailHelpers
   def last_email_link
     Delayed::Worker.new.work_off
-    body = ActionMailer::Base.deliveries.last.body.decoded.to_s
+    body = last_email.body.decoded.to_s
     link = %r{http://localhost/email_confirmations([^";]*)}.match(body)
     link[0]
+  end
+
+  def last_email
+    ActionMailer::Base.deliveries.last
+  end
+
+  def mails_count
+    ActionMailer::Base.deliveries.size
   end
 end

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "capybara/minitest"
+
+class NoticationSettings < SystemTest
+  include Capybara::Minitest::Assertions
+
+  test "changing email notification settings" do
+    user = create(:user)
+    ownership1, ownership2 = create_list(:ownership, 2, user: user)
+
+    visit edit_profile_path(as: user)
+
+    assert_text I18n.t("profiles.edit.notifier.email_notifications")
+
+    notifier_form_selector = "form[action='/notifier']"
+
+    within_element notifier_form_selector do
+      assert_checked_field notifier_on_radio(ownership1)
+      assert_unchecked_field notifier_off_radio(ownership1)
+      assert_checked_field notifier_on_radio(ownership2)
+      assert_unchecked_field notifier_off_radio(ownership2)
+
+      choose notifier_off_radio(ownership1)
+
+      click_button I18n.t("profiles.edit.notifier.update")
+    end
+
+    assert_changes :mails_count, from: 0, to: 1 do
+      Delayed::Worker.new.work_off
+    end
+
+    assert_equal I18n.t("mailer.notifiers_changed.subject"), last_email.subject
+
+    assert_selector "#flash_notice", text: I18n.t("notifier.update.success")
+
+    within_element notifier_form_selector do
+      assert_unchecked_field notifier_on_radio(ownership1)
+      assert_checked_field notifier_off_radio(ownership1)
+      assert_checked_field notifier_on_radio(ownership2)
+      assert_unchecked_field notifier_off_radio(ownership2)
+    end
+  end
+
+  test "email notification settings not shown to user who owns no gems" do
+    user = create(:user)
+
+    visit edit_profile_path(as: user)
+
+    assert_no_text I18n.t("profiles.edit.notifier.email_notifications")
+  end
+
+  def notifier_on_radio(ownership)
+    "ownerships_#{ownership.id}_on"
+  end
+
+  def notifier_off_radio(ownership)
+    "ownerships_#{ownership.id}_off"
+  end
+end

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class MailerTest < ActionMailer::TestCase
+  test "gem pushed mail will only send to owner with enabled notifier" do
+    owner_without_notifier, owner_with_notifier = owners = create_list(:user, 2)
+    rubygem = create(:rubygem, owners: owners, number: "0.1.2")
+    owner_without_notifier.ownerships.update_all(notifier: false)
+
+    message_delivery = Mailer.gem_pushed(owner_without_notifier.id, rubygem.versions.last.id)
+
+    assert_instance_of Mail::Message, message_delivery.message
+    assert_equal [owner_with_notifier.email], message_delivery.bcc
+  end
+
+  test "gem pushed mail will not send when all owners disable notifiers" do
+    owners = create_list(:user, 2)
+    rubygem = create(:rubygem, owners: owners, number: "0.1.2")
+    Ownership.update_all(notifier: false)
+
+    message_delivery = Mailer.gem_pushed(owners.first.id, rubygem.versions.last.id)
+
+    assert_instance_of ActionMailer::Base::NullMail, message_delivery.message
+  end
+end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -18,4 +18,14 @@ class MailerPreview < ActionMailer::Preview
   def deletion_failed
     Mailer.deletion_failed(User.last)
   end
+
+  def notifiers_changed
+    ownership = Ownership.where.not(user: nil).last
+    Mailer.notifiers_changed(ownership.user_id)
+  end
+
+  def gem_pushed
+    ownership = Ownership.where.not(user: nil).where(notifier: true).last
+    Mailer.gem_pushed(ownership.user_id, ownership.rubygem.versions.last.id)
+  end
 end


### PR DESCRIPTION
Email gem owners each time a new version is pushed. The intention is to help owners detect compromised gems sooner.

### Tasks

- [x] Send email when user changes their email notification settings
- [x] Test coverage for notification settings

### For subsequent PRs
- Only send emails to users with good deliverability score. Depends on #1982.
- Mitigate emails being used to spam/harass owners added to gems without their consent. To be dealt with in a separate PR. See comments below starting at https://github.com/rubygems/rubygems.org/pull/1950#issuecomment-485467061
