### PR TITLE
Fix "licenses_header" in Japanese

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -1,6 +1,6 @@
 module RubygemsHelper
   def pluralized_licenses_header(version)
-    t("rubygems.show.licenses_header").pluralize(version&.licenses&.length || 0)
+    t("rubygems.show.licenses_header", count: version&.licenses&.length || 0)
   end
 
   def formatted_licenses(license_names)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,7 +344,9 @@ de:
       downloads: Downloads
       title: Gems
     show:
-      licenses_header: Lizenz
+      licenses_header:
+        one: Lizenz
+        other: Lizenzen
       no_licenses: k.A.
       requirements_header: Anforderungen
       show_all_versions: Zeige alle Versionen (%{count} total)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,7 +379,9 @@ en:
       downloads: Downloads
       title: Gems
     show:
-      licenses_header: License
+      licenses_header:
+        one: License
+        other: Licenses
       no_licenses: N/A
       requirements_header: Requirements
       show_all_versions: Show all versions (%{count} total)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -352,7 +352,9 @@ es:
       downloads: Descargas
       title: Gemas
     show:
-      licenses_header: Licencia
+      licenses_header:
+        one: Licencia
+        other: Licencias
       no_licenses: N/A
       requirements_header: Requerimientos
       show_all_versions: Mostrar todas las versiones (%{count} total)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -344,7 +344,9 @@ fr:
       downloads: Téléchargements
       title: Gems
     show:
-      licenses_header: Licence
+      licenses_header:
+        one: License
+        other: Licenses
       no_licenses: aucune
       requirements_header: Dépendances
       show_all_versions: Voir toutes les versions (%{count})

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -344,7 +344,9 @@ ja:
       downloads: ダウンロード
       title: Gems
     show:
-      licenses_header: ライセンス
+      licenses_header:
+        one: ライセンス
+        other: ライセンス
       no_licenses: N/A
       requirements_header: 必須要件
       show_all_versions: 全てのバージョンを表示 (全%{count}項目)

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -344,7 +344,9 @@ nl:
       downloads: Downloads
       title: alle gems
     show:
-      licenses_header: License
+      licenses_header:
+        one: Licentie
+        other: Licenties
       no_licenses: N/A
       requirements_header: Requirements
       show_all_versions: Toon alle versies (%{count} totaal)

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -344,7 +344,9 @@ pt-BR:
       downloads: Downloads
       title: Gems
     show:
-      licenses_header: Licença
+      licenses_header:
+        one: Licença
+        other: Licenças
       no_licenses: N/A
       requirements_header: Requisitos
       show_all_versions: Mostrar todas as versões (%{count})

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -344,7 +344,9 @@ zh-CN:
       downloads: 下载
       title: Gems
     show:
-      licenses_header: 许可
+      licenses_header:
+        one: 许可
+        other: 许可
       no_licenses: 无
       requirements_header: 要求
       show_all_versions: 显示所有 (%{count} 个版本)

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -369,7 +369,9 @@ zh-TW:
       downloads: 下載
       title: Gems
     show:
-      licenses_header: License
+      licenses_header:
+        one: License
+        other: License
       no_licenses: 無
       requirements_header: 必填
       show_all_versions: 顯示所有版本（共 %{count}）


### PR DESCRIPTION
"lincenses_header" is rendered as "ライセンスS" in Japanese.

![image](https://user-images.githubusercontent.com/21557/55677570-83b74980-5925-11e9-879c-684c9228759b.png)

The "S" is for English plural form, which sound very strange.  In fact, there is no plural form in Japanese.

This PR uses I18n feature for plural forms.

![image](https://user-images.githubusercontent.com/21557/55677567-7732f100-5925-11e9-8206-c8cbef66f592.png)

In English, it works the same as before.  In Germany, it is rendered as Lizenz/Lizenzen.

Co-authored-by: Kazuhiro NISHIYAMA <zn@mbf.nifty.com>