### PR TITLE
Send email to gem owners on yank

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -31,4 +31,14 @@ class Mailer < ActionMailer::Base
          to: email,
          subject: I18n.t('mailer.deletion_failed.subject')
   end
+
+  def gem_yanked(yanked_by_user_id, version_id)
+    @yanked_by_user = User.find(yanked_by_user_id)
+    @version = Version.find(version_id)
+    owner_emails = @version.rubygem.owners.pluck(:email)
+
+    mail from: Clearance.configuration.mailer_sender,
+         bcc: owner_emails,
+         subject: "Gem #{@version.to_title} yanked from RubyGems.org"
+  end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -10,6 +10,7 @@ class Deletion < ApplicationRecord
   after_commit :remove_from_storage, on: :create
   after_commit :expire_cache
   after_commit :update_search_index
+  after_commit :send_gem_yanked_mail
 
   attr_accessor :version
 
@@ -72,5 +73,9 @@ class Deletion < ApplicationRecord
   def set_yanked_info_checksum
     checksum = GemInfo.new(version.rubygem.name).info_checksum
     version.update_attribute :yanked_info_checksum, checksum
+  end
+
+  def send_gem_yanked_mail
+    Mailer.delay.gem_yanked(user.id, @version.id)
   end
 end

--- a/app/views/mailer/gem_yanked.html.erb
+++ b/app/views/mailer/gem_yanked.html.erb
@@ -1,0 +1,26 @@
+<p>
+  A gem you are responsible for was recently yanked (deleted) from RubyGems.org.
+</p>
+<p>
+  Gem: <strong><%= @version.to_title %></strong>
+  <br>
+  Yanked by user:
+  <strong>
+    <%= @yanked_by_user.handle %> <%= mail_to(@yanked_by_user.email) unless @yanked_by_user.hide_email? %>
+  </strong>
+</p>
+<p>If this yank is expected, you do not need to take further action.</p>
+<p>
+  <strong>Only if this yank is unexpected</strong>
+  please take immediate steps to secure your account and gems:
+</p>
+<ol>
+  <li>If you suspect your account was compromised:
+    <ol>
+      <li>Change your password: <%= link_to(new_password_url, new_password_url) %></li>
+      <li>Reset your API key: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+      <li>Enable multifactor authentication: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+    </ol>
+  </li>
+  <li>Report this incident to RubyGems.org: <%= link_to(page_url("security"), page_url("security")) %></li>
+</ol>

--- a/lib/mailer_preview.rb
+++ b/lib/mailer_preview.rb
@@ -10,4 +10,9 @@ class MailerPreview < ActionMailer::Preview
   def change_password
     ClearanceMailer.change_password(User.last)
   end
+
+  def gem_yanked
+    ownership = Ownership.where.not(user: nil).last
+    Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id)
+  end
 end


### PR DESCRIPTION
Email gem owners each time a version is yanked. The intention is to help owners detect compromised
accounts and attacker-supplanted gems sooner.