### PR TITLE
Fix broken layout for Japanese

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -68,7 +68,7 @@ ja:
       downloads_counting_html: ダウンロード数
       find_blurb:
       learn:
-        install_rubygems: RubyGemsをインストール
+        install_rubygems: Install RubyGems
   layouts:
     application:
       footer:


### PR DESCRIPTION
I found the button below is broken when I choose Japanese locale.

## Before

![image](https://user-images.githubusercontent.com/1811616/56292043-5e1a1380-6161-11e9-965f-bdef7da3b14b.png)

## After

`"Install RubyGems"` is enough understandable even for Japanase.

![image](https://user-images.githubusercontent.com/1811616/56292084-75f19780-6161-11e9-976f-c20f43467fb1.png)
