### PR TITLE
Fix broken layout for French

### DIFF
--- a/app/assets/stylesheets/modules/home.css
+++ b/app/assets/stylesheets/modules/home.css
@@ -93,6 +93,7 @@
 .home__downloads__desc {
   font-weight: 300;
   font-size: 12px;
+  white-space: nowrap;
   text-transform: uppercase; }
   @media (max-width: 379px) {
     .home__downloads__desc {


### PR DESCRIPTION
I found the layout below is broken when I choose French locale.

## Before

![image](https://user-images.githubusercontent.com/1811616/56292684-940bc780-6162-11e9-9565-90e852433da7.png)

## After

`TÉLÉCHARGEMENTS À CE JOUR` does not contain any line break.

![image](https://user-images.githubusercontent.com/1811616/56292694-9a01a880-6162-11e9-8873-77b2e3ec65cd.png)
