### PR TITLE
Replace oracle java with openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - elasticsearch-5.x
     packages:
       - elasticsearch
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 services:
   - elasticsearch


### PR DESCRIPTION
Fixes:
E: Package 'oracle-java8-set-default' has no installation candidate
apt-get.diagnostics
apt-get install failed 
[failing build](https://travis-ci.org/rubygems/rubygems.org/jobs/522762616#L430)

>  A change probably happened at the webupd8 PPA level or on the Oracle
Java download site.

https://github.com/travis-ci/travis-ci/issues/9512