### PR TITLE
Confirm before unload after enabling multi factor authentication

### DIFF
--- a/app/assets/javascripts/multifactor_auths.js
+++ b/app/assets/javascripts/multifactor_auths.js
@@ -1,0 +1,6 @@
+if($("#recovery-code-list").length){
+  window.addEventListener("beforeunload", function (e) {
+    e.preventDefault();
+    e.returnValue = '';
+  });
+}


### PR DESCRIPTION
This makes us prevent from forgetting to copy recovery codes.