### PR TITLE
Migrate from dalli_cache to mem_cache_store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module Gemcutter
 
     # Using true enables origin-checking CSRF mitigation. Our API can't use this check.
     config.action_controller.forgery_protection_origin_check = false
+    config.active_record.cache_versioning = true
 
     config.rubygems = Application.config_for :rubygems
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :dalli_store,
+    config.cache_store = :mem_cache_store,
                          'localhost:11211',
                          { compress: true, compression_min_size: 524_288 }
     config.public_file_server.headers = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,7 +104,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.cache_store = :dalli_store, ENV['MEMCACHED_ENDPOINT'], {
+  config.cache_store = :mem_cache_store, ENV['MEMCACHED_ENDPOINT'], {
     failover: true,
     socket_timeout: 1.5,
     socket_failure_delay: 0.2,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -104,7 +104,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.cache_store = :dalli_store, ENV['MEMCACHED_ENDPOINT'], {
+  config.cache_store = :mem_cache_store, ENV['MEMCACHED_ENDPOINT'], {
     failover: true,
     socket_timeout: 1.5,
     socket_failure_delay: 0.2,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   config.active_support.test_order = :random
 
-  config.cache_store = :dalli_store
+  config.cache_store = :mem_cache_store
 
   config.active_job.queue_adapter = :test
 end

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -6,10 +6,6 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-# Make Active Record use stable #cache_key alongside new #cache_version method.
-# This is needed for recyclable cache keys.
-# Rails.application.config.active_record.cache_versioning = true
-
 # Use AES-256-GCM authenticated encryption for encrypted cookies.
 # Also, embed cookie expiry in signed or encrypted cookies for increased security.
 #


### PR DESCRIPTION
Enables recyclable cache keys, which is not supported by dalli.
We need dalli gem as mem_cache_store used it internally.
Added default config to application.rb as setting value in
`new_framework_default_5_2.rb` doesn't work. some initialization ordering
issue.

Brefore:
> Rubygem.last.cache_key
=> "rubygems/1-20190423170910485510"

After:
> Rubygem.last.cache_key
=> "rubygems/1"