### PR TITLE
Set expiry on rails session

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,7 +5,7 @@
 
 # Be sure to restart your server when you modify this file.
 
-options = { key: '_rubygems_session' }
+options = { key: '_rubygems_session', expire_after: Gemcutter::REMEMBER_FOR }
 Rails.application.config.session_store :cookie_store, options
 
 # Use the database for sessions instead of the cookie-based default,


### PR DESCRIPTION
We use rails session for locale setting and MFA registration and sign in.
rails session gets destroyed when the user closes the browser, it is still
nice to set an expiry on it.