### PR TITLE
Use Sendgrid Webhook to track failed emails per user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,18 @@ class ApplicationController < ActionController::Base
     render plain: "Request is missing param '#{e.param}'", status: :bad_request
   end
 
+  def self.http_basic_authenticate_with(options = {})
+    before_action(options.except(:name, :password, :realm)) do
+      raise "Invalid authentication options" unless http_basic_authentication_options_valid?(options)
+    end
+    super
+  end
+
   protected
+
+  def http_basic_authentication_options_valid?(options)
+    options[:password].present? && options[:name].present?
+  end
 
   def fastly_expires_in(seconds)
     response.headers["Surrogate-Control"] = "max-age=#{seconds}"

--- a/app/controllers/sendgrid_events_controller.rb
+++ b/app/controllers/sendgrid_events_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class SendgridEventsController < ApplicationController
+  # Safelist documented SendGrid Event attributes
+  # https://sendgrid.com/docs/API_Reference/Event_Webhook/event.html#-Event-objects
+  SENDGRID_EVENT_ATTRIBUTES = %w[
+    email timestamp smtp-id event category sg_event_id sg_message_id reason
+    status response attempt useragent ip url asm_group_id tls unique_args
+    marketing_campaign_id marketing_campaign_name pool type
+  ].freeze
+
+  skip_before_action :verify_authenticity_token, only: :create
+
+  http_basic_authenticate_with(
+    name: Rails.application.secrets.sendgrid_webhook_username,
+    password: Rails.application.secrets.sendgrid_webhook_password
+  )
+
+  def create
+    events_params.each do |event_payload|
+      SendgridEvent.process_later(event_payload)
+    end
+    head :ok
+  end
+
+  private
+
+  def events_params
+    # SendGrid send a JSON array of 1+ events. Each event is a JSON object, see docs:
+    # https://sendgrid.com/docs/for-developers/tracking-events/event/
+    params.require(:_json).map { |event_params| event_params.permit(SENDGRID_EVENT_ATTRIBUTES) }
+  end
+end

--- a/app/models/sendgrid_event.rb
+++ b/app/models/sendgrid_event.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class SendgridEvent < ApplicationRecord
+  # To make allowances for occasional inbox down time, this counts a maximum of one fail per day,
+  # e.g.:
+  #
+  # - If 2 emails are sent on the same day, and both fail, then this counts as only 1 fail, not
+  #   2 fails.
+  #
+  # - If 2 emails are sent on 2 separate days, and both fail, then this counts as 2
+  #   fails, as the failures were on different days.
+  def self.fails_since_last_delivery(email)
+    last_delivered_at = where(email: email, event_type: "delivered").maximum(:occurred_at)
+
+    fails_query =
+      select("DISTINCT(date_trunc('day', occurred_at))")
+        .where(email: email, event_type: %w[dropped bounce])
+
+    fails_query = fails_query.where("occurred_at > ?", last_delivered_at) if last_delivered_at
+
+    fails_query.count
+  end
+
+  def self.process_later(payload)
+    return if where(sendgrid_id: payload[:sg_event_id]).exists?
+
+    transaction do
+      event = create!(
+        sendgrid_id: payload[:sg_event_id],
+        email: payload[:email],
+        event_type: payload[:event],
+        occurred_at: Time.zone.at(payload[:timestamp]),
+        payload: payload,
+        status: "pending"
+      )
+      delay.process(event.id)
+    end
+  end
+
+  def self.process(id)
+    find(id).process
+  end
+
+  def process
+    return unless pending?
+
+    transaction do
+      if email.present?
+        fails_count = self.class.fails_since_last_delivery(email)
+        User.where(email: email).update_all(mail_fails: fails_count)
+      end
+      update_attribute(:status, "processed")
+    end
+  end
+
+  def pending?
+    status == "pending"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,7 +229,7 @@ class User < ApplicationRecord
   end
 
   def update_email!
-    self.attributes = { email: unconfirmed_email, unconfirmed_email: nil }
+    self.attributes = { email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0 }
     save!(validate: false)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,4 +190,8 @@ Rails.application.routes.draw do
     get 'ping' => 'ping#index'
     get 'revision' => 'ping#revision'
   end
+
+  ################################################################################
+  # Incoming Webhook Endpoint
+  resources :sendgrid_events, only: :create, format: false, defaults: { format: :json }
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,14 +12,22 @@
 
 development:
   secret_key_base: 01ade4a4dc594f4e2f1711f225adc0ad38b1f4e0b965191a43eea8a658a97d8d5f7a1255791c491f14ca638d4bbc7d82d8990040e266e3d898670605f2e5676f
+  sendgrid_webhook_username: development_sendgrid_webhook_user
+  sendgrid_webhook_password: 279a2b980eedbfb71132d73e0ad63989b420ebf3c37f159749f58f2003737734ddd409278157ab171182b9a5bf6d4b4215b6a5535a4b6c2829e88ff14ce74644
 
 test:
   secret_key_base: 482e75fe0b819896e400fa4be69a0535382e73a98f147d9f898d6bf2d2d705c85834a91b765b0a4ba018493c38ebaf355acae8ca1f9e654e9c52c6fa969042ac
+  sendgrid_webhook_username: test_sendgrid_webhook_user
+  sendgrid_webhook_password: ecf2a26928de3dbb5b90f38216fc3453f3739774fc4f24e61434e9608d355748beac3d70d49a455ff59e17133cdbd316417da2c7d8f11bdd7cd07f85c4fb321j
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  sendgrid_webhook_username: <%= ENV["SENDGRID_WEBHOOK_USERNAME"] %>
+  sendgrid_webhook_password: <%= ENV["SENDGRID_WEBHOOK_PASSWORD"] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  sendgrid_webhook_username: <%= ENV["SENDGRID_WEBHOOK_USERNAME"] %>
+  sendgrid_webhook_password: <%= ENV["SENDGRID_WEBHOOK_PASSWORD"] %>

--- a/db/migrate/20190423201849_create_sendgrid_events.rb
+++ b/db/migrate/20190423201849_create_sendgrid_events.rb
@@ -1,0 +1,17 @@
+class CreateSendgridEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sendgrid_events do |t|
+      t.string :sendgrid_id, null: false
+      t.string :email
+      t.string :event_type
+      t.datetime :occurred_at
+      t.jsonb :payload, null: false
+      t.string :status, null: false
+
+      t.timestamps
+    end
+
+    add_index :sendgrid_events, :sendgrid_id, unique: true
+    add_index :sendgrid_events, :email
+  end
+end

--- a/db/migrate/20190426190518_add_mail_fails_to_users.rb
+++ b/db/migrate/20190426190518_add_mail_fails_to_users.rb
@@ -1,0 +1,5 @@
+class AddMailFailsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :mail_fails, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_19_175448) do
+ActiveRecord::Schema.define(version: 2019_04_26_190518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -111,6 +111,19 @@ ActiveRecord::Schema.define(version: 2019_04_19_175448) do
     t.index ["name"], name: "index_rubygems_on_name", unique: true
   end
 
+  create_table "sendgrid_events", force: :cascade do |t|
+    t.string "sendgrid_id", null: false
+    t.string "email"
+    t.string "event_type"
+    t.datetime "occurred_at"
+    t.jsonb "payload", null: false
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_sendgrid_events_on_email"
+    t.index ["sendgrid_id"], name: "index_sendgrid_events_on_sendgrid_id", unique: true
+  end
+
   create_table "subscriptions", id: :serial, force: :cascade do |t|
     t.integer "rubygem_id"
     t.integer "user_id"
@@ -141,6 +154,7 @@ ActiveRecord::Schema.define(version: 2019_04_19_175448) do
     t.string "mfa_seed"
     t.integer "mfa_level", default: 0
     t.string "mfa_recovery_codes", default: [], array: true
+    t.integer "mail_fails", default: 0
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -129,4 +129,10 @@ FactoryBot.define do
     version_id { 0 }
     count { 0 }
   end
+
+  factory :sendgrid_event do
+    sequence(:sendgrid_id) { |n| "TestSendgridId#{n}" }
+    status { "pending" }
+    payload { {} }
+  end
 end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ProfileTest < SystemTest
   setup do
-    @user = create(:user, email: "nick@example.com", password: "password12345", handle: "nick1")
+    @user = create(:user, email: "nick@example.com", password: "password12345", handle: "nick1", mail_fails: 1)
 
     page.driver.browser.set_cookie("mfa_feature=true")
   end
@@ -77,6 +77,7 @@ class ProfileTest < SystemTest
 
     fill_in "Email address", with: "nick2@example.com"
     fill_in "Password", with: "password12345"
+
     click_button "Update"
 
     assert page.has_selector? "input[value='nick@example.com']"
@@ -86,11 +87,14 @@ class ProfileTest < SystemTest
 
     link = last_email_link
     assert_not_nil link
-    visit link
 
-    assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
-    visit edit_profile_path
-    assert page.has_selector? "input[value='nick2@example.com']"
+    assert_changes -> { @user.reload.mail_fails }, from: 1, to: 0 do
+      visit link
+
+      assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
+      visit edit_profile_path
+      assert page.has_selector? "input[value='nick2@example.com']"
+    end
   end
 
   test "disabling email on profile" do

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RoutingTest < ActionDispatch::IntegrationTest
   def contoller_in_ui?(controller)
-    !controller.nil? && controller !~ /^api|internal.*$/
+    !controller.nil? && controller !~ /^api|internal|sendgrid_events.*$/
   end
 
   setup do

--- a/test/integration/sendgrid_webhook_test.rb
+++ b/test/integration/sendgrid_webhook_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class SendgridWebhookTest < ActionDispatch::IntegrationTest
+  test "responds 200 OK to valid credentials" do
+    params = [
+      { sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i }
+    ]
+    post "/sendgrid_events", params: params, as: :json, headers: authorization_header
+
+    assert_response :ok
+  end
+
+  test "responds 401 Unauthorized to invalid credentials" do
+    params = [
+      { sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i }
+    ]
+    post "/sendgrid_events", params: params, as: :json, headers: authorization_header(password: "wrong-password")
+
+    assert_response :unauthorized
+  end
+
+  test "errors if credentials configured on server are invalid" do
+    SendgridEventsController.any_instance.stubs(:http_basic_authentication_options_valid?).returns(false)
+    params = [
+      { sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i }
+    ]
+
+    error = assert_raises(RuntimeError) do
+      post "/sendgrid_events", params: params, as: :json, headers: authorization_header
+    end
+    assert_equal("Invalid authentication options", error.message)
+  end
+
+  test "saves events and schedules jobs" do
+    params = [
+      { email: "user1@example.com", sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i, event: "bounce" },
+      { email: "user2@example.com", sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==", timestamp: Time.current.to_i, event: "delivered" }
+    ]
+    post "/sendgrid_events", params: params, as: :json, headers: authorization_header
+
+    assert_response :ok
+
+    events = SendgridEvent.all
+    assert_equal 2, events.size
+    assert_equal "user1@example.com", events.first.email
+    assert_equal "user2@example.com", events.last.email
+    assert events.all?(&:pending?)
+
+    assert_equal 2, Delayed::Job.count
+  end
+
+  def authorization_header(password: Rails.application.secrets.sendgrid_webhook_password)
+    username = Rails.application.secrets.sendgrid_webhook_username
+    encoded_credentials = Base64.encode64("#{username}:#{password}")
+    { "Authorization" => "Basic #{encoded_credentials}" }
+  end
+end

--- a/test/unit/sendgrid_event_test.rb
+++ b/test/unit/sendgrid_event_test.rb
@@ -1,0 +1,162 @@
+require "test_helper"
+
+class SendgridEventTest < ActiveSupport::TestCase
+  context ".fails_since_last_delivery" do
+    should "return 0 for email with no events" do
+      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@example.com")
+    end
+
+    should "return 0 for email with no delivery failures" do
+      create(:sendgrid_event, event_type: "delivered", occurred_at: 1.day.ago, email: "user@example.com")
+
+      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@example.com")
+    end
+
+    should "return number of mail delivery failures" do
+      freeze_time do
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 1.day.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 2.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@example.com")
+      end
+
+      assert_equal 3, SendgridEvent.fails_since_last_delivery("user@example.com")
+    end
+
+    should "return number of delivery failures for given email only" do
+      freeze_time do
+        create(:sendgrid_event, email: "user.a@example.com", event_type: "bounce", occurred_at: 1.day.ago)
+        create(:sendgrid_event, email: "user.b@example.com", event_type: "bounce", occurred_at: 2.days.ago)
+        create(:sendgrid_event, email: "user.a@example.com", event_type: "bounce", occurred_at: 3.days.ago)
+      end
+
+      assert_equal 2, SendgridEvent.fails_since_last_delivery("user.a@example.com")
+      assert_equal 1, SendgridEvent.fails_since_last_delivery("user.b@example.com")
+    end
+
+    should "count no more than one delivery failure per day" do
+      freeze_time do
+        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "dropped", email: "user@example.com")
+        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "bounce", email: "user@example.com")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@example.com")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@example.com")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "dropped", email: "user@example.com")
+      end
+
+      assert_equal 2, SendgridEvent.fails_since_last_delivery("user@example.com")
+    end
+
+    should "only count failures since last successful delivery" do
+      freeze_time do
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 1.day.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "delivered", occurred_at: 2.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 4.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "delivered", occurred_at: 5.days.ago, email: "user@example.com")
+      end
+
+      assert_equal 1, SendgridEvent.fails_since_last_delivery("user@example.com")
+    end
+  end
+
+  context ".process_later" do
+    should "create event" do
+      occurred_at = 1.minute.ago.change(usec: 0)
+
+      SendgridEvent.process_later(
+        email: "user@example.com",
+        sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==",
+        event: "bounce",
+        timestamp: occurred_at.to_i
+      )
+
+      event = SendgridEvent.last
+      assert_equal("user@example.com", event.email)
+      assert_equal("t61hI0Xpmk8XSR1YX4s0Kg==", event.sendgrid_id)
+      assert_equal("bounce", event.event_type)
+      assert_equal(occurred_at, event.occurred_at)
+      assert event.pending?
+      assert_equal(
+        {
+          "email" => "user@example.com",
+          "sg_event_id" => "t61hI0Xpmk8XSR1YX4s0Kg==",
+          "event" => "bounce",
+          "timestamp" => occurred_at.to_i
+        },
+        event.payload
+      )
+    end
+
+    should "schedule job to process event later" do
+      SendgridEvent.process_later(
+        email: "user@example.com",
+        sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==",
+        timestamp: Time.current.to_i
+      )
+
+      assert_equal 1, Delayed::Job.count
+    end
+
+    should "gracefully ignore duplicate events" do
+      2.times do
+        SendgridEvent.process_later(
+          sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==",
+          timestamp: Time.current.to_i
+        )
+      end
+
+      assert_equal 1, SendgridEvent.count
+    end
+  end
+
+  context ".process" do
+    should "process event with given id" do
+      event = create(:sendgrid_event, status: "pending")
+
+      assert_changes -> { event.reload.status }, from: "pending", to: "processed" do
+        SendgridEvent.process(event.id)
+      end
+    end
+  end
+
+  context "#process" do
+    should "update user mail_fails" do
+      user = create(:user)
+      event = create(:sendgrid_event, email: user.email, event_type: "dropped", occurred_at: Time.current)
+
+      assert_changes -> { user.reload.mail_fails }, from: 0, to: 1 do
+        event.process
+      end
+    end
+
+    should "mark event as processed" do
+      event = create(:sendgrid_event, status: "pending")
+
+      assert_changes -> { event.reload.status }, from: "pending", to: "processed" do
+        event.process
+      end
+    end
+
+    should "ignore processed events" do
+      user = create(:user)
+      event = create(
+        :sendgrid_event, status: "processed", email: user.email, event_type: "dropped", occurred_at: Time.current
+      )
+
+      assert_no_changes -> { user.reload.mail_fails } do
+        event.process
+      end
+    end
+  end
+
+  context "#pending?" do
+    should "be true for pending event" do
+      event = SendgridEvent.new(status: "pending")
+      assert event.pending?
+    end
+
+    should "be false for processed event" do
+      event = SendgridEvent.new(status: "processed")
+      refute event.pending?
+    end
+  end
+end


### PR DESCRIPTION
Use SendGrid webhook events to record a user's `mail_fails` count. 

`mail_fails` is the number of failed email deliveries since the recipient's last successful delivery. See implementation for details.

The `mail_fails` count will eventually be used to determine the quality of an email address, and if its worth continuing sending mails to that address. (To be used in #1950 and #1953.)

#### Related tasks

- Set env vars `SENDGRID_WEBHOOK_USERNAME` and `SENDGRID_WEBHOOK_PASSWORD` to random values such as those generated by `rake secret`
- Configure webhook endpoint with these secrets, and to receive these "Actions": "Delivered", "Bounced", "Dropped" (see screengrab below taken from a test SendGrid dashboard):

```
https://SENDGRID_WEBHOOK_USERNAME:SENDGRID_WEBHOOK_PASSWORD@www.rubygems.org/sendgrid_events
```

<img width="1263" alt="Screen Shot 2019-04-27 at 14 55 47" src="https://user-images.githubusercontent.com/31698/60366209-b764b580-99e2-11e9-9520-4eb3dd02932e.png">

