### PR TITLE
Revert "Set httpOnly and expiry on rails session"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,7 +5,7 @@
 
 # Be sure to restart your server when you modify this file.
 
-options = { key: '_rubygems_session', expire_after: Gemcutter::REMEMBER_FOR }
+options = { key: '_rubygems_session' }
 Rails.application.config.session_store :cookie_store, options
 
 # Use the database for sessions instead of the cookie-based default,


### PR DESCRIPTION
This reverts commit 03a7b26f8f07a9c5f00f5c807592e78ff558ffe8.
Closing browser session deletes cookies which don't have expire_after
set.