### PR TITLE
Refresh ES index before making search requests

### DIFF
--- a/test/integration/page_params_test.rb
+++ b/test/integration/page_params_test.rb
@@ -49,8 +49,8 @@ class PageParamsTest < SystemTest
 
   test "api search with page that can't be converted to a number" do
     create(:rubygem, name: "some", number: "1.0.0")
-    visit api_v1_search_path(page: { "$acunetix" => "1" }, query: "some", format: :json)
     import_and_refresh
+    visit api_v1_search_path(page: { "$acunetix" => "1" }, query: "some", format: :json)
     assert redirect_to(api_v1_search_path(page: "1", query: "some", format: :json))
     refute JSON.parse(page.body).empty?
   end


### PR DESCRIPTION
This test was [failing sporadically](https://travis-ci.org/rubygems/rubygems.org/jobs/532225542#L1393), most likely because index was not upto date when search request was made.