### PR TITLE
#1897 Fixed the version number api call issue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :rubygems, param: :name, only: [], constraints: { name: Patterns::ROUTE_PATTERN } do
         resources :versions, param: :number, only: :show, constraints: {
-          number: /#{Gem::Version::VERSION_PATTERN}(?=\.json\z)|#{Gem::Version::VERSION_PATTERN}/
+          number: /#{Gem::Version::VERSION_PATTERN}(?=\.json\z)|#{Gem::Version::VERSION_PATTERN}(?=\.yaml\z)|#{Gem::Version::VERSION_PATTERN}/
         }
       end
     end

--- a/test/integration/api/v2/version_information_test.rb
+++ b/test/integration/api/v2/version_information_test.rb
@@ -18,6 +18,11 @@ class VersionInformationTest < ActionDispatch::IntegrationTest
     assert_equal '2.0.0', json_response["number"]
   end
 
+  test "return success for yaml extension api call" do
+    request_endpoint(@rubygem, '2.0.0', 'yaml')
+    assert_response :success
+  end
+
   test "has required fields" do
     request_endpoint(@rubygem, '2.0.0')
     json_response = JSON.load(@response.body)


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/issues/1897

As this issue says when doing an api call with version number.yaml it shows version not available. This issue has been solved by changing the routes.rb file. I have added another regex check while API call.
I added a test case is integration tests where I checked If an API call with .yaml extn is successful. 

example : https://rubygems.org/api/v2/rubygems/rails/versions/5.2.2.yaml 
this used to show "this version is not available" even when it was while with .json extn it worked.
Now with this fix .yaml extn can be used without error.