### PR TITLE
Fix NoMethodError of gemcutter:imort:process

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -18,7 +18,7 @@ namespace :gemcutter do
       puts "Processing #{gems.size} gems..."
       gems.each do |path|
         puts "Processing #{path}"
-        cutter = Pusher.new(nil, File.open(path))
+        cutter = Pusher.new(User.new, File.open(path))
 
         cutter.process
         puts cutter.message unless cutter.code == 200


### PR DESCRIPTION
When I ran 
`bundle exec rake gemcutter:import:process #{INSTALLATION_DIRECTORY}/cache`
in accordance with _Development Setup_ , I got
``"ERROR!"
#<NoMethodError: undefined method `email' for nil:NilClass>``

Modifying
`nil` to `User.new`
in `:import` `:process` in `lib/tasks/gemcutter.rake`
fixes the problem.