### PR TITLE
Return true for successful Pusher saves

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -40,6 +40,7 @@ class Pusher
   else
     after_write
     notify("Successfully registered gem: #{version.to_title}", 200)
+    true
   end
 
   def pull_spec

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -248,6 +248,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "On POST to create for existing gem" do
       setup do
+        create(:global_web_hook, user: @user, url: "http://example.org")
         rubygem = create(:rubygem, name: "test")
         create(:ownership,
           rubygem: rubygem,
@@ -257,7 +258,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           number: "0.0.0",
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
-        assert_difference 'Delayed::Job.count', 5 do
+        assert_difference 'Delayed::Job.count', 6 do
           post :create, body: gem_file("test-1.0.0.gem").read
         end
       end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -271,7 +271,7 @@ class PusherTest < ActiveSupport::TestCase
 
     context "when cutter is saved" do
       setup do
-        @cutter.save
+        assert_equal true, @cutter.save
       end
 
       should "set gem file size" do


### PR DESCRIPTION
Since https://github.com/rubygems/rubygems.org/pull/1995, Rubygems hasn't been sending webhooks for gem pushes. That's because calling `gemcutter.process` always returns `false`, which is surprising.

This PR fixes that behaviour in `gemcutter.process`, and adds a (slightly crude) test that webhooks are fired on create.