### PR TITLE
Change mfa recovery continue arrow from unicode symbol to css

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -168,3 +168,20 @@ span#github-btn {
 .recovery-code-list__item {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
+
+.t-link--arrow {
+  font-weight: bold;
+}
+
+.t-link--arrow:after {
+  content: "";
+  display: inline-block;
+  margin-left: 5px;
+  padding: 5px;
+  box-shadow: 3px -3px 0 0 #e9573f inset;
+  transform: rotate(225deg);
+}
+
+.t-link--arrow:hover:after {
+  box-shadow: 3px -3px 0 0 rgba(233, 87, 63, 0.7) inset;
+}

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -7,5 +7,5 @@
     <% end %>
   </ul>
   <p><%= t '.note' %></p>
-  <p><%= link_to t('.continue'), edit_profile_path %></p>
+  <p><%= link_to t('.continue'), edit_profile_path, class: "t-link--arrow" %></p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,7 +182,7 @@ en:
       qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
       success: You have successfully enabled multifactor authentication.
     recovery:
-      continue: Continue 🡒
+      continue: Continue
       title: Recovery codes
       note: "You MUST keep the recovery codes safe to prevent losing your account. Each of the code can be used once if you lose your authenticator."
     destroy:


### PR DESCRIPTION
I had used an Unicode character. the symbol was broken for some users

closes: #2012

![Screenshot from 2019-05-30 11-27-59](https://user-images.githubusercontent.com/7680662/58649543-fe9b5000-8329-11e9-84ad-65d6ae9b7980.png)
