### PR TITLE
Update roadie-rails from 1.3.0 to 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'rack-utf8_sanitizer'
 gem 'rbtrace', '~> 0.4.8'
 gem 'rdoc'
 gem 'rest-client', require: 'rest_client'
-gem 'roadie-rails', '~> 1.3.0'
+gem 'roadie-rails'
 gem 'sass', require: false
 gem 'shoryuken', '~> 2.1.0', require: false
 gem 'statsd-instrument', '~> 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     compact_index (0.11.0)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    css_parser (1.6.0)
+    css_parser (1.7.0)
       addressable
     daemons (1.3.1)
     dalli (2.7.9)
@@ -263,7 +263,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     psych (3.1.0)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     rack (2.0.7)
     rack-attack (6.0.0)
       rack (>= 1.0, < 3)
@@ -321,11 +321,11 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    roadie (3.4.0)
+    roadie (3.5.0)
       css_parser (~> 1.4)
-      nokogiri (~> 1.5)
-    roadie-rails (1.3.0)
-      railties (>= 3.0, < 5.3)
+      nokogiri (~> 1.8)
+    roadie-rails (2.1.0)
+      railties (>= 5.1, < 6.1)
       roadie (~> 3.1)
     rotp (4.1.0)
       addressable (~> 2.5)
@@ -441,7 +441,7 @@ DEPENDENCIES
   rbtrace (~> 0.4.8)
   rdoc
   rest-client
-  roadie-rails (~> 1.3.0)
+  roadie-rails
   rotp
   rqrcode
   rubocop

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,8 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Gemcutter::HOST,
                                                protocol: Gemcutter::PROTOCOL }
 
-  config.action_mailer.asset_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
+  # roadie-rails recommends not setting action_mailer.asset_host and use its own configuration for URL options
+  config.roadie.url_options = { host: "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}" }
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = [:en]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,7 +80,8 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Gemcutter::HOST,
                                                protocol: Gemcutter::PROTOCOL }
 
-  config.action_mailer.asset_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
+  # roadie-rails recommends not setting action_mailer.asset_host and use its own configuration for URL options
+  config.roadie.url_options = { host: "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}" }
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = [:en]


### PR DESCRIPTION
2.1.0
Rails 6 support (#88) - Gleb Mazovetskiy (glebm)

2.0.0

Drop support for Ruby before 2.5.
Drop support for Rails before 5.1.
Add support for Ruby 2.5.
Add support for Ruby 2.6.
Fix arity of Roadie::Rails::Mailer#roadie_mail - Adrian Lehmann (ownadi)