### PR TITLE
Enable bootsnap in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails-i18n"
 
 gem "autoprefixer-rails"
 gem "aws-sdk", "~> 2.2"
+gem "bootsnap"
 gem "clearance"
 gem "clearance-deprecated_password_strategies"
 gem "daemons"
@@ -56,7 +57,6 @@ group :development, :test do
 end
 
 group :development do
-  gem "bootsnap", require: false
   gem "rails-erd"
   gem "listen"
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,8 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-
-env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
-dev_mode = ['', nil, 'development'].include? env
-
-require 'bootsnap/setup' if dev_mode && !ENV['NO_BOOTSNAP']
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
We have been using it in development since https://github.com/rubygems/rubygems.org/pull/1686