### PR TITLE
Replace sass with sassc-rails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mv /app/config/database.yml.example /app/config/database.yml
 
 RUN gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without deploy
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=1234 bin/rails assets:precompile
+RUN RAILS_ENV=production SECRET_KEY_BASE=1234 PRECOMPILE=true bin/rails assets:precompile
 
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "rbtrace", "~> 0.4.8"
 gem "rdoc"
 gem "rest-client", require: "rest_client"
 gem "roadie-rails"
-gem "sass", require: false
+gem "sassc-rails", require: false
 gem "shoryuken", "~> 2.1.0", require: false
 gem "statsd-instrument", "~> 2.3.0"
 gem "uglifier", ">= 1.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,15 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    sass (3.4.24)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.1)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     shoryuken (2.1.3)
       aws-sdk-core (~> 2)
       celluloid (~> 0.17)
@@ -369,6 +377,7 @@ GEM
     statsd-instrument (2.3.2)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.9)
     timers (4.1.2)
       hitimes
     to_regexp (0.2.1)
@@ -446,7 +455,7 @@ DEPENDENCIES
   rqrcode
   rubocop
   rubocop-performance
-  sass
+  sassc-rails
   shoryuken (~> 2.1.0)
   shoulda
   sprockets-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'active_job/railtie'
 require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
 require 'elasticsearch/rails/instrumentation'
+require 'sassc-rails' if ENV['RAILS_ENV'] != 'production' || ENV['PRECOMPILE']
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Related: #2003
Technically, [sprockets 3 doesn't support sassc](https://github.com/rails/sprockets/issues/588#issuecomment-438019730) and has implicit dependency on (ruby-) sass, hence the following error on precompilation:
```
LoadError: cannot load such file -- sass
/home/aditya/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in
`require'
/home/aditya/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in
`block in require'
/home/aditya/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in
`load_dependency'
/home/aditya/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in
`require'
/home/aditya/.rvm/gems/ruby-2.5.3/gems/sprockets-3.7.2/lib/sprockets/autoload/sass.rb:1:in
`<top (required)>'
```
We need to add `require 'sassc-rails'` to fix this. Alternatively, we could wait for sprockets 4 release.

I tried adding the require in rake task but it doesn't work.
```ruby
  namespace :sassc do
    require 'sassc-rails'

    desc "asset precomplication with sassc"
    task precompile: :environment do
      Rake::Task["assets:precompile"].invoke
    end
  end
```

Only change in minified css when using sassc is following which is non-consequential:
```diff
@@ -1327,8 +1327,8 @@ pre code {
        left: -10px;
        height: 100%;
        width: 10px;
-       background-image: -webkit-gradient(linear, left top, right top, from(transparent), to(#fff));
-       background-image: linear-gradient(to right, transparent 0%, #fff 100%)
+       background-image: -webkit-gradient(linear, left top, right top, from(transparent), to(white));
+       background-image: linear-gradient(to right, transparent 0%, white 100%)
 }
``` 