### PR TITLE
soft purge versions

### DIFF
--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -7,6 +7,6 @@ class GemCachePurger
     end
 
     Rails.cache.delete("deps/v1/#{gem_name}")
-    Fastly.delay.purge("versions")
+    Fastly.delay.purge("versions", true)
   end
 end

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -17,7 +17,7 @@ class GemCachePurgerTest < ActiveSupport::TestCase
     should "purge cdn cache" do
       Fastly.expects(:purge).with("info/#{@gem_name}")
       Fastly.expects(:purge).with("names")
-      Fastly.expects(:purge).with("versions")
+      Fastly.expects(:purge).with("versions", true)
 
       GemCachePurger.call(@gem_name)
       Delayed::Worker.new.work_off


### PR DESCRIPTION
Attempt to use soft-purge to prevent thundering herd after every gem is pushed.