### PR TITLE
Add lock! method to User class and use it in lock_user script.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,9 +206,9 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
-  def lock!
+  def block!
     transaction do
-      update_attribute(:email, "security+locked-#{handle}@rubygems.org")
+      update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{id}-#{handle}@rubygems.org")
       disable_mfa!
       update!(
         password: SecureRandom.alphanumeric,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,19 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
+  def lock!
+    transaction do
+      update_attribute(:email, "security+locked-#{handle}@rubygems.org")
+      disable_mfa!
+      update!(
+        password: SecureRandom.alphanumeric,
+        remember_token: nil,
+        remember_token_expires_at: nil,
+        api_key: nil
+      )
+    end
+  end
+
   private
 
   def verify_digit_otp(seed, otp)

--- a/script/block_user
+++ b/script/block_user
@@ -2,7 +2,7 @@
 
 if ARGV.empty?
   puts "Locks a user account so it can't be used."
-  puts "USAGE: script/lock_user USERNAME"
+  puts "USAGE: script/block_user USERNAME"
   exit
 end
 
@@ -13,7 +13,7 @@ ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 begin
-  User.find_by!(handle: handle).lock!
+  User.find_by!(handle: handle).block!
   puts "Done."
 rescue ActiveRecord::RecordNotFound
   puts "User #{handle} not found."

--- a/script/lock_user
+++ b/script/lock_user
@@ -2,7 +2,7 @@
 
 if ARGV.empty?
   puts "Locks a user account so it can't be used."
-  puts "USAGE: script/malicious_user USERNAME"
+  puts "USAGE: script/lock_user USERNAME"
   exit
 end
 
@@ -12,15 +12,9 @@ puts "Locking user #{handle}..."
 ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
-user = User.where(handle: handle).first
-
-user.update_attribute(:email, "security+locked-#{handle}@rubygems.org")
-user.disable_mfa!
-user.update!(
-  password: SecureRandom.alphanumeric,
-  remember_token: nil,
-  remember_token_expires_at: nil,
-  api_key: nil
-)
-
-puts "Done."
+begin
+  User.find_by!(handle: handle).lock!
+  puts "Done."
+rescue ActiveRecord::RecordNotFound
+  puts "User #{handle} not found."
+end

--- a/script/lock_user
+++ b/script/lock_user
@@ -17,4 +17,5 @@ begin
   puts "Done."
 rescue ActiveRecord::RecordNotFound
   puts "User #{handle} not found."
+  exit 1 # return non-zero on fail
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -144,8 +144,8 @@ class SignInTest < SystemTest
     end
   end
 
-  test "sign in to locked account" do
-    User.find_by!(email: "nick@example.com").lock!
+  test "sign in to blocked account" do
+    User.find_by!(email: "nick@example.com").block!
 
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -143,4 +143,15 @@ class SignInTest < SystemTest
       assert page.has_content? "Sign in"
     end
   end
+
+  test "sign in to locked account" do
+    User.find_by!(email: "nick@example.com").lock!
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Sign in"
+
+    assert page.has_content? "Sign in"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,12 +31,16 @@ class ActiveSupport::TestCase
     skip("Toxiproxy is not running, but was required for this test.") unless Toxiproxy.running?
   end
 
-  def assert_changed(object, attribute)
-    original = object.send(attribute)
+  def assert_changed(object, *attributes)
+    original_attributes = attributes.map { |a| [a, object.send(a)] }.to_h
     yield if block_given?
-    latest = object.reload.send(attribute)
-    assert_not_equal original, latest,
-      "Expected #{object.class} #{attribute} to change but still #{latest}"
+    reloaded_object = object.reload
+    attributes.each do |attribute|
+      original = original_attributes[attribute]
+      latest = reloaded_object.send(attribute)
+      assert_not_equal original, latest,
+        "Expected #{object.class} #{attribute} to change but still #{latest}"
+    end
   end
 end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -277,6 +277,16 @@ class UserTest < ActiveSupport::TestCase
           next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
           assert @user.otp_verified?(next_otp)
         end
+
+        should "can be locked" do
+          assert_changed(@user, :email, :password, :api_key, :mfa_seed, :remember_token) do
+            @user.lock!
+          end
+
+          assert @user.email.start_with?("security+locked-")
+          assert @user.mfa_recovery_codes.empty?
+          assert @user.mfa_disabled?
+        end
       end
 
       context "when disabled" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -278,12 +278,13 @@ class UserTest < ActiveSupport::TestCase
           assert @user.otp_verified?(next_otp)
         end
 
-        should "can be locked" do
+        should "can be blocked" do
           assert_changed(@user, :email, :password, :api_key, :mfa_seed, :remember_token) do
-            @user.lock!
+            @user.block!
           end
 
           assert @user.email.start_with?("security+locked-")
+          assert @user.email.end_with?("@rubygems.org")
           assert @user.mfa_recovery_codes.empty?
           assert @user.mfa_disabled?
         end


### PR DESCRIPTION
@indirect This is my idea from https://github.com/rubygems/rubygems.org/pull/2045#discussion_r298801780. User locking is now "first-class" citizen in codebase covered by tests and used in `lock_user` script.