### PR TITLE
[GSoC]Add autocompletion for search boxes

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -1,0 +1,155 @@
+$(function() {
+  $('#home_query').autocomplete();
+  $('#query').autocomplete();
+});
+
+
+(function($) {
+  $.fn.autocomplete = function() {
+    var indexNumber = -1;
+    var previousForm = 'null';
+    var originalForm = 'null';
+    var _that = this;
+    this.attr('autocomplete', 'off');
+    var listName = this.attr('id') + "SuggestList";
+    this.after("<ul id=" + listName + "></ul>");
+    var $list = $('#' + listName);
+    $list.attr('class', 'suggest-list');
+
+    function getListLength(){
+      return $list.find('li').length;
+    };
+
+    function listItemExists(){
+      return getListLength();
+    }
+
+    function isNotIndexNumberOutofList(){
+    return (indexNumber != -1 || indexNumber == getListLength()) ?  true: false;
+    };
+
+    function selectListItem(){
+      if ( isNotIndexNumberOutofList() ){
+        $list.find('li').eq(indexNumber).focusItem();
+        _that.val($list.find('.selected').text());
+      } else {
+        _that.val(originalForm);
+      };
+    };
+
+    function addDataToSuggestList(data) {
+      $list.find('li').remove();
+      for (var i = 0; i < data.length && i < 10; i++) {
+        var newItem = $('<li>').text(data[i]);
+        $(newItem).attr('class', 'menu-item');
+        $list.append(newItem);
+      }
+      indexNumber = -1;
+      $list.show();
+    };
+
+    $.fn.focusItem = function() {
+      $('li').removeClass('selected');
+      this.addClass('selected');
+      return this;
+    };
+
+    function correctIndexNumber() {
+      switch (indexNumber){
+        case -2: return getListLength() - 1; break;
+        case getListLength(): return -1; break;
+        default: return indexNumber; break;
+      };
+    };
+
+    function movePrev(){
+      indexNumber--;
+      indexNumber = correctIndexNumber();
+    };
+
+    function moveNext(){
+      indexNumber++;
+      indexNumber = correctIndexNumber(indexNumber);
+    }
+
+    function upSelected() {
+      $list.find('li').removeClass('selected');
+      movePrev();
+      selectListItem(indexNumber);
+      $list.show();
+    };
+
+    function downSelected(){
+      $list.find('li').removeClass('selected');
+      moveNext();
+      selectListItem();
+      $list.show();
+    };
+
+    this.blur(function() {
+      $list.hide();
+    });
+    this.focus(function() {
+      if (listItemExists()) {
+        $list.show();
+      }
+    });
+
+    function upSelect(e){
+      return (e.keyCode == 38 || (e.ctrlKey && e.keyCode == 80)) ? true : false;
+    };
+
+    function downSelect(e){
+      return (e.keyCode == 40 || (e.ctrlKey && e.keyCode == 78)) ? true : false;
+    };
+
+    this.keyup(function(e) {
+      e.preventDefault();
+      var input = $.trim($(this).val());
+      if (input.length >= 2 && previousForm != input) {
+        originalForm = _that.val();
+        $.ajax({
+          url: '/api/v1/search/autocomplete',
+          type: 'GET',
+          data: ('query=' + input),
+          processData: false,
+          contentType: false,
+          dataType: 'json'
+        }).done(function(data) {
+          if (data.length) {
+            addDataToSuggestList(data);
+          } else {
+            $list.hide();
+          };
+        });
+      };
+      if (upSelect(e)) {
+        upSelected();
+      } else if (downSelect(e)) {
+        downSelected();
+      };
+      if (input.length < 2) {
+        $list.hide();
+        $list.find('li').remove();
+      };
+      if (!listItemExists()) {
+        $list.hide();
+      };
+      previousForm = $.trim($(this).val());
+    });
+
+    this.parent().on({
+      'mousedown': function() {
+        _that.val($(this).text())
+        _that.parent().submit();
+      },
+      'mouseenter': function() {
+        $(this).focusItem();
+        indexNumber = $('.selected').index();
+      },
+      'mouseleave': function() {
+        $(this).removeClass('selected');
+      }
+    }, ('#' + listName + ' > .menu-item'));
+  };
+})(jQuery);

--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -1,155 +1,76 @@
 $(function() {
-  $('#home_query').autocomplete();
-  $('#query').autocomplete();
-});
+  if ($('#home_query').length){
+    autocomplete($('#home_query'));
+    var suggest = $('#suggest-home');
+  } else {
+    autocomplete($('#query'));
+    var suggest = $('#suggest');
+  }
 
+  var indexNumber = -1;
 
-(function($) {
-  $.fn.autocomplete = function() {
-    var indexNumber = -1;
-    var previousForm = 'null';
-    var originalForm = 'null';
-    var _that = this;
-    this.attr('autocomplete', 'off');
-    var listName = this.attr('id') + "SuggestList";
-    this.after("<ul id=" + listName + "></ul>");
-    var $list = $('#' + listName);
-    $list.attr('class', 'suggest-list');
-
-    function getListLength(){
-      return $list.find('li').length;
-    };
-
-    function listItemExists(){
-      return getListLength();
-    }
-
-    function isNotIndexNumberOutofList(){
-    return (indexNumber != -1 || indexNumber == getListLength()) ?  true: false;
-    };
-
-    function selectListItem(){
-      if ( isNotIndexNumberOutofList() ){
-        $list.find('li').eq(indexNumber).focusItem();
-        _that.val($list.find('.selected').text());
-      } else {
-        _that.val(originalForm);
-      };
-    };
-
-    function addDataToSuggestList(data) {
-      $list.find('li').remove();
-      for (var i = 0; i < data.length && i < 10; i++) {
-        var newItem = $('<li>').text(data[i]);
-        $(newItem).attr('class', 'menu-item');
-        $list.append(newItem);
-      }
-      indexNumber = -1;
-      $list.show();
-    };
-
-    $.fn.focusItem = function() {
-      $('li').removeClass('selected');
-      this.addClass('selected');
-      return this;
-    };
-
-    function correctIndexNumber() {
-      switch (indexNumber){
-        case -2: return getListLength() - 1; break;
-        case getListLength(): return -1; break;
-        default: return indexNumber; break;
-      };
-    };
-
-    function movePrev(){
-      indexNumber--;
-      indexNumber = correctIndexNumber();
-    };
-
-    function moveNext(){
-      indexNumber++;
-      indexNumber = correctIndexNumber(indexNumber);
-    }
-
-    function upSelected() {
-      $list.find('li').removeClass('selected');
-      movePrev();
-      selectListItem(indexNumber);
-      $list.show();
-    };
-
-    function downSelected(){
-      $list.find('li').removeClass('selected');
-      moveNext();
-      selectListItem();
-      $list.show();
-    };
-
-    this.blur(function() {
-      $list.hide();
-    });
-    this.focus(function() {
-      if (listItemExists()) {
-        $list.show();
-      }
-    });
-
-    function upSelect(e){
-      return (e.keyCode == 38 || (e.ctrlKey && e.keyCode == 80)) ? true : false;
-    };
-
-    function downSelect(e){
-      return (e.keyCode == 40 || (e.ctrlKey && e.keyCode == 78)) ? true : false;
-    };
-
-    this.keyup(function(e) {
-      e.preventDefault();
-      var input = $.trim($(this).val());
-      if (input.length >= 2 && previousForm != input) {
-        originalForm = _that.val();
+  function autocomplete(search) {
+    search.bind('input', function(e) {
+      var term = $.trim($(search).val());
+      if (term.length >= 2) {
         $.ajax({
           url: '/api/v1/search/autocomplete',
           type: 'GET',
-          data: ('query=' + input),
+          data: ('query=' + term),
           processData: false,
-          contentType: false,
           dataType: 'json'
         }).done(function(data) {
-          if (data.length) {
-            addDataToSuggestList(data);
-          } else {
-            $list.hide();
-          };
+          addToSuggestList(search, data);
         });
-      };
-      if (upSelect(e)) {
-        upSelected();
-      } else if (downSelect(e)) {
-        downSelected();
-      };
-      if (input.length < 2) {
-        $list.hide();
-        $list.find('li').remove();
-      };
-      if (!listItemExists()) {
-        $list.hide();
-      };
-      previousForm = $.trim($(this).val());
+      } else {
+        suggest.find('li').remove();
+      }
     });
 
-    this.parent().on({
-      'mousedown': function() {
-        _that.val($(this).text())
-        _that.parent().submit();
-      },
-      'mouseenter': function() {
-        $(this).focusItem();
-        indexNumber = $('.selected').index();
-      },
-      'mouseleave': function() {
-        $(this).removeClass('selected');
-      }
-    }, ('#' + listName + ' > .menu-item'));
+    search.keydown(function(e) {
+      if (e.keyCode == 38) {
+        indexNumber--;
+        focusItem(search);
+      } else if (e.keyCode == 40) {
+        indexNumber++;
+        focusItem(search);
+      };
+    });
   };
-})(jQuery);
+
+  function addToSuggestList(search, data) {
+    suggest.find('li').remove();
+
+    for (var i = 0; i < data.length && i < 10; i++) {
+      var newItem = $('<li>').text(data[i]);
+      $(newItem).attr('class', 'menu-item');
+      suggest.append(newItem);
+
+      /* submit the search form if li item was clicked */
+      newItem.click(function() {
+        search.val($(this).html());
+        search.parent().submit()
+      });
+
+      newItem.hover(function () {
+        $('li').removeClass('selected');
+        $(this).addClass("selected");
+      });
+    }
+
+    indexNumber = -1;
+  };
+
+  function focusItem(search){
+    var suggestLength = suggest.find('li').length;
+    if (indexNumber >= suggestLength) indexNumber = 0;
+    if (indexNumber < 0) indexNumber = suggestLength - 1;
+
+    $('li').removeClass('selected');
+    suggest.find('li').eq(indexNumber).addClass('selected');
+    search.val(suggest.find('.selected').text());
+  };
+
+  /* remove suggest drop down if clicked anywhere on page */
+  $('html').click(function(e) { suggest.find('li').remove(); });
+});

--- a/app/assets/stylesheets/modules/search.css
+++ b/app/assets/stylesheets/modules/search.css
@@ -96,7 +96,6 @@
   color: #e9573f; }
 
 .home__search {
-  margin-bottom: 5px;
   padding-right: 48px;
   box-shadow: 0 0 0px 5px rgba(20, 28, 34, .1);
   box-sizing: border-box;
@@ -155,4 +154,8 @@ dt {
 
 dd input {
   max-width: none !important;;
+}
+
+.home__search-wrap center {
+  margin-top: 5px;
 }

--- a/app/assets/stylesheets/suggest-list.css
+++ b/app/assets/stylesheets/suggest-list.css
@@ -6,16 +6,18 @@
   list-style: none;
   color: #ffffff;
   background-color: rgba(20, 28, 34, 0.8);
-  border-radius: 5px;
 }
+
 .suggest-list > li{
   margin-bottom: 2px;
   padding: 4px;
 }
 .suggest-list > .selected{
   background-color: rgba(233, 87, 63, 0.8);
-  font-weight: bold;
-  border-radius: 4px;
+}
+
+.menu-item:hover {
+  cursor: pointer;
 }
 
 .mobile-nav-is-expanded .suggest-list {

--- a/app/assets/stylesheets/suggest-list.css
+++ b/app/assets/stylesheets/suggest-list.css
@@ -1,0 +1,23 @@
+.suggest-list {
+  position: absolute;
+  z-index: 1000;
+  width: 100%;
+  padding: 0;
+  list-style: none;
+  color: #ffffff;
+  background-color: rgba(20, 28, 34, 0.8);
+  border-radius: 5px;
+}
+.suggest-list > li{
+  margin-bottom: 2px;
+  padding: 4px;
+}
+.suggest-list > .selected{
+  background-color: rgba(233, 87, 63, 0.8);
+  font-weight: bold;
+  border-radius: 4px;
+}
+
+.mobile-nav-is-expanded .suggest-list {
+  width: calc(100% - 24px);
+}

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,13 +1,18 @@
 class Api::V1::SearchesController < Api::BaseController
-  before_action :set_page, only: :show
-  before_action :verify_query_string, only: :show
+  before_action :set_page, only: %i[show autocomplete]
+  before_action :verify_query_string, only: %i[show autocomplete]
 
   def show
-    @rubygems = ElasticSearcher.new(query_params, api: true, page: @page).search
+    @rubygems = ElasticSearcher.new(query_params, page: @page).search(api: true)
     respond_to do |format|
       format.json { render json: @rubygems }
       format.yaml { render yaml: @rubygems }
     end
+  end
+
+  def autocomplete
+    results = ElasticSearcher.new(params[:query], page: @page).suggestions
+    render json: results
   end
 
   private

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SearchesController < Api::BaseController
   before_action :verify_query_string, only: %i[show autocomplete]
 
   def show
-    @rubygems = ElasticSearcher.new(query_params, page: @page).search(api: true)
+    @rubygems = ElasticSearcher.new(query_params, page: @page).api_search
     respond_to do |format|
       format.json { render json: @rubygems }
       format.yaml { render yaml: @rubygems }

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -40,6 +40,13 @@ module RubygemSearchable
         summary:           latest_version&.summary,
         description:       latest_version&.description,
         updated:           updated_at,
+        suggest: {
+          input: name,
+          weight: downloads,
+          contexts: {
+            yanked: versions.none?(&:indexed?)
+          }
+        },
         dependencies: {
           development: deps&.select { |r| r.rubygem && r.scope == "development" },
           runtime: deps&.select { |r| r.rubygem && r.scope == "runtime" }
@@ -68,6 +75,10 @@ module RubygemSearchable
       end
       indexes :description, type: "text", analyzer: "english" do
         indexes :raw, analyzer: "simple"
+      end
+      instance_eval do
+        context = { name: "yanked", type: "category" }
+        @mapping[:suggest] = { type: "completion", contexts: context }
       end
       indexes :yanked, type: "boolean"
       indexes :downloads, type: "integer"

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -40,18 +40,11 @@ module RubygemSearchable
         summary:           latest_version&.summary,
         description:       latest_version&.description,
         updated:           updated_at,
-        suggest: {
-          input: name,
-          weight: downloads,
-          contexts: {
-            yanked: versions.none?(&:indexed?)
-          }
-        },
         dependencies: {
           development: deps&.select { |r| r.rubygem && r.scope == "development" },
           runtime: deps&.select { |r| r.rubygem && r.scope == "runtime" }
         }
-      }
+      }.merge!(suggest_json)
     end
 
     settings number_of_shards: 1,
@@ -97,6 +90,20 @@ module RubygemSearchable
         .includes(:latest_version, :gem_download)
         .references(:versions)
         .by_downloads
+    end
+
+    private
+
+    def suggest_json
+      {
+        suggest: {
+          input: name,
+          weight: downloads,
+          contexts: {
+            yanked: versions.none?(&:indexed?)
+          }
+        }
+      }
     end
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>
-    <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem_html'), autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search" %>
+    <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem_html'), autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search", :autocomplete => "off" %>
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t('layouts.application.header.search_gem_html') %></span>
       <center>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,6 +5,7 @@
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>
     <%= search_field_tag :query, params[:query], :placeholder => t('layouts.application.header.search_gem_html'), autofocus: current_page?(root_url), :id => 'home_query', :class => "home__search", :autocomplete => "off" %>
+    <ul id="suggest-home" class="suggest-list"></ul>
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t('layouts.application.header.search_gem_html') %></span>
       <center>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,8 @@
 
         <div class="header__nav-links-wrap">
           <%= form_tag search_path, class: search_form_class, method: :get do %>
-            <%= search_field_tag :query, params[:query], placeholder: t('.header.search_gem_html'), class: "header__search" %>
+            <%= search_field_tag :query, params[:query], placeholder: t(".header.search_gem_html"), class: "header__search", autocomplete: "off" %>
+            <ul id="suggest" class="suggest-list"></ul>
             <%= label_tag :query do %>
               <span class="t-hidden"><%= t(".header.search_gem_html") %></span>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,9 @@ Rails.application.routes.draw do
         end
       end
 
-      resource :search, only: :show
+      resource :search, only: :show do
+        get :autocomplete
+      end
 
       resources :web_hooks, only: %i[create index] do
         collection do

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -1,17 +1,29 @@
 class ElasticSearcher
-  def initialize(query, page: 1, api: false)
+  def initialize(query, page: 1)
     @query  = query
     @page   = page
-    @api    = api
   end
 
-  def search
+  def search(api: false)
+    @api = api
     result = Rubygem.__elasticsearch__.search(search_definition).page(@page)
     result.response # ES query is triggered here to allow fallback. avoids lazy loading done in the view
     @api ? result.map(&:_source) : [nil, result]
   rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Elasticsearch::Transport::Transport::Error => e
     result = Rubygem.legacy_search(@query).page(@page)
     @api ? result : [error_msg(e), result]
+  end
+
+  def suggestions
+    result = Rubygem.__elasticsearch__.search(suggestions_definition).page(@page)
+    result = result.response.suggest[:completion_suggestion][0][:options]
+    names = []
+    result.each do |gem|
+      names << gem[:_source].name
+    end
+    names
+  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Elasticsearch::Transport::Transport::Error
+    Rubygem.legacy_search(@query).page(@page)
   end
 
   private
@@ -70,6 +82,15 @@ class ElasticSearcher
       source source_array
       # Return suggestions unless there's no query from the user
       suggest :suggest_name, text: query_str, term: { field: "name.suggest", suggest_mode: "always" } if query_str.present?
+    end
+  end
+
+  def suggestions_definition
+    query_str = @query
+
+    Elasticsearch::DSL::Search.search do
+      suggest :completion_suggestion, prefix: query_str, completion: { field: "suggest", contexts: { yanked: false }, size: 30 }
+      source "name"
     end
   end
 

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -23,7 +23,7 @@ class ElasticSearcher
     end
     names
   rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Elasticsearch::Transport::Transport::Error
-    Rubygem.legacy_search(@query).page(@page)
+    Array(nil)
   end
 
   private

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -49,4 +49,27 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
       YAML.safe_load body
     end
   end
+
+  context "on GET to autocomplete with query=ma" do
+    setup do
+      @match1 = create(:rubygem, name: "match1")
+      @match2 = create(:rubygem, name: "match2")
+      @other = create(:rubygem, name: "other")
+      create(:version, rubygem: @match1)
+      create(:version, rubygem: @match2)
+      create(:version, rubygem: @other)
+      import_and_refresh
+      get :autocomplete, params: { query: "ma" }
+      @body = JSON.parse(response.body)
+    end
+
+    should respond_with :success
+    should "return gems name" do
+      assert_equal 2, @body.size
+      assert_equal "match1", @body[0]
+    end
+    should "not contain other gems" do
+      assert_not @body.include?("other")
+    end
+  end
 end

--- a/test/integration/autocompletes_test.rb
+++ b/test/integration/autocompletes_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+require "capybara/minitest"
+
+class AutocompletesTest < SystemTest
+  include ESHelper
+
+  setup do
+    Capybara.server_port = 3000
+    Capybara.server_host = "localhost"
+    Capybara.app_host = "http://localhost:3000"
+    Capybara.current_driver = :selenium_chrome_headless
+    Capybara.default_max_wait_time = 10
+    Selenium::WebDriver.logger.level = :error # In this version of Capybara, 'deprecated' warn appeears. This line suppress them.
+
+    rubygem = create(:rubygem, name: "rubocop")
+    create(:version, rubygem: rubygem, indexed: true)
+    rubygem = create(:rubygem, name: "rubocop-performance")
+    create(:version, rubygem: rubygem, indexed: true)
+    import_and_refresh
+
+    visit root_path
+    @fill_field = find_by_id "home_query"
+    @fill_field.set "rubo"
+    wait_for_ajax
+  end
+
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop do
+        active = page.evaluate_script("jQuery.active")
+        break if active.zero?
+      end
+    end
+  end
+
+  test "search field" do
+    @fill_field.set "rubocop"
+    click_on class: "home__search__icon"
+    assert page.has_content? "search"
+    assert page.has_content? "rubocop"
+  end
+
+  test "selected field is only one with cursor selecting" do
+    find(".suggest-list").all("li").each(&:hover)
+    assert_selector ".selected", count: 1
+  end
+
+  test "selected field is only one with arrow key selecting" do
+    @fill_field.native.send_keys :down
+    find ".selected"
+    @fill_field.native.send_keys :down
+    assert_selector ".selected", count: 1
+  end
+
+  test "suggest list doesn't appear with gem not existing" do
+    @fill_field.set "ruxyz"
+    assert_all_of_selectors "#home_querySuggestList", visible: :hidden
+  end
+
+  test "suggest list doesn't appear unless the search field is focused" do
+    find("h1").click
+    assert_all_of_selectors "#home_querySuggestList", visible: :hidden
+  end
+
+  test "down arrow key to choose suggestion" do
+    @fill_field.native.send_keys :down
+    assert page.has_no_field? "home_query", with: "rubo"
+  end
+
+  test "up arrow key to choose suggestion" do
+    @fill_field.native.send_keys :up
+    assert page.has_no_field? "home_query", with: "rubo"
+  end
+
+  test "ctrl + n key to choose suggestion" do
+    @fill_field.native.send_keys [:control, "n"]
+    assert page.has_no_field? "home_query", with: "rubo"
+  end
+
+  test "ctrl + p key to choose suggestion" do
+    @fill_field.native.send_keys [:control, "p"]
+    assert page.has_no_field? "home_query", with: "rubo"
+  end
+
+  test "search form should be focused when up from the top of suggestion list" do
+    @fill_field.native.send_keys :down, :up
+    assert page.has_field? "home_query", with: "rubo"
+    assert page.has_no_content? ".selected"
+  end
+
+  test "search form should be focused when down from the bottom of suggestion list" do
+    @fill_field.native.send_keys :up, :down
+    assert page.has_field? "home_query", with: "rubo"
+    assert page.has_no_content? ".selected"
+  end
+
+  test "down arrow key should loop" do
+    @fill_field.native.send_keys :down, :down, :down, :down
+    assert find(".menu-item", match: :first).matches_css?(".selected")
+  end
+
+  test "up arrow key should loop" do
+    @fill_field.native.send_keys :up, :up, :up, :up
+    assert find("#home_querySuggestList").all(".menu-item").last.matches_css?(".selected")
+  end
+
+  test "mouse hover a suggest item to choose suggestion" do
+    find("li", text: "rubocop", match: :first).hover
+    assert_selector ".selected"
+  end
+
+  test "mouse click a suggestion item to submit" do
+    find("li", text: "rubocop", match: :first).click
+    assert_equal current_path, search_path || "/gems/"
+    assert page.has_content? "rubocop"
+  end
+
+  teardown do
+    Capybara.default_max_wait_time = 2
+    Capybara.use_default_driver
+    Capybara.default_host
+    Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
+  end
+end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -320,7 +320,8 @@ class PusherTest < ActiveSupport::TestCase
           "summary"           => "old summary",
           "description"       => "Some awesome gem",
           "updated"           => "2016-07-04T00:00:00.000Z",
-          "dependencies"      => { "development" => [], "runtime" => [] }
+          "dependencies"      => { "development" => [], "runtime" => [] },
+          "suggest"           => { "input" => "gemsgemsgems", "weight" => 0, "contexts" => { "yanked" => false } }
         }
 
         assert_equal expected_response, response["_source"]

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -179,6 +179,12 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       suggestions = %w[keyword keywo keywordo]
       assert_equal suggestions, response.suggestions.terms
     end
+
+    should "return names of suggestion gems" do
+      response = ElasticSearcher.new("keywor").suggestions
+      suggestions = %w[keyword keywordo]
+      assert_equal suggestions, %W[#{response[0]} #{response[1]}]
+    end
   end
 
   context "advanced search" do


### PR DESCRIPTION
This PR goal is to provide autocomplete function(incremental search) for search boxes.
Currently this branch has two main parts.
1. Elasticsearch in model
Using n-gram filter, "name" can be autocompleted.
2. JavaScript in view
Using JQuery autocomplete with the gem 'jquery-ui-rails' , autocompletion work for the search box on the top page.

There are some problems for my implementation.  Please check to run the tests.

Sorry, I accidentally closed the PR. 