### PR TITLE
Skip exact match in websearch results.

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,11 +3,11 @@ class SearchesController < ApplicationController
 
   def show
     return unless params[:query]&.is_a?(String)
-    @error_msg, @gems = ElasticSearcher.new(params[:query], page: @page).search
+    @error_msg, @gems = ElasticSearcher.new(params[:query], page: @page, skip_exact_match: true).search
     limit_total_count if @gems.total_count > Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
 
     @exact_match = Rubygem.name_is(params[:query]).with_versions.first
-    redirect_to rubygem_path(@exact_match) if @exact_match && @gems.size == 1
+    redirect_to rubygem_path(@exact_match) if @exact_match && @gems.empty?
   end
 
   def advanced

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -17,6 +17,7 @@ module RubygemSearchable
 
       {
         name:              name,
+        exact_name:        name,
         downloads:         downloads,
         version:           latest_version&.number,
         version_downloads: latest_version&.downloads_count,
@@ -58,6 +59,7 @@ module RubygemSearchable
              }
 
     mapping do
+      indexes :exact_name, type: "text", analyzer: "keyword"
       indexes :name, type: "text", analyzer: "rubygem" do
         indexes :suggest, analyzer: "simple"
       end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -49,7 +49,7 @@ class SearchesControllerTest < ActionController::TestCase
       refute page.has_selector?("a[href='#{rubygem_path(@brando)}']")
     end
     should "display 'gems' in pagination summary" do
-      assert page.has_content?("all 2 gems")
+      assert page.has_content?("Displaying 1 gem")
     end
   end
 
@@ -76,7 +76,7 @@ class SearchesControllerTest < ActionController::TestCase
       page.assert_no_selector("a[href='#{rubygem_path(@brando)}']")
     end
     should "display pagination summary" do
-      page.assert_text("all 2 gems")
+      page.assert_text("Displaying 1 gem")
     end
     should "not see suggestions" do
       page.assert_no_text("Maybe you mean")

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -294,6 +294,7 @@ class PusherTest < ActiveSupport::TestCase
                                                         id:    @rubygem.id
         expected_response = {
           "name"              => "gemsgemsgems",
+          "exact_name"        => "gemsgemsgems",
           "downloads"         => 0,
           "version"           => "0.1.1",
           "version_downloads" => 0,

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -90,6 +90,20 @@ class RubygemSearchableTest < ActiveSupport::TestCase
     end
   end
 
+  context "skip exact match" do
+    setup do
+      create(:rubygem, name: "example", number: "0.0.1")
+      create(:rubygem, name: "example-ng", number: "0.0.1")
+      import_and_refresh
+    end
+
+    should "not return gem with 100% name match" do
+      _, response = ElasticSearcher.new("example", skip_exact_match: true).search
+      assert_equal 1, response.size
+      assert_equal "example-ng", response.first.name
+    end
+  end
+
   context "multi_match" do
     setup do
       # without download, _score is calculated to 0.0


### PR DESCRIPTION
Another take on #1740. To be able to filter out exact match on name in ES new index needs to be created using `keyword` analyzer. I'm not sure, but potentially ES re-index will be needed in production.

before:
![screenshot-rubygems org-2019 07 04-01-21-33](https://user-images.githubusercontent.com/193936/60630506-c42a4480-9dfa-11e9-82d5-15207fc62ed0.png)

after:
![screenshot-localhost-3000-2019 07 04-01-21-22](https://user-images.githubusercontent.com/193936/60630512-c8566200-9dfa-11e9-82d6-e1e9a66cdf89.png)
