### PR TITLE
Render 2FA QR code as PNG and resize it to fit within the 1password QR scanner

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -10,7 +10,7 @@ class MultifactorAuthsController < ApplicationController
     session[:mfa_seed] = @seed
     session[:mfa_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
     text = ROTP::TOTP.new(@seed, issuer: issuer).provisioning_uri(current_user.email)
-    @qrcode_svg = RQRCode::QRCode.new(text, level: :l).as_svg
+    @qrcode_svg = RQRCode::QRCode.new(text, level: :l).as_svg(module_size: 6)
   end
 
   def create


### PR DESCRIPTION
This PR is a fix for #2060

At the moment, the QR code is rendered as a SVG, which makes it not easy to resize to fit it within the 1Password QR scanner. To fix this issue i've changed the QR code to be rendered as a PNG with a fixed height/width.

I've tested this with 1Password and the Google Authenticator to make sure the image is large enough for devices to scan.

Example QR Code:

<img width="1156" alt="Screen Shot 2019-07-16 at 10 58 12 pm" src="https://user-images.githubusercontent.com/996377/61297043-bcb56300-a81e-11e9-9aa3-a78ceb4639ee.png">
