### PR TITLE
 Use to instead of bcc in gem push mails

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -47,8 +47,10 @@ class Mailer < ActionMailer::Base
 
     @pushed_by_user = User.find(pushed_by_user_id)
 
-    mail bcc: owners_to_notify,
-         subject: I18n.t("mailer.gem_pushed.subject", gem: @version.to_title,
-           default: "Gem %{gem} pushed to RubyGems.org")
+    owners_to_notify.each do |owner|
+      mail to: owner,
+          subject: I18n.t("mailer.gem_pushed.subject", gem: @version.to_title,
+            default: "Gem %{gem} pushed to RubyGems.org")
+    end
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -232,7 +232,7 @@
 	<style type="text/css" media="screen">
 		/* Linked Styles */
 		body { padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none }
-		a { color:#a88123; text-decoration:none }
+		a { color:#e9573f; text-decoration:none }
 		p { padding:0 !important; margin:0 !important }
 
 		/* Mobile styles */

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -9,7 +9,7 @@ class MailerTest < ActionMailer::TestCase
     message_delivery = Mailer.gem_pushed(owner_without_notifier.id, rubygem.versions.last.id)
 
     assert_instance_of Mail::Message, message_delivery.message
-    assert_equal [owner_with_notifier.email], message_delivery.bcc
+    assert_equal [owner_with_notifier.email], message_delivery.to
   end
 
   test "gem pushed mail will not send when all owners disable notifiers" do

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -367,7 +367,7 @@ class PusherTest < ActiveSupport::TestCase
 
       email = ActionMailer::Base.deliveries.last
       assert_equal "Gem #{@version.to_title} pushed to RubyGems.org", email.subject
-      assert_equal [@user.email], email.bcc
+      assert_equal [@user.email], email.to
     end
   end
 


### PR DESCRIPTION
It was sending mails with empty `to` and no `bcc`. 