### PR TITLE
Only mail gem pushes to owners with OK inboxes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
     twitter_username
   ].freeze
 
+  MAX_MAIL_FAILS = 3
+
   before_destroy :yank_gems
 
   has_many :ownerships, dependent: :destroy
@@ -62,7 +64,11 @@ class User < ApplicationRecord
   end
 
   def self.notifiable_owners
-    where(ownerships: { notifier: true })
+    where(ownerships: { notifier: true }).ok_deliverability
+  end
+
+  def self.ok_deliverability
+    where("mail_fails <= ?", MAX_MAIL_FAILS)
   end
 
   def name

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -821,4 +821,26 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal expected_order, @news
     end
   end
+
+  context "#notifiable_owners" do
+    setup do
+      @rubygem = create(:rubygem)
+    end
+
+    should "only include owners with notifier" do
+      with_notifier = create(:ownership, notifier: true, rubygem: @rubygem).user
+      without_notifier = create(:ownership, notifier: false, rubygem: @rubygem).user
+
+      assert_equal [with_notifier], @rubygem.notifiable_owners
+    end
+
+    should "only include owners with ok deliverability" do
+      without_ok_deliverability = create(:user, mail_fails: 4)
+      with_ok_deliverability = create(:user, mail_fails: 3)
+      create(:ownership, user: without_ok_deliverability, notifier: true, rubygem: @rubygem)
+      create(:ownership, user: with_ok_deliverability, notifier: true, rubygem: @rubygem)
+
+      assert_equal [with_ok_deliverability], @rubygem.notifiable_owners
+    end
+  end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -829,7 +829,7 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "only include owners with notifier" do
       with_notifier = create(:ownership, notifier: true, rubygem: @rubygem).user
-      without_notifier = create(:ownership, notifier: false, rubygem: @rubygem).user
+      _without_notifier = create(:ownership, notifier: false, rubygem: @rubygem).user
 
       assert_equal [with_notifier], @rubygem.notifiable_owners
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -426,7 +426,7 @@ class UserTest < ActiveSupport::TestCase
   context ".ok_deliverability" do
     should "only include owners with no more than 3 mail fails" do
       with_ok_deliverability = create(:user, mail_fails: 3)
-      without_ok_deliverability = create(:user, mail_fails: 4)
+      _without_ok_deliverability = create(:user, mail_fails: 4)
 
       assert_equal [with_ok_deliverability], User.ok_deliverability
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -422,4 +422,13 @@ class UserTest < ActiveSupport::TestCase
       assert @user.remember_me?
     end
   end
+
+  context ".ok_deliverability" do
+    should "only include owners with no more than 3 mail fails" do
+      with_ok_deliverability = create(:user, mail_fails: 3)
+      without_ok_deliverability = create(:user, mail_fails: 4)
+
+      assert_equal [with_ok_deliverability], User.ok_deliverability
+    end
+  end
 end


### PR DESCRIPTION
Once #1982 has been live for a week or so, it'd be interesting to know what the higher values of `users.mail_fails` are and use that to inform the value of `MAX_ACCEPTABLE_MAIL_FAILS` which is currently set to 3 on @sonalkr132's advice.
