### PR TITLE
Disable email sent for gem push

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -99,9 +99,10 @@ class Pusher
 
   def after_write
     @version_id = version.id
-    version.rubygem.notifiable_owners.each do |notified_user|
-      Mailer.delay.gem_pushed(user.id, @version_id, notified_user.id)
-    end
+    # disabled until we upgrade our sendgrid account
+    # version.rubygem.notifiable_owners.each do |notified_user|
+    #   Mailer.delay.gem_pushed(user.id, @version_id, notified_user.id)
+    # end
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     GemCachePurger.call(rubygem.name)

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -259,7 +259,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           number: "0.0.0",
           updated_at: 1.year.ago,
           created_at: 1.year.ago)
-        assert_difference "Delayed::Job.count", 7 do
+        assert_difference "Delayed::Job.count", 6 do
           post :create, body: gem_file("test-1.0.0.gem").read
         end
       end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -334,7 +334,7 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
-      assert_difference "Delayed::Job.count", 6 do
+      assert_difference "Delayed::Job.count", 5 do
         @cutter.save
       end
     end
@@ -362,13 +362,13 @@ class PusherTest < ActiveSupport::TestCase
       assert_equal "new summary", response["_source"]["summary"]
     end
 
-    should "send gem pushed email" do
-      Delayed::Worker.new.work_off
+    # should "send gem pushed email" do
+    #   Delayed::Worker.new.work_off
 
-      email = ActionMailer::Base.deliveries.last
-      assert_equal "Gem #{@version.to_title} pushed to RubyGems.org", email.subject
-      assert_equal [@user.email], email.to
-    end
+    #   email = ActionMailer::Base.deliveries.last
+    #   assert_equal "Gem #{@version.to_title} pushed to RubyGems.org", email.subject
+    #   assert_equal [@user.email], email.to
+    # end
   end
 
   context "pushing to s3 fails" do


### PR DESCRIPTION
This was blocking release to production as our sendgrid account
won't support the volume of mails being sent without upgrade.
We will re-enable it when our account gets upgraded.

We need to fix a couple of hackerone reports.. at least one of the reporters there is getting impatient and I would prefer to not have our production releases blocked.

Related: #1950
cc: @indirect , @eliotsykes