### PR TITLE
Add exponential backoff rate limit to endpoints using mfa

### DIFF
--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -120,7 +120,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       setup do
         @rubygem = create(:rubygem, name: "test", number: "0.0.1")
         @rubygem.ownerships.create(user: @user)
-        stay_under_limit_for("clearance/ip/api/1")
+        stay_under_limit_for("api/ip/1")
       end
 
       should "allow gem yank by ip" do
@@ -245,7 +245,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should "throttle profile update" do
       cookies[:remember_token] = @user.remember_token
 
-      exceed_limit_for("clearance/remember_token")
+      exceed_limit_for("clearance/ip/1")
       patch "/profile",
         headers: { REMOTE_ADDR: @ip_address }
 
@@ -255,7 +255,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should "throttle profile delete" do
       cookies[:remember_token] = @user.remember_token
 
-      exceed_limit_for("clearance/remember_token")
+      exceed_limit_for("clearance/ip/1")
       delete "/profile",
         headers: { REMOTE_ADDR: @ip_address }
 
@@ -303,7 +303,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       setup do
         @rubygem = create(:rubygem, name: "test", number: "0.0.1")
         @rubygem.ownerships.create(user: @user)
-        exceed_limit_for("clearance/ip/api/1")
+        exceed_limit_for("api/ip/1")
       end
 
       should "throttle gem yank by ip" do


### PR DESCRIPTION
Exponential backoff was needed as with 100 req/10 min limit used in
other endpoints would have been inefficient against brute force of
mfa code.
30 sec window would have had probability of 1/10000 (1 - (1 - p)^n, where p = 10^-6 and n = 100)
for successfully guessing the key *at least once* if limits were 100 req/10 min.
Using binomial distribution, a HO reporter calculcated that after
6932 trials, he would have had more than 50% chance of successfully
guessing the key at least once.
Limits used in this change would allow 4 trails per week and total
of 33 years for 6932 trials.