### PR TITLE
Adds pwned passwords integration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,11 @@ class User < ApplicationRecord
   }, allow_nil: true
 
   validates :twitter_username, length: { within: 0..20 }, allow_nil: true
-  validates :password, length: { within: 10..200 }, allow_nil: true, unless: :skip_password_validation?
+  validates :password,
+    length: { within: 10..200 },
+    not_pwned: { message: "has previously appeared in a data breach and should not be used" },
+    allow_nil: true,
+    unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness
 
   enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2 }, _prefix: :mfa

--- a/lib/not_pwned_validator.rb
+++ b/lib/not_pwned_validator.rb
@@ -71,7 +71,8 @@ class NotPwnedValidator < ActiveModel::EachValidator
   # @return [Integer] The number of times that the password has been compromised
   def pwned_check(password)
     hash = Digest::SHA1.hexdigest(password).upcase
-    prefix = hash.first(5)
+    prefix = hash[0..4]
+    suffix = hash[5..-1]
 
     response = RestClient::Request.execute(
       method: :get,
@@ -83,7 +84,7 @@ class NotPwnedValidator < ActiveModel::EachValidator
     )
 
     hits = response.body.split("\r\n").map { |line| line.split(":") }
-    found = hits.find { |hit| hash = "#{prefix}#{hit.first}" }
+    found = hits.find { |hit| hit[0] == suffix }
 
     if found
       found.last.to_i

--- a/lib/not_pwned_validator.rb
+++ b/lib/not_pwned_validator.rb
@@ -51,6 +51,8 @@ class NotPwnedValidator < ActiveModel::EachValidator
   # @param value [String] The value of the attribute on the record that is the
   #   subject of the validation
   def validate_each(record, attribute, value)
+    # Short circuit the validation for tests, unless explicitly enabled
+    return if Rails.env.test? && !options[:enable_in_testing]
     return if value.blank?
     begin
       pwned_count = pwned_check(value)
@@ -83,10 +85,6 @@ class NotPwnedValidator < ActiveModel::EachValidator
     else
       0
     end
-  end
-
-  def on_error
-    options[:on_error] || DEFAULT_ON_ERROR
   end
 
   def threshold

--- a/lib/not_pwned_validator.rb
+++ b/lib/not_pwned_validator.rb
@@ -73,9 +73,15 @@ class NotPwnedValidator < ActiveModel::EachValidator
   # @return [Integer] The number of times that the password has been compromised
   def pwned_check(password)
     hash = Digest::SHA1.hexdigest(password).upcase
-    response = RestClient.get("https://api.pwnedpasswords.com/range/#{hash.first(5)}", {
-      user_agent: "RubyGems.org"
-    })
+
+    response = RestClient::Request.execute(
+      method: :get,
+      url: "https://api.pwnedpasswords.com/range/#{hash.first(5)}",
+      timeout: 3,
+      headers: {
+        user_agent: "RubyGems.org"
+      }
+    )
 
     hits = response.body.split("\r\n").map { |line| line.split(":") }
     hit = hits.find {|hit| "#{hash.first(5)}#{hit.first}" == hash }

--- a/lib/not_pwned_validator.rb
+++ b/lib/not_pwned_validator.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Adapted from Phil Nash's pwned gem to use the HIBP V3 API with zero additional
+# dependencies for rubygems.org
+#
+# MIT License (MIT), Copyright (c) 2018 Phil Nash
+#
+# Original source code: https://git.io/fjHb3
+
+##
+# An +ActiveModel+ validator to check passwords against the Pwned Passwords API.
+#
+# @example Validate a password on a +User+ model with the default options.
+#     class User < ApplicationRecord
+#       validates :password, not_pwned: true
+#     end
+#
+# @example Validate a password on a +User+ model with a custom error message.
+#     class User < ApplicationRecord
+#       validates :password, not_pwned: { message: "has been pwned %{count} times" }
+#     end
+#
+# @example Validate a password on a +User+ model that allows the password to have been breached once.
+#     class User < ApplicationRecord
+#       validates :password, not_pwned: { threshold: 1 }
+#     end
+class NotPwnedValidator < ActiveModel::EachValidator
+  ##
+  # The default threshold for whether a breach is considered pwned. The default
+  # is 0, so any password that appears in a breach will mark the record as
+  # invalid.
+  DEFAULT_THRESHOLD = 0
+
+  ##
+  # Validates the +value+ against the Pwned Passwords API. If the +pwned_count+
+  # is higher than the optional +threshold+ then the record is marked as
+  # invalid.
+  #
+  # In the case of an API error the validator will either mark the
+  # record as valid or invalid. Alternatively it will run an associated proc or
+  # re-raise the original error.
+  #
+  # The validation will short circuit and return with no errors added if the
+  # password is blank. Technically the empty string is not a password that is
+  # reported to be found in data breaches, so returns +false+, short circuiting
+  # that using +value.blank?+ saves us a trip to the API.
+  #
+  # @param record [ActiveModel::Validations] The object being validated
+  # @param attribute [Symbol] The attribute on the record that is currently
+  #   being validated.
+  # @param value [String] The value of the attribute on the record that is the
+  #   subject of the validation
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    begin
+      pwned_count = pwned_check(value)
+      if pwned_count > threshold
+        record.errors.add(attribute, :not_pwned, options.merge(count: pwned_count))
+      end
+    rescue RestClient::ExceptionWithResponse => error
+      # Do nothing, consider the record valid
+    end
+  end
+
+  private
+
+  ##
+  # Check for pwned passwords from the HIBP V3 API.
+  #
+  # @param password [String] The password being validated
+  # @return [Integer] The number of times that the password has been compromised
+  def pwned_check(password)
+    hash = Digest::SHA1.hexdigest(password).upcase
+    response = RestClient.get("https://api.pwnedpasswords.com/range/#{hash.first(5)}", {
+      user_agent: "RubyGems.org"
+    })
+
+    hits = response.body.split("\r\n").map { |line| line.split(":") }
+    hit = hits.find {|hit| "#{hash.first(5)}#{hit.first}" == hash }
+
+    if hit
+      hit.last.to_i
+    else
+      0
+    end
+  end
+
+  def on_error
+    options[:on_error] || DEFAULT_ON_ERROR
+  end
+
+  def threshold
+    threshold = options[:threshold] || DEFAULT_THRESHOLD
+    raise TypeError, "#{self.class.to_s} option 'threshold' must be of type Integer" unless threshold.is_a? Integer
+    threshold
+  end
+end

--- a/test/unit/not_pwned_validator_test.rb
+++ b/test/unit/not_pwned_validator_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class NotPwnedValidatorTest < ActiveSupport::TestCase
+  class Model
+    include ActiveModel::Validations
+
+    attr_accessor :password
+  end
+
+  def create_model(password)
+    Model.new.tap { |model| model.password = password }
+  end
+
+  context "when not pwned" do
+    should "reports the model as valid" do
+      Model.validates :password, not_pwned: { message: "has previously appeared in a data breach", enable_in_testing: true }
+      model = create_model("this is totally not pwned")
+
+      RestClient::Request.expects(:execute).at_least_once.returns(stub(body: "02A9ABF721849928613FD023AFC9136E7FC:1"))
+
+      assert model.valid?
+      assert_nil model.errors[:password].first
+    end
+  end
+
+  context "when pwned" do
+    should "marks the model as invalid" do
+      Model.validates :password, not_pwned: { message: "has previously appeared in a data breach", enable_in_testing: true }
+      model = create_model('1234567890')
+
+      RestClient::Request.expects(:execute).at_least_once.returns(stub(body: "7ACBA4F54F55AAFC33BB06BBBF6CA803E9A:2250015"))
+
+      refute model.valid?
+      assert_contains model.errors[:password], "has previously appeared in a data breach"
+    end
+  end
+end

--- a/test/unit/not_pwned_validator_test.rb
+++ b/test/unit/not_pwned_validator_test.rb
@@ -12,7 +12,7 @@ class NotPwnedValidatorTest < ActiveSupport::TestCase
   end
 
   context "when not pwned" do
-    should "reports the model as valid" do
+    should "report the model as valid" do
       Model.validates :password, not_pwned: { message: "has previously appeared in a data breach", enable_in_testing: true }
       model = create_model("this is totally not pwned")
 

--- a/test/unit/not_pwned_validator_test.rb
+++ b/test/unit/not_pwned_validator_test.rb
@@ -26,7 +26,7 @@ class NotPwnedValidatorTest < ActiveSupport::TestCase
   context "when pwned" do
     should "marks the model as invalid" do
       Model.validates :password, not_pwned: { message: "has previously appeared in a data breach", enable_in_testing: true }
-      model = create_model('1234567890')
+      model = create_model("1234567890")
 
       RestClient::Request.expects(:execute).at_least_once.returns(stub(body: "7ACBA4F54F55AAFC33BB06BBBF6CA803E9A:2250015"))
 


### PR DESCRIPTION
Check if the password chosen by the user has already been compromised in a data breach.

This uses the new [Pwned Passwords API](https://haveibeenpwned.com/API/v3#PwnedPasswords) which “implements a k-Anonymity model that allows a password to be searched for by partial hash”.

You can read more about the k-Anonymity model in [Troy Hunt's blog post about it](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/), but the gist of it is that it allows passwords to be checked for breaches without revealing the password to a third party.

If the API cannot be reached or it errors out, the pwned password check is bypassed and the password is presumed to be valid.

If anyone has suggestion on how to improve the tests for this, I'd gladly hear them.