### PR TITLE
Password validation using Unpwn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "sprockets-rails"
 gem "rack-attack"
 gem "rqrcode"
 gem "rotp"
-gem "unpwn", "~> 0.2.0"
+gem "unpwn", "~> 0.3.0"
 
 # Logging
 gem "lograge"

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "sprockets-rails"
 gem "rack-attack"
 gem "rqrcode"
 gem "rotp"
+gem "unpwn", git: "https://github.com/indirect/unpwn.git"
 
 # Logging
 gem "lograge"

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "sprockets-rails"
 gem "rack-attack"
 gem "rqrcode"
 gem "rotp"
-gem "unpwn", git: "https://github.com/indirect/unpwn.git"
+gem "unpwn", "~> 0.2.0"
 
 # Logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
     minitest (5.11.3)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
-    msgpack (1.2.10)
+    msgpack (1.3.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
@@ -389,7 +389,7 @@ GEM
     unicorn (5.5.0.1.g6836)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    unpwn (0.2.0)
+    unpwn (0.3.0)
       bloomer (~> 1.0)
       pwned (~> 1.2)
     validates_formatting_of (0.9.0)
@@ -462,7 +462,7 @@ DEPENDENCIES
   toxiproxy (~> 1.0.0)
   uglifier (>= 1.0.3)
   unicorn (~> 5.5.0.1.g6836)
-  unpwn (~> 0.2.0)
+  unpwn (~> 0.3.0)
   validates_formatting_of
   xml-simple
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/indirect/unpwn.git
-  revision: c38cdced1c65b8df024aeb1dca86a06db945b75a
-  specs:
-    unpwn (0.1.0)
-      bloomer (~> 1.0)
-      pwned (~> 1.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -397,6 +389,9 @@ GEM
     unicorn (5.5.0.1.g6836)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    unpwn (0.2.0)
+      bloomer (~> 1.0)
+      pwned (~> 1.2)
     validates_formatting_of (0.9.0)
       activemodel
     websocket-driver (0.7.0)
@@ -467,7 +462,7 @@ DEPENDENCIES
   toxiproxy (~> 1.0.0)
   uglifier (>= 1.0.3)
   unicorn (~> 5.5.0.1.g6836)
-  unpwn!
+  unpwn (~> 0.2.0)
   validates_formatting_of
   xml-simple
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/indirect/unpwn.git
+  revision: c38cdced1c65b8df024aeb1dca86a06db945b75a
+  specs:
+    unpwn (0.1.0)
+      bloomer (~> 1.0)
+      pwned (~> 1.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -59,6 +67,10 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
+    bitarray (1.2.0)
+    bloomer (1.0.0)
+      bitarray
+      msgpack
     bootsnap (1.4.3)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -264,6 +276,7 @@ GEM
       pry (~> 0.10)
     psych (3.1.0)
     public_suffix (3.1.0)
+    pwned (1.2.1)
     rack (2.0.7)
     rack-attack (6.0.0)
       rack (>= 1.0, < 3)
@@ -454,6 +467,7 @@ DEPENDENCIES
   toxiproxy (~> 1.0.0)
   uglifier (>= 1.0.3)
   unicorn (~> 5.5.0.1.g6836)
+  unpwn!
   validates_formatting_of
   xml-simple
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,11 @@ class User < ApplicationRecord
   }, allow_nil: true
 
   validates :twitter_username, length: { within: 0..20 }, allow_nil: true
-  validates :password, length: { within: 10..200 }, allow_nil: true, unless: :skip_password_validation?
+  validates :password,
+    length: { within: 10..200 },
+    unpwn: { message: "has previously appeared in a data breach and should not be used" },
+    allow_nil: true,
+    unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness
 
   enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2 }, _prefix: :mfa

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   validates :twitter_username, length: { within: 0..20 }, allow_nil: true
   validates :password,
     length: { within: 10..200 },
-    unpwn: { message: "has previously appeared in a data breach and should not be used" },
+    unpwn: true,
     allow_nil: true,
     unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,9 @@ de:
         email: E-Mail-Adresse
         handle: Benutzername
         password: Passwort
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,9 @@ en:
         email: Email address
         handle: Username
         password: Password
+    errors:
+      messages:
+        unpwn: has previously appeared in a data breach and should not be used
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,6 +43,9 @@ es:
         email: Dirección email
         handle: Usuario
         password: Contraseña
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,6 +43,9 @@ fr:
         email: Adresse e-mail
         handle: Pseudonyme
         password: Mot de passe
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,6 +43,9 @@ ja:
         email: Emailアドレス
         handle: ユーザー名
         password: パスワード
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -43,6 +43,9 @@ nl:
         email: E-mailadres
         handle: Gebruikersnaam
         password: Wachtwoord
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -43,6 +43,9 @@ pt-BR:
         email: Email
         handle: Usuário
         password: Senha
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -43,6 +43,9 @@ zh-CN:
         email: Email
         handle: 账号
         password: 密码
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -43,6 +43,9 @@ zh-TW:
         email: Email
         handle: 帳號
         password: 密碼
+    errors:
+      messages:
+        unpwn:
   clearance_mailer:
     change_password:
       title:

--- a/lib/unpwn_validator.rb
+++ b/lib/unpwn_validator.rb
@@ -12,6 +12,6 @@ class UnpwnValidator < ActiveModel::EachValidator
   private
 
   def unpwn
-    @unpwn ||= Unpwn.new(min: nil, max: nil)
+    @unpwn ||= Unpwn.new(min: nil, max: nil, request_options: { read_timeout: 3 })
   end
 end

--- a/lib/unpwn_validator.rb
+++ b/lib/unpwn_validator.rb
@@ -1,0 +1,17 @@
+require "unpwn"
+
+class UnpwnValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :unpwn) unless unpwn.acceptable?(value)
+  rescue Pwned::TimeoutError # rubocop:disable Lint/HandleExceptions
+    # Do nothing if the HTTP call timesout, consider the value valid
+  rescue Pwned::Error # rubocop:disable Lint/HandleExceptions
+    # Do nothing if the HTTP call fails, consider the value valid
+  end
+
+  private
+
+  def unpwn
+    @unpwn ||= Unpwn.new(min: nil, max: nil)
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   factory :user do
     email
     handle
-    password { "password12345" }
+    password { "?98,TUESDAY,SHOWN,exactly,56?" }
     api_key { "secret123" }
     email_confirmed { true }
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   factory :user do
     email
     handle
-    password { "?98,TUESDAY,SHOWN,exactly,56?" }
+    password { PasswordHelpers::SECURE_TEST_PASSWORD }
     api_key { "secret123" }
     email_confirmed { true }
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -127,7 +127,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { password: "password1234" }
+          password_reset: { password: "@61:details:THOSE:present:71@" }
         }
       end
 
@@ -145,7 +145,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { reset_api_key: "false", password: "password1234" }
+          password_reset: { reset_api_key: "false", password: "@61:details:THOSE:present:71@" }
         }
       end
 
@@ -163,7 +163,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { reset_api_key: "true", password: "password1234" }
+          password_reset: { reset_api_key: "true", password: "@61:details:THOSE:present:71@" }
         }
       end
 

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -127,7 +127,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { password: "@61:details:THOSE:present:71@" }
+          password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
 
@@ -145,7 +145,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { reset_api_key: "false", password: "@61:details:THOSE:present:71@" }
+          password_reset: { reset_api_key: "false", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
 
@@ -163,7 +163,7 @@ class PasswordsControllerTest < ActionController::TestCase
         put :update, params: {
           user_id: @user.id,
           token: @user.confirmation_token,
-          password_reset: { reset_api_key: "true", password: "@61:details:THOSE:present:71@" }
+          password_reset: { reset_api_key: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -12,7 +12,7 @@ class UsersControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when email and password are given" do
       should "create a user" do
-        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@" } }
+        post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         assert User.find_by(email: "foo@bar.com")
       end
     end
@@ -27,7 +27,7 @@ class UsersControllerTest < ActionController::TestCase
 
     context "when extra parameters given" do
       should "create a user if parameters are ok" do
-        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@", handle: "foo" } }
+        post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "foo" } }
         assert_equal "foo", User.where(email: "foo@bar.com").pluck(:handle).first
       end
 
@@ -39,7 +39,7 @@ class UsersControllerTest < ActionController::TestCase
 
     context "confirmation mail" do
       setup do
-        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@", handle: "foo" } }
+        post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "foo" } }
         Delayed::Worker.new.work_off
       end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -12,7 +12,7 @@ class UsersControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when email and password are given" do
       should "create a user" do
-        post :create, params: { user: { email: "foo@bar.com", password: "secret12345" } }
+        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@" } }
         assert User.find_by(email: "foo@bar.com")
       end
     end
@@ -27,7 +27,7 @@ class UsersControllerTest < ActionController::TestCase
 
     context "when extra parameters given" do
       should "create a user if parameters are ok" do
-        post :create, params: { user: { email: "foo@bar.com", password: "secret12345", handle: "foo" } }
+        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@", handle: "foo" } }
         assert_equal "foo", User.where(email: "foo@bar.com").pluck(:handle).first
       end
 
@@ -39,7 +39,7 @@ class UsersControllerTest < ActionController::TestCase
 
     context "confirmation mail" do
       setup do
-        post :create, params: { user: { email: "foo@bar.com", password: "secretpassword", handle: "foo" } }
+        post :create, params: { user: { email: "foo@bar.com", password: "@61:details:THOSE:present:71@", handle: "foo" } }
         Delayed::Worker.new.work_off
       end
 

--- a/test/helpers/password_helpers.rb
+++ b/test/helpers/password_helpers.rb
@@ -1,0 +1,3 @@
+module PasswordHelpers
+  SECURE_TEST_PASSWORD = "?98,TUESDAY,SHOWN,exactly,56?".freeze
+end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -37,7 +37,7 @@ class PasswordResetTest < SystemTest
     expected_path = "/users/#{@user.id}/password/edit"
     assert_equal expected_path, page.current_path, "removes confirmation token from url"
 
-    fill_in "Password", with: "secret54321"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Save this password"
     assert_equal dashboard_path, page.current_path
 
@@ -45,7 +45,7 @@ class PasswordResetTest < SystemTest
 
     visit sign_in_path
     fill_in "Email or Username", with: @user.email
-    fill_in "Password", with: "secret54321"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -80,10 +80,10 @@ class PasswordResetTest < SystemTest
 
     visit password_reset_link
 
-    fill_in "Password", with: "secret54321"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Save this password"
 
-    assert @user.reload.authenticated? "secret54321"
+    assert @user.reload.authenticated? "@61:details:THOSE:present:71@"
   end
 
   test "restting password when mfa is enabled" do
@@ -95,7 +95,7 @@ class PasswordResetTest < SystemTest
     fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     click_button "Authenticate"
 
-    fill_in "Password", with: "secret3210"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Save this password"
 
     assert page.has_content?("Sign out")

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -37,7 +37,7 @@ class PasswordResetTest < SystemTest
     expected_path = "/users/#{@user.id}/password/edit"
     assert_equal expected_path, page.current_path, "removes confirmation token from url"
 
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
     assert_equal dashboard_path, page.current_path
 
@@ -45,7 +45,7 @@ class PasswordResetTest < SystemTest
 
     visit sign_in_path
     fill_in "Email or Username", with: @user.email
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -80,10 +80,10 @@ class PasswordResetTest < SystemTest
 
     visit password_reset_link
 
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
 
-    assert @user.reload.authenticated? "@61:details:THOSE:present:71@"
+    assert @user.reload.authenticated? PasswordHelpers::SECURE_TEST_PASSWORD
   end
 
   test "restting password when mfa is enabled" do
@@ -95,7 +95,7 @@ class PasswordResetTest < SystemTest
     fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     click_button "Authenticate"
 
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
 
     assert page.has_content?("Sign out")

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ProfileTest < SystemTest
   setup do
-    @user = create(:user, email: "nick@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?", handle: "nick1", mail_fails: 1)
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
 
     page.driver.browser.set_cookie("mfa_feature=true")
   end
@@ -37,7 +37,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Username", with: "nick2"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     assert page.has_content? "nick2"
@@ -51,7 +51,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Username", with: "nick2"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     assert page.has_content? "Username has already been taken"
@@ -63,7 +63,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Username", with: "nick1" * 10
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     assert page.has_content? "Username is too long (maximum is 40 characters)"
@@ -76,7 +76,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Email address", with: "nick2@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
 
     click_button "Update"
 
@@ -102,7 +102,7 @@ class ProfileTest < SystemTest
     visit profile_path("nick1")
     click_link "Edit Profile"
 
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     check "Hide email in public profile"
     click_button "Update"
 
@@ -116,7 +116,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Twitter username", with: "nick1"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     visit profile_path("nick1")
@@ -130,7 +130,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     click_button "Delete"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Confirm"
 
     assert page.has_content? "Your account deletion request has been enqueued."\

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ProfileTest < SystemTest
   setup do
-    @user = create(:user, email: "nick@example.com", password: "password12345", handle: "nick1", mail_fails: 1)
+    @user = create(:user, email: "nick@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?", handle: "nick1", mail_fails: 1)
 
     page.driver.browser.set_cookie("mfa_feature=true")
   end
@@ -37,7 +37,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Username", with: "nick2"
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Update"
 
     assert page.has_content? "nick2"
@@ -51,7 +51,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Username", with: "nick2"
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Update"
 
     assert page.has_content? "Username has already been taken"
@@ -63,7 +63,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Username", with: "nick1" * 10
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Update"
 
     assert page.has_content? "Username is too long (maximum is 40 characters)"
@@ -76,7 +76,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     fill_in "Email address", with: "nick2@example.com"
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
 
     click_button "Update"
 
@@ -102,7 +102,7 @@ class ProfileTest < SystemTest
     visit profile_path("nick1")
     click_link "Edit Profile"
 
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     check "Hide email in public profile"
     click_button "Update"
 
@@ -116,7 +116,7 @@ class ProfileTest < SystemTest
 
     click_link "Edit Profile"
     fill_in "Twitter username", with: "nick1"
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Update"
 
     visit profile_path("nick1")
@@ -130,7 +130,7 @@ class ProfileTest < SystemTest
     click_link "Edit Profile"
 
     click_button "Delete"
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Confirm"
 
     assert page.has_content? "Your account deletion request has been enqueued."\

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -6,7 +6,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
 
     @ip_address = "1.2.3.4"
-    @user = create(:user, email: "nick@example.com", password: "secret12345")
+    @user = create(:user, email: "nick@example.com", password: "@61:details:THOSE:present:71@")
   end
 
   def exceeding_limit

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -6,7 +6,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
 
     @ip_address = "1.2.3.4"
-    @user = create(:user, email: "nick@example.com", password: "@61:details:THOSE:present:71@")
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD)
   end
 
   def exceeding_limit

--- a/test/integration/session_test.rb
+++ b/test/integration/session_test.rb
@@ -7,9 +7,9 @@ class SessionTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    create(:user, handle: "johndoe", password: "chunkybacon")
+    create(:user, handle: "johndoe", password: "!01-WITHIN-HEALTH-india-33!")
     @last_session_token = retrive_authenticity_token sign_in_path
-    post session_path(session: { who: "johndoe", password: "chunkybacon" })
+    post session_path(session: { who: "johndoe", password: "!01-WITHIN-HEALTH-india-33!" })
     ActionController::Base.allow_forgery_protection = true # default is false
   end
 
@@ -19,7 +19,7 @@ class SessionTest < ActionDispatch::IntegrationTest
 
   test "authenticity_token of guest session should be invalid in authenticated session" do
     post session_path(
-      session: { who: "johndoe", password: "chunkybacon" },
+      session: { who: "johndoe", password: "!01-WITHIN-HEALTH-india-33!" },
       authenticity_token: @last_session_token
     )
 
@@ -31,9 +31,9 @@ class SessionTest < ActionDispatch::IntegrationTest
     @last_session_token = retrive_authenticity_token edit_profile_path
     delete sign_out_path(authenticity_token: request.session[:_csrf_token])
 
-    create(:user, handle: "bob", password: "lovesunicorns")
+    create(:user, handle: "bob", password: "!01-WITHIN-HEALTH-india-33!")
     post session_path(
-      session: { who: "bob", password: "lovesunicorns" },
+      session: { who: "bob", password: "!01-WITHIN-HEALTH-india-33!" },
       authenticity_token: request.session[:_csrf_token]
     )
 

--- a/test/integration/session_test.rb
+++ b/test/integration/session_test.rb
@@ -7,9 +7,9 @@ class SessionTest < ActionDispatch::IntegrationTest
   end
 
   setup do
-    create(:user, handle: "johndoe", password: "!01-WITHIN-HEALTH-india-33!")
+    create(:user, handle: "johndoe", password: PasswordHelpers::SECURE_TEST_PASSWORD)
     @last_session_token = retrive_authenticity_token sign_in_path
-    post session_path(session: { who: "johndoe", password: "!01-WITHIN-HEALTH-india-33!" })
+    post session_path(session: { who: "johndoe", password: PasswordHelpers::SECURE_TEST_PASSWORD })
     ActionController::Base.allow_forgery_protection = true # default is false
   end
 
@@ -19,7 +19,7 @@ class SessionTest < ActionDispatch::IntegrationTest
 
   test "authenticity_token of guest session should be invalid in authenticated session" do
     post session_path(
-      session: { who: "johndoe", password: "!01-WITHIN-HEALTH-india-33!" },
+      session: { who: "johndoe", password: PasswordHelpers::SECURE_TEST_PASSWORD },
       authenticity_token: @last_session_token
     )
 
@@ -31,9 +31,9 @@ class SessionTest < ActionDispatch::IntegrationTest
     @last_session_token = retrive_authenticity_token edit_profile_path
     delete sign_out_path(authenticity_token: request.session[:_csrf_token])
 
-    create(:user, handle: "bob", password: "!01-WITHIN-HEALTH-india-33!")
+    create(:user, handle: "bob", password: PasswordHelpers::SECURE_TEST_PASSWORD)
     post session_path(
-      session: { who: "bob", password: "!01-WITHIN-HEALTH-india-33!" },
+      session: { who: "bob", password: PasswordHelpers::SECURE_TEST_PASSWORD },
       authenticity_token: request.session[:_csrf_token]
     )
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class SignInTest < SystemTest
   setup do
-    create(:user, email: "nick@example.com", password: "secret12345")
-    create(:user, email: "john@example.com", password: "secret12345",
+    create(:user, email: "nick@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?")
+    create(:user, email: "john@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?",
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
 
@@ -13,7 +13,7 @@ class SignInTest < SystemTest
   test "signing in" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -22,7 +22,7 @@ class SignInTest < SystemTest
   test "signing in with uppercase email" do
     visit sign_in_path
     fill_in "Email or Username", with: "Nick@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -41,7 +41,7 @@ class SignInTest < SystemTest
   test "signing in with wrong email" do
     visit sign_in_path
     fill_in "Email or Username", with: "someone@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
@@ -53,12 +53,12 @@ class SignInTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     visit sign_in_path
     fill_in "Email or Username", with: "email@person.com"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
@@ -68,7 +68,7 @@ class SignInTest < SystemTest
   test "signing in with current valid otp when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -82,7 +82,7 @@ class SignInTest < SystemTest
   test "signing in with invalid otp when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -96,7 +96,7 @@ class SignInTest < SystemTest
   test "signing in with valid recovery code when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -110,7 +110,7 @@ class SignInTest < SystemTest
   test "signing in with invalid recovery code when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -124,7 +124,7 @@ class SignInTest < SystemTest
   test "signing out" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     click_link "Sign out"
@@ -135,7 +135,7 @@ class SignInTest < SystemTest
   test "session expires in two weeks" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     travel 15.days do
@@ -149,7 +149,7 @@ class SignInTest < SystemTest
 
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
 
     assert page.has_content? "Sign in"

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class SignInTest < SystemTest
   setup do
-    create(:user, email: "nick@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?")
-    create(:user, email: "john@example.com", password: "?98,TUESDAY,SHOWN,exactly,56?",
+    create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD)
+    create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
 
@@ -13,7 +13,7 @@ class SignInTest < SystemTest
   test "signing in" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -22,7 +22,7 @@ class SignInTest < SystemTest
   test "signing in with uppercase email" do
     visit sign_in_path
     fill_in "Email or Username", with: "Nick@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
@@ -41,7 +41,7 @@ class SignInTest < SystemTest
   test "signing in with wrong email" do
     visit sign_in_path
     fill_in "Email or Username", with: "someone@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
@@ -53,12 +53,12 @@ class SignInTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     visit sign_in_path
     fill_in "Email or Username", with: "email@person.com"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
@@ -68,7 +68,7 @@ class SignInTest < SystemTest
   test "signing in with current valid otp when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -82,7 +82,7 @@ class SignInTest < SystemTest
   test "signing in with invalid otp when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -96,7 +96,7 @@ class SignInTest < SystemTest
   test "signing in with valid recovery code when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -110,7 +110,7 @@ class SignInTest < SystemTest
   test "signing in with invalid recovery code when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Multifactor authentication"
@@ -124,7 +124,7 @@ class SignInTest < SystemTest
   test "signing out" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     click_link "Sign out"
@@ -135,7 +135,7 @@ class SignInTest < SystemTest
   test "session expires in two weeks" do
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     travel 15.days do
@@ -149,7 +149,7 @@ class SignInTest < SystemTest
 
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
     assert page.has_content? "Sign in"

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -6,7 +6,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     assert page.has_selector? "#flash_notice", text: "A confirmation mail has been sent to your email address."
@@ -16,7 +16,7 @@ class SignUpTest < SystemTest
     visit sign_up_path
 
     fill_in "Email", with: "email@person.com"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     assert page.has_content? "errors prohibited"
@@ -27,7 +27,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "thisusernameiswaytoolongseriouslywaytoolong"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     assert page.has_content? "error prohibited"
@@ -39,7 +39,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     assert page.has_content? "error prohibited"
@@ -61,7 +61,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "@61:details:THOSE:present:71@"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
     link = last_email_link

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -6,7 +6,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     assert page.has_selector? "#flash_notice", text: "A confirmation mail has been sent to your email address."
@@ -16,7 +16,7 @@ class SignUpTest < SystemTest
     visit sign_up_path
 
     fill_in "Email", with: "email@person.com"
-    fill_in "Password", with: "password"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     assert page.has_content? "errors prohibited"
@@ -27,7 +27,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "thisusernameiswaytoolongseriouslywaytoolong"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     assert page.has_content? "error prohibited"
@@ -39,7 +39,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     assert page.has_content? "error prohibited"
@@ -61,7 +61,7 @@ class SignUpTest < SystemTest
 
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
-    fill_in "Password", with: "secretpassword"
+    fill_in "Password", with: "@61:details:THOSE:present:71@"
     click_button "Sign up"
 
     link = last_email_link

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class YankTest < SystemTest
   setup do
-    @user = create(:user, password: "password12345")
+    @user = create(:user, password: "?98,TUESDAY,SHOWN,exactly,56?")
     @rubygem = create(:rubygem, name: "sandworm")
     create(:ownership, user: @user, rubygem: @rubygem)
     Dir.chdir(Dir.mktmpdir)
 
     visit sign_in_path
     fill_in "Email or Username", with: @user.email
-    fill_in "Password", with: "password12345"
+    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
     click_button "Sign in"
   end
 

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class YankTest < SystemTest
   setup do
-    @user = create(:user, password: "?98,TUESDAY,SHOWN,exactly,56?")
+    @user = create(:user, password: PasswordHelpers::SECURE_TEST_PASSWORD)
     @rubygem = create(:rubygem, name: "sandworm")
     create(:ownership, user: @user, rubygem: @rubygem)
     Dir.chdir(Dir.mktmpdir)
 
     visit sign_in_path
     fill_in "Email or Username", with: @user.email
-    fill_in "Password", with: "?98,TUESDAY,SHOWN,exactly,56?"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,9 @@ class ActiveSupport::TestCase
   setup do
     I18n.locale = :en
     Rails.cache.clear
+
+    # Don't connect to the Pwned Passwords API in tests
+    Pwned.stubs(:pwned?).returns(false)
   end
 
   def page

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "shoulda"
 require "helpers/gem_helpers"
 require "helpers/email_helpers"
 require "helpers/es_helper"
+require "helpers/password_helpers"
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true
@@ -17,6 +18,7 @@ class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
   include GemHelpers
   include EmailHelpers
+  include PasswordHelpers
 
   setup do
     I18n.locale = :en

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -74,15 +74,15 @@ class UserTest < ActiveSupport::TestCase
 
     context "password" do
       should "be between 10 and 200 characters" do
-        user = build(:user, password: "a" * 9)
+        user = build(:user, password: "%5a&12ed/")
         refute user.valid?
         assert_contains user.errors[:password], "is too short (minimum is 10 characters)"
 
-        user.password = "a" * 201
+        user.password = "#{"a8b5d2d451" * 20}a"
         refute user.valid?
         assert_contains user.errors[:password], "is too long (maximum is 200 characters)"
 
-        user.password = "secretpassword"
+        user.password = "633!cdf7b3426c9%f6dd1a0b62d4ce44c4f544e%"
         user.valid?
         assert_nil user.errors[:password].first
       end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -91,6 +91,12 @@ class UserTest < ActiveSupport::TestCase
         user = build(:user, password: "")
         refute user.valid?
       end
+
+      should "be invalid when it's found in a data breach" do
+        user = build(:user, password: "1234567890")
+        refute user.valid?
+        assert_contains user.errors[:password], "has previously appeared in a data breach and should not be used"
+      end
     end
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -78,7 +78,7 @@ class UserTest < ActiveSupport::TestCase
         refute user.valid?
         assert_contains user.errors[:password], "is too short (minimum is 10 characters)"
 
-        user.password = "#{"a8b5d2d451" * 20}a"
+        user.password = "#{'a8b5d2d451' * 20}a"
         refute user.valid?
         assert_contains user.errors[:password], "is too long (maximum is 200 characters)"
 


### PR DESCRIPTION
Check if the password chosen by the user has already been compromised in a data breach.

This uses the [Unpwn](https://github.com/indirect/unpwn) gem by Andre Arko as suggested in #2052. Unpwn 1.0 hasn't been publised to RubyGems.org yet, so this shouldn't be merged before that happens…

> Unpwn checks passwords locally against the top one million passwords, as provided by the nbp project. Then, it uses the haveibeenpwned API to check proposed passwords against the largest corpus of publicly dumped passwords in the world.

The [Pwned Passwords API](https://haveibeenpwned.com/API/v3#PwnedPasswords) “implements a k-Anonymity model that allows a password to be searched for by partial hash”.

You can read more about the k-Anonymity model in [Troy Hunt's blog post about it](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/), but the gist of it is that it allows passwords to be checked for breaches without revealing the password to a third party.

If the API cannot be reached or it errors out, the pwned password check is bypassed and the password is presumed to be valid.