### PR TITLE
Normalize params before using as key in rack attack

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -17,7 +17,7 @@ class EmailConfirmationsController < ApplicationController
 
   # used to resend confirmation mail for email validation
   def create
-    user = User.find_by(email: email_params)
+    user = find_user_for_create
 
     if user
       user.generate_confirmation_token
@@ -38,6 +38,10 @@ class EmailConfirmationsController < ApplicationController
   end
 
   private
+
+  def find_user_for_create
+    Clearance.configuration.user_model.find_by_normalized_email email_params
+  end
 
   def email_params
     params.require(:email_confirmation).permit(:email).fetch(:email, "")

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -40,6 +40,10 @@ class Rack::Attack
     protected_actions.any? { |hash| hash[:controller] == route_params[:controller] && hash[:action] == route_params[:action] }
   end
 
+  safelist("assets path") do |req|
+    req.path.starts_with?("/assets") && req.request_method == "GET"
+  end
+
   # 100 req in 10 min
   # 200 req in 100 min
   # 300 req in 1000 min (0.7 days)

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -379,5 +379,23 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         end
       end
     end
+
+    context "with per email limits" do
+      setup { update_limit_for("password/email:#{@user.email}", exceeding_limit) }
+
+      should "throttle for sign in ignoring case" do
+        post "/passwords",
+          params: { password: { email: "Nick@example.com" } }
+
+        assert_response :too_many_requests
+      end
+
+      should "throttle for sign in ignoring spaces" do
+        post "/passwords",
+          params: { password: { email: "n ick@example.com" } }
+
+        assert_response :too_many_requests
+      end
+    end
   end
 end


### PR DESCRIPTION
`Nick@example.com`, `n ick@example.com` etc should have a single key for rate limit. Clearance normalizes these before authentication [[1](https://github.com/thoughtbot/clearance/blob/master/lib/clearance/user.rb#L115-L121)].
Issue reported and solution suggested on HO.