### PR TITLE
Add gem typo exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,10 +50,11 @@ gem "lograge"
 gem "logstash-event"
 
 group :development, :test do
+  gem "m", "~> 1.5", require: false
+  gem "pry-byebug"
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "toxiproxy", "~> 1.0.0"
-  gem "pry-byebug"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,9 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    m (1.5.1)
+      method_source (>= 0.6.7)
+      rake (>= 0.9.2.2)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -424,6 +427,7 @@ DEPENDENCIES
   listen
   lograge
   logstash-event
+  m (~> 1.5)
   mail
   minitest
   mocha

--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -7,6 +7,7 @@ class GemTypo
 
   DOWNLOADS_THRESHOLD = 10_000_000
   SIZE_THRESHOLD = 4
+  EXCEPTIONS = %w[strait]
 
   def initialize(rubygem_name)
     @rubygem_name       = rubygem_name.downcase
@@ -15,6 +16,7 @@ class GemTypo
 
   def protected_typo?
     return false if @rubygem_name.size < GemTypo::SIZE_THRESHOLD
+    return false if GemTypo::EXCEPTIONS.include?(@rubygem_name)
 
     protected_gems.each do |protected_gem|
       distance = levenshtein_distance(@rubygem_name, protected_gem)

--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -7,7 +7,7 @@ class GemTypo
 
   DOWNLOADS_THRESHOLD = 10_000_000
   SIZE_THRESHOLD = 4
-  EXCEPTIONS = %w[strait]
+  EXCEPTIONS = %w[strait].freeze
 
   def initialize(rubygem_name)
     @rubygem_name       = rubygem_name.downcase

--- a/test/unit/gem_typo_test.rb
+++ b/test/unit/gem_typo_test.rb
@@ -35,6 +35,13 @@ class GemTypoTest < ActiveSupport::TestCase
         assert_equal true, gem_typo.protected_typo?
       end
 
+      should "return false for exceptions" do
+        GemTypo::EXCEPTIONS.push("fourss")
+        gem_typo = GemTypo.new("fourss")
+        assert_equal false, gem_typo.protected_typo?
+        GemTypo::EXCEPTIONS.delete("fourss")
+      end
+
       should "return false for three characher distance" do
         gem_typo = GemTypo.new("foursss")
         assert_equal false, gem_typo.protected_typo?

--- a/test/unit/gem_typo_test.rb
+++ b/test/unit/gem_typo_test.rb
@@ -36,10 +36,15 @@ class GemTypoTest < ActiveSupport::TestCase
       end
 
       should "return false for exceptions" do
-        GemTypo::EXCEPTIONS.push("fourss")
+        old_exceptions = GemTypo::EXCEPTIONS
+        Kernel.silence_warnings do
+          GemTypo::EXCEPTIONS = %w[fourss].freeze
+        end
         gem_typo = GemTypo.new("fourss")
         assert_equal false, gem_typo.protected_typo?
-        GemTypo::EXCEPTIONS.delete("fourss")
+        Kernel.silence_warnings do
+          GemTypo::EXCEPTIONS = old_exceptions
+        end
       end
 
       should "return false for three characher distance" do


### PR DESCRIPTION
This is the fastest thing that could possibly work, in the longer term I
think we'll need to have a database table so that we can modify the
exception list without needing to merge PRs and deploy code.