### PR TITLE
Add translation for "Change Avatar"

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -7,7 +7,7 @@
     <%= form.label :avatar, :class => 'form__label'  %>
     <div class="l-overflow">
       <%= gravatar(160) %>
-      <%= link_to t('.change'), 'https://www.gravatar.com', :class => 't-text t-link' %>
+      <%= link_to t('.change_avatar'), 'https://www.gravatar.com', :class => 't-text t-link' %>
     </div>
   </div>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -213,6 +213,7 @@ de:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation:
       enter_password:
       hide_email: Verberge E-Mails in öffentlichem Profil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
       update: Update
   profiles:
     edit:
+      change: Change Avatar
       email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
       enter_password: Please enter your account's password
       hide_email: Hide email in public profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,7 +223,7 @@ en:
       update: Update
   profiles:
     edit:
-      change: Change Avatar
+      change_avatar: Change Avatar
       email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
       enter_password: Please enter your account's password
       hide_email: Hide email in public profile

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,9 +3,9 @@ es:
   failure_when_forbidden: Por favor verifica la URL o inténtalo nuevamente.
   feed_latest: RubyGems.org | Gemas más recientes
   feed_subscribed: RubyGems.org | Suscripciones a gemas
-  footer_about_html: RubyGems.org es el servicio de alojamiento de Gemas de la comunidad de Ruby. 
-    <a href="%{publish_docs}">Publica tus gemas</a> instantáneamente y luego <a href="%{install_docs}">instálalas</a>. 
-    Usa <a href="%{api_docs}">la API</a> para saber más sobre <a href="%{gem_list}">las gemas disponibles</a>. 
+  footer_about_html: RubyGems.org es el servicio de alojamiento de Gemas de la comunidad de Ruby.
+    <a href="%{publish_docs}">Publica tus gemas</a> instantáneamente y luego <a href="%{install_docs}">instálalas</a>.
+    Usa <a href="%{api_docs}">la API</a> para saber más sobre <a href="%{gem_list}">las gemas disponibles</a>.
     <a href="%{contributing_docs}">Conviértete en colaborador</a> y mejora este sitio con tus cambios.
   footer_sponsors_html: RubyGems.org es posible gracias la colaboración de la fantástica comunidad de Ruby.
     <a href="https://www.fastly.com/">Fastly</a> provee ancho de banda y soporte de CDN
@@ -214,7 +214,7 @@ es:
       success: Has actualizado exitosamente la configuración de tus notificaciones por email.
     show:
       info: Para facilitar la detección de cambios no autorizados en tus gemas, te enviamos un email
-        cada vez que una nueva versión es subida a RubyGems.org. Recibiendo y leyendo estos emails 
+        cada vez que una nueva versión es subida a RubyGems.org. Recibiendo y leyendo estos emails
         ayudas a proteger el ecosistema de Ruby.
       on: Activado
       off: Desactivado
@@ -223,6 +223,7 @@ es:
       update: Actualizar
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation: Por favor confirma tu nueva dirección de correo %{unconfirmed_email}
       enter_password: Por favor introduce tu contraseña
       hide_email: Ocultar correo electrónico en perfil público

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -213,6 +213,7 @@ fr:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation: Veuillez confirmer votre nouvelle adresse email %{unconfirmed_email}
       enter_password: Veuillez entrer le mot de passe de votre compte
       hide_email: Ne pas afficher l'email dans le profil public

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -213,6 +213,7 @@ ja:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation: あなたの新しいメールアドレス%{unconfirmed_email}を確認してください。
       enter_password: パスワードを入力してください。
       hide_email: メールアドレスを公開しない

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -213,6 +213,7 @@ nl:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation:
       enter_password:
       hide_email:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -213,6 +213,7 @@ pt-BR:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation:
       enter_password:
       hide_email: Não mostrar meu email

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -213,6 +213,7 @@ zh-CN:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation: 请验证你的新邮箱地址 %{unconfirmed_email}
       enter_password: 输入密码
       hide_email: 在公开的个人资料里面隐藏我的 Email

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -213,6 +213,7 @@ zh-TW:
       update:
   profiles:
     edit:
+      change_avatar:
       email_awaiting_confirmation: 請驗證你的新 Email %{unconfirmed_email}
       enter_password: 輸入密碼
       hide_email: 在公開的個人頁面中隱藏 email


### PR DESCRIPTION
This was reported when I hovered over the "Change" link next to my profile
picture, and is used [here](https://github.com/rubygems/rubygems.org/blob/2b66087896341f6618d493dbb1e4d98fb4e8279e/app/views/profiles/edit.html.erb#L10)

I can't translate this for every other locale, but can apply a machine
translation if that's desired. I've also made this PR open to edits from
maintainers so that anyone can add to it.