### PR TITLE
Add a note about how to report a malicious gem

### DIFF
--- a/app/views/pages/security.html.erb
+++ b/app/views/pages/security.html.erb
@@ -30,6 +30,15 @@
   </p>
 
   <p>
+    <strong>
+      If you find a compromised or malicious gem, please consider it as a security issue:
+      please email <a href="mailto:security@rubygems.org">security@rubygems.org</a> with
+      the gem name or submit a report using <a href="https://hackerone.com/rubygems">HackerOne</a>.
+      Note that it is not in scope for bounty reward.
+    </strong>
+  </p>
+
+  <p>
     <small>
       Please note: the <a href="https://groups.google.com/forum/#!forum/rubygems-developers">
         rubygems-developers mailing list</a>, the


### PR DESCRIPTION
Hi,

Currently, [the page about "Security"](https://rubygems.org/pages/security) does not state how to report a malicious and/or compromised gem.  It says "For any security bug or issue with the RubyGems client or RubyGems.org service, please email security@rubygems.org ...", but it is not clear (at least for @znz and me) that "RubyGems.org service" includes a malicious gem report.

This pull request adds a note that a malicious gem should be handled as a security issue, i.e., security@rubygems.org or HackerOne.  I don't know what is the best way to report such a gem, but anyway, I believe that it should explicit state how to report.