### PR TITLE
Fix erroneous notifiers test

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -110,9 +110,11 @@
   <% end %>
 </div>
 
-<div class="t-body">
-  <h2><%= link_to t('notifiers.show.title'), notifier_path %></h2>
-</div>
+<% if @user.ownerships.any? %>
+  <div class="t-body">
+    <h2><%= link_to t('notifiers.show.title'), notifier_path %></h2>
+  </div>
+<% end %>
 
 <div class="t-body">
   <h2><%= t '.delete.delete_profile' %></h2>

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -46,7 +46,7 @@ class NoticationSettings < SystemTest
 
     visit edit_profile_path(as: user)
 
-    assert_no_text I18n.t("profiles.edit.notifier.email_notifications")
+    assert_no_text I18n.t("notifiers.show.title")
   end
 
   def notifier_on_radio(ownership)

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "capybara/minitest"
 
-class NoticationSettings < SystemTest
+class NotificationSettingsTest < SystemTest
   include Capybara::Minitest::Assertions
 
   test "changing email notification settings" do


### PR DESCRIPTION
The test used an outdated translation key but still passed. The translation is now updated (as is the code being tested) to reflect the original intention of the test ("email notification settings not shown to user who owns no gems").