### PR TITLE
Make settings more visible

### DIFF
--- a/app/assets/stylesheets/type.css
+++ b/app/assets/stylesheets/type.css
@@ -212,3 +212,7 @@ a.t-list__item {
 .t-item--hidden {
   display: none !important;
 }
+
+h1 + .t-body h2 {
+  border-top: none;
+}

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -25,6 +25,6 @@ class Api::V1::ApiKeysController < Api::BaseController
     current_user.reset_api_key!
     flash[:notice] =
       "Your API key has been reset. Don't forget to update your ~/.gem/credentials file!"
-    redirect_to edit_profile_path
+    redirect_to edit_settings_path
   end
 end

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -17,7 +17,7 @@ class MultifactorAuthsController < ApplicationController
     current_user.verify_and_enable_mfa!(@seed, :ui_and_api, otp_param, @expire)
     if current_user.errors.any?
       flash[:error] = current_user.errors[:base].join
-      redirect_to edit_profile_url
+      redirect_to edit_settings_url
     else
       flash[:success] = t(".success")
       render :recovery
@@ -36,7 +36,7 @@ class MultifactorAuthsController < ApplicationController
     else
       flash[:error] = t("multifactor_auths.incorrect_otp")
     end
-    redirect_to edit_profile_url
+    redirect_to edit_settings_url
   end
 
   private
@@ -56,13 +56,13 @@ class MultifactorAuthsController < ApplicationController
   def require_mfa_disabled
     return unless current_user.mfa_enabled?
     flash[:error] = t("multifactor_auths.require_mfa_disabled")
-    redirect_to edit_profile_path
+    redirect_to edit_settings_path
   end
 
   def require_mfa_enabled
     return if current_user.mfa_enabled?
     flash[:error] = t("multifactor_auths.require_mfa_enabled")
-    redirect_to edit_profile_path
+    redirect_to edit_settings_path
   end
 
   def seed_and_expire

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,16 @@
+class SettingsController < ApplicationController
+  before_action :redirect_to_signin, unless: :signed_in?
+  before_action :set_cache_headers
+
+  def edit
+    @user = current_user
+  end
+
+  private
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,6 +72,7 @@
               <div class="header__popup__nav-links">
                 <%= link_to t('.header.dashboard'), dashboard_path, class: "header__nav-link" %>
                 <%= link_to t('.header.edit_profile'), edit_profile_path, class: "header__nav-link" %>
+                <%= link_to t('.header.edit_settings'), edit_settings_path, class: "header__nav-link" %>
                 <%= link_to t('.header.sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
               </div>
             <% else %>

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -7,5 +7,5 @@
     <% end %>
   </ul>
   <p><%= t '.note' %></p>
-  <p><%= link_to t('.continue'), edit_profile_path, class: "t-link--arrow" %></p>
+  <p><%= link_to t('.continue'), edit_settings_path, class: "t-link--arrow" %></p>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -66,54 +66,6 @@
   <div class="submit_field">
     <%= form.submit 'Update', :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
   </div>
-
-  <div class="t-body">
-    <h2><%= t '.reset_password.title' %></h2>
-    <p><%= t('.reset_password.text_html', :link => link_to(t('.reset_password.link_text'), new_password_path)) %></p>
-
-    <h2><%= t '.api_access.title' %></h2>
-    <p>
-      <%= t('.api_access.key_is_html', :key => content_tag(:strong, current_user.api_key)) %>
-    </p>
-    <p>
-      <%= t('.api_access.credentials_html', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
-                                            :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))) %>
-    </p>
-    <pre><code>curl -u <%= current_user.name %> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials</code></pre>
-  </div>
-<% end %>
-
-<%= button_to t('.api_access.reset'), reset_api_v1_api_key_path, :method => :put, :data => {:confirm => t('.api_access.confirm_reset')}, :class => 'form__submit' %>
-
-
-<div class="t-body">
-  <h2><%= t '.mfa.multifactor_auth' %></h2>
-  <% if @user.mfa_enabled? %>
-    <p><%= t '.mfa.enabled' %></p>
-    <%= form_tag multifactor_auth_path, :method => :put, :id => 'mfa-edit' do %>
-      <%= label_tag :level, t('.mfa.level.title'), :class => 'form__label' %>
-      <%= select_tag :level, options_for_select([
-        [t('.mfa.level.ui_and_api'), 'ui_and_api'],
-        [t('.mfa.level.ui_only'), 'ui_only'],
-        [t('.mfa.level.disabled'), 'disabled']], @user.mfa_level), :class => 'form__input form__select' %>
-      <div class="text_field">
-        <%= label_tag :otp, 'OTP code', :class => 'form__label' %>
-        <%= text_field_tag :otp, '', :class => 'form__input', :autocomplete => :off %>
-      </div>
-      <%= submit_tag t('.mfa.update'), :class => 'form__submit' %>
-    <% end %>
-  <% else %>
-    <p>
-      <%= t '.mfa.disabled' %>
-      <%= button_to t('.mfa.go_settings'), new_multifactor_auth_path, :method => 'get', :class => 'form__submit' %>
-    </p>
-  <% end %>
-</div>
-
-<% if @user.ownerships.any? %>
-  <div class="t-body">
-    <h2><%= link_to t('notifiers.show.title'), notifier_path %></h2>
-  </div>
 <% end %>
 
 <div class="t-body">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -65,6 +65,16 @@
             )
           %>
         </div>
+        <div id="profile-settings">
+          <%=
+            link_to(
+              "Edit Settings",
+              edit_settings_path,
+              id: "edit-settings",
+              class: "profile__header__attribute t-link--black"
+            )
+          %>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,0 +1,50 @@
+<% @title = t('.title') %>
+
+<div class="t-body">
+  <h2><%= t '.reset_password.title' %></h2>
+  <p><%= t('.reset_password.text_html', :link => link_to(t('.reset_password.link_text'), new_password_path)) %></p>
+</div>
+
+<div class="t-body">
+  <h2><%= t '.api_access.title' %></h2>
+  <p>
+    <%= t('.api_access.key_is_html', :key => content_tag(:strong, current_user.api_key)) %>
+  </p>
+  <p>
+    <%= t('.api_access.credentials_html', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
+          :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))) %>
+  </p>
+  <pre><code>curl -u <%= current_user.name %> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials</code></pre>
+</div>
+
+<%= button_to t('.api_access.reset'), reset_api_v1_api_key_path, :method => :put, :data => {:confirm => t('.api_access.confirm_reset')}, :class => 'form__submit' %>
+
+<div class="t-body">
+  <h2><%= t '.mfa.multifactor_auth' %></h2>
+  <% if @user.mfa_enabled? %>
+    <p><%= t '.mfa.enabled' %></p>
+    <%= form_tag multifactor_auth_path, :method => :put, :id => 'mfa-edit' do %>
+      <%= label_tag :level, t('.mfa.level.title'), :class => 'form__label' %>
+      <%= select_tag :level, options_for_select([
+        [t('.mfa.level.ui_and_api'), 'ui_and_api'],
+        [t('.mfa.level.ui_only'), 'ui_only'],
+        [t('.mfa.level.disabled'), 'disabled']], @user.mfa_level), :class => 'form__input form__select' %>
+      <div class="text_field">
+        <%= label_tag :otp, 'OTP code', :class => 'form__label' %>
+        <%= text_field_tag :otp, '', :class => 'form__input', :autocomplete => :off %>
+      </div>
+      <%= submit_tag t('.mfa.update'), :class => 'form__submit' %>
+    <% end %>
+  <% else %>
+    <p>
+      <%= t '.mfa.disabled' %>
+      <%= button_to t('.mfa.go_settings'), new_multifactor_auth_path, :method => 'get', :class => 'form__submit' %>
+    </p>
+  <% end %>
+</div>
+
+<% if @user.ownerships.any? %>
+  <div class="t-body">
+    <h2><%= link_to t('notifiers.show.title'), notifier_path %></h2>
+  </div>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -106,6 +106,7 @@ de:
       header:
         dashboard: Dashboard
         edit_profile:
+        edit_settings:
         search_gem_html: Suche Gems&hellip;
         sign_in: Anmelden
         sign_out: Abmelden
@@ -215,14 +216,9 @@ de:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation:
-      enter_password:
-      hide_email: Verberge E-Mails in öffentlichem Profil
-      optional_twitter_username:
-      title: Bearbeite Profil
+      title:
       api_access:
         confirm_reset: Sind Sie sicher? Das kann nicht rückgängig gemacht werden.
         credentials_html: 'Wenn du %{gem_commands_link} über das Terminal oder über die Kommandozeile verwenden möchtest, dann brauchst du die %{gem_credentials_file}-Datei, die du mit dem folgenden Befehl erzeugen kannst:'
@@ -234,10 +230,6 @@ de:
         link_text: Jetzt ein neues Passwort zuschicken lassen.
         text_html: Brauchst du ein neues Passwort? Kein Problem. %{link}
         title: Zurücksetzen des Passworts
-      delete:
-        delete:
-        delete_profile:
-        warning:
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ de:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Verberge E-Mails in öffentlichem Profil
+      optional_twitter_username:
+      title: Bearbeite Profil
+      delete:
+        delete:
+        delete_profile:
+        warning:
     delete:
       title:
       confirm:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,7 @@ en:
       header:
         dashboard: Dashboard
         edit_profile: Edit profile
+        edit_settings: Edit settings
         search_gem_html: Search Gems&hellip;
         sign_in: Sign in
         sign_out: Sign out
@@ -225,14 +226,9 @@ en:
       recommended: recommended
       title: Email notifications
       update: Update
-  profiles:
+  settings:
     edit:
-      change_avatar: Change Avatar
-      email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
-      enter_password: Please enter your account's password
-      hide_email: Hide email in public profile
-      optional_twitter_username: Optional Twitter username. Will be displayed publicly
-      title: Edit profile
+      title: Edit settings
       api_access:
         confirm_reset: Are you sure? This cannot be undone.
         credentials_html: 'If you want to use %{gem_commands_link} from the command line, you''ll need a %{gem_credentials_file} file, which you can generate using the following command:'
@@ -244,10 +240,6 @@ en:
         link_text: Request a new one here.
         text_html: Need a new password? No problem. %{link}
         title: Reset password
-      delete:
-        delete: Delete
-        delete_profile: Delete Profile
-        warning: Deleting your profile is an irreversible action. This can't be undone by contacting support. Please be certain!
       mfa:
         multifactor_auth: Multifactor authentication
         disabled: You have not yet enabled multifactor authentication.
@@ -259,6 +251,18 @@ en:
           disabled: Disabled
           ui_only: UI Only
           ui_and_api: UI and API
+  profiles:
+    edit:
+      change_avatar: Change Avatar
+      email_awaiting_confirmation: Please confirm your new email address %{unconfirmed_email}
+      enter_password: Please enter your account's password
+      hide_email: Hide email in public profile
+      optional_twitter_username: Optional Twitter username. Will be displayed publicly
+      title: Edit profile
+      delete:
+        delete: Delete
+        delete_profile: Delete Profile
+        warning: Deleting your profile is an irreversible action. This can't be undone by contacting support. Please be certain!
     delete:
       title: Delete profile
       confirm: Confirm

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,7 +114,7 @@ es:
       header:
         dashboard: Dashboard
         edit_profile:
-        edit_settings:
+        edit_settings: Configuración
         search_gem_html: Buscar gemas&hellip;
         sign_in: Ingresar
         sign_out: Salir

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -228,7 +228,7 @@ es:
       update: Actualizar
   settings:
     edit:
-      title:
+      title: Editar configuración
       api_access:
         confirm_reset: '¿Seguro? Este cambio no puede deshacerse.'
         credentials_html: 'Si quieres usar %{gem_commands_link} desde la línea de comandos, vas a necesitar un archivo llamado %{gem_credentials_file}, el cual puedes generar usando el siguiente comando:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,6 +114,7 @@ es:
       header:
         dashboard: Dashboard
         edit_profile:
+        edit_settings:
         search_gem_html: Buscar gemas&hellip;
         sign_in: Ingresar
         sign_out: Salir
@@ -225,14 +226,9 @@ es:
       recommended: recomendado
       title: Notificación de email
       update: Actualizar
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation: Por favor confirma tu nueva dirección de correo %{unconfirmed_email}
-      enter_password: Por favor introduce tu contraseña
-      hide_email: Ocultar correo electrónico en perfil público
-      optional_twitter_username: Usuario de Twitter opcional. Será mostrado en tu perfil público
-      title: Editar perfil
+      title:
       api_access:
         confirm_reset: '¿Seguro? Este cambio no puede deshacerse.'
         credentials_html: 'Si quieres usar %{gem_commands_link} desde la línea de comandos, vas a necesitar un archivo llamado %{gem_credentials_file}, el cual puedes generar usando el siguiente comando:'
@@ -244,10 +240,6 @@ es:
         link_text: Solicitar aquí una nueva.
         text_html: '¿Necesitas una nueva contraseña? Sin problemas. %{link}'
         title: Reestablecer contraseña
-      delete:
-        delete: Eliminar
-        delete_profile: Eliminar Perfil
-        warning: Eliminar tu perfil es una acción irreversible. No puede deshacerse contactando a soporte. ¡Por favor hazlo solo si estás seguro!
       mfa:
         multifactor_auth: Autenticación de múltiples factores
         disabled: Todavía no activaste la Autenticación de Múltiples Factores.
@@ -259,6 +251,18 @@ es:
           disabled: Desactivada
           ui_only: Solo Interfaz de Usuario
           ui_and_api: Interfaz de Usuario y API
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation: Por favor confirma tu nueva dirección de correo %{unconfirmed_email}
+      enter_password: Por favor introduce tu contraseña
+      hide_email: Ocultar correo electrónico en perfil público
+      optional_twitter_username: Usuario de Twitter opcional. Será mostrado en tu perfil público
+      title: Editar perfil
+      delete:
+        delete: Eliminar
+        delete_profile: Eliminar Perfil
+        warning: Eliminar tu perfil es una acción irreversible. No puede deshacerse contactando a soporte. ¡Por favor hazlo solo si estás seguro!
     delete:
       title: Eliminar perfil
       confirm: Confirmar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -106,6 +106,7 @@ fr:
       header:
         dashboard: Dashboard
         edit_profile:
+        edit_settings:
         search_gem_html: Recherche de Gems&hellip;
         sign_in: Connexion
         sign_out: Déconnexion
@@ -215,14 +216,9 @@ fr:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation: Veuillez confirmer votre nouvelle adresse email %{unconfirmed_email}
-      enter_password: Veuillez entrer le mot de passe de votre compte
-      hide_email: Ne pas afficher l'email dans le profil public
-      optional_twitter_username: Nom d'utilisateur Twitter optionnel. Sera affiché publiquement
-      title: Modification de profil
+      title:
       api_access:
         confirm_reset: Êtes-vous sûr ? Cette action ne peut être annulée.
         credentials_html: 'Si vous voulez utiliser %{gem_commands_link} de la ligne de commande, vous aurez besoin d''un fichier %{gem_credentials_file}, que vous pouvez générer avec la commande suivante :'
@@ -234,10 +230,6 @@ fr:
         link_text: Demandez un nouveau mot de passe ici.
         text_html: Besoin d'un nouveau mot de passe ? Pas de problème. %{link}
         title: Renvoi de mot de passe
-      delete:
-        delete: Supprimer
-        delete_profile: Supprimer le profil
-        warning: La suppression de votre profil est une action irréversible. Cela ne peut pas être annulé en contactant le support. Réfléchissez-bien avant de continuer !
       mfa:
         multifactor_auth: Authentification Multifacteur
         disabled: Vous n'avez pas encore activé l'authentification multifacteur.
@@ -249,6 +241,18 @@ fr:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation: Veuillez confirmer votre nouvelle adresse email %{unconfirmed_email}
+      enter_password: Veuillez entrer le mot de passe de votre compte
+      hide_email: Ne pas afficher l'email dans le profil public
+      optional_twitter_username: Nom d'utilisateur Twitter optionnel. Sera affiché publiquement
+      title: Modification de profil
+      delete:
+        delete: Supprimer
+        delete_profile: Supprimer le profil
+        warning: La suppression de votre profil est une action irréversible. Cela ne peut pas être annulé en contactant le support. Réfléchissez-bien avant de continuer !
     delete:
       title: Supprimer le profil
       confirm: Confirmer

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -106,6 +106,7 @@ ja:
       header:
         dashboard: ダッシュボード
         edit_profile:
+        edit_settings:
         search_gem_html: 検索…
         sign_in: ログイン
         sign_out: ログアウト
@@ -215,14 +216,9 @@ ja:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation: あなたの新しいメールアドレス%{unconfirmed_email}を確認してください。
-      enter_password: パスワードを入力してください。
-      hide_email: メールアドレスを公開しない
-      optional_twitter_username: Twitterのユーザー名(任意,公開)
-      title: プロフィールを編集する
+      title:
       api_access:
         confirm_reset: この操作は取り消せませんが、本当によろしいですか?
         credentials_html: 'もしコマンドラインから%{gem_commands_link}を使いたい場合、%{gem_credentials_file}ファイルが必要になります。このファイルは以下のコマンドで再生成することができます:'
@@ -234,10 +230,6 @@ ja:
         link_text: ここから新規に発行することができます。
         text_html: 新しいパスワードが必要ですか? %{link}
         title: パスワードのリセット
-      delete:
-        delete: アカウント削除
-        delete_profile: 削除
-        warning: アカウントの削除は不可逆的操作です。これはサポートに連絡しても取り消すことはできません。ご注意ください。
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ ja:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation: あなたの新しいメールアドレス%{unconfirmed_email}を確認してください。
+      enter_password: パスワードを入力してください。
+      hide_email: メールアドレスを公開しない
+      optional_twitter_username: Twitterのユーザー名(任意,公開)
+      title: プロフィールを編集する
+      delete:
+        delete: アカウント削除
+        delete_profile: 削除
+        warning: アカウントの削除は不可逆的操作です。これはサポートに連絡しても取り消すことはできません。ご注意ください。
     delete:
       title: アカウント削除
       confirm: 確認

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -106,6 +106,7 @@ nl:
       header:
         dashboard: Dashboard
         edit_profile:
+        edit_settings:
         search_gem_html: Gems Zoeken&hellip;
         sign_in: Inloggen
         sign_out: Uitloggen
@@ -215,14 +216,9 @@ nl:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation:
-      enter_password:
-      hide_email:
-      optional_twitter_username:
-      title: Wijzig profiel
+      title:
       api_access:
         confirm_reset: Weet je het zeker? Dit kan niet ongedaan worden gemaakt.
         credentials_html: 'Als je de %{gem_commands_link} vanaf de command-line wilt gebruiken, heb je een %{gem_credentials_file} bestand nodig. Je kunt deze genereren met het volgende commando:'
@@ -234,10 +230,6 @@ nl:
         link_text: Vraag hier een nieuwe aan.
         text_html: Nieuw wachtwoord nodig? Geen probleem. %{link}
         title: Reset wachtwoord
-      delete:
-        delete:
-        delete_profile:
-        warning:
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ nl:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email:
+      optional_twitter_username:
+      title: Wijzig profiel
+      delete:
+        delete:
+        delete_profile:
+        warning:
     delete:
       title:
       confirm:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -106,6 +106,7 @@ pt-BR:
       header:
         dashboard: Painel de Controle
         edit_profile:
+        edit_settings:
         search_gem_html: Buscar Gems&hellip;
         sign_in: Fazer Login
         sign_out: Sair
@@ -215,14 +216,9 @@ pt-BR:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation:
-      enter_password:
-      hide_email: Não mostrar meu email
-      optional_twitter_username:
-      title: Editar Perfil
+      title:
       api_access:
         confirm_reset: Tem certeza?
         credentials_html: 'Se você quiser usar %{gem_commands_link} pela linha comando, você vai precisar de um arquivo %{gem_credentials_file}. Para gerar este arquivo rode o seguinte comando:'
@@ -234,10 +230,6 @@ pt-BR:
         link_text: Solicitar uma nova senha.
         text_html: Esqueceu sua senha? Sem problema. %{link}
         title: Resetar senha
-      delete:
-        delete:
-        delete_profile:
-        warning:
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ pt-BR:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation:
+      enter_password:
+      hide_email: Não mostrar meu email
+      optional_twitter_username:
+      title: Editar Perfil
+      delete:
+        delete:
+        delete_profile:
+        warning:
     delete:
       title:
       confirm:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -106,6 +106,7 @@ zh-CN:
       header:
         dashboard: 控制台
         edit_profile:
+        edit_settings:
         search_gem_html: 搜索 Gems&hellip;
         sign_in: 登录
         sign_out: 退出
@@ -215,14 +216,9 @@ zh-CN:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation: 请验证你的新邮箱地址 %{unconfirmed_email}
-      enter_password: 输入密码
-      hide_email: 在公开的个人资料里面隐藏我的 Email
-      optional_twitter_username: Twitter 账号（可选）
-      title: 修改个人资料
+      title:
       api_access:
         confirm_reset: 确定要重置吗？此动作执行后将无法撤销
         credentials_html: 如果你希望在命令行中使用 %{gem_commands_link}，你需要一个 %{gem_credentials_file} 文件，可用下面的命令生成：
@@ -234,10 +230,6 @@ zh-CN:
         link_text: 这里找回密码
         text_html: 需要一个新密码？没问题，访问 %{link}
         title: 重置密码
-      delete:
-        delete: 删除
-        delete_profile: 删除个人资料
-        warning: 警告
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ zh-CN:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation: 请验证你的新邮箱地址 %{unconfirmed_email}
+      enter_password: 输入密码
+      hide_email: 在公开的个人资料里面隐藏我的 Email
+      optional_twitter_username: Twitter 账号（可选）
+      title: 修改个人资料
+      delete:
+        delete: 删除
+        delete_profile: 删除个人资料
+        warning: 警告
     delete:
       title:
       confirm:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -106,6 +106,7 @@ zh-TW:
       header:
         dashboard: 控制台
         edit_profile:
+        edit_settings:
         search_gem_html: 搜尋 Gems&hellip;
         sign_in: 登入
         sign_out: 登出
@@ -215,14 +216,9 @@ zh-TW:
       recommended:
       title:
       update:
-  profiles:
+  settings:
     edit:
-      change_avatar:
-      email_awaiting_confirmation: 請驗證你的新 Email %{unconfirmed_email}
-      enter_password: 輸入密碼
-      hide_email: 在公開的個人頁面中隱藏 email
-      optional_twitter_username: Twitter 帳號（可選）
-      title: 編輯個人檔案
+      title:
       api_access:
         confirm_reset: 確定要重設嗎？此動作無法還原
         credentials_html: 如果你需要從 command line 中執行 %{gem_commands_link}，你需要先準備 %{gem_credentials_file} 這個檔案，用以下的指令可以產生：
@@ -234,10 +230,6 @@ zh-TW:
         link_text: 從這裡設定新密碼
         text_html: 需要重設密碼？沒問題。 %{link}
         title: 重設密碼
-      delete:
-        delete: 刪除
-        delete_profile: 刪除個人資料
-        warning: 警告
       mfa:
         multifactor_auth:
         disabled:
@@ -249,6 +241,18 @@ zh-TW:
           disabled:
           ui_only:
           ui_and_api:
+  profiles:
+    edit:
+      change_avatar:
+      email_awaiting_confirmation: 請驗證你的新 Email %{unconfirmed_email}
+      enter_password: 輸入密碼
+      hide_email: 在公開的個人頁面中隱藏 email
+      optional_twitter_username: Twitter 帳號（可選）
+      title: 編輯個人檔案
+      delete:
+        delete: 刪除
+        delete_profile: 刪除個人資料
+        warning: 警告
     delete:
       title:
       confirm:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
     resource :multifactor_auth, only: %i[new create update]
+    resource :settings, only: :edit
     resource :profile, only: %i[edit update] do
       member do
         get :delete

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -134,9 +134,9 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         put :reset
       end
     end
-    should "redirect to the edit profile page" do
+    should "redirect to the edit settings page" do
       put :reset
-      assert_redirected_to edit_profile_path
+      assert_redirected_to edit_settings_path
     end
   end
 

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -19,7 +19,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to("the profile edit page") { edit_profile_path }
+        should redirect_to("the settings page") { edit_settings_path }
       end
 
       context "on POST to create mfa" do
@@ -28,7 +28,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to("the profile edit page") { edit_profile_path }
+        should redirect_to("the settings page") { edit_settings_path }
         should "keep mfa enabled" do
           assert @user.reload.mfa_enabled?
         end
@@ -42,7 +42,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             end
 
             should respond_with :redirect
-            should redirect_to("the profile edit page") { edit_profile_path }
+            should redirect_to("the settings page") { edit_settings_path }
             should "disable mfa" do
               refute @user.reload.mfa_enabled?
             end
@@ -54,7 +54,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             end
 
             should respond_with :redirect
-            should redirect_to("the profile edit page") { edit_profile_path }
+            should redirect_to("the settings page") { edit_settings_path }
             should "disable mfa" do
               refute @user.reload.mfa_enabled?
             end
@@ -67,7 +67,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             end
 
             should respond_with :redirect
-            should redirect_to("the profile edit page") { edit_profile_path }
+            should redirect_to("the settings page") { edit_settings_path }
             should set_flash.to("Your OTP code is incorrect.")
             should "keep mfa enabled" do
               assert @user.reload.mfa_enabled?
@@ -82,7 +82,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           end
 
           should respond_with :redirect
-          should redirect_to("the profile edit page") { edit_profile_path }
+          should redirect_to("the settings page") { edit_settings_path }
           should "update mfa level to mfa_ui_only now" do
             assert @user.reload.mfa_ui_only?
           end
@@ -94,7 +94,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           end
 
           should respond_with :redirect
-          should redirect_to("the profile edit page") { edit_profile_path }
+          should redirect_to("the settings page") { edit_settings_path }
           should "update make mfa level to mfa_ui_and_api now" do
             assert @user.reload.mfa_ui_and_api?
           end
@@ -137,7 +137,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           end
 
           should respond_with :redirect
-          should redirect_to("the profile edit page") { edit_profile_path }
+          should redirect_to("the settings page") { edit_settings_path }
           should "set error flash message" do
             refute_empty flash[:error]
           end
@@ -153,7 +153,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to("the profile edit page") { edit_profile_path }
+        should redirect_to("the settings page") { edit_settings_path }
         should "keep mfa disabled" do
           refute @user.reload.mfa_enabled?
         end

--- a/test/integration/api_key_reset_test.rb
+++ b/test/integration/api_key_reset_test.rb
@@ -12,8 +12,7 @@ class ApiKeyResetTest < SystemTest
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    visit profile_path(@user.handle)
-    click_link "Edit Profile"
+    visit edit_settings_path
 
     old_api_key = @user.api_key
     click_button "Reset my API key"

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -8,7 +8,7 @@ class NotificationSettingsTest < SystemTest
     user = create(:user)
     ownership1, ownership2 = create_list(:ownership, 2, user: user)
 
-    visit edit_profile_path(as: user)
+    visit edit_settings_path(as: user)
 
     click_link I18n.t("notifiers.show.title")
 
@@ -44,7 +44,7 @@ class NotificationSettingsTest < SystemTest
   test "email notification settings not shown to user who owns no gems" do
     user = create(:user)
 
-    visit edit_profile_path(as: user)
+    visit edit_settings_path(as: user)
 
     assert_no_text I18n.t("notifiers.show.title")
   end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -70,8 +70,7 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    visit profile_path(@user)
-    click_link "Edit Profile"
+    visit edit_settings_path
 
     click_link "Request a new one here."
 

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -14,21 +14,6 @@ class ProfileTest < SystemTest
     click_button "Sign in"
   end
 
-  def enable_mfa
-    key = ROTP::Base32.random_base32
-    @user.enable_mfa!(key, :ui_only)
-  end
-
-  def change_auth_level(type)
-    page.select type
-    find("#mfa-edit input[type=submit]").click
-  end
-
-  def mfa_key
-    key_regex = /( (\w{4})){8}/
-    page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
-  end
-
   test "changing handle" do
     sign_in
 
@@ -135,84 +120,5 @@ class ProfileTest < SystemTest
 
     assert page.has_content? "Your account deletion request has been enqueued."\
       " We will send you a confirmation mail when your request has been processed."
-  end
-
-  test "enabling multifactor authentication with valid otp" do
-    sign_in
-    visit profile_path("nick1")
-    click_link "Edit Profile"
-    click_button "Register a new device"
-
-    assert page.has_content? "Enabling multifactor auth"
-
-    totp = ROTP::TOTP.new(mfa_key)
-    page.fill_in "otp", with: totp.now
-    click_button "Enable"
-
-    assert page.has_content? "Recovery codes"
-
-    click_link "Continue"
-
-    assert page.has_content? "You have enabled multifactor authentication."
-  end
-
-  test "enabling multifactor authentication with invalid otp" do
-    sign_in
-    visit profile_path("nick1")
-    click_link "Edit Profile"
-    click_button "Register a new device"
-
-    assert page.has_content? "Enabling multifactor auth"
-
-    totp = ROTP::TOTP.new(ROTP::Base32.random_base32)
-    page.fill_in "otp", with: totp.now
-    click_button "Enable"
-
-    assert page.has_content? "You have not yet enabled multifactor authentication."
-  end
-
-  test "disabling multifactor authentication with valid otp" do
-    sign_in
-    enable_mfa
-    visit profile_path("nick1")
-    click_link "Edit Profile"
-
-    page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
-    change_auth_level "Disabled"
-
-    assert page.has_content? "You have not yet enabled multifactor authentication."
-  end
-
-  test "disabling multifactor authentication with invalid otp" do
-    sign_in
-    enable_mfa
-    visit profile_path("nick1")
-    click_link "Edit Profile"
-
-    key = ROTP::Base32.random_base32
-    page.fill_in "otp", with: ROTP::TOTP.new(key).now
-    change_auth_level "Disabled"
-
-    assert page.has_content? "You have enabled multifactor authentication."
-  end
-
-  test "disabling multifactor authentication with recovery code" do
-    sign_in
-    visit profile_path("nick1")
-    click_link "Edit Profile"
-    click_button "Register a new device"
-
-    totp = ROTP::TOTP.new(mfa_key)
-    page.fill_in "otp", with: totp.now
-    click_button "Enable"
-
-    assert page.has_content? "Recovery codes"
-
-    recoveries = page.find_by_id("recovery-code-list").text.split
-    click_link "Continue"
-    page.fill_in "otp", with: recoveries.sample
-    change_auth_level "Disabled"
-
-    assert page.has_content? "You have not yet enabled multifactor authentication."
   end
 end

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SettingsTest < SystemTest
   setup do
-    @user = create(:user, email: "nick@example.com", password: "password12345", handle: "nick1", mail_fails: 1)
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
 
     page.driver.browser.set_cookie("mfa_feature=true")
   end

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class SettingsTest < SystemTest
+  setup do
+    @user = create(:user, email: "nick@example.com", password: "password12345", handle: "nick1", mail_fails: 1)
+
+    page.driver.browser.set_cookie("mfa_feature=true")
+  end
+
+  def sign_in
+    visit sign_in_path
+    fill_in "Email or Username", with: @user.reload.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+  end
+
+  def enable_mfa
+    key = ROTP::Base32.random_base32
+    @user.enable_mfa!(key, :ui_only)
+  end
+
+  def change_auth_level(type)
+    page.select type
+    find("#mfa-edit input[type=submit]").click
+  end
+
+  def mfa_key
+    key_regex = /( (\w{4})){8}/
+    page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
+  end
+
+  test "enabling multifactor authentication with valid otp" do
+    sign_in
+    visit edit_settings_path
+    click_button "Register a new device"
+
+    assert page.has_content? "Enabling multifactor auth"
+
+    totp = ROTP::TOTP.new(mfa_key)
+    page.fill_in "otp", with: totp.now
+    click_button "Enable"
+
+    assert page.has_content? "Recovery codes"
+
+    click_link "Continue"
+
+    assert page.has_content? "You have enabled multifactor authentication."
+  end
+
+  test "enabling multifactor authentication with invalid otp" do
+    sign_in
+    visit edit_settings_path
+    click_button "Register a new device"
+
+    assert page.has_content? "Enabling multifactor auth"
+
+    totp = ROTP::TOTP.new(ROTP::Base32.random_base32)
+    page.fill_in "otp", with: totp.now
+    click_button "Enable"
+
+    assert page.has_content? "You have not yet enabled multifactor authentication."
+  end
+
+  test "disabling multifactor authentication with valid otp" do
+    sign_in
+    enable_mfa
+    visit edit_settings_path
+
+    page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
+    change_auth_level "Disabled"
+
+    assert page.has_content? "You have not yet enabled multifactor authentication."
+  end
+
+  test "disabling multifactor authentication with invalid otp" do
+    sign_in
+    enable_mfa
+    visit edit_settings_path
+
+    key = ROTP::Base32.random_base32
+    page.fill_in "otp", with: ROTP::TOTP.new(key).now
+    change_auth_level "Disabled"
+
+    assert page.has_content? "You have enabled multifactor authentication."
+  end
+
+  test "disabling multifactor authentication with recovery code" do
+    sign_in
+    visit edit_settings_path
+    click_button "Register a new device"
+
+    totp = ROTP::TOTP.new(mfa_key)
+    page.fill_in "otp", with: totp.now
+    click_button "Enable"
+
+    assert page.has_content? "Recovery codes"
+
+    recoveries = page.find_by_id("recovery-code-list").text.split
+    click_link "Continue"
+    page.fill_in "otp", with: recoveries.sample
+    change_auth_level "Disabled"
+
+    assert page.has_content? "You have not yet enabled multifactor authentication."
+  end
+end


### PR DESCRIPTION
This aims for a sharp distinction between the user's profile (avatar, twitter, etc) and the settings regarding the user's account (api key, 2fa, etc).

It also helps to improve security settings visibility by explicitly adding 'Edit settings' on the navbar dropdown menu (#2057).