### PR TITLE
Show gem owners that are not using MFA when logged in as owner

### DIFF
--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -65,9 +65,11 @@ $('.stats__graph__gem__meter').each(function() {
 });
 
 //gem page
-$('.gem__users__mfa-text').on('click', function() {
-  $('.gem__users__mfa-text').toggleClass('t-item--hidden');
+$(document).ready(function() {
+  $('.gem__users__mfa-text.mfa-warn').on('click', function() {
+    $('.gem__users__mfa-text.mfa-warn').toggleClass('t-item--hidden');
 
-  $owners = $('.gem__users__mfa-disabled');
-  $owners.toggleClass('t-item--hidden');
+    $owners = $('.gem__users__mfa-disabled');
+    $owners.toggleClass('t-item--hidden');
+  });
 });

--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -63,3 +63,11 @@ $('.stats__graph__gem__meter').each(function() {
   bar_width = $(this).data("bar_width");
   $(this).animate({ width: bar_width + '%' }, 700).removeClass('t-item--hidden');
 });
+
+//gem page
+$('.gem__users__mfa-text').on('click', function() {
+  $('.gem__users__mfa-text').toggleClass('t-item--hidden');
+
+  $owners = $('.gem__users__mfa-disabled');
+  $owners.toggleClass('t-item--hidden');
+});

--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -58,6 +58,10 @@
     background-color: #e9573f;
     opacity: .5; }
 
+.gem__users__mfa-text {
+  font-size: 9px;
+  color: #e9573f;
+}
 .gem__downloads-wrap {
   margin-bottom: 30px; }
 

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -92,6 +92,10 @@ module RubygemsHelper
     rubygem.owners.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
   end
 
+  def links_to_owners_without_mfa(rubygem)
+    rubygem.owners.without_mfa.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
+  end
+
   def link_to_user(user)
     link_to gravatar(48, "gravatar-#{user.id}", user), profile_path(user.display_id),
       alt: user.display_handle, title: user.display_handle

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,10 @@ class User < ApplicationRecord
     where(ownerships: { notifier: true })
   end
 
+  def self.without_mfa
+    where(mfa_level: "disabled")
+  end
+
   def name
     handle || email
   end

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -5,15 +5,19 @@
       <%= links_to_owners(rubygem) %>
     </div>
 
-    <% if rubygem.owned_by?(current_user) && rubygem.owners.without_mfa.present? %>
-      <span class="gem__users__mfa-text"><%= t '.not_using_mfa_warning_show' %></span>
+    <% if  rubygem.owned_by?(current_user) %>
+      <% if rubygem.owners.without_mfa.present? %>
+        <span class="gem__users__mfa-text mfa-warn"><%= t '.not_using_mfa_warning_show' %></span>
 
-      <div class="gem__users__mfa-disabled t-item--hidden">
-        <span class="gem__users__mfa-text t-item--hidden"><%= t '.not_using_mfa_warning_hide' %></span>
-        <div class="gem__users">
-          <%= links_to_owners_without_mfa(rubygem) %>
+        <div class="gem__users__mfa-disabled t-item--hidden">
+          <span class="gem__users__mfa-text mfa-warn t-item--hidden"><%= t '.not_using_mfa_warning_hide' %></span>
+          <div class="gem__users">
+            <%= links_to_owners_without_mfa(rubygem) %>
+          </div>
         </div>
-      </div>
+      <% else %>
+          <span class="gem__users__mfa-text mfa-info"><%= t '.using_mfa_info' %></span>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -5,8 +5,7 @@
       <%= links_to_owners(rubygem) %>
     </div>
 
-
-    <% if rubygem.owned_by?(current_user) %>
+    <% if rubygem.owned_by?(current_user) && rubygem.owners.without_mfa.present? %>
       <span class="gem__users__mfa-text"><%= t '.not_using_mfa_warning_show' %></span>
 
       <div class="gem__users__mfa-disabled t-item--hidden">

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -4,6 +4,18 @@
     <div class="gem__users">
       <%= links_to_owners(rubygem) %>
     </div>
+
+
+    <% if rubygem.owned_by?(current_user) %>
+      <span class="gem__users__mfa-text"><%= t '.not_using_mfa_warning_show' %></span>
+
+      <div class="gem__users__mfa-disabled t-item--hidden">
+        <span class="gem__users__mfa-text t-item--hidden"><%= t '.not_using_mfa_warning_hide' %></span>
+        <div class="gem__users">
+          <%= links_to_owners_without_mfa(rubygem) %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <% if latest_version.pusher.present? %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -290,6 +290,8 @@ de:
       header: "%{title} Abhängigkeiten"
     gem_members:
       authors_header: Autoren
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: Besitzer
       pushed_by:
       yanked_by:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -294,6 +294,7 @@ de:
       not_using_mfa_warning_hide:
       owners_header: Besitzer
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: SHA 256-Prüfsumme
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
       not_using_mfa_warning_hide: "* The following owners are not using MFA. Click to hide."
       owners_header: Owners
       pushed_by: Pushed by
+      using_mfa_info: "* All owners are using MFA."
       yanked_by: Yanked by
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,8 @@ en:
       header: "%{title} Dependencies"
     gem_members:
       authors_header: Authors
+      not_using_mfa_warning_show: "* Some owners are not using MFA. Click for the complete list."
+      not_using_mfa_warning_hide: "* The following owners are not using MFA. Click to hide."
       owners_header: Owners
       pushed_by: Pushed by
       yanked_by: Yanked by

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -304,6 +304,7 @@ es:
       not_using_mfa_warning_hide:
       owners_header: Propietarios
       pushed_by: Subida por
+      using_mfa_info:
       yanked_by: Borrada por
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -300,6 +300,8 @@ es:
       header: "dependencias de %{title}"
     gem_members:
       authors_header: Autores
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: Propietarios
       pushed_by: Subida por
       yanked_by: Borrada por

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -300,11 +300,11 @@ es:
       header: "dependencias de %{title}"
     gem_members:
       authors_header: Autores
-      not_using_mfa_warning_show:
-      not_using_mfa_warning_hide:
+      not_using_mfa_warning_show: "* Algunos propietarios no están usando MFA. Haga click para ver la lista completa."
+      not_using_mfa_warning_hide: "* Los siguientes propietarios no están usando MFA. Haga click para ocultar."
       owners_header: Propietarios
       pushed_by: Subida por
-      using_mfa_info:
+      using_mfa_info: "* Todos los propietarios están usando MFA."
       yanked_by: Borrada por
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -290,6 +290,8 @@ fr:
       header: Dépendances de %{title}
     gem_members:
       authors_header: Auteurs
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: Propriétaires
       pushed_by:
       yanked_by:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -294,6 +294,7 @@ fr:
       not_using_mfa_warning_hide:
       owners_header: Propriétaires
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: Total de contrôle SHA 256
     index:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -290,6 +290,8 @@ ja:
       header: "%{title}依存性"
     gem_members:
       authors_header: 作者
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: オーナー
       pushed_by:
       yanked_by:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -294,6 +294,7 @@ ja:
       not_using_mfa_warning_hide:
       owners_header: オーナー
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: SHA 256チェックサム
     index:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -291,6 +291,8 @@ nl:
     gem_members:
       authors_header:
       owners_header: Eigenaren
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       pushed_by:
       yanked_by:
       sha_256_checksum: SHA 256 checksum

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -294,6 +294,7 @@ nl:
       not_using_mfa_warning_show:
       not_using_mfa_warning_hide:
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -290,6 +290,8 @@ pt-BR:
       header:
     gem_members:
       authors_header: Autores
+      not_using_mfa_warning_show: "* Alguns donos não estão usando MFA. Clique para a lista completa."
+      not_using_mfa_warning_hide: "* Os seguintes donos não estão usando MFA. Clique para esconder."
       owners_header: Donos
       pushed_by:
       yanked_by:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -294,6 +294,7 @@ pt-BR:
       not_using_mfa_warning_hide: "* Os seguintes donos não estão usando MFA. Clique para esconder."
       owners_header: Donos
       pushed_by:
+      using_mfa_info: "* Todos os donos estão usando MFA."
       yanked_by:
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -294,6 +294,7 @@ zh-CN:
       not_using_mfa_warning_hide:
       owners_header: 所有者
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: SHA 256 checksum
     index:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -290,6 +290,8 @@ zh-CN:
       header: "%{title} 依赖关系"
     gem_members:
       authors_header: 作者
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: 所有者
       pushed_by:
       yanked_by:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -290,6 +290,8 @@ zh-TW:
       header: "%{title} 相依性套件"
     gem_members:
       authors_header: 作者
+      not_using_mfa_warning_show:
+      not_using_mfa_warning_hide:
       owners_header: 擁有者
       pushed_by:
       yanked_by:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -294,6 +294,7 @@ zh-TW:
       not_using_mfa_warning_hide:
       owners_header: 擁有者
       pushed_by:
+      using_mfa_info:
       yanked_by:
       sha_256_checksum: SHA 256 checksum
     index:

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -86,9 +86,10 @@ class GemsSystemTest < SystemTest
     visit rubygem_path(@rubygem, as: @user.id)
 
     assert page.has_selector?(".gem__users__mfa-disabled .gem__users a")
+    assert page.has_selector?(".gem__users__mfa-text.mfa-warn")
   end
 
-  test "does not show mfa warning when logged in as owner but everyone has mfa enabled" do
+  test "show mfa enabled when logged in as owner but everyone has mfa enabled" do
     @user.enable_mfa!("some-seed", "ui_and_api")
     user_with_mfa = create(:user, mfa_level: "ui_only")
 
@@ -96,7 +97,8 @@ class GemsSystemTest < SystemTest
 
     visit rubygem_path(@rubygem, as: @user.id)
 
-    assert page.has_no_selector?(".gem__users__mfa-text")
+    assert page.has_no_selector?(".gem__users__mfa-text.mfa-warn")
+    assert page.has_selector?(".gem__users__mfa-text.mfa-info")
   end
 
   test "does not show owners without mfa when not logged in as owner" do
@@ -108,5 +110,7 @@ class GemsSystemTest < SystemTest
     visit rubygem_path(@rubygem)
 
     assert page.has_no_selector?(".gem__users__mfa-disabled .gem__users a")
+    assert page.has_no_selector?(".gem__users__mfa-text.mfa-warn")
+    assert page.has_no_selector?(".gem__users__mfa-text.mfa-info")
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -88,6 +88,17 @@ class GemsSystemTest < SystemTest
     assert page.has_selector?(".gem__users__mfa-disabled .gem__users a")
   end
 
+  test "does not show mfa warning when logged in as owner but everyone has mfa enabled" do
+    @user.enable_mfa!("some-seed", "ui_and_api")
+    user_with_mfa = create(:user, mfa_level: "ui_only")
+
+    @rubygem.owners << [@user, user_with_mfa]
+
+    visit rubygem_path(@rubygem, as: @user.id)
+
+    assert page.has_no_selector?(".gem__users__mfa-text")
+  end
+
   test "does not show owners without mfa when not logged in as owner" do
     @user.enable_mfa!("some-seed", "ui_and_api")
     user_without_mfa = create(:user, mfa_level: "disabled")

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -76,4 +76,26 @@ class GemsSystemTest < SystemTest
     assert page.has_content? "Subscribe"
     assert_empty @user.subscribed_gems
   end
+
+  test "shows owners without mfa when logged in as owner" do
+    @user.enable_mfa!("some-seed", "ui_and_api")
+    user_without_mfa = create(:user, mfa_level: "disabled")
+
+    @rubygem.owners << [@user, user_without_mfa]
+
+    visit rubygem_path(@rubygem, as: @user.id)
+
+    assert page.has_selector?(".gem__users__mfa-disabled .gem__users a")
+  end
+
+  test "does not show owners without mfa when not logged in as owner" do
+    @user.enable_mfa!("some-seed", "ui_and_api")
+    user_without_mfa = create(:user, mfa_level: "disabled")
+
+    @rubygem.owners << [@user, user_without_mfa]
+
+    visit rubygem_path(@rubygem)
+
+    assert page.has_no_selector?(".gem__users__mfa-disabled .gem__users a")
+  end
 end

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -37,7 +37,7 @@ class YankTest < SystemTest
     assert page.has_content?("Yanked by")
 
     css = %(div.gem__users a[alt=#{@user.handle}])
-    assert page.has_css?(css, count: 2)
+    assert page.has_css?(css, count: 3)
   end
 
   test "yanked gem entirely then someone else pushes a new version" do

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -120,7 +120,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
     should "create links to gem owners without mfa" do
       with_mfa = create(:user, mfa_level: "ui_and_api")
-      without_mfa = Array.new(2) { create(:user, mfa_level: "disabled") }
+      without_mfa = create_list(:user, 2, mfa_level: "disabled")
       rubygem = create(:rubygem, owners: [*without_mfa, with_mfa])
 
       expected_links = without_mfa.sort_by(&:id).map do |u|

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -117,6 +117,21 @@ class RubygemsHelperTest < ActionView::TestCase
       assert_equal expected_links, links_to_owners(@rubygem)
       assert links_to_owners(@rubygem).html_safe?
     end
+
+    should "create links to gem owners without mfa" do
+      with_mfa = create(:user, mfa_level: "ui_and_api")
+      without_mfa = Array.new(2) { create(:user, mfa_level: "disabled") }
+      rubygem = create(:rubygem, owners: [*without_mfa, with_mfa])
+
+      expected_links = without_mfa.sort_by(&:id).map do |u|
+        link_to gravatar(48, "gravatar-#{u.id}", u),
+          profile_path(u.display_id),
+          alt: u.display_handle,
+          title: u.display_handle
+      end.join
+      assert_equal expected_links, links_to_owners_without_mfa(rubygem)
+      assert links_to_owners_without_mfa(rubygem).html_safe?
+    end
   end
 
   context "simple_markup" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -307,6 +307,20 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context ".without_mfa" do
+    setup do
+      create(:user, handle: "has_mfa", mfa_level: "ui_and_api")
+      create(:user, handle: "no_mfa", mfa_level: "disabled")
+    end
+
+    should "return only users without mfa" do
+      users_without_mfa = User.without_mfa
+
+      assert_equal 1, users_without_mfa.size
+      assert_equal "no_mfa", users_without_mfa.first.handle
+    end
+  end
+
   context "rubygems" do
     setup do
       @user     = create(:user)


### PR DESCRIPTION
As a response to recent gem exploits, we are seeing an increased desire to ensure all gem owners are using MFA.

This PR adds a way for gem owners to check if their fellow owners are using MFA. Regular users **can't** see this. 

The following gif shows the behavior when logged in as an owner and MFA is not enabled for everyone:

![rubygem_owner_view](https://user-images.githubusercontent.com/5934604/65086159-1bb26800-d987-11e9-8e62-bf46f3fe364f.gif)

The following screenshot shows the behavior when logged in as an owner and MFA is enabled for everyone:

![image](https://user-images.githubusercontent.com/5934604/65149909-5e148d00-d9f9-11e9-9b14-aacc920da599.png)