### PR TITLE
Add ruolo to gem typo exceptions

### DIFF
--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -7,7 +7,7 @@ class GemTypo
 
   DOWNLOADS_THRESHOLD = 10_000_000
   SIZE_THRESHOLD = 4
-  EXCEPTIONS = %w[strait upguard].freeze
+  EXCEPTIONS = %w[ruolo strait upguard].freeze
 
   def initialize(rubygem_name)
     @rubygem_name       = rubygem_name.downcase


### PR DESCRIPTION
I have been trying to publish a gem (source: https://github.com/mfinelli/ruolo) but it keeps getting denied for being too close to "roo". I didn't dig into how you calculate this but I don't think people will confuse "ruolo" (a gem for rbac) with "roo" a gem for dealing with excel files. This PR adds ruolo to the exception list.