### PR TITLE
Remove exact match from search page

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,9 +5,6 @@ class SearchesController < ApplicationController
     return unless params[:query]&.is_a?(String)
     @error_msg, @gems = ElasticSearcher.new(params[:query], page: @page).search
     limit_total_count if @gems.total_count > Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
-
-    @exact_match = Rubygem.name_is(params[:query]).with_versions.first
-    redirect_to rubygem_path(@exact_match) if @exact_match && @gems.size == 1
   end
 
   def advanced

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -9,17 +9,7 @@
 <% if @gems %>
   <% @subtitle = t('.subtitle', :query => content_tag(:em, h(params[:query]))) %>
 
-  <% if @exact_match %>
-    <header class="gems__header">
-      <p class="gems__meter"><%= t '.exact_match' %></p>
-    </header>
-    <% content_for :head do %>
-      <link rel="prerender prefetch" href="<%= rubygem_url(@exact_match) %>">
-    <% end %>
-    <%= render partial: 'rubygems/rubygem', object: @exact_match %>
-  <% end %>
-
-  <header class="gems__header push">
+  <header class="gems__header push--s">
     <p class="gems__meter"><%= page_entries_info(@gems, :entry_name => 'gem').html_safe %></p>
   </header>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -322,7 +322,6 @@ de:
       downloads:
       updated:
     show:
-      exact_match: Exakte Übereinstimmung
       subtitle: für %{query}
       month_update:
       week_update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,7 +332,6 @@ en:
       downloads: Downloads
       updated: Updated
     show:
-      exact_match: Exact match
       subtitle: for %{query}
       month_update: Updated last month (%{count})
       week_update: Updated last week (%{count})

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -332,7 +332,6 @@ es:
       downloads: Descargas
       updated: Actualizada
     show:
-      exact_match: Coincidencia exacta
       subtitle: para %{query}
       month_update: Actualizadas en el último mes (%{count})
       week_update: Actualizadas en la última semana (%{count})

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -322,7 +322,6 @@ fr:
       downloads: Téléchargements
       updated: Mis à jour
     show:
-      exact_match: Titre exact
       subtitle: pour %{query}
       month_update:
       week_update:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -322,7 +322,6 @@ ja:
       downloads: ダウンロード数
       updated: 更新日
     show:
-      exact_match: 完全一致
       subtitle: '%{query}の検索結果'
       month_update:
       week_update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -322,7 +322,6 @@ nl:
       downloads:
       updated:
     show:
-      exact_match: Exacte match
       subtitle: voor %{query}
       month_update:
       week_update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -322,7 +322,6 @@ pt-BR:
       downloads:
       updated:
     show:
-      exact_match: Busca exata
       subtitle: para %{query}
       month_update:
       week_update:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -322,7 +322,6 @@ zh-CN:
       downloads: 下载数
       updated: 更新时间
     show:
-      exact_match: 精确匹配
       subtitle: "%{query}"
       month_update:
       week_update:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -322,7 +322,6 @@ zh-TW:
       downloads: 下載數
       updated: 最後更新時間
     show:
-      exact_match: 完全符合
       subtitle: "%{query}"
       month_update:
       week_update:

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -84,18 +84,6 @@ class SearchesControllerTest < ActionController::TestCase
     end
   end
 
-  context "on GET to show with search parameters with a single exact match" do
-    setup do
-      @sinatra = create(:rubygem, name: "sinatra")
-      create(:version, rubygem: @sinatra)
-      import_and_refresh
-      get :show, params: { query: "sinatra" }
-    end
-
-    should respond_with :redirect
-    should redirect_to("the gem") { rubygem_path(@sinatra) }
-  end
-
   context "on GET to show with non string search parameter" do
     setup do
       get :show, params: { query: { foo: "bar" } }

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -14,7 +14,6 @@ class SearchTest < SystemTest
     click_button "search_submit"
 
     assert page.has_content? "LDAP"
-    assert page.has_content? "Exact match"
 
     assert page.has_content? "LDAP-PLUS"
   end
@@ -36,7 +35,6 @@ class SearchTest < SystemTest
     rubygem = create(:rubygem, name: "LDAP")
     create(:version, rubygem: rubygem, number: "1.1.1", indexed: true)
     create(:version, rubygem: rubygem, number: "2.2.2", indexed: false)
-    create(:version, rubygem: rubygem, number: "3.3.3", indexed: true)
     import_and_refresh
 
     visit search_path
@@ -46,7 +44,6 @@ class SearchTest < SystemTest
 
     assert page.has_content?("1.1.1")
     refute page.has_content?("2.2.2")
-    assert page.has_content?("3.3.3")
   end
 
   test "search page with a non valid format" do


### PR DESCRIPTION
this was needed when we were using postgres search, exact match
may have been buried in results.
this is not an issue with elasticsearch, exact match would get highest
score and always be first/top result.

Closes: #2137, #2049, #1709