### PR TITLE
Please don't index /names

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /downloads/
 Disallow: /gems?letter=*
 Disallow: /search?*
+Disallow: /names


### PR DESCRIPTION
Just noticed this URL popped up in Google. Let's not index this and confuse anyone else (Myself included):

<img width="785" alt="Screen Shot 2019-10-07 at 16 23 52" src="https://user-images.githubusercontent.com/12610/66345849-dd252300-e91e-11e9-9d12-b6249c82fdc4.png">
