### PR TITLE
Update contributing.md for running js tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ Follow the instructions below on how to install Bundler and setup the database.
   * Setup information: `brew info postgresql`
 * Install memcached: `brew install memcached`
   * Show all memcached options: `memcached -h`
+* Install Google-Chrome: `brew cask install google-chrome`
 
 #### Environment (Linux - Debian/Ubuntu)
 
@@ -94,6 +95,9 @@ Follow the instructions below on how to install Bundler and setup the database.
   * Help to setup database <https://wiki.debian.org/PostgreSql>
 * Install memcached: `apt-get install memcached`
   * Show all memcached options: `memcached -h`
+* Install Google-Chrome:
+  * Download latest stable: `wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
+  * Install chrome: sudo dpkg -i google-chrome-stable_current_amd64.deb
 
 #### Getting the code
 


### PR DESCRIPTION
Added chrome installation for js testing using selenium headless chrome

This is part of the following pull request where js testing is required:
https://github.com/rubygems/rubygems.org/pull/2029