### PR TITLE
Add PROFILE env variable dev switch for perf work

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,31 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Rubygems.org checks for the presence of an env variable called PROFILE that
+  # switches several settings to a more "production-like" value for profiling
+  # and benchmarking the application locally. All changes you make to the app
+  # will require restart.
+  if ENV['PROFILE']
+    config.cache_classes = true
+    config.eager_load = true
+
+    config.logger = ActiveSupport::Logger.new(STDOUT)
+    config.log_level = :info
+
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {
+      'Cache-Control' => 'max-age=315360000, public',
+      'Expires' => 'Thu, 31 Dec 2037 23:55:55 GMT'
+    }
+    config.assets.js_compressor = :uglifier
+    config.assets.css_compressor = :sass
+    config.assets.compile = false
+    config.assets.digest = true
+    config.assets.debug = false
+
+    config.active_record.migration_error = false
+    config.active_record.verbose_query_logs = false
+    config.action_view.cache_template_loading = true
+  end
 end


### PR DESCRIPTION
See commit message for more reasoning about why I think this should be added.

I decided to put it all in one block at the end so that it was in just one area of the config rather than all over the place. Makes it easier for others to ignore. I think it's better that this lives in development.rb rather than somewhere else so that it can only be used with RAILS_ENV=development, though we could potentially use an initializer instead that also checked `Rails.env`.