### PR TITLE
Expose the default gems for Ruby 2.7.

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -10,13 +10,10 @@ module Patterns
   GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64
-    benchmark
-    cgi
     cgi-session
     complex
     continuation
     coverage
-    delegate
     digest
     drb
     english
@@ -25,7 +22,6 @@ module Patterns
     expect
     fiber
     find
-    getoptlong
     install
     io-nonblock
     io-wait
@@ -37,13 +33,10 @@ module Patterns
     net-ftp
     net-http
     net-imap
-    net-pop
     net-protocol
-    net-smtp
     nkf
     observer
     open-uri
-    open3
     optparse
     pathname
     pp
@@ -51,7 +44,6 @@ module Patterns
     prime
     profile
     profiler
-    pstore
     pty
     rational
     rbconfig
@@ -63,7 +55,6 @@ module Patterns
     securerandom
     set
     shellwords
-    singleton
     socket
     syslog
     tempfile


### PR DESCRIPTION
Related with https://github.com/rubygems/rubygems.org/pull/1932.

I have a plan to ship default gems for Ruby 2.7. This pull request will expose the release ready libraries.