### PR TITLE
Fix factories in Version tests, make tests 25% faster

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -332,6 +332,10 @@ class Version < ApplicationRecord
     Deletion.find_by(rubygem: rubygem.name, number: number, platform: platform)&.user unless indexed
   end
 
+  def prerelease
+    self[:prerelease] || !!to_gem_version.prerelease?
+  end
+
   private
 
   def platform_and_number_are_unique
@@ -348,7 +352,7 @@ class Version < ApplicationRecord
   end
 
   def update_prerelease
-    self[:prerelease] = !!to_gem_version.prerelease? # rubocop:disable Style/DoubleNegation
+    self[:prerelease] = prerelease
   end
 
   def full_nameify!

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -333,7 +333,7 @@ class Version < ApplicationRecord
   end
 
   def prerelease
-    self[:prerelease] || !!to_gem_version.prerelease?
+    self[:prerelease] ||= !!to_gem_version.prerelease?
   end
 
   private
@@ -349,10 +349,6 @@ class Version < ApplicationRecord
     string_authors = authors.is_a?(Array) && authors.grep(String)
     return unless string_authors.blank? || string_authors.size != authors.size
     errors.add :authors, "must be an Array of Strings"
-  end
-
-  def update_prerelease
-    self[:prerelease] = prerelease
   end
 
   def full_nameify!

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
       if evaluator.linkset
         rubygem.linkset = evaluator.linkset
       else
-        create(:linkset, rubygem: rubygem)
+        build(:linkset, rubygem: rubygem)
       end
     end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -6,11 +6,13 @@ class VersionTest < ActiveSupport::TestCase
 
   context "#as_json" do
     setup do
-      @version = create(:version, summary: "some words")
+      @version = build(:version, summary: "some words")
     end
 
     should "only have relevant API fields" do
+      @version.send(:update_prerelease) # called usually on save, calling here to set prerelease properly
       json = @version.as_json
+
       fields = %w[number built_at summary description authors platform
                   ruby_version rubygems_version prerelease downloads_count licenses
                   requirements sha metadata created_at]
@@ -28,13 +30,12 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal @version.summary, json["summary"]
       assert_equal @version.licenses, json["licenses"]
       assert_equal @version.requirements, json["requirements"]
-      assert_equal @version.created_at, json["created_at"]
     end
   end
 
   context "#to_xml" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
     end
 
     should "only have relevant API fields" do
@@ -186,7 +187,7 @@ class VersionTest < ActiveSupport::TestCase
   context "with a rubygems version" do
     setup do
       @required_rubygems_version = ">= 2.6.4"
-      @version = create(:version)
+      @version = build(:version)
     end
 
     should "have a rubygems version" do
@@ -198,7 +199,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "without a rubygems version" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
     end
 
     should "not have a rubygems version" do
@@ -211,7 +212,7 @@ class VersionTest < ActiveSupport::TestCase
   context "with a ruby version" do
     setup do
       @required_ruby_version = ">= 1.9.3"
-      @version = create(:version)
+      @version = build(:version)
     end
     subject { @version }
 
@@ -225,7 +226,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "without a ruby version" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
     end
     subject { @version }
 
@@ -239,7 +240,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a version" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
       @info = "some info"
     end
     subject { @version }
@@ -263,6 +264,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "save full name" do
+      @version.save!
       assert_equal "#{@version.rubygem.name}-#{@version.number}", @version.full_name
       assert_equal @version.number, @version.slug
     end
@@ -335,7 +337,7 @@ class VersionTest < ActiveSupport::TestCase
 
     context "#to_bundler" do
       should "give feature release version and bugfix up to current version for patched versions" do
-        patched_version = create(:version, number: "1.0.3")
+        patched_version = build(:version, number: "1.0.3")
         name = patched_version.rubygem.name
         actual = patched_version.to_bundler
         expected = %(gem '#{name}', '~> 1.0', '>= 1.0.3')
@@ -344,7 +346,7 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "give only feature release version if no bug fix" do
-        no_bugfix = create(:version, number: "1.0")
+        no_bugfix = build(:version, number: "1.0")
         name = no_bugfix.rubygem.name
         actual = no_bugfix.to_bundler
         expected = %(gem '#{name}', '~> 1.0')
@@ -353,7 +355,7 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "give only feature release version if long version specified with no bugfix" do
-        long_version = create(:version, number: "1.0.0.0")
+        long_version = build(:version, number: "1.0.0.0")
         name = long_version.rubygem.name
         actual = long_version.to_bundler
         expected = %(gem '#{name}', '~> 1.0')
@@ -362,7 +364,7 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "give feature release version up to current version if long version specified with bugfix" do
-        long_version = create(:version, number: "1.0.3.0")
+        long_version = build(:version, number: "1.0.3.0")
         name = long_version.rubygem.name
         actual = long_version.to_bundler
         expected = %(gem '#{name}', '~> 1.0', '>= 1.0.3.0')
@@ -371,7 +373,7 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "give bugfix version if < 1.0.0" do
-        early_version = create(:version, number: "0.1.2")
+        early_version = build(:version, number: "0.1.2")
         name = early_version.rubygem.name
         actual = early_version.to_bundler
         expected = %(gem '#{name}', '~> 0.1.2')
@@ -453,11 +455,11 @@ class VersionTest < ActiveSupport::TestCase
 
   context "when indexing" do
     setup do
-      @rubygem = create(:rubygem)
-      @first_version  = create(:version, rubygem: @rubygem, number: "0.0.1", built_at: 7.days.ago)
-      @second_version = create(:version, rubygem: @rubygem, number: "0.0.2", built_at: 6.days.ago)
-      @third_version  = create(:version, rubygem: @rubygem, number: "0.0.3", built_at: 5.days.ago)
-      @fourth_version = create(:version, rubygem: @rubygem, number: "0.0.4", built_at: 5.days.ago)
+      @rubygem = build(:rubygem)
+      @first_version  = build(:version, rubygem: @rubygem, number: "0.0.1", built_at: 7.days.ago)
+      @second_version = build(:version, rubygem: @rubygem, number: "0.0.2", built_at: 6.days.ago)
+      @third_version  = build(:version, rubygem: @rubygem, number: "0.0.3", built_at: 5.days.ago)
+      @fourth_version = build(:version, rubygem: @rubygem, number: "0.0.4", built_at: 5.days.ago)
     end
 
     should "always sort properly" do
@@ -515,8 +517,8 @@ class VersionTest < ActiveSupport::TestCase
       @gem = create(:rubygem)
       create(:version, rubygem: @gem, number: "0.5")
       create(:version, rubygem: @gem, number: "0.3")
-      create(:version, rubygem: @gem, number: "0.7")
-      create(:version, rubygem: @gem, number: "0.2")
+      @version_one_latest = create(:version, rubygem: @gem, number: "0.7")
+      @version_one_earlier = create(:version, rubygem: @gem, number: "0.2")
       @gem.reload # make sure to reload the versions just created
     end
 
@@ -527,24 +529,21 @@ class VersionTest < ActiveSupport::TestCase
     should "know its latest version" do
       assert_equal "0.7", @gem.versions.most_recent.number
     end
-  end
 
-  context "with multiple rubygems and versions created out of order" do
-    setup do
-      @gem_one = create(:rubygem)
-      @gem_two = create(:rubygem)
-      @version_one_latest  = create(:version, rubygem: @gem_one, number: "0.2")
-      @version_one_earlier = create(:version, rubygem: @gem_one, number: "0.1")
-      @version_two_latest  = create(:version, rubygem: @gem_two, number: "1.0")
-      @version_two_earlier = create(:version, rubygem: @gem_two, number: "0.5")
-    end
+    context "with multiple rubygems and versions created out of order" do
+      setup do
+        @gem_two = create(:rubygem)
+        @version_two_latest  = create(:version, rubygem: @gem_two, number: "1.0")
+        @version_two_earlier = create(:version, rubygem: @gem_two, number: "0.5")
+      end
 
-    should "be able to fetch the latest versions" do
-      assert_contains Version.latest.map(&:id), @version_one_latest.id
-      assert_contains Version.latest.map(&:id), @version_two_latest.id
+      should "be able to fetch the latest versions" do
+        assert_contains Version.latest.map(&:id), @version_one_latest.id
+        assert_contains Version.latest.map(&:id), @version_two_latest.id
 
-      assert_does_not_contain Version.latest.map(&:id), @version_one_earlier.id
-      assert_does_not_contain Version.latest.map(&:id), @version_two_earlier.id
+        assert_does_not_contain Version.latest.map(&:id), @version_one_earlier.id
+        assert_does_not_contain Version.latest.map(&:id), @version_two_earlier.id
+      end
     end
   end
 
@@ -753,28 +752,28 @@ class VersionTest < ActiveSupport::TestCase
 
   context "checksums" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
     end
 
     should "be available from the database" do
       assert_equal "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=",
-        @version.reload.sha256
+        @version.sha256
     end
 
     should "convert to hex on sha256_hex" do
       assert_equal "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
-        @version.reload.sha256_hex
+        @version.sha256_hex
     end
 
     should "should return nil on sha256_hex when sha not avaible" do
-      version = create(:version, sha256: nil)
-      assert_nil version.sha256_hex
+      @version.sha256 = nil
+      assert_nil @version.sha256_hex
     end
   end
 
   context "created_between" do
     setup do
-      @version = create(:version)
+      @version = build(:version)
       @start_time = Time.zone.parse("2017-10-10")
       @end_time = Time.zone.parse("2017-11-10")
     end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -6,7 +6,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "#as_json" do
     setup do
-      @version = build(:version, summary: "some words", created_at: Time.now)
+      @version = build(:version, summary: "some words", created_at: Time.now.in_time_zone)
     end
 
     should "only have relevant API fields" do

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -305,6 +305,7 @@ class VersionTest < ActiveSupport::TestCase
         number: "0.4.0.pre")
 
       assert @version.prerelease
+      assert @version.read_attribute(:prerelease) # This checks to see if the callback worked
       assert new_version.prerelease
 
       @version.rubygem.reorder_versions
@@ -483,8 +484,8 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with mixed release and prerelease versions" do
     setup do
-      @prerelease = create(:version, number: "1.0.rc1")
-      @release    = create(:version, number: "1.0")
+      @prerelease = build(:version, number: "1.0.rc1")
+      @release    = build(:version, number: "1.0")
     end
 
     should "know if it is a prelease version" do
@@ -493,6 +494,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "return prerelease gems from the prerelease named scope" do
+      [@prerelease, @release].each(&:save!)
       assert_equal [@prerelease], Version.prerelease
       assert_equal [@release],    Version.release
     end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -10,7 +10,6 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "only have relevant API fields" do
-      @version.send(:update_prerelease) # called usually on save, calling here to set prerelease properly
       json = @version.as_json
 
       fields = %w[number built_at summary description authors platform

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -6,7 +6,7 @@ class VersionTest < ActiveSupport::TestCase
 
   context "#as_json" do
     setup do
-      @version = build(:version, summary: "some words")
+      @version = build(:version, summary: "some words", created_at: Time.now)
     end
 
     should "only have relevant API fields" do
@@ -19,6 +19,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal fields.map(&:to_s).sort, json.keys.sort
       assert_equal @version.authors, json["authors"]
       assert_equal @version.built_at, json["built_at"]
+      assert_equal @version.created_at, json["created_at"]
       assert_equal @version.description, json["description"]
       assert_equal @version.downloads_count, json["downloads_count"]
       assert_equal @version.metadata, json["metadata"]

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -755,11 +755,6 @@ class VersionTest < ActiveSupport::TestCase
       @version = build(:version)
     end
 
-    should "be available from the database" do
-      assert_equal "tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=",
-        @version.sha256
-    end
-
     should "convert to hex on sha256_hex" do
       assert_equal "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
         @version.sha256_hex


### PR DESCRIPTION
Before:
```
$ bundle exec ruby -Iapp -Ilib -Itest test/unit/version_test.rb
...
Finished in 2.197927s, 36.8529 runs/s, 74.6158 assertions/s.

$ rake test
...
Finished in 73.659252s, 17.1194 runs/s, 32.2295 assertions/s
```

After:
```
$ bundle exec ruby -Iapp -Ilib -Itest test/unit/version_test.rb
...
Finished in 1.511227s, 53.5988 runs/s, 107.8594 assertions/s.

$ rake test 
...
Finished in 52.842494s, 23.8634 runs/s, 44.9070 assertions/s.
```

The gains in the suite are probably from fixing/removing the linkset creation. 

This test class still creates way too many records, but the next step will be refactoring test setup for the scope tests, which will be a lot more work than what I've done here!