### PR TITLE
Tell people to use `gem signin` instead of curl.

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -79,7 +79,7 @@
       <%= t('.api_access.credentials_html', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
                                             :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))) %>
     </p>
-    <pre><code>curl -u <%= current_user.name %> https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials</code></pre>
+    <pre><code>gem signin</code></pre>
   </div>
 <% end %>
 


### PR DESCRIPTION
Fixes #2026.

The text before the command still makes sense, but there's no need to mention the file it generates. I don't know how i18n-related stuff is typically handled for rubygems.org, however, so for now I only changed the command.