### PR TITLE
Fix nokogiri error when running rake tasks inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apk add --no-cache \
   ca-certificates \
   bash \
   tzdata \
+  xz-libs \
   && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /app


### PR DESCRIPTION
master is currently breaking in CI due to Nokogiri trying to load a
dynamic library:

Example Build: https://travis-ci.org/rubygems/rubygems.org/jobs/632830328

```
LoadError: Error loading shared library liblzma.so.5: No such file or directory (needed by /usr/local/bundle/ruby/2.6.0/gems/nokogiri-1.10.5/lib/nokogiri/nokogiri.so) - /usr/local/bundle/ruby/2.6.0/gems/nokogiri-1.10.5/lib/nokogiri/nokogiri.so

/usr/local/bundle/ruby/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'

/usr/local/bundle/ruby/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
```

It appears that this library used to be shipped in the ruby alpine
docker image but is no longer the case.

This fix installs the package that holds this library so rake/rails inside docker
is able to run again.