### PR TITLE
Use jQuery 3 framework

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require jquery
+//= require jquery3
 //= require jquery_ujs
 //= require clipboard
 //= require github_buttons


### PR DESCRIPTION
There is currently an error in the console being raised for Firefox browsers which is coming from jQuery in relation to our CSP headers. (we don't allow scripts to edit inline attributes in the CSP)

    Content Security Policy: The page’s settings blocked the loading of a resource at inline (“script-src”).

There are two possible fixes for this issue. Firstly is to allow `unsafe_inline` in the CSP policy, which i don't believe the security trade-off is worth the risk of reducing the possibility of XSS.

The second fix is to update jQuery from 1.x to 3.x which doesn't cause this issue. I think this is the better solution, the version jump is huge but our use of JS is fairly minimal and uses very stable APIs. I've gone through the pages that has javascript functionality and checked to make sure that everything still works.

closes #2196 