### PR TITLE
move Brakeman into the Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_install:
 
 before_script:
   - gem install bundler-audit -v 0.6.1
-  - gem install brakeman -v 4.3.1
   - bundle audit update
   - cp config/database.yml.example config/database.yml
   - bundle exec rake db:create db:migrate db:test:prepare
@@ -47,7 +46,7 @@ script:
   - bundle exec rails test
   - bundle exec rake rubocop
   - bundle audit check
-  - brakeman -c config/brakeman.yml -o /dev/stdout
+  - bundle exec brakeman
   - script/build_docker.sh
 
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-performance", require: false
+  gem "brakeman", require: false
   gem "toxiproxy", "~> 1.0.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       msgpack
     bootsnap (1.4.5)
       msgpack (~> 1.0)
+    brakeman (4.7.2)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (2.18.0)
@@ -403,6 +404,7 @@ DEPENDENCIES
   autoprefixer-rails
   aws-sdk (~> 2.2)
   bootsnap
+  brakeman
   capybara (~> 2.18)
   clearance
   clearance-deprecated_password_strategies


### PR DESCRIPTION
We use the [Brakeman](https://rubygems.org/gems/brakeman) gem to scan the rubygems.org code base for any security related issues during CI, but we install this gem manually via `gem install`.

https://github.com/rubygems/rubygems.org/blob/8e1d619ea19d918fcafd353278d6fd9d8a5f0555/.travis.yml#L41

We should make this part of the application via the Gemfile so other people can run it and also let Dependabot keep it up to date.