### PR TITLE
Update Bundler to 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,4 +465,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Good practice to keep Bundler up to date. I don't expect any major issues with jumping over to `2.x` in production