### PR TITLE
Confirm email when blocking user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,6 +221,7 @@ class User < ApplicationRecord
   def block!
     transaction do
       update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{id}-#{handle}@rubygems.org")
+      confirm_email!
       disable_mfa!
       update!(
         password: SecureRandom.alphanumeric,


### PR DESCRIPTION
If we don't confirm the email address when blocking the user, the next call to `update!` might fail the validation check.