### PR TITLE
Update `json` gem to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.2.0)
+    json (2.3.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)


### PR DESCRIPTION
Running any `rake` command on ruby-dev is causing an exception to raise and not make it possible to run tests/setup database etc.

[Example failing build](https://github.com/rubygems/rubygems.org/pull/2210/checks?check_run_id=404943595#step:5:1386)

```
rake aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
Traceback (most recent call last):
        ...
        2: from /Users/colby/.asdf/installs/ruby/2.7.0-dev/lib/ruby/gems/2.8.0/gems/json-2.2.0/lib/json/common.rb:156:in `new'
        1: from /Users/colby/.asdf/installs/ruby/2.7.0-dev/lib/ruby/gems/2.8.0/gems/json-2.2.0/lib/json/common.rb:156:in `initialize'
```

This error is coming from the `json` gem and the simple fix to resolve the problem is to just update the gem.