### PR TITLE
Add Github funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: [rubytogether.org, rubycentral.org]


### PR DESCRIPTION
Add custom links so Github can display the funding links in the header.