### PR TITLE
Update CSP to allow connect-src to https://fastly-insights.com

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.config.content_security_policy do |policy|
     policy.object_src  :none
     policy.script_src  :self, "https://secure.gaug.es", "https://www.fastly-insights.com"
     policy.style_src   :self, "https://fonts.googleapis.com"
-    policy.connect_src :self, "https://s3-us-west-2.amazonaws.com/rubygems-dumps/", "https://*.fastly-insights.com", "https://api.github.com"
+    policy.connect_src :self, "https://s3-us-west-2.amazonaws.com/rubygems-dumps/", "https://*.fastly-insights.com", "https://fastly-insights.com", "https://api.github.com"
   end
 
   # Specify URI for violation reports


### PR DESCRIPTION
There is currently a bunch of errors showing up in the JS console that relates to the Fastly Insights scripts trying to talk to `https://fastly-insights.com` and violating our CSP policy.

    insights.js?k=3e63c3cd-fc37-4b19-80b9-65ce64af060a:55 Refused to connect to 'https://fastly-insights.com/api/v1/config/3e63c3cd-fc37-4b19-80b9-65ce64af060a' because it violates the following Content Security Policy directive: "connect-src 'self' https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com https://api.github.com".

This PR adds an entry for `https://fastly-insights.com` into our CSP to resolve the issue.

resolves #2214 