### PR TITLE
Fix postgres docker image now requiring a password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:9.6
     ports:
       - "5432:5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   cache:
     image: memcached
     ports:


### PR DESCRIPTION
The Postgresql docker image was recently updated to require a password to be set when starting the image:

```
$ docker-compose up db
Starting rubygemsorg_db_1 ... done
Attaching to rubygemsorg_db_1
db_1      | Error: Database is uninitialized and superuser password is not specified.
db_1      |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1      |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1      |
db_1      |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1      |        connections without a password. This is *not* recommended.
db_1      |
db_1      |        See PostgreSQL documentation about "trust":
db_1      |        https://www.postgresql.org/docs/current/auth-trust.html
rubygemsorg_db_1 exited with code 1
```

We probably want to keep the same behavior of not needing to set a password for the docker images used for development.

This PR adds the `POSTGRES_HOST_AUTH_METHOD=trust` environment variable to allow the Postgres docker image to start without a password set.