### PR TITLE
Fix Dockerfile build failing to precompile assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
   tzdata \
   && rm -rf /var/cache/apk/*
 
-RUN mkdir -p /app /app/config
+RUN mkdir -p /app /app/config /app/log/
 WORKDIR /app
 
 RUN gem update --system 2.6.10


### PR DESCRIPTION
The delayed job initialiser was failing to write to /app/log/delayed_job.log, causing precompilation to fail

I received the following error message when attempting to run `docker build .`

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /app/log/delayed_job.log
```

Creating the /app/log directory in the Dockerfile fixed this