### PR TITLE
Rubygem ownership checks w/more performant methods

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -123,7 +123,7 @@ class Rubygem < ApplicationRecord
   end
 
   def unowned?
-    ownerships.blank?
+    ownerships.empty?
   end
 
   def indexed_versions?
@@ -132,7 +132,7 @@ class Rubygem < ApplicationRecord
 
   def owned_by?(user)
     return false unless user
-    ownerships.exists?(user_id: user.id)
+    ownerships.any? { |o| o.user_id == user.id }
   end
 
   def to_s

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -338,24 +338,23 @@ class RubygemTest < ActiveSupport::TestCase
 
     context "with a user" do
       setup do
-        @rubygem.save
-        @user = create(:user)
+        @user = build(:user)
       end
 
       should "be owned by a user in ownership" do
-        create(:ownership, user: @user, rubygem: @rubygem)
+        @rubygem.ownerships.new(user: @user)
         assert @rubygem.owned_by?(@user)
         refute @rubygem.unowned?
       end
 
       should "be not owned if no ownerships" do
-        assert @rubygem.ownerships.empty?
+        assert_empty @rubygem.ownerships
         refute @rubygem.owned_by?(@user)
         assert @rubygem.unowned?
       end
 
       should "be not owned if no user" do
-        assert_equal false, @rubygem.owned_by?(nil)
+        refute @rubygem.owned_by?(nil)
         assert @rubygem.unowned?
       end
     end


### PR DESCRIPTION
- any?/empty? will use exists?-style SELECT 1 as one queries if the relationship is not loaded, but will use the loaded relation if it has already been loaded.
- this also means the tests no longer need to persist, because these methods work the same way for unpersisted data.