### PR TITLE
add Better Errors gem for better rails debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ group :development, :test do
   gem "rubocop-performance", require: false
   gem "brakeman", require: false
   gem "toxiproxy", "~> 1.0.0"
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,12 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
+    better_errors (2.6.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bitarray (1.2.0)
     bloomer (1.0.0)
       bitarray
@@ -126,6 +132,7 @@ GEM
       addressable
     daemons (1.3.1)
     dalli (2.7.10)
+    debug_inspector (0.0.3)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -409,6 +416,8 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   aws-sdk (~> 2.2)
+  better_errors
+  binding_of_caller
   bootsnap
   brakeman
   capybara (~> 2.18)


### PR DESCRIPTION
As the title says, i want to add the [Better Errors gem](https://github.com/BetterErrors/better_errors) that provides a really nice page for debugging rails errors in development.