### PR TITLE
Remove useless association tests

### DIFF
--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class DeletionTest < ActiveSupport::TestCase
-  should belong_to :user
-
   setup do
     @user = create(:user)
     Pusher.new(@user, gem_file).process

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -1,9 +1,6 @@
 require "test_helper"
 
 class DependencyTest < ActiveSupport::TestCase
-  should belong_to :rubygem
-  should belong_to :version
-
   context "with dependency" do
     setup do
       @version = create(:version)

--- a/test/unit/linkset_test.rb
+++ b/test/unit/linkset_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class LinksetTest < ActiveSupport::TestCase
-  should belong_to :rubygem
-
   context "with a linkset" do
     setup do
       @linkset = build(:linkset)

--- a/test/unit/ownership_test.rb
+++ b/test/unit/ownership_test.rb
@@ -5,9 +5,7 @@ class OwnershipTest < ActiveSupport::TestCase
     assert build(:ownership).valid?
   end
 
-  should belong_to :rubygem
   should have_db_index :rubygem_id
-  should belong_to :user
   should have_db_index :user_id
 
   context "with ownership" do

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -7,9 +7,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
     subject { @rubygem }
 
-    should have_many(:owners).through(:ownerships)
     should have_many(:ownerships).dependent(:destroy)
-    should have_many(:subscribers).through(:subscriptions)
     should have_many(:subscriptions).dependent(:destroy)
     should have_many(:versions).dependent(:destroy)
     should have_many(:web_hooks).dependent(:destroy)

--- a/test/unit/subscription_test.rb
+++ b/test/unit/subscription_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class SubscriptionTest < ActiveSupport::TestCase
-  should belong_to :rubygem
-  should belong_to :user
   should validate_uniqueness_of(:rubygem_id).scoped_to(:user_id)
   should validate_presence_of(:rubygem)
   should validate_presence_of(:user)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -8,9 +8,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   should have_many(:ownerships).dependent(:destroy)
-  should have_many(:rubygems).through(:ownerships)
-  should have_many(:subscribed_gems).through(:subscriptions)
-  should have_many(:deletions)
   should have_many(:subscriptions).dependent(:destroy)
   should have_many(:web_hooks).dependent(:destroy)
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -1,9 +1,6 @@
 require "test_helper"
 
 class VersionTest < ActiveSupport::TestCase
-  should belong_to :rubygem
-  should have_many :dependencies
-
   context "#as_json" do
     setup do
       @version = build(:version, summary: "some words", created_at: Time.now.in_time_zone)

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -1,9 +1,6 @@
 require "test_helper"
 
 class WebHookTest < ActiveSupport::TestCase
-  should belong_to :user
-  should belong_to :rubygem
-
   should "be valid for normal hook" do
     hook = create(:web_hook)
     refute hook.global?


### PR DESCRIPTION
This PR removes useless model association tests. Testing purely for association presence in a codebase such as Rubygems.org is useless and I believe it's an anti-pattern. Removing or changing the association by accident is captured and flagged by countless other tests.