### PR TITLE
Fix incorrect number of news items (Issue #1682)

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -2,13 +2,19 @@ class NewsController < ApplicationController
   before_action -> { set_page Gemcutter::NEWS_MAX_PAGES }
 
   def show
-    @rubygems = Rubygem.news(Gemcutter::NEWS_DAYS_LIMIT).page(@page).per(Gemcutter::NEWS_PER_PAGE)
+    @rubygems = Rubygem.preload(:latest_version, :gem_download)
+      .news(Gemcutter::NEWS_DAYS_LIMIT)
+      .page(@page)
+      .per(Gemcutter::NEWS_PER_PAGE)
     limit_total_count
   end
 
   def popular
     @title = t(".title")
-    @rubygems = Rubygem.by_downloads.news(Gemcutter::POPULAR_DAYS_LIMIT).page(@page).per(Gemcutter::NEWS_PER_PAGE)
+    @rubygems = Rubygem.preload(:latest_version, :gem_download)
+      .popular(Gemcutter::POPULAR_DAYS_LIMIT)
+      .page(@page)
+      .per(Gemcutter::NEWS_PER_PAGE)
     limit_total_count
 
     render :show

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -86,10 +86,14 @@ class Rubygem < ApplicationRecord
   end
 
   def self.news(days)
-    includes(:latest_version, :gem_download)
-      .with_versions
+    joins(:latest_version)
       .where("versions.created_at BETWEEN ? AND ?", days.ago.in_time_zone, Time.zone.now)
-      .order("versions.created_at DESC")
+      .group(:id)
+      .order("MAX(versions.created_at) DESC")
+  end
+
+  def self.popular(days)
+    joins(:gem_download).order("MAX(gem_downloads.count) DESC").news(days)
   end
 
   def all_errors(version = nil)

--- a/test/functional/news_controller_test.rb
+++ b/test/functional/news_controller_test.rb
@@ -5,6 +5,7 @@ class NewsControllerTest < ActionController::TestCase
     @rubygem1 = create(:rubygem, downloads: 10)
     @rubygem2 = create(:rubygem, downloads: 20)
     @rubygem3 = create(:rubygem, downloads: 30)
+    10.times { |i| create(:version, rubygem: @rubygem2, created_at: 5.days.ago, platform: "platform#{i}") }
     create(:version, rubygem: @rubygem2, created_at: 5.days.ago)
     create(:version, rubygem: @rubygem3, created_at: 6.days.ago)
     create(:version, rubygem: @rubygem1, created_at: 59.days.ago)
@@ -20,10 +21,11 @@ class NewsControllerTest < ActionController::TestCase
     end
 
     should "order by created_at of gem version" do
-      expected_order = [@rubygem2, @rubygem3]
+      expected_order = [@rubygem2, @rubygem3].map(&:name)
+      actual_order = assert_select("h2.gems__gem__name").map(&:text)
 
-      assert_select("a.gems__gem > span > h2").each_with_index do |element, index|
-        assert_match(/#{expected_order[index].name}/, element.text)
+      expected_order.each_with_index do |expected_gem_name, i|
+        assert_match(/#{expected_gem_name}/, actual_order[i])
       end
     end
 
@@ -44,10 +46,11 @@ class NewsControllerTest < ActionController::TestCase
     end
 
     should "order by gem downloads" do
-      expected_order = [@rubygem3, @rubygem2, @rubygem1]
+      expected_order = [@rubygem3, @rubygem2, @rubygem1].map(&:name)
+      actual_order = assert_select("h2.gems__gem__name").map(&:text)
 
-      assert_select("a.gems__gem > span > h2").each_with_index do |element, index|
-        assert_match(/#{expected_order[index].name}/, element.text)
+      expected_order.each_with_index do |expected_gem_name, i|
+        assert_match(/#{expected_gem_name}/, actual_order[i])
       end
     end
 

--- a/test/functional/news_controller_test.rb
+++ b/test/functional/news_controller_test.rb
@@ -67,13 +67,18 @@ class NewsControllerTest < ActionController::TestCase
       get :show
     end
 
-    should "display expected entries" do
+    should "order by created_at of gem version" do
       expected_order = [@rubygem2, @rubygem3].map(&:name)
       actual_order = assert_select("h2.gems__gem__name").map(&:text)
 
       expected_order.each_with_index do |expected_gem_name, i|
         assert_match(/#{expected_gem_name}/, actual_order[i])
       end
+    end
+
+    should "display correct number of entries" do
+      entries = assert_select("h2.gems__gem__name")
+      assert_equal(entries.size, 2)
     end
   end
 end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -808,41 +808,37 @@ class RubygemTest < ActiveSupport::TestCase
       @rubygem1 = create(:rubygem, downloads: 10)
       @rubygem2 = create(:rubygem, downloads: 20)
       @rubygem3 = create(:rubygem, downloads: 30)
-      @rubygem4 = create(:rubygem, downloads: 40)
-      @rubygem5 = create(:rubygem, downloads: 50)
-      create(:version, rubygem: @rubygem2, created_at: 5.days.ago)
-      create(:version, rubygem: @rubygem1, created_at: 6.days.ago)
-      create(:version, rubygem: @rubygem3, created_at: 8.days.ago)
-      create(:version, rubygem: @rubygem4, created_at: 30.days.ago)
-      create(:version, rubygem: @rubygem5, created_at: 71.days.ago)
+      create(:version, rubygem: @rubygem1, created_at: (Gemcutter::NEWS_DAYS_LIMIT - 2.days).ago)
+      create(:version, rubygem: @rubygem2, created_at: (Gemcutter::NEWS_DAYS_LIMIT - 1.day).ago)
+      create(:version, rubygem: @rubygem3, created_at: (Gemcutter::POPULAR_DAYS_LIMIT + 1.day).ago)
     end
 
     context ".news" do
       setup do
-        @news = Rubygem.news(7.days)
+        @news = Rubygem.news(Gemcutter::NEWS_DAYS_LIMIT)
       end
 
-      should "not include gems updated since given days" do
+      should "not include gems updated prior to Gemcutter::NEWS_DAYS_LIMIT days ago" do
         assert_not_includes @news, @rubygem3
       end
 
       should "order by created_at of gem version" do
-        expected_order = [@rubygem2, @rubygem1]
+        expected_order = [@rubygem1, @rubygem2]
         assert_equal expected_order, @news
       end
     end
 
     context ".popular" do
       setup do
-        @popular_gems = Rubygem.popular(70.days)
+        @popular_gems = Rubygem.popular(Gemcutter::POPULAR_DAYS_LIMIT)
       end
 
-      should "not include gems updated prior to certain date" do
-        assert_not_includes @popular_gems, @rubygem5
+      should "not include gems updated prior to Gemcutter::POPULAR_DAYS_LIMIT days ago" do
+        assert_not_includes @popular_gems, @rubygem3
       end
 
-      should "order by created_at of gem version" do
-        expected_order = [@rubygem4, @rubygem3, @rubygem2, @rubygem1]
+      should "order by number of downloads" do
+        expected_order = [@rubygem2, @rubygem1]
         assert_equal expected_order, @popular_gems
       end
     end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -803,24 +803,48 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context ".news" do
+  context "with downloaded gems and versions created at specific times" do
     setup do
-      @rubygem1 = create(:rubygem)
-      @rubygem2 = create(:rubygem)
-      @rubygem3 = create(:rubygem)
+      @rubygem1 = create(:rubygem, downloads: 10)
+      @rubygem2 = create(:rubygem, downloads: 20)
+      @rubygem3 = create(:rubygem, downloads: 30)
+      @rubygem4 = create(:rubygem, downloads: 40)
+      @rubygem5 = create(:rubygem, downloads: 50)
       create(:version, rubygem: @rubygem2, created_at: 5.days.ago)
       create(:version, rubygem: @rubygem1, created_at: 6.days.ago)
       create(:version, rubygem: @rubygem3, created_at: 8.days.ago)
-      @news = Rubygem.news(7.days)
+      create(:version, rubygem: @rubygem4, created_at: 30.days.ago)
+      create(:version, rubygem: @rubygem5, created_at: 71.days.ago)
     end
 
-    should "not include gems updated since given days" do
-      assert_not_includes @news, @rubygem3
+    context ".news" do
+      setup do
+        @news = Rubygem.news(7.days)
+      end
+
+      should "not include gems updated since given days" do
+        assert_not_includes @news, @rubygem3
+      end
+
+      should "order by created_at of gem version" do
+        expected_order = [@rubygem2, @rubygem1]
+        assert_equal expected_order, @news
+      end
     end
 
-    should "order by created_at of gem version" do
-      expected_order = [@rubygem2, @rubygem1]
-      assert_equal expected_order, @news
+    context ".popular" do
+      setup do
+        @popular_gems = Rubygem.popular(70.days)
+      end
+
+      should "not include gems updated prior to certain date" do
+        assert_not_includes @popular_gems, @rubygem5
+      end
+
+      should "order by created_at of gem version" do
+        expected_order = [@rubygem4, @rubygem3, @rubygem2, @rubygem1]
+        assert_equal expected_order, @popular_gems
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes issue #1682. It appears that this bug is reproducible when the news or popular pages include a gem with multiple platforms. In the SQL query generated by the existing `Rubygem.news` method, the `rubygems` table is joined with the `versions` table on the condition that the `latest` column is `true`. Because a gem’s distinct platforms each have one `versions` record with `latest` set to `true`, the `Rubygem.news` SQL query will return duplicate `rubygems.*` rows for gems that support multiple platforms.