### PR TITLE
Fix cases where #create could silently fail

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::OwnersController < Api::BaseController
   def create
     owner = User.find_by_name(params[:email])
     if owner
-      @rubygem.ownerships.create(user: owner)
+      @rubygem.ownerships.create!(user: owner)
       render plain: "Owner added successfully."
     else
       render plain: "Owner could not be found.", status: :not_found

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -13,9 +13,11 @@ class Api::V1::OwnersController < Api::BaseController
 
   def create
     owner = User.find_by_name(params[:email])
-    if owner
+    if owner && !owner.rubygems.include?(@rubygem)
       @rubygem.ownerships.create!(user: owner)
       render plain: "Owner added successfully."
+    elsif owner
+      render plain: "Owner already exists."
     else
       render plain: "Owner could not be found.", status: :not_found
     end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -117,7 +117,7 @@ class Pusher
   def update
     rubygem.disown if rubygem.versions.indexed.count.zero?
     rubygem.update_attributes_from_gem_specification!(version, spec)
-    rubygem.create_ownership(user)
+    rubygem.create_ownership!(user)
     set_info_checksum
 
     true

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -194,7 +194,7 @@ class Rubygem < ApplicationRecord
     new_record? || (versions.indexed.none? && not_protected?)
   end
 
-  def create_ownership(user)
+  def create_ownership!(user)
     ownerships.create!(user: user) if unowned?
   end
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -195,7 +195,7 @@ class Rubygem < ApplicationRecord
   end
 
   def create_ownership(user)
-    ownerships.create(user: user) if unowned?
+    ownerships.create!(user: user) if unowned?
   end
 
   def update_versions!(version, spec)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,7 +257,7 @@ class User < ApplicationRecord
   def yank_gems
     versions_to_yank = only_owner_gems.map(&:versions).flatten
     versions_to_yank.each do |v|
-      deletions.create(version: v)
+      deletions.create!(version: v)
     end
   end
 end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -139,8 +139,8 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
     context "when creating ownership fails" do
       should "respond with error" do
-        error_type = ActiveRecord::ConnectionTimeoutError
-        ActiveRecord::Associations::CollectionProxy.any_instance.stubs(:create!).raises(error_type, "timed out")
+        error_type = ActiveRecord::RecordInvalid
+        ActiveRecord::Associations::CollectionProxy.any_instance.stubs(:create!).raises(error_type, Ownership.new)
         assert_raises error_type do
           post :create, params: { rubygem_id: @rubygem.to_param, email: @second_user.email }, format: :json
         end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -136,6 +136,16 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         assert @rubygem.owners.include?(@third_user)
       end
     end
+
+    context "when creating ownership fails" do
+      should "respond with error" do
+        error_type = ActiveRecord::ConnectionTimeoutError
+        ActiveRecord::Associations::CollectionProxy.any_instance.stubs(:create!).raises(error_type, "timed out")
+        assert_raises error_type do
+          post :create, params: { rubygem_id: @rubygem.to_param, email: @second_user.email }, format: :json
+        end
+      end
+    end
   end
 
   should "route DELETE" do

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -137,6 +137,14 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       end
     end
 
+    context "when adding the same owner" do
+      should "respond with correct message" do
+        @rubygem.ownerships.create(user: @second_user)
+        post :create, params: { rubygem_id: @rubygem.to_param, email: @second_user.email }, format: :json
+        assert_equal "Owner already exists.", @response.body
+      end
+    end
+
     context "when creating ownership fails" do
       should "respond with error" do
         error_type = ActiveRecord::RecordInvalid

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -326,14 +326,14 @@ class RubygemTest < ActiveSupport::TestCase
       end
 
       should "be able to assign ownership when no owners exist" do
-        @rubygem.create_ownership(@user)
+        @rubygem.create_ownership!(@user)
         assert_equal @rubygem.reload.owners, [@user]
       end
 
       should "not be able to assign ownership when owners exist" do
         @new_user = create(:user)
         @rubygem.ownerships.create(user: @new_user)
-        @rubygem.create_ownership(@user)
+        @rubygem.create_ownership!(@user)
         assert_equal @rubygem.reload.owners, [@new_user]
       end
     end


### PR DESCRIPTION
Based on #2234 I noticed that there were 3 uses of ActiveRecord's `#create` that did not handle the failing case. I've changed the calls to `#create!` which will throw an exception if it fails.