### PR TITLE
Disable typo protection for now

### DIFF
--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -14,8 +14,6 @@ class GemTypo
   end
 
   def protected_typo?
-    return false
-
     return false if @rubygem_name.size < GemTypo::SIZE_THRESHOLD
 
     gem_typo_exceptions = GemTypoException.all.pluck(:name)

--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -14,6 +14,8 @@ class GemTypo
   end
 
   def protected_typo?
+    return false
+
     return false if @rubygem_name.size < GemTypo::SIZE_THRESHOLD
 
     gem_typo_exceptions = GemTypoException.all.pluck(:name)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -19,7 +19,7 @@ class Rubygem < ApplicationRecord
     uniqueness: { case_sensitive: false },
     if: :needs_name_validation?
   validate :blacklist_names_exclusion
-  validate :protected_gem_typo, on: :create, unless: -> { Array(validation_context).include?(:typo_exception) }
+  # validate :protected_gem_typo, on: :create, unless: -> { Array(validation_context).include?(:typo_exception) }
 
   after_create :update_unresolved
   before_destroy :mark_unresolved

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -309,19 +309,19 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
     end
 
-    context "On POST to create with a protected gem name" do
-      setup do
-        above_downloads_thres = GemTypo::DOWNLOADS_THRESHOLD + 1
-        create(:rubygem, name: "best", downloads: above_downloads_thres)
-        post :create, body: gem_file("test-1.0.0.gem").read
-      end
+    # context "On POST to create with a protected gem name" do
+    #   setup do
+    #     above_downloads_thres = GemTypo::DOWNLOADS_THRESHOLD + 1
+    #     create(:rubygem, name: "best", downloads: above_downloads_thres)
+    #     post :create, body: gem_file("test-1.0.0.gem").read
+    #   end
 
-      should respond_with :forbidden
-      should "not register new gem" do
-        assert_equal 1, Rubygem.count
-        assert_equal "There was a problem saving your gem: Name 'test' is too close to typo-protected gem: best", @response.body
-      end
-    end
+    #   should respond_with :forbidden
+    #   should "not register new gem" do
+    #     assert_equal 1, Rubygem.count
+    #     assert_equal "There was a problem saving your gem: Name 'test' is too close to typo-protected gem: best", @response.body
+    #   end
+    # end
 
     context "On POST to create for someone else's gem" do
       setup do


### PR DESCRIPTION
This is a good idea, but it's blocking a lot of legitimate gems, and
it's too hard for our limited support time to go to manually allowing
gems through.

A Slack feed of gems that look like they might be typos to allow humans
to review would be a more practical way to implement this sort of idea.
Better yet, a Slack message with a single button to yank the gem and/or
the user who pushed the gem. :looks hopefully in @colby-swandale's
direction: