### PR TITLE
 Honeybadger has removed `disabled` option in favor of `report_data`

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,5 +4,5 @@ Honeybadger.exception_filter do |notice|
 end
 
 Honeybadger.configure do |config|
-  config.disabled = true if Rails.env.development?
+  config.report_data = false if Rails.env.development?
 end


### PR DESCRIPTION
Rails is unable to boot in development due to:

    /Users/colby/.asdf/installs/ruby/2.6.5/lib/ruby/gems/2.6.0/gems/honeybadger-4.5.6/lib/honeybadger/config/ruby.rb:31:in `method_missing': undefined method `disabled=' for #<Honeybadger::Config::Ruby:0x00007fd2f5441158> (NoMethodError)

As per the title, Honeybadger has [removed the disabled option](https://docs.honeybadger.io/lib/ruby/support/v4-upgrade#exception_filter) in favor of `report_data`