### PR TITLE
Remove filter to show only gems that are not yanked in search.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,7 @@ Metrics/ModuleLength:
   Exclude:
     - lib/patterns.rb
     - app/models/concerns/rubygem_searchable.rb
+    - app/helpers/rubygems_helper.rb
 
 Metrics/PerceivedComplexity:
   Max: 10 # TODO: Lower to 7

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -7,7 +7,7 @@ if($("#advanced-search").length){
   var $updated     = $('input#updated');
   var $yanked      = $('input#yanked');
 
-    $name.add($summary)
+  $name.add($summary)
     .add($description)
     .add($downloads)
     .add($updated)
@@ -20,6 +20,6 @@ if($("#advanced-search").length){
       var updated     = $updated.val().length > 0 ? 'updated: ' + $updated.val() : '';
       var yanked      = $yanked.is(":checked") ? 'yanked: true' : '';
 
-        $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated + ' ' + yanked));
+      $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated + ' ' + yanked));
   });
 }

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -5,18 +5,21 @@ if($("#advanced-search").length){
   var $description = $('input#description');
   var $downloads   = $('input#downloads');
   var $updated     = $('input#updated');
+  var $yanked      = $('input#yanked');
 
-  $name.add($summary)
+    $name.add($summary)
     .add($description)
     .add($downloads)
     .add($updated)
+    .add($yanked)
     .on('input', function(e) {
       var name        = $name.val().length > 0 ? 'name: ' + $name.val() : '';
       var summary     = $summary.val().length > 0 ? 'summary: ' + $summary.val() : '';
       var description = $description.val().length > 0 ? 'description: ' + $description.val() : '';
       var downloads   = $downloads.val().length > 0 ? 'downloads: ' + $downloads.val() : '';
       var updated     = $updated.val().length > 0 ? 'updated: ' + $updated.val() : '';
+      var yanked      = $yanked.is(":checked") ? 'yanked: true' : '';
 
-      $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated));
+        $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated + ' ' + yanked));
   });
 }

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -13,13 +13,13 @@ if($("#advanced-search").length){
     .add($updated)
     .add($yanked)
     .on('input', function(e) {
-      var name        = $name.val().length > 0 ? 'name: ' + $name.val() : '';
-      var summary     = $summary.val().length > 0 ? 'summary: ' + $summary.val() : '';
-      var description = $description.val().length > 0 ? 'description: ' + $description.val() : '';
-      var downloads   = $downloads.val().length > 0 ? 'downloads: ' + $downloads.val() : '';
-      var updated     = $updated.val().length > 0 ? 'updated: ' + $updated.val() : '';
+      var name        = $name.val().length > 0 ? 'name: ' + $name.val() + ' ' : '';
+      var summary     = $summary.val().length > 0 ? 'summary: ' + $summary.val() + ' ' : '';
+      var description = $description.val().length > 0 ? 'description: ' + $description.val() + ' ' : '';
+      var downloads   = $downloads.val().length > 0 ? 'downloads: ' + $downloads.val() + ' ' : '';
+      var updated     = $updated.val().length > 0 ? 'updated: ' + $updated.val() + ' ' : '';
       var yanked      = $yanked.is(":checked") ? 'yanked: true' : '';
 
-      $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated + ' ' + yanked));
+      $main.val($.trim(name + summary + description + downloads + updated + yanked));
   });
 }

--- a/app/assets/stylesheets/modules/gems.css
+++ b/app/assets/stylesheets/modules/gems.css
@@ -106,3 +106,12 @@
   font-size: 12px;
   line-height: 1.66;
   text-transform: uppercase; }
+
+.gems__gem__badge {
+    padding: 2px 3px; /* pixel unit */
+    border-radius: 10%;
+    font-size: 15px;
+    text-align: center;
+    background: #e9573f;
+    color: #fefefe;
+}

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -114,7 +114,7 @@ module RubygemsHelper
     (rubygem.latest_version || rubygem.versions.last)&.number
   end
 
-  def is_yanked?(rubygem)
+  def yanked?(rubygem)
     rubygem.yanked if rubygem.respond_to?(:yanked)
   end
 

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -114,6 +114,10 @@ module RubygemsHelper
     (rubygem.latest_version || rubygem.versions.last)&.number
   end
 
+  def is_yanked?(rubygem)
+    rubygem.yanked if rubygem.respond_to?(:yanked)
+  end
+
   def github_params(link)
     "user=#{link.path.split('/').second}&repo=#{link.path.split('/').third}&type=star&count=true&size=large"
   end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -29,9 +29,9 @@ module SearchesHelper
 
   def aggregation_bool_count(aggregration, field, filter)
     count = aggregration["buckets"][field]["doc_count"]
-    return unless count > 0 && !params[:query].include?("#{field}:#{filter}")
+    return unless count > 0
 
-    path = search_path(params: { query: "#{params[:query]} AND #{field}:#{filter}" })
+    path = search_path(params: { query: "#{params[:query]} #{field}: #{filter}" })
     link_to "#{field.capitalize} (#{count})", path, class: "t-link--black"
   end
 end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -26,4 +26,12 @@ module SearchesHelper
     update_info = (duration == 30.days ? t("searches.show.month_update", count: count) : t("searches.show.week_update", count: count))
     link_to update_info, path, class: "t-link--black"
   end
+
+  def aggregation_bool_count(aggregration, field, filter)
+    count = aggregration["buckets"][field]["doc_count"]
+    return unless count > 0 && !params[:query].include?("#{field}:#{filter}")
+
+    path = search_path(params: { query: "#{params[:query]} AND #{field}:#{filter}" })
+    link_to "#{field.capitalize} (#{count})", path, class: "t-link--black"
+  end
 end

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -1,25 +1,25 @@
 <%= link_to rubygem_path(rubygem.name), :class => 'gems__gem' do %>
   <% if yanked?(rubygem) %>
     <span class="gems__gem__info">
-    <h2 class="gems__gem__name">
-      <%= rubygem.name %>
-      <span class="gems__gem__badge"><%= t('searches.advanced.yanked') %></span>
-    </h2>
-    <p class="gems__gem__desc t-text"><%= t('rubygems.show_yanked.not_hosted_notice') %></p>
-  </span>
+      <h2 class="gems__gem__name">
+        <%= rubygem.name %>
+        <span class="gems__gem__badge"><%= t('searches.advanced.yanked') %></span>
+      </h2>
+      <p class="gems__gem__desc t-text"><%= t('rubygems.show_yanked.not_hosted_notice') %></p>
+    </span>
   <% else %>
     <span class="gems__gem__info">
-    <h2 class="gems__gem__name">
-      <%= rubygem.name %>
-      <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
-    </h2>
-    <p class="gems__gem__desc t-text"><%= short_info(rubygem) %></p>
-  </span>
+      <h2 class="gems__gem__name">
+        <%= rubygem.name %>
+        <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
+      </h2>
+      <p class="gems__gem__desc t-text"><%= short_info(rubygem) %></p>
+    </span>
     <p class="gems__gem__downloads__count">
       <%= download_count rubygem %>
       <span class="gems__gem__downloads__heading">
-      <%= t('rubygems.index.downloads') %>
-    </span>
+        <%= t('rubygems.index.downloads') %>
+      </span>
     </p>
   <% end %>
 <% end %>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -3,6 +3,9 @@
     <h2 class="gems__gem__name">
       <%= rubygem.name %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
+      <% if is_yanked?(rubygem) %>
+        <span class="gems__gem__badge">Yanked</span>
+      <% end %>
     </h2>
     <p class="gems__gem__desc t-text"><%= short_info(rubygem) %></p>
   </span>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -1,18 +1,25 @@
 <%= link_to rubygem_path(rubygem.name), :class => 'gems__gem' do %>
-  <span class="gems__gem__info">
+  <% if yanked?(rubygem) %>
+    <span class="gems__gem__info">
+    <h2 class="gems__gem__name">
+      <%= rubygem.name %>
+      <span class="gems__gem__badge">Yanked</span>
+    </h2>
+    <p class="gems__gem__desc t-text"><%= t('rubygems.show_yanked.not_hosted_notice') %></p>
+  </span>
+  <% else %>
+    <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= rubygem.name %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
-      <% if yanked?(rubygem) %>
-        <span class="gems__gem__badge">Yanked</span>
-      <% end %>
     </h2>
     <p class="gems__gem__desc t-text"><%= short_info(rubygem) %></p>
   </span>
-  <p class="gems__gem__downloads__count">
-    <%= download_count rubygem %>
-    <span class="gems__gem__downloads__heading">
+    <p class="gems__gem__downloads__count">
+      <%= download_count rubygem %>
+      <span class="gems__gem__downloads__heading">
       <%= t('rubygems.index.downloads') %>
     </span>
-  </p>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -3,7 +3,7 @@
     <h2 class="gems__gem__name">
       <%= rubygem.name %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
-      <% if is_yanked?(rubygem) %>
+      <% if yanked?(rubygem) %>
         <span class="gems__gem__badge">Yanked</span>
       <% end %>
     </h2>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -3,7 +3,7 @@
     <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= rubygem.name %>
-      <span class="gems__gem__badge">Yanked</span>
+      <span class="gems__gem__badge"><%= t('searches.advanced.yanked') %></span>
     </h2>
     <p class="gems__gem__desc t-text"><%= t('rubygems.show_yanked.not_hosted_notice') %></p>
   </span>

--- a/app/views/searches/_aggregations.html.erb
+++ b/app/views/searches/_aggregations.html.erb
@@ -4,6 +4,7 @@
     <%= aggregation_match_count aggregations['matched_field'], 'name' %>
     <%= aggregation_match_count aggregations['matched_field'], 'description' %>
     <%= aggregation_match_count aggregations['matched_field'], 'summary' %>
+    <%= aggregation_bool_count aggregations['matched_field'], 'yanked', true %>
     <%= aggregation_count aggregations['date_range'], 7.days, 1 %>
     <%= aggregation_count aggregations['date_range'], 30.days, 0 %>
   </div>

--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -24,5 +24,8 @@
 
     <dt><%= label_tag :updated, t(".updated"), class: "form__label" %></dt>
     <dd><%= text_field_tag :updated, "", placeholder: ">#{1.week.ago.strftime('%F')}", class: "form__input"%></dd>
+
+    <dt><%= label_tag :yanked, t(".include_yanked"), class: "form__label" %></dt>
+    <dd><%= check_box_tag :yanked, "true", false, class: "form__checkbox__input" %></dd>
   </dl>
 </div>

--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -25,7 +25,7 @@
     <dt><%= label_tag :updated, t(".updated"), class: "form__label" %></dt>
     <dd><%= text_field_tag :updated, "", placeholder: ">#{1.week.ago.strftime('%F')}", class: "form__input"%></dd>
 
-    <dt><%= label_tag :yanked, t(".include_yanked"), class: "form__label" %></dt>
+    <dt><%= label_tag :yanked, t("searches.advanced.yanked"), class: "form__label" %></dt>
     <dd><%= check_box_tag :yanked, "true", false, class: "form__checkbox__input" %></dd>
   </dl>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -328,6 +328,7 @@ de:
       description:
       downloads:
       updated:
+      yanked: ""
     show:
       subtitle: für %{query}
       month_update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,7 +338,7 @@ en:
       description: Description
       downloads: Downloads
       updated: Updated
-      include_yanked: Include Yanked?
+      yanked: Yanked
     show:
       subtitle: for %{query}
       month_update: Updated last month (%{count})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,6 +338,7 @@ en:
       description: Description
       downloads: Downloads
       updated: Updated
+      include_yanked: Include Yanked?
     show:
       subtitle: for %{query}
       month_update: Updated last month (%{count})

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -338,6 +338,7 @@ es:
       description: Descripción
       downloads: Descargas
       updated: Actualizada
+      yanked: ""
     show:
       subtitle: para %{query}
       month_update: Actualizadas en el último mes (%{count})

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -328,6 +328,7 @@ fr:
       description: Description
       downloads: Téléchargements
       updated: Mis à jour
+      yanked: ""
     show:
       subtitle: pour %{query}
       month_update:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -328,6 +328,7 @@ ja:
       description: 説明
       downloads: ダウンロード数
       updated: 更新日
+      yanked: ""
     show:
       subtitle: '%{query}の検索結果'
       month_update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -328,6 +328,7 @@ nl:
       description:
       downloads:
       updated:
+      yanked: ""
     show:
       subtitle: voor %{query}
       month_update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -328,6 +328,7 @@ pt-BR:
       description:
       downloads:
       updated:
+      yanked: ""
     show:
       subtitle: para %{query}
       month_update:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -328,6 +328,7 @@ zh-CN:
       description: 描述
       downloads: 下载数
       updated: 更新时间
+      yanked: ""
     show:
       subtitle: "%{query}"
       month_update:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -328,6 +328,7 @@ zh-TW:
       description: 描述
       downloads: 下載數
       updated: 最後更新時間
+      yanked: ""
     show:
       subtitle: "%{query}"
       month_update:

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -59,7 +59,7 @@ class ElasticSearcher
       end
 
       # only return gems that are not yanked unless filter is used
-      post_filter { term yanked: false } unless query_str.delete(" ").include? "yanked:true"
+      post_filter { term yanked: false } unless query_str.gsub(/[[:space:]]/, "").include? "yanked:true"
 
       source source_array
       # Return suggestions unless there's no query from the user

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -34,8 +34,8 @@ class ElasticSearcher
                 end
               end
               minimum_should_match 1
-              # only return gems that are not yanked
-              # filter { term yanked: false }
+              # only return gems that are not yanked unless filter is used
+              filter { term yanked: false } unless query_str.include? "yanked"
             end
           end
 

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -35,7 +35,7 @@ class ElasticSearcher
               end
               minimum_should_match 1
               # only return gems that are not yanked
-              filter { term yanked: false }
+              # filter { term yanked: false }
             end
           end
 

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -59,7 +59,7 @@ class ElasticSearcher
       end
 
       # only return gems that are not yanked unless filter is used
-      post_filter { term yanked: false } unless query_str.include? "yanked:true"
+      post_filter { term yanked: false } unless query_str.delete(" ").include? "yanked:true"
 
       source source_array
       # Return suggestions unless there's no query from the user

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -34,8 +34,6 @@ class ElasticSearcher
                 end
               end
               minimum_should_match 1
-              # only return gems that are not yanked unless filter is used
-              filter { term yanked: false } unless query_str.include? "yanked"
             end
           end
 
@@ -48,7 +46,8 @@ class ElasticSearcher
         filters do
           filters name: { terms: { name: [query_str] } },
                   summary: { terms: { "summary.raw" => [query_str] } },
-                  description: { terms: { "description.raw" => [query_str] } }
+                  description: { terms: { "description.raw" => [query_str] } },
+                  yanked: { terms: { yanked: [true] } }
         end
       end
 
@@ -58,6 +57,9 @@ class ElasticSearcher
           ranges [{ from: "now-7d/d", to: "now" }, { from: "now-30d/d", to: "now" }]
         end
       end
+
+      # only return gems that are not yanked unless filter is used
+      post_filter { term yanked: false } unless query_str.include? "yanked:true"
 
       source source_array
       # Return suggestions unless there's no query from the user

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -101,6 +101,7 @@ class ElasticSearcher
        summary
        description
        downloads
-       version]
+       version
+       yanked]
   end
 end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -18,7 +18,7 @@ class SearchTest < SystemTest
     assert page.has_content? "LDAP-PLUS"
   end
 
-  test "searching for a yanked gem" do
+  test "searching for a yanked gem without yanked filter" do
     rubygem = create(:rubygem, name: "LDAP")
     create(:version, rubygem: rubygem, indexed: false)
     import_and_refresh
@@ -29,6 +29,19 @@ class SearchTest < SystemTest
     click_button "search_submit"
 
     assert page.has_content? "No gems found"
+  end
+
+  test "searching for a yanked gem with yanked filter" do
+    rubygem = create(:rubygem, name: "LDAP")
+    create(:version, :yanked, rubygem: rubygem)
+    import_and_refresh
+
+    visit search_path
+
+    fill_in "query", with: "LDAP yanked:true"
+    click_button "search_submit"
+
+    assert page.has_content? "Displaying 1 gem"
   end
 
   test "searching for a gem with yanked versions" do

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -28,7 +28,8 @@ class SearchTest < SystemTest
     fill_in "query", with: "LDAP"
     click_button "search_submit"
 
-    assert page.has_content? "No gems found"
+    assert page.has_content? "LDAP"
+    assert page.has_content? "Yanked"
   end
 
   test "searching for a gem with yanked versions" do

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -28,8 +28,7 @@ class SearchTest < SystemTest
     fill_in "query", with: "LDAP"
     click_button "search_submit"
 
-    assert page.has_content? "LDAP"
-    assert page.has_content? "Yanked"
+    assert page.has_content? "No gems found"
   end
 
   test "searching for a gem with yanked versions" do

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -85,10 +85,8 @@ class RubygemSearchableTest < ActiveSupport::TestCase
 
     should "show yanked gems in the result" do
       _, response = ElasticSearcher.new("example").search
-      assert_equal 2, response.size
-      names_order = %w[example_1 example_2]
-      assert_equal names_order, response.results.map(&:name)
-      assert_equal true, response.first.yanked
+      assert_equal 1, response.size
+      assert_equal "example_2", response.first.name
     end
   end
 
@@ -169,8 +167,11 @@ class RubygemSearchableTest < ActiveSupport::TestCase
     setup do
       rubygem1 = create(:rubygem, name: "example", downloads: 101)
       rubygem2 = create(:rubygem, name: "web-rubygem", downloads: 99)
+      rubygem3 = create(:rubygem, name: "yanked-gem", downloads: 500)
       create(:version, rubygem: rubygem1, summary: "special word with web-rubygem")
       create(:version, rubygem: rubygem2, description: "example special word")
+      create(:version, rubygem: rubygem3, indexed: false)
+
       import_and_refresh
     end
 
@@ -208,6 +209,12 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       _, response = ElasticSearcher.new("name:web*").search
       assert_equal 1, response.size
       assert_equal "web-rubygem", response.first.name
+    end
+
+    should "show yanked on filter true" do
+      _, response = ElasticSearcher.new("yanked:true").search
+      assert_equal 1, response.size
+      assert_equal "yanked-gem", response.first.name
     end
   end
 

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -83,7 +83,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       import_and_refresh
     end
 
-    should "show yanked gems in the result" do
+    should "filter yanked gems from the result" do
       _, response = ElasticSearcher.new("example").search
       assert_equal 1, response.size
       assert_equal "example_2", response.first.name

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -83,10 +83,12 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       import_and_refresh
     end
 
-    should "filter yanked gems from the result" do
+    should "show yanked gems in the result" do
       _, response = ElasticSearcher.new("example").search
-      assert_equal 1, response.size
-      assert_equal "example_2", response.first.name
+      assert_equal 2, response.size
+      names_order = %w[example_1 example_2]
+      assert_equal names_order, response.results.map(&:name)
+      assert_equal true, response.first.yanked
     end
   end
 


### PR DESCRIPTION
Fixes #2110 
Remove the filter which was blocking the yanked gems to appear in the search results.
Please give suggestions if anything more is required in UI.