### PR TITLE
Eliminate a query from versions index

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -262,10 +262,6 @@ class Rubygem < ApplicationRecord
     version
   end
 
-  def first_created_date
-    versions.by_earliest_created_at.first.created_at
-  end
-
   # returns days left before the reserved namespace will be released
   # 100 + 1 days are added so that last_protected_day / 1.day = 1
   def protected_days

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -4,7 +4,7 @@
     <p><%= t('.not_hosted_notice') %></p>
   </div>
 <% else %>
-  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@rubygem.first_created_date)) %>:</h3>
+  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@versions.map(&:created_at).min)) %>:</h3>
   <div class="versions">
     <ul class="t-list__items">
       <%= render @versions %>

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -122,17 +122,6 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.versions.most_recent
     end
 
-    should "can find when the first created date was" do
-      travel_to Time.zone.now do
-        create(:version, rubygem: @rubygem, number: "3.0.0", created_at: 1.day.ago)
-        create(:version, rubygem: @rubygem, number: "2.0.0", created_at: 2.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0", created_at: 3.days.ago)
-        create(:version, rubygem: @rubygem, number: "1.0.0.beta", created_at: 4.days.ago)
-
-        assert_equal 4.days.ago.to_date, @rubygem.first_created_date.to_date
-      end
-    end
-
     should "have a most_recent version if only a platform version exists" do
       version1 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "linux")
 


### PR DESCRIPTION
Benchmark:

```ruby
ActiveRecord::Base.logger = Logger.new(nil) # for sanity

rubygem = Rubygem.find_by(name: "sorbet-static") # 2.8k versions or more
versions = rubygem.versions
minitest = Rubygem.find_by(name: "minitest")
minitest_versions = minitest.versions

raise unless rubygem.first_created_date == versions.map(&:created_at).min

Benchmark.ips do |x|
  x.report("master-sorbet-static") { rubygem.first_created_date }
  x.report("dkubb-sorbet-static") { versions.map(&:created_at).min }

  x.report("master-minitest") { minitest.first_created_date }
  x.report("dkubb-minitest") { minitest_versions.map(&:created_at).min }

  x.compare!
end

```

Result: 

```
Warming up --------------------------------------
master-sorbet-static     1.000  i/100ms
 dkubb-sorbet-static    57.000  i/100ms
     master-minitest   119.000  i/100ms
      dkubb-minitest     1.434k i/100ms
Calculating -------------------------------------
master-sorbet-static    318.280  (± 6.6%) i/s -      1.574k in   4.999603s
 dkubb-sorbet-static    503.619  (±13.1%) i/s -      2.508k in   5.082251s
     master-minitest      1.195k (± 9.9%) i/s -      5.950k in   5.035828s
      dkubb-minitest     13.837k (± 4.0%) i/s -     70.266k in   5.086270s

Comparison:
      dkubb-minitest:    13837.2 i/s
     master-minitest:     1194.8 i/s - 11.58x  slower
 dkubb-sorbet-static:      503.6 i/s - 27.48x  slower
master-sorbet-static:      318.3 i/s - 43.47x  slower
```