### PR TITLE
Remove update to old rubygems in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ADD https://github.com/bundler/bundler-api/raw/master/versions.list /app/config/
 
 RUN mv /app/config/database.yml.example /app/config/database.yml
 
-RUN gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without deploy
+RUN gem install bundler io-console --no-doc && bundle install --jobs 20 --retry 5 --without deploy
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=1234 bin/rails assets:precompile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN apk add --no-cache \
 RUN mkdir -p /app /app/config /app/log/
 WORKDIR /app
 
-RUN gem update --system 2.6.10
-
 COPY . /app
 
 ADD https://github.com/bundler/bundler-api/raw/master/versions.list /app/config/versions.list


### PR DESCRIPTION
I'm not 100% sure why we update RubyGems to an old version in the Dockerfile. When i build the Dockerfile, we're using the version of RubyGems that shipped with Ruby. So this seems like something we can remove.

```
$ docker run -i -t rubygems-org /bin/bash
bash-5.0# gem -v
3.0.3
bash-5.0# ruby -v
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux-musl]
```