### PR TITLE
Shift helper methods to fix cop failures

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,6 +43,7 @@ Rails/OutputSafety:
   Exclude:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/rubygems_helper.rb'
+    - 'app/helpers/links_helper.rb'
 
 # Offense count: 38
 # Cop supports --auto-correct.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,4 +62,18 @@ module ApplicationHelper
     return title unless title_url
     link_to title, title_url, class: "t-link--black"
   end
+
+  def nice_date_for(time)
+    time.to_date.to_formatted_s(:long)
+  end
+
+  def simple_markup(text)
+    if text =~ /^==+ [A-Z]/
+      options = RDoc::Options.new
+      options.pipe = true
+      sanitize RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new(options))
+    else
+      content_tag :p, escape_once(sanitize(text.strip)), nil, false
+    end
+  end
 end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,0 +1,48 @@
+module LinksHelper
+  def subscribe_link(rubygem)
+    if signed_in?
+      if rubygem.subscribers.find_by_id(current_user.id)
+        link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem),
+                class: [:toggler, "gem__link", "t-list__item"], id: "unsubscribe",
+                method: :delete
+      else
+        link_to t(".links.subscribe"), rubygem_subscription_path(rubygem),
+                class: %w[toggler gem__link t-list__item], id: "subscribe",
+                method: :post
+      end
+    else
+      link_to t(".links.subscribe"), sign_in_path,
+              class: [:toggler, "gem__link", "t-list__item"], id: :subscribe
+    end
+  end
+
+  def unsubscribe_link(rubygem)
+    return unless signed_in?
+    style = "t-item--hidden" unless rubygem.subscribers.find_by_id(current_user.id)
+
+    link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem),
+            class: [:toggler, "gem__link", "t-list__item", style], id: "unsubscribe",
+            method: :delete, remote: true
+  end
+
+  def atom_link(rubygem)
+    link_to t(".links.rss"), rubygem_versions_path(rubygem, format: "atom"),
+            class: "gem__link t-list__item", id: :rss
+  end
+
+  def reverse_dependencies_link(rubygem)
+    link_to_page :reverse_dependencies, rubygem_reverse_dependencies_path(rubygem)
+  end
+
+  def badge_link(rubygem)
+    badge_url = "https://badge.fury.io/rb/#{rubygem.name}/install"
+    link_to t(".links.badge"), badge_url, class: "gem__link t-list__item", id: :badge
+  end
+
+  def report_abuse_link(rubygem)
+    encoded_title = CGI.escape("Reporting Abuse on #{rubygem.name}")
+    report_abuse_url = "http://help.rubygems.org/discussion/new" \
+      "?discussion[private]=1&discussion[title]=#{encoded_title}"
+    link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: "gem__link t-list__item"
+  end
+end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -31,63 +31,6 @@ module RubygemsHelper
     end.join("\n").html_safe
   end
 
-  def simple_markup(text)
-    if text =~ /^==+ [A-Z]/
-      options = RDoc::Options.new
-      options.pipe = true
-      sanitize RDoc::Markup.new.convert(text, RDoc::Markup::ToHtml.new(options))
-    else
-      content_tag :p, escape_once(sanitize(text.strip)), nil, false
-    end
-  end
-
-  def subscribe_link(rubygem)
-    if signed_in?
-      if rubygem.subscribers.find_by_id(current_user.id)
-        link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem),
-          class: [:toggler, "gem__link", "t-list__item"], id: "unsubscribe",
-          method: :delete
-      else
-        link_to t(".links.subscribe"), rubygem_subscription_path(rubygem),
-          class: %w[toggler gem__link t-list__item], id: "subscribe",
-          method: :post
-      end
-    else
-      link_to t(".links.subscribe"), sign_in_path,
-        class: [:toggler, "gem__link", "t-list__item"], id: :subscribe
-    end
-  end
-
-  def unsubscribe_link(rubygem)
-    return unless signed_in?
-    style = "t-item--hidden" unless rubygem.subscribers.find_by_id(current_user.id)
-
-    link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem),
-      class: [:toggler, "gem__link", "t-list__item", style], id: "unsubscribe",
-      method: :delete, remote: true
-  end
-
-  def atom_link(rubygem)
-    link_to t(".links.rss"), rubygem_versions_path(rubygem, format: "atom"),
-      class: "gem__link t-list__item", id: :rss
-  end
-
-  def reverse_dependencies_link(rubygem)
-    link_to_page :reverse_dependencies, rubygem_reverse_dependencies_path(rubygem)
-  end
-
-  def badge_link(rubygem)
-    badge_url = "https://badge.fury.io/rb/#{rubygem.name}/install"
-    link_to t(".links.badge"), badge_url, class: "gem__link t-list__item", id: :badge
-  end
-
-  def report_abuse_link(rubygem)
-    encoded_title = CGI.escape("Reporting Abuse on #{rubygem.name}")
-    report_abuse_url = "http://help.rubygems.org/discussion/new" \
-      "?discussion[private]=1&discussion[title]=" + encoded_title
-    link_to t(".links.report_abuse"), report_abuse_url.html_safe, class: "gem__link t-list__item"
-  end
-
   def links_to_owners(rubygem)
     rubygem.owners.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
   end
@@ -99,10 +42,6 @@ module RubygemsHelper
   def link_to_user(user)
     link_to gravatar(48, "gravatar-#{user.id}", user), profile_path(user.display_id),
       alt: user.display_handle, title: user.display_handle
-  end
-
-  def nice_date_for(time)
-    time.to_date.to_formatted_s(:long)
   end
 
   def show_all_versions_link?(rubygem)

--- a/test/unit/helpers/pages_helper_test.rb
+++ b/test/unit/helpers/pages_helper_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class PagesHelperTest < ActionView::TestCase
+  include ApplicationHelper
   include RubygemsHelper
 
   context "downloads" do

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class RubygemsHelperTest < ActionView::TestCase
   include Rails.application.routes.url_helpers
   include ApplicationHelper
+  include LinksHelper
   include ERB::Util
 
   context "licenses header" do


### PR DESCRIPTION
`app/helpers/rubygems_helper.rb` was exceeding 100 lines of code.
So, shifting a few methods around to avoid cop failures