### PR TITLE
Rename navbar from news to releases

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,8 @@
               </a>
             <% end %>
 
-            <%= link_to "News", news_url, class: "header__nav-link #{active?(news_path)}" %>
+            <%= link_to "Releases", news_url, class: "header__nav-link #{active?(news_path)}" %>
+            <%= link_to t('.footer.blog'), "http://blog.rubygems.org", class: "header__nav-link" %>
 
             <%- if request.path_info == '/gems' %>
               <%= link_to "Gems", rubygems_path, class: "header__nav-link is-active" %>
@@ -59,7 +60,6 @@
             <%- end %>
 
             <%= link_to t('.footer.guides'), "http://guides.rubygems.org", class: "header__nav-link" %>
-            <%= link_to t('.footer.contribute'), "http://guides.rubygems.org/contributing/", class: "header__nav-link" %>
 
             <% if signed_in? %>
               <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
@@ -131,7 +131,7 @@
             <%= link_to t('.footer.data'), page_path("data"), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.discussion_forum'), "https://groups.google.com/group/rubygems-org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.statistics'), stats_path, class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.blog'), "http://blog.rubygems.org", class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.contribute'), "http://guides.rubygems.org/contributing/", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/about' %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer is-active" %>
             <%- else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,8 @@ Rails.application.routes.draw do
       end
     end
     resources :stats, only: :index
-    resource :news, path: 'news', only: [:show] do
+    get "/news" => redirect("/releases")
+    resource :news, path: 'releases', only: [:show] do
       get :popular, on: :collection
     end
     resource :notifier, only: %i[update show]


### PR DESCRIPTION
As part of my work for improving the documentation for both guides.rubygems.org and Bundler docs. I came across a fix that I think would be helpful. The tab News was quite confusing. I clicked on it expecting to probably see a list of news/ blog posts about the project. It'll be helpful to use a word that relates more to newly released and popular gems. Thought of using either one of these options Releases or New? 

I also moved the link to the blog to the navbar to improve visibility.