### PR TITLE
Remove bundler-audit usage in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,12 @@ before_install:
   - script/install_toxiproxy.sh
 
 before_script:
-  - gem install bundler-audit -v 0.6.1
-  - bundle audit update
   - cp config/database.yml.example config/database.yml
   - bundle exec rake db:create db:migrate db:test:prepare
 
 script:
   - bundle exec rails test
   - bundle exec rake rubocop
-  - bundle audit check
   - bundle exec brakeman
   - script/build_docker.sh
 


### PR DESCRIPTION
## Summary

Bundler audit currently makes CI fail for any PR that does not fix any unpatched gem vulnerability, which is not helpful for anyone making contributions to RubyGems.org.

I want to replace the functionality with Github security alerts and Dependabot, which will promptly alert us RubyGems.org maintainers of any dependency vulnerability outside of CI.