### PR TITLE
Remove reserved names for Ruby 2.8/3.0

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -30,7 +30,6 @@ module Patterns
     pathname
     pp
     prettyprint
-    profile
     profiler
     pty
     rational

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -21,13 +21,9 @@ module Patterns
     expect
     fiber
     find
-    install
     io-nonblock
     io-wait
-    jruby
     mkmf
-    mri
-    mruby
     nkf
     open-uri
     optparse
@@ -42,8 +38,6 @@ module Patterns
     resolv
     resolv-replace
     rinda
-    ruby
-    rubygems
     securerandom
     set
     shellwords
@@ -54,9 +48,16 @@ module Patterns
     tsort
     un
     unicode_normalize
-    uninstall
     win32ole
     ubygems
+
+    jruby
+    mri
+    mruby
+    ruby
+    rubygems
+    install
+    uninstall
     sidekiq-pro
     graphql-pro
 

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -16,7 +16,6 @@ module Patterns
     coverage
     digest
     drb
-    english
     enumerator
     erb
     expect
@@ -27,21 +26,14 @@ module Patterns
     io-wait
     jruby
     mkmf
-    monitor
     mri
     mruby
-    net-ftp
-    net-http
-    net-imap
-    net-protocol
     nkf
-    observer
     open-uri
     optparse
     pathname
     pp
     prettyprint
-    prime
     profile
     profiler
     pty
@@ -57,20 +49,13 @@ module Patterns
     shellwords
     socket
     syslog
-    tempfile
     thread
     time
-    timeout
-    tmpdir
-    tracer
     tsort
     un
     unicode_normalize
     uninstall
-    uri
-    weakref
     win32ole
-    yaml
     ubygems
     sidekiq-pro
     graphql-pro


### PR DESCRIPTION
The ruby core team have a plan to extract stdlib to rubygems as `the default gems`.

I removed 1st group for the Ruby 2.8/3.0 from the reserved names. 

Can anyone merge this? And Can you notify me before deploy it? Because I must push the same time for reserving them on the rubygems.org.

Thanks!