### PR TITLE
Add unanalyzed name field to ES to support prefix search 

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -60,6 +60,7 @@ module RubygemSearchable
     mapping do
       indexes :name, type: "text", analyzer: "rubygem" do
         indexes :suggest, analyzer: "simple"
+        indexes :unanalyzed, type: "keyword", index: "true"
       end
       indexes :summary, type: "text", analyzer: "english" do
         indexes :raw, analyzer: "simple"

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -29,8 +29,15 @@ class ElasticSearcher
               should do
                 query_string do
                   query query_str
-                  fields ["name^5", "summary^3", "description"]
+                  fields ["name^5", "summary^2", "description"]
                   default_operator "and"
+                end
+              end
+
+              should do
+                prefix "name.unanalyzed" do
+                  value query_str
+                  boost 7
                 end
               end
 

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -33,6 +33,7 @@ class ElasticSearcher
                   default_operator "and"
                 end
               end
+
               minimum_should_match 1
               # only return gems that are not yanked
               filter { term yanked: false }

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -292,4 +292,20 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "query matches gem name prefix" do
+    setup do
+      %w[term-ansicolor term-an].each do |gem_name|
+        create(:rubygem, name: gem_name, number: "0.0.1", downloads: 10)
+      end
+      import_and_refresh
+    end
+
+    should "return results" do
+      _, response = ElasticSearcher.new("term-ans").search
+
+      assert_equal 1, response.size
+      assert_equal "term-ansicolor", response.first.name
+    end
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/rubygems/rubygems.org/issues/1662
rubygem analyzer tokenizes on Patterns::SPECIAL_CHARACTERS, which meant
name like `term-ansicolor` were indexed as [term, ansicolor].
Techinaically, full text search (ans matching ansicolor) on name should work
but it doesn't.

This can also have been solved with n-gram analyzer or completion suggester.
We may switch to them when we add autocomplete.