### PR TITLE
Reset push rate limit on successful gem push

### DIFF
--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def create
-    gemcutter = Pusher.new(@api_user, request.body)
+    gemcutter = Pusher.new(@api_user, request.body, request.remote_ip)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
 
     render plain: gemcutter.message, status: gemcutter.code

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -106,7 +106,7 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     GemCachePurger.call(rubygem.name)
-    RackAttackReset.gem_push_backoff(@remote_ip)
+    RackAttackReset.gem_push_backoff(@remote_ip) if @remote_ip.present?
     StatsD.increment "push.success"
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,6 +6,8 @@ class Rack::Attack
   LIMIT_PERIOD = 10.minutes
   PUSH_LIMIT_PERIOD = 60.minutes
   EXP_BASE_LIMIT_PERIOD = 100.seconds
+  EXP_BACKOFF_LEVELS = [1, 2, 3].freeze
+  PUSH_EXP_THROTTLE_KEY = "api/exp/push/ip".freeze
 
   ### Prevent Brute-Force Login Attacks ###
 
@@ -51,19 +53,25 @@ class Rack::Attack
   # 200 req in 100 seconds
   # 400 req in 10000 seconds (2.7 hours)
   # 600 req in 1000000 seconds (277.7 hours)
-  (1..3).each do |level|
+  EXP_BACKOFF_LEVELS.each do |level|
     throttle("clearance/ip/#{level}", limit: EXP_BASE_REQUEST_LIMIT * level, period: (EXP_BASE_LIMIT_PERIOD**level).seconds) do |req|
       req.ip if protected_route?(protected_ui_actions, req.path, req.request_method)
     end
   end
 
-  (1..3).each do |level|
+  EXP_BACKOFF_LEVELS.each do |level|
     throttle("api/ip/#{level}", limit: EXP_BASE_REQUEST_LIMIT * level, period: (EXP_BASE_LIMIT_PERIOD**level).seconds) do |req|
       req.ip if protected_route?(protected_api_actions, req.path, req.request_method)
     end
   end
 
   protected_push_action = [{ controller: "api/v1/rubygems", action: "create" }]
+
+  EXP_BACKOFF_LEVELS.each do |level|
+    throttle("#{PUSH_EXP_THROTTLE_KEY}/#{level}", limit: EXP_BASE_REQUEST_LIMIT * level, period: (EXP_BASE_LIMIT_PERIOD**level).seconds) do |req|
+      req.ip if protected_route?(protected_push_action, req.path, req.request_method)
+    end
+  end
 
   throttle("api/push/ip", limit: PUSH_LIMIT, period: PUSH_LIMIT_PERIOD) do |req|
     req.ip if protected_route?(protected_push_action, req.path, req.request_method)

--- a/lib/rack_attack_reset.rb
+++ b/lib/rack_attack_reset.rb
@@ -1,0 +1,7 @@
+module RackAttackReset
+  def self.gem_push_backoff(remote_ip)
+    Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
+      Rack::Attack.cache.reset_count("#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}", Rack::Attack::EXP_BASE_LIMIT_PERIOD**level)
+    end
+  end
+end

--- a/lib/rack_attack_reset.rb
+++ b/lib/rack_attack_reset.rb
@@ -1,7 +1,24 @@
 module RackAttackReset
-  def self.gem_push_backoff(remote_ip)
-    Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
-      Rack::Attack.cache.reset_count("#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}", Rack::Attack::EXP_BASE_LIMIT_PERIOD**level)
+  class << self
+    def gem_push_backoff(remote_ip)
+      Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
+        keys(level, remote_ip).each { |key| Rack::Attack.cache.store.delete(key) }
+      end
+    end
+
+    private
+
+    def keys(level, remote_ip)
+      period            = Rack::Attack::EXP_BASE_LIMIT_PERIOD**level
+      time_counter      = (Time.now.to_i / period).to_i
+      # counter may have incremented by 1 since the key was set, best to reset prev counter as well.
+      # pre time counter/window key is applicable for +1 second after the counter has changed
+      # see: https://github.com/kickstarter/rack-attack/pull/85
+      prev_time_counter = time_counter - 1
+      prefix            = Rack::Attack.cache.prefix
+
+      ["#{prefix}:#{time_counter}:#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}",
+       "#{prefix}:#{prev_time_counter}:#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}"]
     end
   end
 end

--- a/test/integration/api/v1/rubygems_test.rb
+++ b/test/integration/api/v1/rubygems_test.rb
@@ -12,4 +12,25 @@ class Api::V1::RubygemsTest < ActionDispatch::IntegrationTest
     get "/api/v1/gems?api_key[]=#{@user.api_key}&api_key[]=key1", as: :json
     assert_response :unauthorized
   end
+
+  test "request has remote addr present" do
+    ip_address = "1.2.3.4"
+    RackAttackReset.expects(:gem_push_backoff).with(ip_address).once
+
+    post "/api/v1/gems",
+          params: gem_file("test-1.0.0.gem").read,
+          headers: { REMOTE_ADDR: ip_address, HTTP_AUTHORIZATION: @user.api_key, CONTENT_TYPE: "application/octet-stream" }
+
+    assert_response :success
+  end
+
+  test "request has remote addr absent" do
+    RackAttackReset.expects(:gem_push_backoff).never
+
+    post "/api/v1/gems",
+          params: gem_file("test-1.0.0.gem").read,
+          headers: { REMOTE_ADDR: "", HTTP_AUTHORIZATION: @user.api_key, CONTENT_TYPE: "application/octet-stream" }
+
+    assert_response :success
+  end
 end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -228,9 +228,12 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         should "reset gem push rate limit rack attack key" do
           Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
             period = exp_base_limit_period**level
-            period_throttle_key = "#{Time.now.to_i / period}:#{@push_exp_throttle_level_key}"
 
-            assert_nil Rack::Attack.cache.read(period_throttle_key)
+            time_counter = (Time.now.to_i / period).to_i
+            prev_time_counter = time_counter - 1
+
+            assert_nil Rack::Attack.cache.read("#{time_counter}:#{@push_exp_throttle_level_key}")
+            assert_nil Rack::Attack.cache.read("#{prev_time_counter}:#{@push_exp_throttle_level_key}")
           end
         end
 


### PR DESCRIPTION
We have rate limit with exp bacioff on endpoints with mfa to mitigate brute force of the otp code
https://security.stackexchange.com/questions/185905/maximum-tries-for-2fa-code
Check https://github.com/rubygems/rubygems.org/pull/2078 for more info on the attack.

Ideally, we only need to throttle 401 unauthorized requests to mitigate this, however rack-attack doesn't have option of rate limit on response status. resetting rate limit cache on successful push is the closest alternative (smiliar [usecase](https://github.com/gitlabhq/gitlabhq/blob/4529c19950e412f0461910585414f8633d3b1b18/lib/gitlab/auth/ip_rate_limiter.rb#L17)).

Exp rate limit was [removed from push](https://github.com/rubygems/rubygems.org/pull/2268) as we had used incorrect back off period and users were seeing unreasonable backoff time. This has since been [fixed](https://github.com/rubygems/rubygems.org/pull/2270), max back off period is now of 11 days.