### PR TITLE
Only show indexed gems on email notification setting page

### DIFF
--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -2,7 +2,7 @@ class NotifiersController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
 
   def show
-    @ownerships = current_user.ownerships.by_gem_name
+    @ownerships = current_user.ownerships.by_indexed_gem_name
   end
 
   def update

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -32,7 +32,7 @@ class Mailer < ApplicationMailer
 
   def notifiers_changed(user_id)
     @user = User.find(user_id)
-    @ownerships = @user.ownerships.by_gem_name
+    @ownerships = @user.ownerships.by_indexed_gem_name
 
     mail to: @user.email,
          subject: I18n.t("mailer.notifiers_changed.subject",

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -4,8 +4,11 @@ class Ownership < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :rubygem_id }
 
-  def self.by_gem_name
-    joins(:rubygem).order("rubygems.name ASC")
+  def self.by_indexed_gem_name
+    joins(:rubygem)
+      .joins("LEFT JOIN versions ON versions.rubygem_id = rubygems.id")
+      .where("indexed = true")
+      .order("rubygems.name ASC")
   end
 
   def safe_destroy

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -6,7 +6,10 @@ class NotificationSettingsTest < SystemTest
 
   test "changing email notification settings" do
     user = create(:user)
-    ownership1, ownership2 = create_list(:ownership, 2, user: user)
+    rubygem1 = create(:rubygem, number: "0.0.1")
+    rubygem2 = create(:rubygem, number: "0.0.2")
+    ownership1 = create(:ownership, rubygem: rubygem1, user: user)
+    ownership2 = create(:ownership, rubygem: rubygem2, user: user)
 
     visit edit_profile_path(as: user)
 
@@ -47,6 +50,20 @@ class NotificationSettingsTest < SystemTest
     visit edit_profile_path(as: user)
 
     assert_no_text I18n.t("notifiers.show.title")
+  end
+
+  test "email notification setting does not show for yanked gems" do
+    user = create(:user)
+    create(:rubygem, number: "0.0.1", owners: [user])
+
+    yanked_rubygem = create(:rubygem, name: "yanked-gem", owners: [user])
+    create(:version, rubygem: yanked_rubygem, indexed: false)
+
+    visit edit_profile_path(as: user)
+
+    click_link I18n.t("notifiers.show.title")
+
+    assert_no_text "yanked-gem"
   end
 
   def notifier_on_radio(ownership)


### PR DESCRIPTION
although, we keeps track of gems with all yanked versions, users
don't need to see it in UI.
user will still notification if a version was pushed (default enabled).

closes: #2158