### PR TITLE
Use metadata uri instead of linkset for github links

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -15,16 +15,6 @@ module RubygemsHelper
     link_to(t(".links.#{id}"), url, rel: "nofollow", class: %w[gem__link t-list__item], id: id) if url.present?
   end
 
-  def link_to_github(rubygem)
-    if !rubygem.linkset.code.nil? && URI(rubygem.linkset.code).host == "github.com"
-      URI(@rubygem.linkset.code)
-    elsif !rubygem.linkset.home.nil? && URI(rubygem.linkset.home).host == "github.com"
-      URI(rubygem.linkset.home)
-    end
-  rescue URI::InvalidURIError
-    nil
-  end
-
   def link_to_directory
     ("A".."Z").map do |letter|
       link_to(letter, rubygems_path(letter: letter), class: "gems__nav-link")
@@ -118,7 +108,18 @@ module RubygemsHelper
     rubygem.yanked if rubygem.respond_to?(:yanked)
   end
 
-  def github_params(link)
-    "user=#{link.path.split('/').second}&repo=#{link.path.split('/').third}&type=star&count=true&size=large"
+  def link_to_github(rubygem)
+    if rubygem.links.source_code_uri.present? && URI(rubygem.links.source_code_uri).host == "github.com"
+      URI(rubygem.links.source_code_uri)
+    elsif rubygem.links.homepage_uri.present? && URI(rubygem.links.homepage_uri).host == "github.com"
+      URI(rubygem.links.homepage_uri)
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def github_params(rubygem)
+    link = link_to_github(rubygem)
+    "user=#{link.path.split('/').second}&repo=#{link.path.split('/').third}&type=star&count=true&size=large" if link
   end
 end

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -1,6 +1,7 @@
 <div class="gem__aside l-col--r--pad">
-  <% if @rubygem.linkset.present? && github_link = link_to_github(@rubygem) %>
-    <%= render partial: "rubygems/github_button", locals: { github_link: github_link } %>
+
+  <% if github_data_params = github_params(@rubygem) %>
+    <%= render partial: "rubygems/github_button", locals: { github_data_params: github_data_params } %>
   <% end %>
 
   <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">

--- a/app/views/rubygems/_github_button.html.erb
+++ b/app/views/rubygems/_github_button.html.erb
@@ -1,4 +1,4 @@
-<span class="github-btn" id="github-btn" data-params=<%= github_params(github_link) %> %>
+<span class="github-btn" id="github-btn" data-params=<%= github_data_params %> %>
   <a class="gh-btn" id="gh-btn" href="#" target="_blank" aria-label="">
     <span class="gh-ico" aria-hidden="true"></span>
     <span class="gh-text" id="gh-text"></span>

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -113,4 +113,20 @@ class GemsSystemTest < SystemTest
     assert page.has_no_selector?(".gem__users__mfa-text.mfa-warn")
     assert page.has_no_selector?(".gem__users__mfa-text.mfa-info")
   end
+
+  test "shows github link when source_code_uri is set" do
+    github_link = "http://github.com/user/project"
+    create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "source_code_uri" => github_link })
+
+    visit rubygem_path(@rubygem)
+    assert page.has_selector?(".github-btn")
+  end
+
+  test "shows github link when homepage_uri is set" do
+    github_link = "http://github.com/user/project"
+    create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "homepage_uri" => github_link })
+
+    visit rubygem_path(@rubygem)
+    assert page.has_selector?(".github-btn")
+  end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -129,4 +129,12 @@ class GemsSystemTest < SystemTest
     visit rubygem_path(@rubygem)
     assert page.has_selector?(".github-btn")
   end
+
+  test "does not show github link when homepage_uri is not github" do
+    notgithub_link = "http://notgithub.com/user/project"
+    create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "homepage_uri" => notgithub_link })
+
+    visit rubygem_path(@rubygem)
+    assert page.has_no_selector?(".github-btn")
+  end
 end

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -159,7 +159,7 @@ class RubygemsHelperTest < ActionView::TestCase
     context "with invalid uri" do
       setup do
         linkset = build(:linkset, code: "http://github.com/\#{github_username}/\#{project_name}")
-        @rubygem = build(:rubygem, linkset: linkset)
+        @rubygem = create(:rubygem, linkset: linkset, number: "0.0.1")
       end
 
       should "not raise error" do
@@ -175,7 +175,7 @@ class RubygemsHelperTest < ActionView::TestCase
       setup do
         @github_link = "http://github.com/user/project"
         linkset = build(:linkset, code: @github_link)
-        @rubygem = build(:rubygem, linkset: linkset)
+        @rubygem = create(:rubygem, linkset: linkset, number: "0.0.1")
       end
 
       should "return parsed uri" do
@@ -187,7 +187,7 @@ class RubygemsHelperTest < ActionView::TestCase
       setup do
         @github_link = "http://github.com/user/project"
         linkset = build(:linkset, home: @github_link)
-        @rubygem = build(:rubygem, linkset: linkset)
+        @rubygem = create(:rubygem, linkset: linkset, number: "0.0.1")
       end
 
       should "return parsed uri" do


### PR DESCRIPTION
We had deprecated Linkset a while back, must have missed updating
these functions. Links fallbacks to Linkset.
Fixes: github button not shown when homepage_uri or source_code_uri
is set.

closes: #2314