### PR TITLE
Check for yanked version before repush fail message

### DIFF
--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -73,6 +73,17 @@ class PushTest < ActionDispatch::IntegrationTest
     assert_match(/cannot process this gem/, response.body)
   end
 
+  test "republish a yanked version" do
+    rubygem = create(:rubygem, name: "sandworm")
+    create(:version, number: "1.0.0", indexed: false, rubygem: rubygem)
+
+    build_gem "sandworm", "1.0.0"
+
+    push_gem "sandworm-1.0.0.gem"
+    assert_response :conflict
+    assert_match(/A yanked version already exists \(sandworm-1.0.0\)/, response.body)
+  end
+
   def push_gem(path)
     post api_v1_rubygems_path,
       env: { "RAW_POST_DATA" => File.read(path) },


### PR DESCRIPTION
message shown for all repush failures was a bit misleading:
```
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.
```

closes: #2013