### PR TITLE
Disallow news from robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,4 @@ Disallow: /downloads/
 Disallow: /gems?letter=*
 Disallow: /search?*
 Disallow: /names
+Disallow: /news


### PR DESCRIPTION
We will be using /releases for same resource, disallowing news so
that this doesn't affect our SEO. We will remove it after we have
added redirect on fastly.