### PR TITLE
Use just the dependency name as a link

### DIFF
--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -6,11 +6,13 @@
         <% dependencies.each do |dependency| %>
           <% if rubygem = dependency.rubygem %>
             <%= link_to rubygem_path(rubygem), :class => 't-list__item push--s' do %>
-              <strong><%= rubygem.name %></strong> <%= dependency.clean_requirements %>
+              <strong><%= rubygem.name %></strong>
             <% end %>
+            <span> <%= dependency.clean_requirements %></span>
           <% elsif dependency&.name %>
             <p class="t-list__item gem__unregistered" title="unregistered gem">
-              <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>
+              <strong><%= dependency.name %></strong>
+              <span> <%= dependency.clean_requirements %></span>
             </p>
           <% end %>
         <% end %>


### PR DESCRIPTION
Because the gem name currently includes the version restrictions as part of the link, there is not possible to copy just the version restrictions. It usually needs to copy a lot more. Since I am copying the version restrictions from Rubygems.org relatively often, this become annoying to me over the years.

So this is proposal to fix this, by not including the versions into the link. I think that just the gem dependency name should be enough, since it is enough for the versions on the left side.

However, I have not tested this at all, because I don't have rubygems.org development environment installed. So if it does not really work, please take is as a suggestion a fix it appropriately. Thx