### PR TITLE
Move requirement text out of dependency link

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -209,6 +209,9 @@
   .gem__version-wrap .gem__version__date {
     font-weight: 400; }
 
+.gem__requirement-wrap a.t-list__item {
+    display: inline-block; }
+
 .gem__unregistered {
   color: #a6aab2;
   cursor: help;

--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -158,6 +158,9 @@ a.page__heading {
 .push--s {
   margin-top: 20px; }
 
+.push--top-s {
+  margin-top: 15px; }
+
 /* style used to be applied on iframe of github_buttons */
 span#github-btn {
   display: block;

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -5,9 +5,12 @@
       <div class="t-list__items">
         <% dependencies.each do |dependency| %>
           <% if rubygem = dependency.rubygem %>
-            <%= link_to rubygem_path(rubygem), :class => 't-list__item push--s' do %>
-              <strong><%= rubygem.name %></strong> <%= dependency.clean_requirements %>
-            <% end %>
+            <li class="gem__requirement-wrap">
+              <%= link_to rubygem_path(rubygem), :class => 't-list__item push--top-s' do %>
+                <strong><%= rubygem.name %></strong>
+              <% end %>
+              <%= dependency.clean_requirements %>
+            </li>
           <% elsif dependency&.name %>
             <p class="t-list__item gem__unregistered" title="unregistered gem">
               <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>


### PR DESCRIPTION
display: block and link was making it difficult to copy.

before, one would have to guess block width if copying from right. copy from left just wouldn't work.
![Screenshot from 2020-04-21 20-33-32](https://user-images.githubusercontent.com/7680662/79883147-2cd9c080-8411-11ea-9d72-bdf00ab8ae56.png)

after, two separate items make it easier to copy:
![Screenshot from 2020-04-21 20-34-20](https://user-images.githubusercontent.com/7680662/79883137-2a776680-8411-11ea-8c91-e83287514263.png)

