### PR TITLE
cache total count of rubygems for six hours

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -54,7 +54,7 @@ class Rubygem < ApplicationRecord
 
   def self.total_count
     Rails.cache.fetch("gem/total_count", expires_in: 6.hours) do
-      count_by_sql "SELECT COUNT(*) from (SELECT DISTINCT rubygem_id FROM versions WHERE indexed = true) AS v"
+      Version.indexed.distinct.count(:rubygem_id)
     end
   end
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -53,7 +53,9 @@ class Rubygem < ApplicationRecord
   end
 
   def self.total_count
-    count_by_sql "SELECT COUNT(*) from (SELECT DISTINCT rubygem_id FROM versions WHERE indexed = true) AS v"
+    Rails.cache.fetch("gem/total_count", expires_in: 6.hours) do
+      count_by_sql "SELECT COUNT(*) from (SELECT DISTINCT rubygem_id FROM versions WHERE indexed = true) AS v"
+    end
   end
 
   def self.latest(limit = 5)

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -611,10 +611,6 @@ class RubygemTest < ActiveSupport::TestCase
       refute @thin.pushable?
     end
 
-    should "give a count of only rubygems with versions" do
-      assert_equal 6, Rubygem.total_count
-    end
-
     should "only return the latest gems with versions" do
       assert_equal [@rack, @thor, @dust, @json, @rake],        Rubygem.latest
       assert_equal [@rack, @thor, @dust, @json, @rake, @thin], Rubygem.latest(6)
@@ -623,6 +619,28 @@ class RubygemTest < ActiveSupport::TestCase
     should "only latest downloaded versions" do
       assert_equal [@thin, @rake, @json, @thor, @rack],        Rubygem.downloaded
       assert_equal [@thin, @rake, @json, @thor, @rack, @dust], Rubygem.downloaded(6)
+    end
+
+    context ".total_count" do
+      setup {  @expected_total = 6 }
+
+      should "give a count of only rubygems with versions" do
+        assert_equal @expected_total, Rubygem.total_count
+      end
+
+      should "write to cache" do
+        Rails.cache.expects(:write).with("gem/total_count", @expected_total, { expires_in: 6.hours })
+        Rubygem.total_count
+      end
+
+      context "cache hit" do
+        setup { Rubygem.total_count }
+
+        should "not use sql to get result" do
+          Rubygem.expects(:count_by_sql).never
+          assert_equal @expected_total, Rubygem.total_count
+        end
+      end
     end
   end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -622,7 +622,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     context ".total_count" do
-      setup {  @expected_total = 6 }
+      setup { @expected_total = 6 }
 
       should "give a count of only rubygems with versions" do
         assert_equal @expected_total, Rubygem.total_count
@@ -637,7 +637,7 @@ class RubygemTest < ActiveSupport::TestCase
         setup { Rubygem.total_count }
 
         should "not use sql to get result" do
-          Rubygem.expects(:count_by_sql).never
+          Version.expects(:where).never
           assert_equal @expected_total, Rubygem.total_count
         end
       end


### PR DESCRIPTION
this would save ~600ms spent in select * on versions table.
Keeping the page fast is more important than accurate total count,
there won't be huge change in total within 6 hours anyway.

response time on my local:
```
# miss
$ time curl http://localhost:3000/stats -o /dev/null                                                                     
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                        
                                 Dload  Upload   Total   Spent    Left  Speed                                                                                          
100 15278  100 15278    0     0  15186      0  0:00:01  0:00:01 --:--:-- 15186                                                                                         

real    0m1.019s
user    0m0.010s
sys     0m0.005s

# hit
$ time curl http://localhost:3000/stats -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15278  100 15278    0     0  46579      0 --:--:-- --:--:-- --:--:-- 46579

real    0m0.354s
user    0m0.022s
sys     0m0.007s
```