### PR TITLE
Update exp back off endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,12 +1,12 @@
 class Rack::Attack
   REQUEST_LIMIT = 100
-  EXP_BASE_REQUEST_LIMIT = 200
+  EXP_BASE_REQUEST_LIMIT = 300
   PUSH_LIMIT = 400
   REQUEST_LIMIT_PER_EMAIL = 10
   LIMIT_PERIOD = 10.minutes
   PUSH_LIMIT_PERIOD = 60.minutes
-  EXP_BASE_LIMIT_PERIOD = 100.seconds
-  EXP_BACKOFF_LEVELS = [1, 2, 3].freeze
+  EXP_BASE_LIMIT_PERIOD = 300.seconds
+  EXP_BACKOFF_LEVELS = [1, 2].freeze
   PUSH_EXP_THROTTLE_KEY = "api/exp/push/ip".freeze
 
   ### Prevent Brute-Force Login Attacks ###
@@ -60,9 +60,8 @@ class Rack::Attack
     req.ip if protected_route?(protected_ui_actions, req.path, req.request_method)
   end
 
-  # 200 req in 100 seconds
-  # 400 req in 10000 seconds (2.7 hours)
-  # 600 req in 1000000 seconds (277.7 hours)
+  # 300 req in 300 seconds
+  # 600 req in 90000 seconds (25 hours)
   EXP_BACKOFF_LEVELS.each do |level|
     throttle("clearance/ip/#{level}", limit: EXP_BASE_REQUEST_LIMIT * level, period: (EXP_BASE_LIMIT_PERIOD**level).seconds) do |req|
       req.ip if protected_route?(protected_ui_mfa_actions, req.path, req.request_method)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -87,13 +87,6 @@ class Rack::Attack
     req.ip if protected_route?(protected_push_action, req.path, req.request_method)
   end
 
-  # Throttle GET request for api_key by IP address
-  protected_api_key_action = [{ controller: "api/v1/api_keys", action: "show" }]
-
-  throttle("api_key/ip", limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
-    req.ip if protected_route?(protected_api_key_action, req.path, req.request_method)
-  end
-
   # Throttle yank requests
   YANK_LIMIT = 10
   protected_yank_action = [{ controller: "api/v1/deletions", action: "create" }]
@@ -117,6 +110,8 @@ class Rack::Attack
     protected_route = protected_route?(protected_sessions_action, req.path, req.request_method)
     User.normalize_email(req.params['session']['who']).presence if protected_route && req.params['session']
   end
+
+  protected_api_key_action = [{ controller: "api/v1/api_keys", action: "show" }]
 
   throttle("api_key/basic_auth", limit: REQUEST_LIMIT, period: LIMIT_PERIOD) do |req|
     if protected_route?(protected_api_key_action, req.path, req.request_method)

--- a/test/helpers/rate_limit_helpers.rb
+++ b/test/helpers/rate_limit_helpers.rb
@@ -1,0 +1,98 @@
+module RateLimitHelpers
+  def exceeding_limit
+    (Rack::Attack::REQUEST_LIMIT * 1.25).to_i
+  end
+
+  def exceeding_email_limit
+    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 1.25).to_i
+  end
+
+  def exceeding_exp_base_limit
+    (Rack::Attack::EXP_BASE_REQUEST_LIMIT * 1.25).to_i
+  end
+
+  def under_limit
+    (Rack::Attack::REQUEST_LIMIT * 0.5).to_i
+  end
+
+  def under_email_limit
+    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 0.5).to_i
+  end
+
+  def limit_period
+    Rack::Attack::LIMIT_PERIOD
+  end
+
+  def push_limit_period
+    Rack::Attack::PUSH_LIMIT_PERIOD
+  end
+
+  def exp_base_limit_period
+    Rack::Attack::EXP_BASE_LIMIT_PERIOD
+  end
+
+  def exceed_limit_for(scope)
+    update_limit_for("#{scope}:#{@ip_address}", exceeding_limit)
+  end
+
+  def exceed_email_limit_for(scope)
+    update_limit_for("#{scope}:#{@user.email}", exceeding_email_limit)
+  end
+
+  def exceed_push_limit_for(scope)
+    exceeding_push_limit = (Rack::Attack::PUSH_LIMIT * 1.25).to_i
+    update_limit_for("#{scope}:#{@ip_address}", exceeding_push_limit, push_limit_period)
+  end
+
+  def exceed_exp_base_limit_for(scope)
+    update_limit_for("#{scope}:#{@ip_address}", exceeding_exp_base_limit, exp_base_limit_period)
+  end
+
+  def stay_under_limit_for(scope)
+    update_limit_for("#{scope}:#{@ip_address}", under_limit)
+  end
+
+  def stay_under_email_limit_for(scope)
+    update_limit_for("#{scope}:#{@user.email}", under_email_limit)
+  end
+
+  def stay_under_push_limit_for(scope)
+    under_push_limit = (Rack::Attack::PUSH_LIMIT * 0.5).to_i
+    update_limit_for("#{scope}:#{@user.email}", under_push_limit)
+  end
+
+  def stay_under_exponential_limit(scope)
+    Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
+      under_backoff_limit = (Rack::Attack::EXP_BASE_REQUEST_LIMIT * level) - 1
+      throttle_level_key = "#{scope}/#{level}:#{@ip_address}"
+      under_backoff_limit.times { Rack::Attack.cache.count(throttle_level_key, exp_base_limit_period**level) }
+    end
+  end
+
+  def update_limit_for(key, limit, period = limit_period)
+    limit.times { Rack::Attack.cache.count(key, period) }
+  end
+
+  def exceed_exponential_limit_for(scope, level)
+    expo_exceeding_limit = exceeding_exp_base_limit * level
+    expo_limit_period = exp_base_limit_period**level
+    expo_exceeding_limit.times { Rack::Attack.cache.count("#{scope}:#{@ip_address}", expo_limit_period) }
+  end
+
+  def encode(username, password)
+    ActionController::HttpAuthentication::Basic
+      .encode_credentials(username, password)
+  end
+
+  def expected_retry_after(level)
+    now = Time.now.to_i
+    period = Rack::Attack::EXP_BASE_LIMIT_PERIOD**level
+    (period - (now % period)).to_s
+  end
+
+  def assert_throttle_at(level)
+    assert_response :too_many_requests
+    assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+    assert @response.headers["Retry-After"].to_i < @mfa_max_period[level]
+  end
+end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -132,16 +132,6 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
-    should "allow api_key show" do
-      stay_under_limit_for("api_key/ip")
-
-      get "/api/v1/api_key.json",
-        env: { "HTTP_AUTHORIZATION" => encode(@user.handle, @user.password) },
-        headers: { REMOTE_ADDR: @ip_address }
-
-      assert_response :success
-    end
-
     should "allow email confirmation resend" do
       stay_under_limit_for("clearance/ip/1")
       stay_under_email_limit_for("email_confirmations/email")
@@ -281,16 +271,6 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
       post "/passwords",
         params: { password: { email: @user.email } },
-        headers: { REMOTE_ADDR: @ip_address }
-
-      assert_response :too_many_requests
-    end
-
-    should "throttle api_key show" do
-      exceed_limit_for("api_key/ip")
-
-      get "/api/v1/api_key.json",
-        env: { "HTTP_AUTHORIZATION" => encode(@user.handle, @user.password) },
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,100 +1,15 @@
 require "test_helper"
+require "helpers/rate_limit_helpers"
 
 class RackAttackTest < ActionDispatch::IntegrationTest
+  include RateLimitHelpers
+
   setup do
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rails.cache.clear
 
     @ip_address = "1.2.3.4"
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD)
-  end
-
-  def exceeding_limit
-    (Rack::Attack::REQUEST_LIMIT * 1.25).to_i
-  end
-
-  def exceeding_email_limit
-    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 1.25).to_i
-  end
-
-  def exceeding_exp_base_limit
-    (Rack::Attack::EXP_BASE_REQUEST_LIMIT * 1.25).to_i
-  end
-
-  def under_limit
-    (Rack::Attack::REQUEST_LIMIT * 0.5).to_i
-  end
-
-  def under_email_limit
-    (Rack::Attack::REQUEST_LIMIT_PER_EMAIL * 0.5).to_i
-  end
-
-  def limit_period
-    Rack::Attack::LIMIT_PERIOD
-  end
-
-  def push_limit_period
-    Rack::Attack::PUSH_LIMIT_PERIOD
-  end
-
-  def exp_base_limit_period
-    Rack::Attack::EXP_BASE_LIMIT_PERIOD
-  end
-
-  def exceed_limit_for(scope)
-    update_limit_for("#{scope}:#{@ip_address}", exceeding_limit)
-  end
-
-  def exceed_email_limit_for(scope)
-    update_limit_for("#{scope}:#{@user.email}", exceeding_email_limit)
-  end
-
-  def exceed_push_limit_for(scope)
-    exceeding_push_limit = (Rack::Attack::PUSH_LIMIT * 1.25).to_i
-    update_limit_for("#{scope}:#{@ip_address}", exceeding_push_limit, push_limit_period)
-  end
-
-  def exceed_exp_base_limit_for(scope)
-    update_limit_for("#{scope}:#{@ip_address}", exceeding_exp_base_limit, exp_base_limit_period)
-  end
-
-  def stay_under_limit_for(scope)
-    update_limit_for("#{scope}:#{@ip_address}", under_limit)
-  end
-
-  def stay_under_email_limit_for(scope)
-    update_limit_for("#{scope}:#{@user.email}", under_email_limit)
-  end
-
-  def stay_under_push_limit_for(scope)
-    under_push_limit = (Rack::Attack::PUSH_LIMIT * 0.5).to_i
-    update_limit_for("#{scope}:#{@user.email}", under_push_limit)
-  end
-
-  def stay_under_exp_base_limit_for(scope)
-    under_exp_base_limit = (Rack::Attack::EXP_BASE_REQUEST_LIMIT * 0.5).to_i
-    update_limit_for("#{scope}:#{@user.email}", under_exp_base_limit, exp_base_limit_period)
-  end
-
-  def update_limit_for(key, limit, period = limit_period)
-    limit.times { Rack::Attack.cache.count(key, period) }
-  end
-
-  def exceed_exponential_limit_for(scope, level)
-    expo_exceeding_limit = exceeding_exp_base_limit * level
-    expo_limit_period = exp_base_limit_period**level
-    expo_exceeding_limit.times { Rack::Attack.cache.count("#{scope}:#{@ip_address}", expo_limit_period) }
-  end
-
-  def encode(username, password)
-    ActionController::HttpAuthentication::Basic
-      .encode_credentials(username, password)
-  end
-
-  def expected_retry_after(level)
-    now = Time.now.to_i
-    period = Rack::Attack::EXP_BASE_LIMIT_PERIOD**level
-    (period - (now % period)).to_s
   end
 
   context "requests is lower than limit" do
@@ -149,45 +64,12 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         @rubygem.ownerships.create(user: @user)
       end
 
-      should "allow gem yank by ip" do
-        stay_under_exp_base_limit_for("api/ip/1")
-
-        delete "/api/v1/gems/yank",
-          params: { gem_name: @rubygem.to_param, version: @rubygem.latest_version.number },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
-
-        assert_response :success
-      end
-
       should "allow gem push by ip" do
         stay_under_push_limit_for("api/push/ip")
 
         post "/api/v1/gems",
           params: gem_file("test-1.0.0.gem").read,
           headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, CONTENT_TYPE: "application/octet-stream" }
-
-        assert_response :success
-      end
-
-      should "allow owner add by ip" do
-        second_user = create(:user)
-        stay_under_exp_base_limit_for("api/ip/1")
-
-        post "/api/v1/gems/#{@rubygem.name}/owners",
-          params: { rubygem_id: @rubygem.to_param, email: second_user.email },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
-
-        assert_response :success
-      end
-
-      should "allow owner remove by ip" do
-        second_user = create(:user)
-        @rubygem.ownerships.create(user: second_user)
-        stay_under_exp_base_limit_for("api/ip/1")
-
-        delete "/api/v1/gems/#{@rubygem.name}/owners",
-          params: { rubygem_id: @rubygem.to_param, email: second_user.email },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
 
         assert_response :success
       end
@@ -239,6 +121,71 @@ class RackAttackTest < ActionDispatch::IntegrationTest
             headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, CONTENT_TYPE: "application/octet-stream" }
 
           assert_response :ok
+        end
+      end
+
+      context "ui requests" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          stay_under_exponential_limit("clearance/ip")
+        end
+
+        should "allow for mfa sign in" do
+          post "/session", params: { session: { who: @user.handle, password: @user.password } } # sets session[:mfa_user]
+
+          post "/session/mfa_create",
+            params: { otp: ROTP::TOTP.new(@user.mfa_seed).now },
+            headers: { REMOTE_ADDR: @ip_address }
+
+          assert_redirected_to "/dashboard"
+        end
+
+        should "allow mfa forgot password" do
+          @user.forgot_password!
+          post "/users/#{@user.id}/password/mfa_edit",
+            params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.mfa_seed).now },
+            headers: { REMOTE_ADDR: @ip_address }
+
+          assert_response :ok
+        end
+      end
+
+      context "api requests" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          stay_under_exponential_limit("api/ip")
+
+          @rubygem = create(:rubygem, name: "test", number: "0.0.1")
+          @rubygem.ownerships.create(user: @user)
+        end
+
+        should "allow gem yank by ip" do
+          delete "/api/v1/gems/yank",
+            params: { gem_name: @rubygem.to_param, version: @rubygem.latest_version.number },
+            headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, HTTP_OTP: ROTP::TOTP.new(@user.mfa_seed).now }
+
+          assert_response :success
+        end
+
+        should "allow owner add by ip" do
+          second_user = create(:user)
+
+          post "/api/v1/gems/#{@rubygem.name}/owners",
+            params: { rubygem_id: @rubygem.to_param, email: second_user.email },
+            headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, HTTP_OTP: ROTP::TOTP.new(@user.mfa_seed).now }
+
+          assert_response :success
+        end
+
+        should "allow owner remove by ip" do
+          second_user = create(:user)
+          @rubygem.ownerships.create(user: second_user)
+
+          delete "/api/v1/gems/#{@rubygem.name}/owners",
+            params: { rubygem_id: @rubygem.to_param, email: second_user.email },
+            headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, HTTP_OTP: ROTP::TOTP.new(@user.mfa_seed).now }
+
+          assert_response :success
         end
       end
     end
@@ -339,16 +286,6 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         @rubygem.ownerships.create(user: @user)
       end
 
-      should "throttle gem yank by ip" do
-        exceed_exp_base_limit_for("api/ip/1")
-
-        delete "/api/v1/gems/yank",
-          params: { gem_name: @rubygem.to_param, version: @rubygem.latest_version.number },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
-
-        assert_response :too_many_requests
-      end
-
       should "throttle gem push by ip" do
         exceed_push_limit_for("api/push/ip")
 
@@ -358,42 +295,18 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
         assert_response :too_many_requests
       end
-
-      should "throttle owner add by ip" do
-        second_user = create(:user)
-        exceed_exp_base_limit_for("api/ip/1")
-
-        post "/api/v1/gems/#{@rubygem.name}/owners",
-          params: { rubygem_id: @rubygem.to_param, email: second_user.email },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
-
-        assert_response :too_many_requests
-      end
-
-      should "throttle owner remove by ip" do
-        second_user = create(:user)
-        @rubygem.ownerships.create(user: second_user)
-        exceed_exp_base_limit_for("api/ip/1")
-
-        delete "/api/v1/gems/#{@rubygem.name}/owners",
-          params: { rubygem_id: @rubygem.to_param, email: second_user.email },
-          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key }
-
-        assert_response :too_many_requests
-      end
     end
 
     context "exponential backoff" do
+      setup { @mfa_max_period = { 1 => 100, 2 => 10_000, 3 => 1_000_000 } }
+
       Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
         should "throttle for mfa sign in at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
+            post "/session/mfa_create", headers: { REMOTE_ADDR: @ip_address }
 
-            post "/session/mfa_create",
-              headers: { REMOTE_ADDR: @ip_address }
-
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+            assert_throttle_at(level)
           end
         end
 
@@ -405,53 +318,70 @@ class RackAttackTest < ActionDispatch::IntegrationTest
               params: gem_file("test-0.0.0.gem").read,
               headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: @user.api_key, CONTENT_TYPE: "application/octet-stream" }
 
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+            assert_throttle_at(level)
           end
         end
 
         should "throttle mfa create at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
+            post "/multifactor_auth", headers: { REMOTE_ADDR: @ip_address }
 
-            post "/multifactor_auth",
-              headers: { REMOTE_ADDR: @ip_address }
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+            assert_throttle_at(level)
           end
         end
 
         should "throttle mfa update at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
+            put "/multifactor_auth", headers: { REMOTE_ADDR: @ip_address }
 
-            put "/multifactor_auth",
-              headers: { REMOTE_ADDR: @ip_address }
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+            assert_throttle_at(level)
           end
         end
 
         should "throttle api key show at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("api/ip/#{level}", level)
+            get "/api/v1/api_key.json", headers: { REMOTE_ADDR: @ip_address }
 
-            get "/api/v1/api_key.json",
-              headers: { REMOTE_ADDR: @ip_address }
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+            assert_throttle_at(level)
           end
         end
 
         should "throttle mfa forgot password at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
+            post "/users/#{@user.id}/password/mfa_edit", headers: { REMOTE_ADDR: @ip_address }
 
-            post "/users/#{@user.id}/password/mfa_edit",
-              headers: { REMOTE_ADDR: @ip_address }
+            assert_throttle_at(level)
+          end
+        end
 
-            assert_response :too_many_requests
-            assert_equal expected_retry_after(level), @response.headers["Retry-After"]
+        should "throttle gem yank by ip #{level}" do
+          freeze_time do
+            exceed_exponential_limit_for("api/ip/#{level}", level)
+            delete "/api/v1/gems/yank", headers: { REMOTE_ADDR: @ip_address }
+
+            assert_throttle_at(level)
+          end
+        end
+
+        should "throttle owner add by ip #{level}" do
+          freeze_time do
+            exceed_exponential_limit_for("api/ip/#{level}", level)
+            post "/api/v1/gems/somegem/owners", headers: { REMOTE_ADDR: @ip_address }
+
+            assert_throttle_at(level)
+          end
+        end
+
+        should "throttle owner remove by ip #{level}" do
+          freeze_time do
+            exceed_exponential_limit_for("api/ip/#{level}", level)
+            delete "/api/v1/gems/somegem/owners", headers: { REMOTE_ADDR: @ip_address }
+
+            assert_throttle_at(level)
           end
         end
       end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -298,7 +298,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     end
 
     context "exponential backoff" do
-      setup { @mfa_max_period = { 1 => 100, 2 => 10_000, 3 => 1_000_000 } }
+      setup { @mfa_max_period = { 1 => 300, 2 => 90_000 } }
 
       Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
         should "throttle for mfa sign in at level #{level}" do


### PR DESCRIPTION
Only endpoints with mfa need exp back off, extraneous endpoints were added in https://github.com/rubygems/rubygems.org/pull/2078

mfa create and udpate and api show actions use otp but were not in exp back off limits.