### PR TITLE
Use permit to only allow string params on gem index

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -9,7 +9,7 @@ class RubygemsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @letter = Rubygem.letterize(params[:letter])
+        @letter = Rubygem.letterize(gem_params[:letter])
         @gems   = Rubygem.letter(@letter).includes(:latest_version, :gem_download).page(@page)
       end
       format.atom do
@@ -40,5 +40,9 @@ class RubygemsController < ApplicationController
 
   def set_blacklisted_gem
     @blacklisted_gem = params[:id].downcase
+  end
+
+  def gem_params
+    params.permit(:letter, :format, :page)
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -38,6 +38,11 @@ class GemsTest < ActionDispatch::IntegrationTest
     css = %(link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.0.0"])
     assert page.has_css?(css, visible: false)
   end
+
+  test "letter param is not string" do
+    get rubygems_path(letter: ["S"])
+    assert_response :success
+  end
 end
 
 class GemsSystemTest < SystemTest


### PR DESCRIPTION
Fixes:
```
TypeError: no implicit conversion of Array into String
[PROJECT_ROOT]/app/models/rubygem.rb:72 :in `match?`
70
71   def self.letterize(letter)
72     /\A[A-Za-z]\z/.match?(letter) ? letter.upcase : "A"
73   end
[PROJECT_ROOT]/app/models/rubygem.rb:72 :in `letterize`
[PROJECT_ROOT]/app/controllers/rubygems_controller.rb:12 :in `block (2 levels) in index`
[PROJECT_ROOT]/app/controllers/rubygems_controller.rb:10 :in `index`
[PROJECT_ROOT]/app/middleware/redirector.rb:23 :in `call`
```