### PR TITLE
Add limit to just_updated subquery

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::ActivitiesController < Api::BaseController
   private
 
   def render_rubygems(versions)
-    rubygems = versions.includes(:dependencies, rubygem: %i[linkset gem_download]).map do |version|
+    rubygems = versions.includes(:dependencies, :gem_download, rubygem: %i[linkset gem_download]).map do |version|
       version.rubygem.payload(version)
     end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -141,11 +141,13 @@ class Version < ApplicationRecord
     subquery = <<-SQL
       versions.rubygem_id IN (SELECT versions.rubygem_id
                                 FROM versions
+                            WHERE versions.indexed = 'true'
                             GROUP BY versions.rubygem_id
-                              HAVING COUNT(versions.id) > 1)
+                              HAVING COUNT(versions.id) > 1
+                              ORDER BY MAX(created_at) DESC LIMIT :limit)
     SQL
 
-    where(subquery)
+    where(subquery, limit: limit)
       .joins(:rubygem)
       .indexed
       .by_created_at


### PR DESCRIPTION
Previously, this was scanning the complete versions table which was unnecessary when we only wanted to show 50 versions order by created_at.
Adding limit and order by with agg on created_at in subquery would
ensure we selecting over relevant rows only. Reduces ~1200ms. Solution taken from: https://stackoverflow.com/questions/19175411/group-by-and-order-by-on-different-columns

query plan:
https://gist.github.com/sonalkr132/d42a2eac814d9d0e470aa97a94dccede

```
# before
$ time curl http://localhost:3000/api/v1/activity/just_updated.json -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 56324  100 56324    0     0  26381      0  0:00:02  0:00:02 --:--:-- 26381

real    0m2.162s
user    0m0.026s
sys     0m0.004s

# after
$ time curl http://localhost:3000/api/v1/activity/just_updated.json -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 56324  100 56324    0     0  68188      0 --:--:-- --:--:-- --:--:-- 68106

real    0m0.838s
user    0m0.007s
sys     0m0.006s
```