### PR TITLE
Fix hidden downloads bar on stats page

### DIFF
--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -61,7 +61,7 @@ $(document).ready(function() {
 //stats page
 $('.stats__graph__gem__meter').each(function() {
   bar_width = $(this).data("bar_width");
-  $(this).animate({ width: bar_width + '%' }, 700).removeClass('t-item--hidden');
+  $(this).animate({ width: bar_width + '%' }, 700).removeClass('t-item--hidden').css("display", "block");
 });
 
 //gem page

--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -98,7 +98,7 @@
   @media (min-width: 710px) {
     .stats__graph__gem__meter-wrap {
       margin-left: 3%;
-      margin-left: calc(30px);
+      margin-left: calc(28px);
       width: 97%;
       width: calc(100% - 30px); } }
 

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+require "capybara/minitest"
+
+class StatsTest < SystemTest
+  setup do
+    headless_chrome_driver
+    @rubygem = create(:rubygem, number: "0.0.1", downloads: 100)
+  end
+
+  test "downloads animation bar" do
+    visit stats_path
+    assert page.find(:css, ".stats__graph__gem__meter")
+    assert page.has_content?(@rubygem.downloads)
+  end
+
+  teardown { Capybara.use_default_driver }
+end

--- a/test/integration/transitive_dependencies_test.rb
+++ b/test/integration/transitive_dependencies_test.rb
@@ -2,23 +2,7 @@ require "test_helper"
 require "capybara/minitest"
 
 class TransitiveDependenciesTest < SystemTest
-  setup do
-    Selenium::WebDriver.logger.level = :error
-    Capybara.app_host = "http://localhost:3000"
-    Capybara.server_host = "localhost"
-    Capybara.server_port = "3000"
-
-    Capybara.register_driver :chrome do |app|
-      options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
-      client = Selenium::WebDriver::Remote::Http::Default.new
-      client.read_timeout = 120
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
-    end
-
-    Capybara.javascript_driver = :chrome
-    Capybara.current_driver = Capybara.javascript_driver
-    Capybara.default_max_wait_time = 4
-  end
+  setup { headless_chrome_driver }
 
   test "loading transitive dependencies using ajax" do
     @version_one = create(:version)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,12 +51,19 @@ class ActiveSupport::TestCase
         "Expected #{object.class} #{attribute} to change but still #{latest}"
     end
   end
+
+  def headless_chrome_driver
+    Capybara.current_driver = :selenium_chrome_headless
+    Capybara.default_max_wait_time = 2
+    Selenium::WebDriver.logger.level = :error
+  end
 end
 
 class ActionDispatch::IntegrationTest
   setup { host! Gemcutter::HOST }
 end
 Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
+Capybara.always_include_port = true
 
 class SystemTest < ActionDispatch::IntegrationTest
   include Capybara::DSL


### PR DESCRIPTION
since jquery3, animate (show()) doesn't override display: none set in stylesheet.
fixes hidden downloads bar:
https://web.archive.org/web/20200418225315/https://rubygems.org/stats

Related: https://github.com/rubygems/rubygems.org/pull/2202