### PR TITLE
Add rake task to delete extraneous dependencies

### DIFF
--- a/lib/tasks/extraneous_dependencies.rake
+++ b/lib/tasks/extraneous_dependencies.rake
@@ -1,0 +1,97 @@
+namespace :extraneous_dependencies do
+  def fetch_spec_deps(full_name)
+    spec_uri = URI("https://rubygems.org/quick/Marshal.4.8/#{full_name}.gemspec.rz")
+    http = Net::HTTP.new(spec_uri.host, spec_uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Get.new(spec_uri.request_uri)
+    res = http.request(request)
+
+    raise StandardError, "fetch deps request for #{full_name} failed #{res.inspect}" unless res.code == "200"
+
+    spec_obj = Marshal.load(Gem::Util.inflate(res.body))
+
+    spec_run_deps = spec_obj.dependencies.map do |s|
+      s.name.downcase if s.type == :runtime && Rubygem.where(name: s.name).present?
+    end.compact.sort
+
+    spec_dev_deps = spec_obj.dependencies.map do |s|
+      s.name.downcase if s.type == :development && Rubygem.where(name: s.name).present?
+    end.compact.sort
+
+    [spec_run_deps, spec_dev_deps]
+  end
+
+  desc "Remove dependencies from DB where it doesn't match the gemspec"
+  task clean: :environment do
+    ActiveRecord::Base.logger.level = 1
+    versions = Version.joins("inner join dependencies on versions.id = dependencies.version_id")
+      .where("date_trunc('day', dependencies.created_at) = '2009-09-02 00:00:00'::timestamp")
+      .where("versions.indexed = 'true'")
+      .distinct("versions.id")
+
+    total              = versions.count
+    processed          = 0
+    errored            = 0
+    dev_mis_match      = 0
+    run_mis_match      = 0
+    mis_match_versions = 0
+
+    Rails.logger.info "[extraneous_dependencies:clean] found #{total} versions for clean up"
+    versions.each do |version|
+      print format("\r%.2f%% (%d/%d) complete", processed.to_f / total * 100.0, processed, total)
+
+      spec_run_deps, spec_dev_deps = fetch_spec_deps(version.full_name)
+
+      db_run_deps = {}
+      db_dev_deps = {}
+      db_deps = version.dependencies.to_a
+      db_deps.each do |d|
+        db_run_deps[d.id.to_s] = d.rubygem.name.downcase if d.scope == "runtime" && d.rubygem.present?
+        db_dev_deps[d.id.to_s] = d.rubygem.name.downcase if d.scope == "development" && d.rubygem.present?
+      end
+
+      deps_to_delete = []
+      if spec_run_deps != db_run_deps.values.sort
+        db_run_deps.each do |id, name|
+          deps_to_delete << id unless spec_run_deps.include?(name)
+        end
+
+        run_mis_match += 1
+        Rails.logger.info("[extraneous_dependencies:clean] spec and db run deps don't match "\
+          "for: #{version.full_name} spec: #{spec_run_deps} db: #{db_run_deps}")
+      end
+
+      if spec_dev_deps != db_dev_deps.values.sort
+        unique_dev_deps = []
+        db_dev_deps.sort.to_h.each do |id, name|
+          if unique_dev_deps.include?(name)
+            deps_to_delete << id
+          else
+            unique_dev_deps << name
+          end
+        end
+
+        dev_mis_match += 1
+        Rails.logger.info("[extraneous_dependencies:clean] spec and db dev deps don't match "\
+          "for: #{version.full_name} spec: #{spec_dev_deps} db: #{db_dev_deps}")
+      end
+
+      if deps_to_delete.present?
+        mis_match_versions += 1
+        Rails.logger.info("[extraneous_dependencies:clean] deleting dependencies with ids: #{deps_to_delete}")
+        Dependency.destroy(deps_to_delete)
+      end
+    rescue StandardError => e
+      errored += 1
+      Rails.logger.error("[extraneous_dependencies:clean] skipping #{version.inspect} - #{e.message}")
+    ensure
+      processed += 1
+    end
+
+    Rails.logger.info("[extraneous_dependencies:clean] #{total_deleted_deps} dependencies deleted")
+    Rails.logger.info("[extraneous_dependencies:clean] #{errored}/#{processed} errors")
+    Rails.logger.info("[extraneous_dependencies:clean] #{mis_match_versions}/#{processed} version mismatches " \
+      "(run_deps: #{run_mis_match}, dev_deps: #{dev_mis_match})")
+  end
+end

--- a/lib/tasks/extraneous_dependencies.rake
+++ b/lib/tasks/extraneous_dependencies.rake
@@ -14,11 +14,11 @@ namespace :extraneous_dependencies do
     spec_obj = Marshal.load(Gem::Util.inflate(res.body))
 
     spec_run_deps = spec_obj.dependencies.map do |s|
-      s.name.downcase if s.type == :runtime && Rubygem.where(name: s.name).present?
+      s.name.to_s.downcase if s.type == :runtime && Rubygem.where(name: s.name.to_s).present?
     end.compact.sort
 
     spec_dev_deps = spec_obj.dependencies.map do |s|
-      s.name.downcase if s.type == :development && Rubygem.where(name: s.name).present?
+      s.name.to_s.downcase if s.type == :development && Rubygem.where(name: s.name.to_s).present?
     end.compact.sort
 
     [spec_run_deps, spec_dev_deps]

--- a/lib/tasks/helpers/compact_index_tasks_helper.rb
+++ b/lib/tasks/helpers/compact_index_tasks_helper.rb
@@ -1,0 +1,18 @@
+module CompactIndexTasksHelper
+  module_function
+
+  def update_last_checksum(rubygem, task)
+    last_version = rubygem.versions.order(Arel.sql("COALESCE(yanked_at, created_at) desc, number desc, platform desc")).first
+
+    gem_info = GemInfo.new(last_version.rubygem.name).compact_index_info
+    cs = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
+
+    if last_version.indexed
+      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.info_checksum} new_checksum: #{cs}")
+      last_version.update_attribute :info_checksum, cs
+    else
+      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.yanked_info_checksum} new_checksum: #{cs}")
+      last_version.update_attribute :yanked_info_checksum, cs
+    end
+  end
+end


### PR DESCRIPTION
It looks like when bulk uploading gems to rubygems.org, we unintentially
ended up adding some development dependencies in runtime scope. Ex:
```
def db(full_name)
  version = Version.find_by(full_name: full_name)
  version.dependencies.each {|d| puts "#{d.rubygem} #{d.requirements} #{d.scope} #{d.created_at}" };
end

db "zomg-1.0.2"
hoe (3.22.1) >= 1.7.0 runtime 2009-07-25 17:46:24 UTC  # extraneous
hoe (3.22.1) >= 1.7.0 development 2009-09-02 04:55:06 UTC
ruby2ruby (2.4.4) >= 0 runtime 2009-07-25 17:46:24 UTC

```
You may notice, we partially fixed this by adding hoe as
development depdendency on 2009-09-02. hoe as runtime dependency
needs to removed as it was incorrectly added and gemspec file mentions
hoe as development dependency only. Can be checked here:
https://rubygems.org/quick/Marshal.4.8/zomg-1.0.2.gemspec.rz

This rake task is based on above observations and uses 2009-09-02 as filter
for potential versions (total 3548) with this issue.
logs for running this on local can be found here:
https://gist.github.com/sonalkr132/72dfc4b6f3bda878dc0b7f89d8517923

we found some development dependencies (added on same date)
to be redundant as well. Those will be removed as well.

```
db "rack-maintenance-0.1.1"
rake (13.0.1) >= 1.0 runtime 2009-08-30 21:09:37 UTC
rspec (3.9.0) >= 0 development 2009-08-30 21:09:37 UTC
rspec (3.9.0) >= 0 development 2009-09-02 06:38:52 UTC
yard (0.9.24) >= 0 development 2009-08-30 21:09:37 UTC
yard (0.9.24) >= 0 development 2009-09-02 06:38:52 UTC

```
3505 version's run deps and 30 version's dev deps mismatched in 3512
versions out of total 3548.

both gemspec and db dependency names are downcased to avoid following
cases:
```
gemspec "rubyhelpers-0.1.1"
 => development: ["redcloth"], runtime: []  # redcloth doesn't exist

db "rubyhelpers-0.1.1"
RedCloth (4.3.2) >= 0 runtime 2009-07-25 17:55:11 UTC
RedCloth (4.3.2) >= 0 development 2009-09-02 05:33:37 UTC

```