### PR TITLE
Add validation for max length on string columns with user input

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -6,8 +6,9 @@ class Dependency < ApplicationRecord
     :use_existing_rubygem,
     :parse_gem_dependency
 
-  validates :requirements, presence: true
-  validates :scope,        inclusion: { in: %w[development runtime] }
+  validates :requirements, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, presence: true
+  validates :unresolved_name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_blank: true
+  validates :scope, inclusion: { in: %w[development runtime] }
 
   attr_accessor :gem_dependency
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -15,6 +15,7 @@ class Rubygem < ApplicationRecord
 
   validate :ensure_name_format, if: :needs_name_validation?
   validates :name,
+    length: { maximum: Gemcutter::MAX_FIELD_LENGTH },
     presence: true,
     uniqueness: { case_sensitive: false },
     if: :needs_name_validation?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
   after_validation :set_unconfirmed_email, if: :email_changed?, on: :update
   before_create :generate_api_key, :generate_confirmation_token
 
-  validates :email, length: { maximum: 254 }
+  validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, presence: true
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -378,8 +378,12 @@ class Version < ApplicationRecord
 
   def metadata_attribute_length
     return if metadata.blank?
+
+    max_key_size = 128
+    max_value_size = 1024
     metadata.each do |key, value|
-      errors.add(:metadata, "metadata field ['#{key}'] is too long (maximum is #{MAX_FIELD_LENGTH} characters)") if value.length > MAX_FIELD_LENGTH
+      errors.add(:metadata, "metadata key ['#{key}'] is too large (maximum is #{max_key_size} bytes)") if key.size > max_key_size
+      errors.add(:metadata, "metadata value ['#{value}'] is too large (maximum is #{max_value_size} bytes)") if value.size > max_value_size
     end
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,7 +1,6 @@
 require "digest/sha2"
 
 class Version < ApplicationRecord
-  MAX_FIELD_LENGTH = 255
   MAX_TEXT_FIELD_LENGTH = 64_000
 
   belongs_to :rubygem, touch: true
@@ -16,11 +15,11 @@ class Version < ApplicationRecord
   serialize :licenses
   serialize :requirements
 
-  validates :number,   format: { with: /\A#{Gem::Version::VERSION_PATTERN}\z/ }
-  validates :platform, format: { with: Rubygem::NAME_PATTERN }
+  validates :number, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: /\A#{Gem::Version::VERSION_PATTERN}\z/ }
+  validates :platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }
   validates :full_name, presence: true, uniqueness: { case_sensitive: false }
   validates :rubygem, presence: true
-  validates :required_rubygems_version, length: { minimum: 1, maximum: MAX_FIELD_LENGTH }, allow_blank: true
+  validates :required_rubygems_version, :licenses, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_blank: true
   validates :description, :summary, :authors, :requirements, length: { minimum: 0, maximum: MAX_TEXT_FIELD_LENGTH }, allow_blank: true
 
   validate :platform_and_number_are_unique, on: :create

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -5,6 +5,7 @@ class WebHook < ApplicationRecord
   belongs_to :rubygem, optional: true
 
   validates_formatting_of :url, using: :url, message: "does not appear to be a valid URL"
+  validates :url, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, presence: true
   validate :unique_hook, on: :create
 
   def self.global

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,4 +74,5 @@ module Gemcutter
   SEARCH_MAX_PAGES = 100 # Limit max page as ES result window is upper bounded by 10_000 records
   STATS_MAX_PAGES = 10
   STATS_PER_PAGE = 10
+  MAX_FIELD_LENGTH = 255
 end

--- a/db/migrate/20200502214958_add_limit_to_required_rubygems_version.rb
+++ b/db/migrate/20200502214958_add_limit_to_required_rubygems_version.rb
@@ -1,0 +1,5 @@
+class AddLimitToRequiredRubygemsVersion < ActiveRecord::Migration[6.0]
+  def change
+    change_column :versions, :required_rubygems_version, :string, limit: Gemcutter::MAX_FIELD_LENGTH
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_31_172741) do
+ActiveRecord::Schema.define(version: 2020_05_02_214958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2019_08_31_172741) do
     t.string "sha256"
     t.hstore "metadata", default: {}, null: false
     t.datetime "yanked_at"
-    t.string "required_rubygems_version"
+    t.string "required_rubygems_version", limit: 255
     t.string "info_checksum"
     t.string "yanked_info_checksum"
     t.bigint "pusher_id"

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -14,6 +14,21 @@ class DependencyTest < ActiveSupport::TestCase
       assert @dependency.valid?
     end
 
+    should "be invalid with requirements longer than maximum field length" do
+      long_requirement_suffix = ".0" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      @dependency.gem_dependency = Gem::Dependency.new("holla", ["= 0#{long_requirement_suffix}"])
+      refute @dependency.valid?
+      assert_equal @dependency.errors.messages[:requirements], ["is too long (maximum is 255 characters)"]
+    end
+
+    should "be invalid with unresolved_name longer than maximum field length" do
+      long_unresolved_name = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      gem_dependency = Gem::Dependency.new(long_unresolved_name, ["= 0.0.0"])
+      dependency = Dependency.create(gem_dependency: gem_dependency)
+      refute dependency.valid?
+      assert_equal dependency.errors.messages[:unresolved_name], ["is too long (maximum is 255 characters)"]
+    end
+
     should "return JSON" do
       @dependency.save
       json = JSON.load(@dependency.to_json)

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -38,6 +38,12 @@ class RubygemTest < ActiveSupport::TestCase
       end
     end
 
+    should "be invalid with name longer than maximum field length" do
+      @rubygem.name = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      refute @rubygem.valid?
+      assert_equal @rubygem.errors.messages[:name], ["is too long (maximum is 255 characters)"]
+    end
+
     should "reorder versions with platforms properly" do
       version3_ruby  = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "ruby")
       version3_mswin = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "mswin")

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -58,7 +58,7 @@ class UserTest < ActiveSupport::TestCase
       should "be less than 255 characters" do
         user = build(:user, email: ("a" * 255) + "@example.com")
         refute user.valid?
-        assert_contains user.errors[:email], "is too long (maximum is 254 characters)"
+        assert_contains user.errors[:email], "is too long (maximum is 255 characters)"
       end
     end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -321,6 +321,24 @@ class VersionTest < ActiveSupport::TestCase
     should allow_value("x86_64-linux").for(:platform)
     should_not allow_value("Gem::Platform::Ruby").for(:platform)
 
+    should "be invalid with platform longer than maximum field length" do
+      @version.platform = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      refute @version.valid?
+      assert_equal @version.errors.messages[:platform], ["is too long (maximum is 255 characters)"]
+    end
+
+    should "be invalid with number longer than maximum field length" do
+      long_number_suffix = ".1" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      @version.number = "1#{long_number_suffix}"
+      refute @version.valid?
+      assert_equal @version.errors.messages[:number], ["is too long (maximum is 255 characters)"]
+    end
+    should "be invalid with licenses longer than maximum field length" do
+      @version.licenses = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+      refute @version.valid?
+      assert_equal @version.errors.messages[:licenses], ["is too long (maximum is 255 characters)"]
+    end
+
     should "give number for #to_s" do
       assert_equal @version.number, @version.to_s
     end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -19,6 +19,13 @@ class WebHookTest < ActiveSupport::TestCase
     assert WebHook.specific.empty?
   end
 
+  should "be invalid with url longer than maximum field length" do
+    long_domain = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)
+    hook = build(:web_hook, url: "https://#{long_domain}.com")
+    refute hook.valid?
+    assert_equal hook.errors.messages[:url], ["is too long (maximum is 255 characters)"]
+  end
+
   should "require user" do
     hook = build(:web_hook, user: nil)
     refute hook.valid?


### PR DESCRIPTION
Rails before 4.2 use to set max limit of 255 in DB for columns with `string` type (`character varying(255)`). This means in existing prod/staging db we have this limit set on all string columns except `required_rubygems_version` (added after 4.2 change).
I am not sure what are we suppose to do about missing `limit: 255` in schema.rb. If someone runs migration today, they won't get the limits set in existing prod DB. I guess we could generate a redundant migration which just sets these limits on string columns?