### PR TITLE
Log 404s in lograge way.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,15 @@ class ApplicationController < ActionController::Base
     super
   end
 
+  def render_not_found
+    respond_to do |format|
+      format.html { render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false }
+      format.json { render json: { error: t(:not_found) }, status: :not_found }
+      format.yaml { render yaml: { error: t(:not_found) }, status: :not_found }
+      format.any(:all) { render text: t(:not_found), status: :not_found }
+    end
+  end
+
   protected
 
   def http_basic_authentication_options_valid?(options)
@@ -80,15 +89,6 @@ class ApplicationController < ActionController::Base
 
   def http_head_locale
     http_accept_language.language_region_compatible_from(I18n.available_locales)
-  end
-
-  def render_not_found
-    respond_to do |format|
-      format.html { render file: Rails.root.join("public", "404.html"), status: :not_found, layout: false }
-      format.json { render json: { error: t(:not_found) }, status: :not_found }
-      format.yaml { render yaml: { error: t(:not_found) }, status: :not_found }
-      format.any(:all) { render text: t(:not_found), status: :not_found }
-    end
   end
 
   def render_forbidden

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,9 @@ require Rails.root.join("config", "secret") if Rails.root.join("config", "secret
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Do not show stacktrace in console, it will be sent to Honeybadger
+  config.middleware.delete(ActionDispatch::DebugExceptions)
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,6 +3,9 @@ require Rails.root.join("config", "secret") if Rails.root.join("config", "secret
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Do not show stacktrace in console, it will be sent to Honeybadger
+  config.middleware.delete(ActionDispatch::DebugExceptions)
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,4 +197,6 @@ Rails.application.routes.draw do
   ################################################################################
   # Incoming Webhook Endpoint
   resources :sendgrid_events, only: :create, format: false, defaults: { format: :json }
+
+  get '*unmatched_route', to: 'application#render_not_found'
 end


### PR DESCRIPTION
- suppress exception backtrace in log

## 404 for unknown url, not sent to honeybadger
```
{"timestamp":"2020-05-03T17:47:37.225Z","env":"production","message":"[404] GET (ApplicationController#render_not_found)","http":{"request_id":"4a1fc5f7-2fe2-4616-9e09-11c1830b202f","method":"GET","status_code":404,"response_time_ms":12.41,"useragent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36","url":"http://localhost:3000/ryba"},"rails":{"controller":"ApplicationController","action":"render_not_found","params":{"unmatched_route":"ryba"},"format":"html","view_time_ms":1.7},"network":{"client":{"ip":"127.0.0.1"}}}
```

## 404 for unknown gem, not sent to honeybadger
```
{"timestamp":"2020-05-03T17:47:53.777Z","env":"production","message":"[404] GET (RubygemsController#show)","http":{"request_id":"dd0b8f46-4ee0-42ea-b1d6-b4bba18001a6","method":"GET","status_code":404,"response_time_ms":31.99,"useragent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36","url":"http://localhost:3000/gems/abcde"},"rails":{"controller":"RubygemsController","action":"show","params":{"id":"abcde"},"format":"html","view_time_ms":1.29,"db_time_ms":11.5},"network":{"client":{"ip":"127.0.0.1"}}}
```

## 500 (simulated by `raise "A"` on index), sent to honeybadger
```
{"timestamp":"2020-05-03T17:49:14.686Z","env":"production","message":"[500] GET (HomeController#index)","http":{"request_id":"acc9e7d6-ac54-458b-b957-2eaa8b807946","method":"GET","status_code":500,"response_time_ms":5.42,"useragent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36","url":"http://localhost:3000/"},"rails":{"controller":"HomeController","action":"index","params":{},"format":"html","view_time_ms":0.0,"db_time_ms":0.0},"network":{"client":{"ip":"127.0.0.1"}},"error":"RuntimeError: A"}
```