### PR TITLE
Fixing duplicated gem names on notifier page

### DIFF
--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -5,9 +5,10 @@ class Ownership < ApplicationRecord
   validates :user_id, uniqueness: { scope: :rubygem_id }
 
   def self.by_indexed_gem_name
-    joins(:rubygem)
-      .joins("LEFT JOIN versions ON versions.rubygem_id = rubygems.id")
-      .where("indexed = true")
+    select("ownerships.*, rubygems.name")
+      .left_joins(rubygem: :versions)
+      .where(versions: { indexed: true })
+      .distinct
       .order("rubygems.name ASC")
   end
 

--- a/test/unit/ownership_test.rb
+++ b/test/unit/ownership_test.rb
@@ -21,6 +21,36 @@ class OwnershipTest < ActiveSupport::TestCase
     should validate_uniqueness_of(:user_id).scoped_to(:rubygem_id)
   end
 
+  context "by_indexed_gem_name" do
+    setup do
+      @ownership = create(:ownership)
+      create_list(:version, 5, rubygem: @ownership.rubygem)
+      @user = @ownership.user
+    end
+
+    should "return only one ownership" do
+      assert_equal 1, @user.ownerships.by_indexed_gem_name.size
+    end
+  end
+
+  context "by_indexed_gen_name order matters" do
+    setup do
+      @user = create(:user)
+      @gems = %w[zork asf medium]
+      @gems.each do |gem_name|
+        created_gem = create(:rubygem, name: gem_name)
+        create_list(:version, 3, rubygem: created_gem)
+        create(:ownership, rubygem: created_gem, user: @user)
+      end
+
+      @ownerships = @user.ownerships.by_indexed_gem_name
+    end
+
+    should "ownwerships should be sorted by rubygem name ascedent order" do
+      assert_equal @gems.sort, (@ownerships.map { |own| own.rubygem.name })
+    end
+  end
+
   context "#safe_destroy" do
     setup do
       @rubygem       = create(:rubygem)


### PR DESCRIPTION
**Issue**
The notifier page is rendering as many Rubygem names as version had. Example (local):

![Screenshot_20200508_030201](https://user-images.githubusercontent.com/1037088/81397282-d7253980-90db-11ea-9a40-a4682deb39cf.png)

In the above repro, I had 3 indexed versions of `angulars` and 2 indexed versions of `four_o_four`, all of them were rendered by the notifier page.

**Possible root cause**

`Ownership.by_indexed_gem_name` is doing a Cartesian product on rubygem-version joins.

**Proposed solution**

Apply a DISTINCT clause.

If accepted, the Notifier page would change back to normal where, rendering every owned Rubygem only once:

![Screenshot_20200508_030230](https://user-images.githubusercontent.com/1037088/81397244-c8d71d80-90db-11ea-9234-da8563b69a57.png)

