### PR TITLE
Cache any indexed version state on Rubygem model.

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -122,7 +122,7 @@ class GemInfo
         LEFT JOIN rubygems rubygems_dependencies
           ON rubygems_dependencies.id = dependencies.rubygem_id
           AND dependencies.scope = 'runtime'")
-      .where("rubygems.name = ? AND indexed = true", @rubygem_name)
+      .where("rubygems.name = ? AND versions.indexed = true", @rubygem_name)
       .group(Arel.sql(group_by_columns))
       .order(Arel.sql("versions.created_at, number, platform, dep_name"))
       .pluck(Arel.sql("#{group_by_columns}, #{dep_req_agg}, #{dep_name_agg}"))

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -32,7 +32,7 @@ class Rubygem < ApplicationRecord
   end
 
   def self.with_versions
-    where("rubygems.id IN (SELECT rubygem_id FROM versions where versions.indexed IS true)")
+    where(indexed: true)
   end
 
   def self.with_one_version
@@ -54,9 +54,7 @@ class Rubygem < ApplicationRecord
   end
 
   def self.total_count
-    Rails.cache.fetch("gem/total_count", expires_in: 6.hours) do
-      Version.indexed.distinct.count(:rubygem_id)
-    end
+    Rubygem.with_versions.count
   end
 
   def self.latest(limit = 5)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -253,6 +253,10 @@ class Rubygem < ApplicationRecord
     end
   end
 
+  def refresh_indexed!
+    update!(indexed: versions.indexed.any?)
+  end
+
   def disown
     ownerships.each(&:delete)
     ownerships.clear

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -208,21 +208,18 @@ class Version < ApplicationRecord
   end
 
   def update_attributes_from_gem_specification!(spec)
-    transaction do
-      update!(
-        authors: spec.authors,
-        description: spec.description,
-        summary: spec.summary,
-        licenses: spec.licenses,
-        metadata: spec.metadata || {},
-        requirements: spec.requirements,
-        built_at: spec.date,
-        required_rubygems_version: spec.required_rubygems_version.to_s,
-        required_ruby_version: spec.required_ruby_version.to_s,
-        indexed: true
-      )
-      rubygem.update!(indexed: true)
-    end
+    update!(
+      authors: spec.authors,
+      description: spec.description,
+      summary: spec.summary,
+      licenses: spec.licenses,
+      metadata: spec.metadata || {},
+      requirements: spec.requirements,
+      built_at: spec.date,
+      required_rubygems_version: spec.required_rubygems_version.to_s,
+      required_ruby_version: spec.required_ruby_version.to_s,
+      indexed: true
+    )
   end
 
   def platform_as_number

--- a/db/migrate/20200508234114_add_indexed_to_rubygems.rb
+++ b/db/migrate/20200508234114_add_indexed_to_rubygems.rb
@@ -1,0 +1,10 @@
+class AddIndexedToRubygems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rubygems, :indexed, :boolean, null: false, default: false
+    add_index :rubygems, :indexed
+
+    say_with_time "populating indexed rubygems table column" do
+      Rubygem.joins(:versions).where(versions: {indexed: true}).update_all(indexed: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_02_214958) do
+ActiveRecord::Schema.define(version: 2020_05_08_234114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -114,7 +114,9 @@ ActiveRecord::Schema.define(version: 2020_05_02_214958) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "slug"
+    t.boolean "indexed", default: false, null: false
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
+    t.index ["indexed"], name: "index_rubygems_on_indexed"
     t.index ["name"], name: "index_rubygems_on_name", unique: true
   end
 

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -30,6 +30,7 @@ class DeletionTest < ActiveSupport::TestCase
 
       should "unindexes" do
         refute @version.indexed?
+        refute @version.rubygem.indexed?
       end
 
       should "be considered deleted" do
@@ -101,7 +102,8 @@ class DeletionTest < ActiveSupport::TestCase
         @deletion.restore!
       end
 
-      should "index version" do
+      should "index rubygem and version" do
+        assert @version.rubygem.indexed?
         assert @version.indexed?
       end
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -286,6 +286,11 @@ class PusherTest < ActiveSupport::TestCase
         assert_not_nil @rubygem.versions.last.info_checksum
       end
 
+      should "indexe rubygem and version" do
+        assert @rubygem.indexed?
+        assert @rubygem.versions.last.indexed?
+      end
+
       should "create rubygem index" do
         @rubygem.update_column("updated_at", Date.new(2016, 07, 04))
         Delayed::Worker.new.work_off

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -633,20 +633,6 @@ class RubygemTest < ActiveSupport::TestCase
       should "give a count of only rubygems with versions" do
         assert_equal @expected_total, Rubygem.total_count
       end
-
-      should "write to cache" do
-        Rails.cache.expects(:write).with("gem/total_count", @expected_total, { expires_in: 6.hours })
-        Rubygem.total_count
-      end
-
-      context "cache hit" do
-        setup { Rubygem.total_count }
-
-        should "not use sql to get result" do
-          Version.expects(:where).never
-          assert_equal @expected_total, Rubygem.total_count
-        end
-      end
     end
   end
 

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -738,6 +738,7 @@ class VersionTest < ActiveSupport::TestCase
     should "have attributes set properly from the specification" do
       @version.update_attributes_from_gem_specification!(@spec)
 
+      assert @version.rubygem.indexed
       assert @version.indexed
       assert_equal @spec.authors.join(", "),              @version.authors
       assert_equal @spec.description,                     @version.description


### PR DESCRIPTION
This is an idea I was thinking about for some time to avoid expensive join on versions just to find out which rubygems do have any indexed version.

:information_source: migration takes ~5s locally (on some older dump)
```
[retro@retro  rubygems.org (cache-indexed-status-on-rubygem *+%)]❤ bin/rake db:migrate         
== 20200508234114 AddIndexedToRubygems: migrating =============================                                                                                                               
-- add_column(:rubygems, :indexed, :boolean, {:null=>false, :default=>false})                                                                                                                 
   -> 0.0037s                                                                                                                                                                                 
-- add_index(:rubygems, :indexed)                                                              
   -> 0.1066s                                                                                                                                                                                 
-- populating indexed rubygems table column                                                                                                                                                   
   -> 4.8659s                                                                                                                                                                                 
   -> 158418 rows                                                                                                                                                                             
== 20200508234114 AddIndexedToRubygems: migrated (4.9762s) ====================                                                                                                               
```

Implementation on Ruby side is a little tricky and relies on `after_save` callback. Versions ordering depends on the same callback as well, thus I consider this safe enough. Alternatively this can be implemented in triggers on DB side as well for super-consistency.

In second commit I'm trying to migrate first code to use this. It is fast enough to make `total_count` un-cached again.

```
Version.indexed.distinct.count(:rubygem_id)
   (519.5ms)  SELECT COUNT(DISTINCT versions.rubygem_id) FROM versions WHERE versions.indexed =   [[indexed, true]]
=> 158418

Rubygem.where(indexed: true).count
   (58.4ms)  SELECT COUNT(*) FROM rubygems WHERE rubygems.indexed =   [[indexed, true]]
=> 158418
```