### PR TITLE
Add constraints to static high_volatage routes

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -77,7 +77,7 @@
     </p>
     <p>
       <%= t('.api_access.credentials_html', :gem_credentials_file => content_tag(:code, '~/.gem/credentials'),
-                                            :gem_commands_link => link_to(t('.api_access.link_text'), page_path('gem_docs'))) %>
+                                            :gem_commands_link => link_to(t('.api_access.link_text'), 'https://guides.rubygems.org/command-reference/', target: 'blank')) %>
     </p>
     <pre><code>gem signin</code></pre>
   </div>

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,3 @@
+HighVoltage.configure do |config|
+  config.routes = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,10 @@ Rails.application.routes.draw do
   end
 
   ################################################################################
+  # high_voltage static routes
+  get 'pages/*id' => 'high_voltage/pages#show', constraints: { id: /(about|data|download|faq|migrate|security|sponsors)/ }, as: :page
+
+  ################################################################################
   # Internal Routes
 
   namespace :internal do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,7 +188,7 @@ Rails.application.routes.draw do
 
   ################################################################################
   # high_voltage static routes
-  get 'pages/*id' => 'high_voltage/pages#show', constraints: { id: /(about|data|download|faq|migrate|security|sponsors)/ }, as: :page
+  get 'pages/*id' => 'high_voltage/pages#show', constraints: { id: /(#{HighVoltage.page_ids.join("|")})/ }, as: :page
 
   ################################################################################
   # Internal Routes

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -46,6 +46,25 @@ class RoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "invalid regex in static page route doesn't raise RegexpError" do
+    assert_raises(ActionController::RoutingError) do
+      get "/pages/%29"
+    end
+  end
+
+  test "long static page route doesn't raise Errno::ENAMETOOLONG" do
+    assert_raises(ActionController::RoutingError) do
+      get "/pages/%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF"\
+        "%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF"\
+        "%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD"\
+        "%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF"\
+        "%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF"\
+        "%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD"\
+        "%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF"\
+        "%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD%EF%BF%BD/etc/passwd"
+    end
+  end
+
   teardown do
     ENV["RAILS_ENV"] = @prev_env
   end


### PR DESCRIPTION
Fixes:
````
Failure:
RoutingTest#test_invalid_regex_in_static_page_route_doesn't_raise_RegexpError
[/home/aditya/rubygems.org/test/integration/routing_test.rb:50]:
[ActionController::RoutingError] exception expected, not Class: <RegexpError>
Message: <"unmatched close parenthesis:
/\\A\\/home\\/aditya\\/rubygems.org\\/app\\/views\\/pages\\/)(\\.(?<locale>en))?(\\.(?<formats>html))?(\\+(?<variants>))?(\\.(?
<handlers>raw|erb|html|builder|ruby))?\\z/">
---Backtrace---
lib/clearance_backdoor.rb:9:in `call'
test/integration/routing_test.rb:51:in `block (2 levels) in
<class:RoutingTest>'
test/integration/routing_test.rb:50:in `block in <class:RoutingTest>'
---------------

Failure:
RoutingTest#test_long_static_page_route_doesn't_raise_Errno::ENAMETOOLONG
[/home/aditya/rubygems.org/test/integration/routing_test.rb:56]:
[ActionController::RoutingError] exception expected, not
Class: <Errno::ENAMETOOLONG>
Message: <"File name too long -
/home/aditya/rubygems.org/app/views/pages/_____________________________________________________________________________________________
___/etc">
---Backtrace---
lib/clearance_backdoor.rb:9:in `call'
test/integration/routing_test.rb:57:in `block (2 levels) in
<class:RoutingTest>'
test/integration/routing_test.rb:56:in `block in <class:RoutingTest>'
---------------
```
https://app.honeybadger.io/projects/40972/faults/57832172
https://app.honeybadger.io/projects/40972/faults/58396022