### PR TITLE
Update staging fastly service id

### DIFF
--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -15,7 +15,7 @@
         "new_relic_license_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:+xYXmnYNjopnCsSP/Ak5WqwhKeg1HoD1:dBst39O+zK1S+NSyWeh07qAYdRrBn2N3cB5v82lksOSrJ4RaA5xxu69UsQiGz0kkdAhOWfwj98o=]",
         "honeybadger_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:TD1e42m2hCnraaRigNZZZao9WKF9S9Nf:Myj5m7maDkOC2GbolUskZ2F+zmRscHE8]",
         "fastly_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:Hig6V1MQP4qgUM0ONuSJ1baySFEjBUtv:38lnkxBDiihzxIKy1qRFlNIkFVK6w77KHkrKAFv23Bcn/Z3h13NjXZO/tkr27AcV]",
-        "fastly_service_id": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:4PJ8m22sz0fVV514tgOaV+G6Imw2TU2h:4hdG2htqLTOP8ky59J+V1VI5l4FCiTef+ixbnaNJU6nriNh2U6c=]",
+        "fastly_service_id": "EJ[1:dMyBt/+IWFvyZkXJmQMOmef2menhqHv6PFoaTCCjUks=:gJyo+Fk4j9bEbYr+Jl7zv0PmenMl2zF7:zkButJ5HOF+6hN4R0GOzPLtXv7tzqP44EUgUGRMqByrG0dRHY10=]",
         "_fastly_domains": "staging.rubygems.org",
         "elasticsearch_url": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:md53NdJnx5PVn95M4NAotzMGZ06ub5wf:pBIlOJ3GHAe1PFeoUzQ0rLQ/uuT/rkXDpOZuJiltcuE30QIdqfmVhT7BoGKl0TRAO6EihH22u46hUarfZugyHZoJN71AD8YngxFgYTFMCH4VXEKEj6YNow6lG+3gshupYK7V9YIP+Bu9]",
         "memcached_endpoint": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:EMi4FLAdV9tWQ8IevfUfr75o6pTo0GAC:ylZl7qFloCf1iUqtEyDsam2ZsEUYcws56jQiR3mT1quTlNQr38fDz5MjeNhMAQfbdGY8KnC2v50Vs1wb1AuKbRUNwU9bGO9pl3E2]",


### PR DESCRIPTION
Fixes `RestClient::NotFound: 404 Not Found` being raised by
Fastly.purge_key on staging