### PR TITLE
Fix pt-BR translation for Edit profile

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -105,7 +105,7 @@ pt-BR:
         uptime: Uptime
       header:
         dashboard: Painel de Controle
-        edit_profile:
+        edit_profile: Editar perfil
         search_gem_html: Buscar Gems&hellip;
         sign_in: Fazer Login
         sign_out: Sair


### PR DESCRIPTION
Edit profile is currently appearing in english when running the pt-BR
application. This commit fix this translation.