### PR TITLE
Add foreing key constraint set null on delete to dependencies.rubygem_id

### DIFF
--- a/db/migrate/20200523170314_add_fk_rubygem_id_nullify_constraint_to_dependencies.rb
+++ b/db/migrate/20200523170314_add_fk_rubygem_id_nullify_constraint_to_dependencies.rb
@@ -1,0 +1,5 @@
+class AddFkRubygemIdNullifyConstraintToDependencies < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :dependencies, :rubygems, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_31_172741) do
+ActiveRecord::Schema.define(version: 2020_05_23_170314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -219,4 +219,5 @@ ActiveRecord::Schema.define(version: 2019_08_31_172741) do
     t.index ["user_id", "rubygem_id"], name: "index_web_hooks_on_user_id_and_rubygem_id"
   end
 
+  add_foreign_key "dependencies", "rubygems", on_delete: :nullify
 end


### PR DESCRIPTION
Update dependencies with dangling rubygem_id to null when gem gets deleted.
According to https://github.com/rubygems/rubygems.org/pull/2361 somehow some records on dependencies table orphaned after their gem identifier deleted. That leads NoMethodError: undefined method `name' for nil:NilClass on page. However we have hooks on delete, it should be good practice to add db constraints

Issue: https://github.com/rubygems/rubygems.org/issues/2362