### PR TITLE
Info checksum rake

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -113,9 +113,9 @@ class GemInfo
   def requirements_and_dependencies
     group_by_columns = "number, platform, sha256, info_checksum, required_ruby_version, required_rubygems_version, versions.created_at"
 
-    dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name)"
+    dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
 
-    dep_name_agg = "string_agg(coalesce(rubygems_dependencies.name, '0'), ',' ORDER BY rubygems_dependencies.name) AS dep_name"
+    dep_name_agg = "string_agg(coalesce(rubygems_dependencies.name, '0'), ',' ORDER BY rubygems_dependencies.name, dependencies.id) AS dep_name"
 
     Rubygem.joins("LEFT JOIN versions ON versions.rubygem_id = rubygems.id
         LEFT JOIN dependencies ON dependencies.version_id = versions.id

--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -1,3 +1,5 @@
+require "tasks/helpers/compact_index_tasks_helper"
+
 namespace :compact_index do
   def yanked_at_time(version)
     query = ["SELECT created_at FROM deletions,
@@ -29,31 +31,29 @@ namespace :compact_index do
   end
 
   desc "Correct Versions' info_checksum attributes for compact index format"
-  task correct_info_checksum: :environment do
-    versions = Version.find_by_sql("SELECT DISTINCT ON(rubygem_id) * FROM versions
-      WHERE rubygem_id NOT IN (SELECT DISTINCT(rubygem_id) FROM versions
-      WHERE created_at > '2016-08-30 05:16:23' OR yanked_at > '2016-08-30 05:16:23')
-      ORDER BY rubygem_id, COALESCE(yanked_at, created_at) DESC, number DESC, platform DESC")
-    mod = ENV["shard"]
-    versions = versions.where("id % 4 = ?", mod.to_i) if mod
+  task correct_info_checksum: :environment do |task|
+    compact_index_versions = GemInfo.compact_index_public_versions
 
-    total = versions.count
-    i = 0
+    i        = 0
+    mismatch = 0
+    total    = compact_index_versions.count
+
     puts "Total: #{total}"
+    compact_index_versions.each do |compact_index_gem|
+      gem_name = compact_index_gem.name
+      gem_info_checksum = compact_index_gem.versions.last.info_checksum
 
-    versions.each do |version|
-      gem_info = GemInfo.new(version.rubygem.name).compact_index_info
-      cs = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
-      if version.indexed
-        version.update_attribute :info_checksum, cs
-      else
-        version.update_attribute :yanked_info_checksum, cs
+      cur_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(gem_name).compact_index_info))
+
+      if cur_info_checksum != gem_info_checksum
+        mismatch += 1
+        rubygem = Rubygem.find_by(name: gem_name)
+        CompactIndexTasksHelper.update_last_checksum(rubygem, task)
       end
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
     end
-    puts
-    puts "Done."
+    Rails.logger.info("[compact_index:correct_info_checksum] #{mismatch}/#{total} gems had info mismatch")
   end
 
   desc "Fill Versions' yanked_info_checksum attributes for compact index format"


### PR DESCRIPTION
fixes info checksum mismatch in gems which has use same dependency
with multiple times. ex:
```
activerecord-postgres-earthdistance expected:
dfcd3a9b12755205ad3ebb0683c108f9 found: b3a1b4a20d3e906d941a3ab0a9006192
activerecord-postgres-earthdistance same deps:
0.1.0 pg:>= 0.11 pg:>= 0
0.1.0 rails:>= 3.0.0 rails:>= 0
```
it could be possible that `rails` requirements ( >= 3.0.0 and >=0)
appear in different order than what is shown above when only ordering
by dependency name.
adding dependency.id to order by ensures that requirements order
don't change, which seems to be happening whenever a new version
of activerecord-postgres-earthdistance is being created.

all gems with duplicate dependencies:
https://gist.github.com/sonalkr132/c745b38687c18b682422faa7635c1705

related: #1566