### PR TITLE
Upload new versions.list file to s3

### DIFF
--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -84,6 +84,9 @@ namespace :compact_index do
     gems = GemInfo.compact_index_public_versions
 
     versions_file.create gems
+
+    version_file_content = File.read(file_path)
+    RubygemFs.instance.store("versions/versions.list", version_file_content)
   end
 
   desc "Update info checksum for multiple ruby or rubygems requirements"


### PR DESCRIPTION
until now we have been using bundler-api repo in docker build. we
will update dockerfile to use new location in s3 in a separate PR.