### PR TITLE
Update dockerfile to download versions file from s3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN gem update --system 2.6.10
 
 COPY . /app
 
-ADD https://github.com/bundler/bundler-api/raw/master/versions.list /app/config/versions.list
+ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions.list /app/config/versions.list
 
 RUN mv /app/config/database.yml.example /app/config/database.yml
 


### PR DESCRIPTION
bundler-api is archieved. rake task to regenerate versions file
will upload to this location in s3.