### PR TITLE
Remove duplicate runtime deps which don't match spec

### DIFF
--- a/lib/tasks/extraneous_dependencies.rake
+++ b/lib/tasks/extraneous_dependencies.rake
@@ -57,8 +57,15 @@ namespace :extraneous_dependencies do
 
       deps_to_delete = []
       if spec_run_deps != db_run_deps.values.sort
+        unique_run_devs = []
         db_run_deps.each do |id, name|
           deps_to_delete << id unless spec_run_deps.include?(name)
+
+          if unique_run_devs.include?(name)
+            deps_to_delete << id
+          else
+            unique_run_devs << name
+          end
         end
 
         run_mis_match += 1


### PR DESCRIPTION
same as duplicate dev deps, some versions have duplicate runtime.
we must have intended to add these as development deps but ended up
adding as runtime deps.

even after this some imported versions will have spec - db mismatch, check [won't fix here](https://gist.github.com/sonalkr132/c73fb008c733ce6f8fd204cf622d2631#file-won-fix-txt). Most of these require adding dependency to db. I am not sure if we should be spending time on evaluating and fixing each of these unless someone complains about them.