### PR TITLE
Update rake tasks to use non-caching info checksum calc

### DIFF
--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -43,7 +43,7 @@ namespace :compact_index do
       gem_name = compact_index_gem.name
       gem_info_checksum = compact_index_gem.versions.last.info_checksum
 
-      cur_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(gem_name).compact_index_info))
+      cur_info_checksum = GemInfo.new(gem_name).info_checksum
 
       if cur_info_checksum != gem_info_checksum
         mismatch += 1
@@ -66,7 +66,7 @@ namespace :compact_index do
     i = 0
     puts "Total: #{total}"
     without_yanked_info_checksum.find_each do |version|
-      cs = Digest::MD5.hexdigest(CompactIndex.info(GemInfo.new(version.rubygem.name).compact_index_info))
+      cs = GemInfo.new(version.rubygem.name).info_checksum
       version.update_attribute :yanked_info_checksum, cs
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)

--- a/lib/tasks/helpers/compact_index_tasks_helper.rb
+++ b/lib/tasks/helpers/compact_index_tasks_helper.rb
@@ -3,9 +3,7 @@ module CompactIndexTasksHelper
 
   def update_last_checksum(rubygem, task)
     last_version = rubygem.versions.order(Arel.sql("COALESCE(yanked_at, created_at) desc, number desc, platform desc")).first
-
-    gem_info = GemInfo.new(last_version.rubygem.name).compact_index_info
-    cs = Digest::MD5.hexdigest(CompactIndex.info(gem_info))
+    cs = GemInfo.new(last_version.rubygem.name).info_checksum
 
     if last_version.indexed
       Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.info_checksum} new_checksum: #{cs}")


### PR DESCRIPTION
It could be possible that prod already has `compact_index_info`
response cached or that we need to update checksum multiple time
in same task (where first update would have cache the response).

info_checksum always queries DB for checksum.