### PR TITLE
Recommend elasticsearch version matching production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,10 @@ Follow the instructions below on how to install Bundler and setup the database.
 * Use Rubygems 2.6.10
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
-  * Pull ElasticSearch `5.1.2` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.1.2`
+  * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`
   * Running Elasticsearch from the command line:
   ```
-  docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:5.1.2
+  docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:5.6.16
   ```
   * Note that `-e "xpack.security.enabled=false"` disables authentication.
 
@@ -87,10 +87,10 @@ Follow the instructions below on how to install Bundler and setup the database.
 * Use Rubygems 2.6.10
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
-  * Pull ElasticSearch `5.1.2` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.1.2`
+  * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`
   * Running Elasticsearch from the command line:
   ```
-  docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:5.1.2
+  docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:5.6.16
   ```
 * Install PostgreSQL: `apt-get install postgresql postgresql-server-dev-all`
   * Help to setup database <https://wiki.debian.org/PostgreSql>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "11211:11211"
   search:
-    image: elasticsearch:5.1.2
+    image: elasticsearch:5.6.16
     environment:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "11211:11211"
   search:
-    image: elasticsearch:5
+    image: elasticsearch:5.1.2
     environment:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1


### PR DESCRIPTION
This PR closes #2378 by recommending an elasticsearch version in the development environment that exactly matches the one in production.

I didn't attempt to upgrade elasticsearch to either 6.x or 7.x, since that's a bigger task that also involves production updates, so we might want to open a separate ticket about that.