### PR TITLE
Don't send mail if confirmation_token is already reset

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -21,7 +21,7 @@ class EmailConfirmationsController < ApplicationController
 
     if user
       user.generate_confirmation_token
-      Mailer.delay.email_confirmation(user) if user.save
+      Delayed::Job.enqueue(EmailConfirmationMailer.new(user.id)) if user.save
     end
     redirect_to root_path, notice: t(".promise_resend")
   end
@@ -29,7 +29,7 @@ class EmailConfirmationsController < ApplicationController
   # used to resend confirmation mail for unconfirmed_email validation
   def unconfirmed
     if current_user.generate_confirmation_token && current_user.save
-      Mailer.delay.email_reset(current_user)
+      Delayed::Job.enqueue EmailResetMailer.new(current_user.id)
       flash[:notice] = t("profiles.update.confirmation_mail_sent")
     else
       flash[:notice] = t("try_again")

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -18,7 +18,7 @@ class ProfilesController < ApplicationController
     @user = current_user.clone
     if @user.update(params_user)
       if @user.unconfirmed_email
-        Mailer.delay.email_reset(current_user)
+        Delayed::Job.enqueue EmailResetMailer.new(current_user.id)
         flash[:notice] = t(".confirmation_mail_sent")
       else
         flash[:notice] = t(".updated")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < Clearance::UsersController
   def create
     @user = user_from_params
     if @user.save
-      Mailer.delay.email_confirmation(@user)
+      Delayed::Job.enqueue EmailConfirmationMailer.new(@user.id)
       flash[:notice] = t(".email_sent")
       redirect_back_or url_after_create
     else

--- a/app/jobs/email_confirmation_mailer.rb
+++ b/app/jobs/email_confirmation_mailer.rb
@@ -1,0 +1,11 @@
+EmailConfirmationMailer = Struct.new(:user_id) do
+  def perform
+    user = User.find(user_id)
+
+    if user.confirmation_token
+      Mailer.email_confirmation(user).deliver
+    else
+      Rails.logger.info("[jobs:email_confirmation_mailer] confirmation token not found. skipping sending mail for #{user.handle}")
+    end
+  end
+end

--- a/app/jobs/email_reset_mailer.rb
+++ b/app/jobs/email_reset_mailer.rb
@@ -1,0 +1,11 @@
+EmailResetMailer = Struct.new(:user_id) do
+  def perform
+    user = User.find(user_id)
+
+    if user.confirmation_token
+      Mailer.email_reset(user).deliver
+    else
+      Rails.logger.info("[jobs:email_reset_mailer] confirmation token not found. skipping sending mail for #{user.handle}")
+    end
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -7,17 +7,17 @@ class Mailer < ApplicationMailer
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   def email_reset(user)
-    @user = User.find(user["id"])
+    @user = user
     mail to: @user.unconfirmed_email,
-         subject: I18n.t("mailer.confirmation_subject",
-           default: "Please confirm your email address with RubyGems.org")
+        subject: I18n.t("mailer.confirmation_subject",
+          default: "Please confirm your email address with RubyGems.org")
   end
 
   def email_confirmation(user)
-    @user = User.find(user["id"])
+    @user = user
     mail to: @user.email,
-         subject: I18n.t("mailer.confirmation_subject",
-           default: "Please confirm your email address with RubyGems.org")
+        subject: I18n.t("mailer.confirmation_subject",
+          default: "Please confirm your email address with RubyGems.org")
   end
 
   def deletion_complete(email)

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -1,9 +1,12 @@
 module EmailHelpers
   def last_email_link
     Delayed::Worker.new.work_off
-    body = last_email.body.decoded.to_s
-    link = %r{http://localhost/email_confirmations([^";]*)}.match(body)
-    link[0]
+    confirmation_link
+  end
+
+  def confirmation_link_from(job)
+    Delayed::Worker.new.run(job)
+    confirmation_link
   end
 
   def last_email
@@ -12,5 +15,11 @@ module EmailHelpers
 
   def mails_count
     ActionMailer::Base.deliveries.size
+  end
+
+  def confirmation_link
+    body = last_email.body.decoded.to_s
+    link = %r{http://localhost/email_confirmations([^";]*)}.match(body)
+    link[0]
   end
 end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -42,4 +42,15 @@ class EmailConfirmationTest < SystemTest
     assert page.has_content? "Sign in"
     assert page.has_selector? "#flash_alert", text: "Please double check the URL or try submitting it again."
   end
+
+  test "requesting multiple confirmation email" do
+    request_confirmation_mail @user.email
+    request_confirmation_mail @user.email
+
+    link = confirmation_link_from(Delayed::Job.first)
+    visit link
+
+    Delayed::Worker.new.work_off
+    assert_empty Delayed::Job.all
+  end
 end


### PR DESCRIPTION
This could happen if user has requested confirmation mail multiple
times and clicked on confimation url (resets token) before rest
of mail were sent.
Fixes following raised from _app_views_mailer_email_reset_erb:
```
ActionView::Template::Error: undefined method `html_safe' for
nil:NilClass
Did you mean?  html_safe?
```