### PR TITLE
Add regex validation to user email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
   after_validation :set_unconfirmed_email, if: :email_changed?, on: :update
   before_create :generate_api_key, :generate_confirmation_token
 
-  validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, presence: true
+  validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {

--- a/test/unit/helpers/dynamic_errors_helper_test.rb
+++ b/test/unit/helpers/dynamic_errors_helper_test.rb
@@ -4,8 +4,17 @@ class DynamicErrorsHelperTest < ActionView::TestCase
   test "returns a div with the errors if the object is invalid" do
     user = build(:user, email: nil)
     user.valid?
-    expected_dom = %(<div class="errorExplanation" id="errorExplanation"><h2>2 errors prohibited this user from being saved</h2><p>There were \
-problems with the following fields:</p><ul><li>Email address is not a valid email</li><li>Email address can't be blank</li></ul></div>)
+    expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
+      <div class="errorExplanation" id="errorExplanation">
+        <h2>3 errors prohibited this user from being saved</h2>
+        <p>There were problems with the following fields:</p>
+        <ul>
+          <li>Email address is not a valid email</li>
+          <li>Email address can't be blank</li>
+          <li>Email address is invalid</li>
+        </ul>
+      </div>
+    HTML
 
     assert_dom_equal expected_dom, error_messages_for(user)
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -60,6 +60,17 @@ class UserTest < ActiveSupport::TestCase
         refute user.valid?
         assert_contains user.errors[:email], "is too long (maximum is 255 characters)"
       end
+
+      should "be valid when it matches URI mail email regex" do
+        user = build(:user, email: "mail@example.com")
+        assert user.valid?
+      end
+
+      should "be invalid when it doesn't match URI mail email regex" do
+        user = build(:user, email: "random[a..z]mdhlwqui@163.com")
+        refute user.valid?
+        assert_contains user.errors[:email], "is invalid"
+      end
     end
 
     context "twitter_username" do


### PR DESCRIPTION
Fixes in delayed job to deliver mails:
```
501 Recipient syntax error

/usr/local/lib/ruby/2.5.0/net/smtp.rb:969:in `check_response'
/usr/local/lib/ruby/2.5.0/net/smtp.rb:937:in `getok'
/usr/local/lib/ruby/2.5.0/net/smtp.rb:865:in `rcptto'
/usr/local/lib/ruby/2.5.0/net/smtp.rb:846:in `block in rcptto_list'
```