### PR TITLE
Enable new cops of rubocop 0.85

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,8 +162,17 @@ Lint/StructNewOverride:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: true
 
 Style/SlicingWithRange:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
   Enabled: true

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -6,7 +6,7 @@ module Patterns
   ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/.freeze
   LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/.freeze
   NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\Z/.freeze
-  URL_VALIDATION_REGEXP = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}.freeze
+  URL_VALIDATION_REGEXP = %r{\Ahttps?://([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([/?]\S*)?\z}.freeze
   GEM_NAME_BLACKLIST    = %w[
     abbrev
     base64

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -60,7 +60,7 @@ class StatsControllerTest < ActionController::TestCase
     should "not have width greater than 100%" do
       assert_select ".stats__graph__gem__meter" do |element|
         element.map { |h| h[:style] }.each do |width|
-          width =~ /width\: (\d+[,.]\d+)%/
+          width =~ /width: (\d+[,.]\d+)%/
           assert Regexp.last_match(1).to_f <= 100, "#{Regexp.last_match(1)} is greater than 100"
         end
       end


### PR DESCRIPTION
Fixes warning lines on running `rubocop`:
```
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/RedundantRegexpCharacterClass (0.85)
 - Style/RedundantRegexpEscape (0.85)
For more information: https://docs.rubocop.org/rubocop/versioning.html
```