### PR TITLE
Delete params key from params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_page(max_page = Gemcutter::MAX_PAGES)
+    sanitize_params
     @page = Gemcutter::DEFAULT_PAGE && return unless params.key?(:page)
     redirect_to_page_with_error && return unless valid_page_param?(max_page)
 
@@ -109,5 +110,9 @@ class ApplicationController < ActionController::Base
 
   def reject_null_char_param
     render plain: "bad request", status: :bad_request if params.to_s.include?("\\u0000")
+  end
+
+  def sanitize_params
+    params.delete(:params)
   end
 end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -11,7 +11,3 @@ Kaminari.configure do |config|
   # config.param_name = :page
   # config.params_on_first_page = false
 end
-
-module Kaminari::Helpers
-  PARAM_KEY_EXCEPT_LIST = %i[authenticity_token commit utf8 _method script_name original_script_name].freeze
-end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -65,6 +65,12 @@ class RoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "any page with pagination doesn't raise TypeError when params exists in url" do
+    assert_nothing_raised do
+      get "/releases?page=2&params=thing"
+    end
+  end
+
   teardown do
     ENV["RAILS_ENV"] = @prev_env
   end


### PR DESCRIPTION
`params` is an arguement of rails method `url_for` and it expects
hash as value. kaminari should be filtering this with `PARAM_KEY_EXCEPT_LIST`
as `params` is supported by `url_for` for internal use (not for end user
to control). However, they don't seem to agree https://github.com/kaminari/kaminari/issues/1025.

Fixes:
```
TypeError: no implicit conversion of String into Hash

[GEM_ROOT]/gems/actionpack-6.0.2.2/lib/action_dispatch/routing/route_set.rb:822 :in `merge!`
[GEM_ROOT]/gems/actionpack-6.0.2.2/lib/action_dispatch/routing/route_set.rb:822:in `url_for`
[GEM_ROOT]/gems/actionpack-6.0.2.2/lib/action_dispatch/routing/url_for.rb:180:in `full_url_for`
[GEM_ROOT]/gems/actionpack-6.0.2.2/lib/action_dispatch/routing/url_for.rb:170:in `url_for`
[GEM_ROOT]/gems/actionview-6.0.2.2/lib/action_view/routing_url_for.rb:89:in `url_for`
[GEM_ROOT]/gems/kaminari-core-1.2.0/lib/kaminari/helpers/tags.rb:39 :in `page_url_for`
```

PARAM_KEY_EXCEPT_LIST is removed as the patch now exists in kaminari.