### PR TITLE
Send email to current email address on request to update email

### DIFF
--- a/app/jobs/email_reset_mailer.rb
+++ b/app/jobs/email_reset_mailer.rb
@@ -3,6 +3,7 @@ EmailResetMailer = Struct.new(:user_id) do
     user = User.find(user_id)
 
     if user.confirmation_token
+      Mailer.email_reset_update(user).deliver
       Mailer.email_reset(user).deliver
     else
       Rails.logger.info("[jobs:email_reset_mailer] confirmation token not found. skipping sending mail for #{user.handle}")

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -13,6 +13,12 @@ class Mailer < ApplicationMailer
           default: "Please confirm your email address with RubyGems.org")
   end
 
+  def email_reset_update(user)
+    @user = user
+    mail to: @user.email,
+         subject: I18n.t("mailer.email_reset_update.subject")
+  end
+
   def email_confirmation(user)
     @user = user
     mail to: @user.email,

--- a/app/views/mailer/email_reset_update.erb
+++ b/app/views/mailer/email_reset_update.erb
@@ -1,0 +1,36 @@
+<% @title = t(".title") %>
+<% @sub_title = "Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          You have requested email update on RubyGems.org. Once you click on confirmation link sent to your new email address, your account will be disassociated from
+          <%= @user.email %>.
+        </p>
+        <p>
+          New email address: <strong><%= @user.unconfirmed_email %></strong>
+        </p>
+        <br/>
+        <p>If this email update is expected, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this email update is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+        <%= render "compromised_instructions"  %>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -147,6 +147,9 @@ de:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,9 @@ en:
       subject: RubyGems.org API key was reset
       title: API KEY RESET
       subtitle: Hi %{handle}
+    email_reset_update:
+      subject: You have requested email address update on RubyGems.org
+      title: EMAIL UPDATE REQUESTED
   news:
     show:
       title: New Releases — All Gems

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -155,6 +155,9 @@ es:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: Nuevos lanzamientos — Todas las Gemas

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -147,6 +147,9 @@ fr:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -147,6 +147,9 @@ ja:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: 新しくリリースされたGem

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -147,6 +147,9 @@ nl:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -147,6 +147,9 @@ pt-BR:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: Novos Releases - Todas as Gems

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -147,6 +147,9 @@ zh-CN:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: 全部新发布 Gems

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -147,6 +147,9 @@ zh-TW:
       subject:
       title:
       subtitle:
+    email_reset_update:
+      subject:
+      title:
   news:
     show:
       title: 最新發佈

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -3,6 +3,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.email_reset(User.last)
   end
 
+  def email_reset_update
+    Mailer.email_reset_update(User.last)
+  end
+
   def email_confirmation
     Mailer.email_confirmation(User.last)
   end


### PR DESCRIPTION
This would ensure unintended email address update don't go unnoticed.
![Screenshot from 2020-06-07 15-10-41](https://user-images.githubusercontent.com/7680662/83965396-2cb65700-a8d1-11ea-882f-495c9646bb38.png)
