### PR TITLE
Send email to owners on gem yank

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -56,13 +56,12 @@ class Mailer < ApplicationMailer
       subject: "Please consider enabling MFA for your account"
   end
 
-  def gem_yanked(yanked_by_user_id, version_id)
+  def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
+    @version        = Version.find(version_id)
+    notified_user   = User.find(notified_user_id)
     @yanked_by_user = User.find(yanked_by_user_id)
-    @version = Version.find(version_id)
-    owner_emails = @version.rubygem.owners.pluck(:email)
 
-    mail from: Clearance.configuration.mailer_sender,
-         bcc: owner_emails,
-         subject: "Gem #{@version.to_title} yanked from RubyGems.org"
+    mail to: notified_user.email,
+         subject: I18n.t("mailer.gem_yanked.subject", gem: @version.to_title)
   end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -55,4 +55,14 @@ class Mailer < ApplicationMailer
     mail to: @user.email,
       subject: "Please consider enabling MFA for your account"
   end
+
+  def gem_yanked(yanked_by_user_id, version_id)
+    @yanked_by_user = User.find(yanked_by_user_id)
+    @version = Version.find(version_id)
+    owner_emails = @version.rubygem.owners.pluck(:email)
+
+    mail from: Clearance.configuration.mailer_sender,
+         bcc: owner_emails,
+         subject: "Gem #{@version.to_title} yanked from RubyGems.org"
+  end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -76,6 +76,8 @@ class Deletion < ApplicationRecord
   end
 
   def send_gem_yanked_mail
-    Mailer.delay.gem_yanked(user.id, @version.id)
+    version.rubygem.notifiable_owners.each do |notified_user|
+      Mailer.delay.gem_yanked(user.id, version.id, notified_user.id)
+    end
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -10,6 +10,7 @@ class Deletion < ApplicationRecord
   after_commit :remove_from_storage, on: :create
   after_commit :expire_cache
   after_commit :update_search_index
+  after_commit :send_gem_yanked_mail
 
   attr_accessor :version
 
@@ -72,5 +73,9 @@ class Deletion < ApplicationRecord
   def set_yanked_info_checksum
     checksum = GemInfo.new(version.rubygem.name).info_checksum
     version.update_attribute :yanked_info_checksum, checksum
+  end
+
+  def send_gem_yanked_mail
+    Mailer.delay.gem_yanked(user.id, @version.id)
   end
 end

--- a/app/views/mailer/gem_yanked.html.erb
+++ b/app/views/mailer/gem_yanked.html.erb
@@ -1,26 +1,56 @@
-<p>
-  A gem you are responsible for was recently yanked (deleted) from RubyGems.org.
-</p>
-<p>
-  Gem: <strong><%= @version.to_title %></strong>
-  <br>
-  Yanked by user:
-  <strong>
-    <%= @yanked_by_user.handle %> <%= mail_to(@yanked_by_user.email) unless @yanked_by_user.hide_email? %>
-  </strong>
-</p>
-<p>If this yank is expected, you do not need to take further action.</p>
-<p>
-  <strong>Only if this yank is unexpected</strong>
-  please take immediate steps to secure your account and gems:
-</p>
-<ol>
-  <li>If you suspect your account was compromised:
-    <ol>
-      <li>Change your password: <%= link_to(new_password_url, new_password_url) %></li>
-      <li>Reset your API key: <%= link_to(edit_profile_url, edit_profile_url) %></li>
-      <li>Enable multifactor authentication: <%= link_to(edit_profile_url, edit_profile_url) %></li>
-    </ol>
-  </li>
-  <li>Report this incident to RubyGems.org: <%= link_to(page_url("security"), page_url("security")) %></li>
-</ol>
+<% @title = t(".title") %>
+<% @sub_title = @version.rubygem.name %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          A version of a gem you are an owner of was recently yanked from RubyGems.org.
+        </p>
+        <p>
+          Gem: <strong><%= link_to @version.to_title, rubygem_version_url(@version.rubygem, @version.slug), target: "_blank" %></strong>
+          <br/>
+          Yanked by user:
+          <strong>
+            <%= link_to @yanked_by_user.handle, profile_url(@yanked_by_user.display_id), target: "_blank" %> <%= mail_to(@yanked_by_user.email) unless @yanked_by_user.hide_email? %>
+          </strong>
+          <br/>
+          Yanked at: <strong><%= @version.yanked_at.to_formatted_s(:rfc822) %></strong>
+        </p>
+        <br/>
+        <p>If this yank is expected, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this yank is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+        <ol>
+          <li>If you suspect your account was compromised:
+            <ul>
+              <li><%= link_to("Change your password", new_password_url) %></li>
+              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
+              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
+            </ul>
+          </li>
+          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
+        </ol>
+        <p>
+          <em>
+            To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.
+          </em>
+        </p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/gem_yanked.html.erb
+++ b/app/views/mailer/gem_yanked.html.erb
@@ -1,0 +1,26 @@
+<p>
+  A gem you are responsible for was recently yanked (deleted) from RubyGems.org.
+</p>
+<p>
+  Gem: <strong><%= @version.to_title %></strong>
+  <br>
+  Yanked by user:
+  <strong>
+    <%= @yanked_by_user.handle %> <%= mail_to(@yanked_by_user.email) unless @yanked_by_user.hide_email? %>
+  </strong>
+</p>
+<p>If this yank is expected, you do not need to take further action.</p>
+<p>
+  <strong>Only if this yank is unexpected</strong>
+  please take immediate steps to secure your account and gems:
+</p>
+<ol>
+  <li>If you suspect your account was compromised:
+    <ol>
+      <li>Change your password: <%= link_to(new_password_url, new_password_url) %></li>
+      <li>Reset your API key: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+      <li>Enable multifactor authentication: <%= link_to(edit_profile_url, edit_profile_url) %></li>
+    </ol>
+  </li>
+  <li>Report this incident to RubyGems.org: <%= link_to(page_url("security"), page_url("security")) %></li>
+</ol>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -140,6 +140,9 @@ de:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title:
@@ -340,7 +343,7 @@ de:
       resend_confirmation:
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Am meisten Heruntergeladen in der gesamten Zeit
       total_downloads: Downloads insgesamt
       total_gems: Gems insgesamt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,9 @@ en:
     gem_pushed:
       subject: Gem %{gem} pushed to RubyGems.org
       title: GEM PUSHED
+    gem_yanked:
+      subject: Gem %{gem} yanked from RubyGems.org
+      title: GEM YANKED
   news:
     show:
       title: New Releases — All Gems
@@ -218,7 +221,7 @@ en:
       success: You have successfully updated your email notification settings.
     show:
       info: To aid detection of unauthorized gem changes, we email you each time a new version of a
-        gem you own is pushed. By receiving and reading these emails, you help protect the Ruby
+        gem you own is pushed or yanked. By receiving and reading these emails, you help protect the Ruby
         ecosystem.
       on: On
       off: Off

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -148,6 +148,9 @@ es:
     gem_pushed:
       subject: Gema %{gem} subida a RubyGems.org
       title: GEMA SUBIDA
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: Nuevos lanzamientos — Todas las Gemas
@@ -350,7 +353,7 @@ es:
       resend_confirmation: ¿No recibiste tu correo electrónico de confirmación?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Más descargadas
       total_downloads: Total de descargas
       total_gems: Gemas totales

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -140,6 +140,9 @@ fr:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems
@@ -340,7 +343,7 @@ fr:
       resend_confirmation: Vous n'avez pas reçu l'email de confirmation ?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Gems les plus téléchargés
       total_downloads: Total de téléchargements
       total_gems: Total de gems

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -140,6 +140,9 @@ ja:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: 新しくリリースされたGem
@@ -340,7 +343,7 @@ ja:
       resend_confirmation: 確認メールが見当たりませんか?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 累計最多ダウンロード数
       total_downloads: 累計ダウンロード数
       total_gems: Gem総数

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -140,6 +140,9 @@ nl:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title:
@@ -340,7 +343,7 @@ nl:
       resend_confirmation: Geen bevestigingsemail ontvangen?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded:
       total_downloads:
       total_gems:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -140,6 +140,9 @@ pt-BR:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: Novos Releases - Todas as Gems

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -140,6 +140,9 @@ zh-CN:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: 全部新发布 Gems
@@ -340,7 +343,7 @@ zh-CN:
       resend_confirmation: 没有收到确认邮件？
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 历史下载次数排行
       total_downloads: 下载总次数
       total_gems: Gems 总数

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -140,6 +140,9 @@ zh-TW:
     gem_pushed:
       subject:
       title:
+    gem_yanked:
+      subject:
+      title:
   news:
     show:
       title: 最新發佈
@@ -340,7 +343,7 @@ zh-TW:
       resend_confirmation: 沒收到確認信？
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 歷史下載次數排行
       total_downloads: 總下載次數
       total_gems: Gems 總數

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -32,4 +32,9 @@ class MailerPreview < ActionMailer::Preview
   def mfa_notification
     Mailer.mfa_notification(User.last.id)
   end
+
+  def gem_yanked
+    ownership = Ownership.where.not(user: nil).last
+    Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id)
+  end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -35,6 +35,6 @@ class MailerPreview < ActionMailer::Preview
 
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
-    Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id)
+    Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)
   end
 end

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -51,6 +51,14 @@ class DeletionTest < ActiveSupport::TestCase
       should "delete the .gem file" do
         assert_nil RubygemFs.instance.get("gems/#{@version.full_name}.gem"), "Rubygem still exists!"
       end
+
+      should "send gem yanked email" do
+        Delayed::Worker.new.work_off
+
+        email = ActionMailer::Base.deliveries.last
+        assert_equal "Gem #{@version.to_title} yanked from RubyGems.org", email.subject
+        assert_equal [@user.email], email.to
+      end
     end
 
     should "call GemCachePurger" do
@@ -61,7 +69,7 @@ class DeletionTest < ActiveSupport::TestCase
   end
 
   should "enque job for updating ES index, spec index and purging cdn" do
-    assert_difference "Delayed::Job.count", 7 do
+    assert_difference "Delayed::Job.count", 8 do
       delete_gem
     end
 


### PR DESCRIPTION
Similar to the notification on gem push, this would ensure unintended gem yank doesn't go unnoticed.
![Screenshot from 2020-06-07 15-08-34](https://user-images.githubusercontent.com/7680662/83965457-799a2d80-a8d1-11ea-80cb-5aeb173d04da.png)
