### PR TITLE
Remove version number from reverse dependencies page subtitle

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -98,6 +98,11 @@ a.page__heading {
     .page__subheading {
       font-size: 30px; } }
 
+.page__subheading--block {
+  display: block;
+  margin-top: 3px;
+}
+
 .page__heading__info {
   font-weight: 200;
   font-size: 16px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -111,6 +111,10 @@
               <% if @subtitle %>
                 <i class="page__subheading"><%= @subtitle.html_safe %></i>
               <% end %>
+
+              <% if @subtitle_block %>
+                <i class="page__subheading page__subheading--block"><%= @subtitle_block.html_safe %></i>
+              <% end %>
             </h1>
           <% end %>
           <%= yield :title %>

--- a/app/views/reverse_dependencies/index.html.erb
+++ b/app/views/reverse_dependencies/index.html.erb
@@ -1,5 +1,5 @@
 <% @title = t('.title', name: @rubygem.name) %>
-<% @subtitle = @latest_version&.slug %>
+<% @subtitle =  t(".subtitle", name: @rubygem.name) %>
 
 <div class="l-overflow">
   <div class="l-colspan--l colspan--l--has-border">

--- a/app/views/reverse_dependencies/index.html.erb
+++ b/app/views/reverse_dependencies/index.html.erb
@@ -1,5 +1,5 @@
 <% @title = t('.title', name: @rubygem.name) %>
-<% @subtitle =  t(".subtitle", name: @rubygem.name) %>
+<% @subtitle_block =  t(".subtitle", name: @rubygem.name) %>
 
 <div class="l-overflow">
   <div class="l-colspan--l colspan--l--has-border">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -319,6 +319,7 @@ de:
   reverse_dependencies:
     index:
       title:
+      subtitle:
     search:
       search_reverse_dependencies_html:
   searches:
@@ -340,7 +341,7 @@ de:
       resend_confirmation:
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Am meisten Heruntergeladen in der gesamten Zeit
       total_downloads: Downloads insgesamt
       total_gems: Gems insgesamt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@ en:
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"
+      subtitle: "Latest version of the following gems require %{name}"
     search:
       search_reverse_dependencies_html: "Search reverse dependencies Gems&hellip;"
   searches:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -329,6 +329,7 @@ es:
   reverse_dependencies:
     index:
       title: "Dependencias inversas para %{name}"
+      subtitle:
     search:
       search_reverse_dependencies_html: "Buscar dependencias inversas Gems&hellip;"
   searches:
@@ -350,7 +351,7 @@ es:
       resend_confirmation: ¿No recibiste tu correo electrónico de confirmación?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Más descargadas
       total_downloads: Total de descargas
       total_gems: Gemas totales

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -319,6 +319,7 @@ fr:
   reverse_dependencies:
     index:
       title: "Dépendances inversées pour %{name}"
+      subtitle:
     search:
       search_reverse_dependencies_html: "Chercher des dépendances inversées Gems&hellip;"
   searches:
@@ -340,7 +341,7 @@ fr:
       resend_confirmation: Vous n'avez pas reçu l'email de confirmation ?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: Gems les plus téléchargés
       total_downloads: Total de téléchargements
       total_gems: Total de gems

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -319,6 +319,7 @@ ja:
   reverse_dependencies:
     index:
       title: "%{name}の被依存性"
+      subtitle:
     search:
       search_reverse_dependencies_html: "被依存性の中から検索…"
   searches:
@@ -340,7 +341,7 @@ ja:
       resend_confirmation: 確認メールが見当たりませんか?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 累計最多ダウンロード数
       total_downloads: 累計ダウンロード数
       total_gems: Gem総数

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -319,6 +319,7 @@ nl:
   reverse_dependencies:
     index:
       title:
+      subtitle:
     search:
       search_reverse_dependencies_html:
   searches:
@@ -340,7 +341,7 @@ nl:
       resend_confirmation: Geen bevestigingsemail ontvangen?
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded:
       total_downloads:
       total_gems:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -319,6 +319,7 @@ pt-BR:
   reverse_dependencies:
     index:
       title: "Dependências Reversas para %{name}"
+      subtitle:
     search:
       search_reverse_dependencies_html: "Buscar Gems com dependências&hellip;"
   searches:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -319,6 +319,7 @@ zh-CN:
   reverse_dependencies:
     index:
       title: "%{name} 的反向依赖"
+      subtitle:
     search:
       search_reverse_dependencies_html:
   searches:
@@ -340,7 +341,7 @@ zh-CN:
       resend_confirmation: 没有收到确认邮件？
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 历史下载次数排行
       total_downloads: 下载总次数
       total_gems: Gems 总数

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -319,6 +319,7 @@ zh-TW:
   reverse_dependencies:
     index:
       title:
+      subtitle:
     search:
       search_reverse_dependencies_html:
   searches:
@@ -340,7 +341,7 @@ zh-TW:
       resend_confirmation: 沒收到確認信？
   stats:
     index:
-      title: 
+      title:
       all_time_most_downloaded: 歷史下載次數排行
       total_downloads: 總下載次數
       total_gems: Gems 總數


### PR DESCRIPTION
The page doesn't show reserve dependencies for the latest version
for the gem, it is confusion to show latest version in the subtitle.