### PR TITLE
Enable sending mail using Parameterized::DeliveryJob

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -37,7 +37,7 @@
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)


### PR DESCRIPTION
Fixes deprecations:
```
DEPRECATION WARNING: Sending mail with DeliveryJob and
Parameterized::DeliveryJob is deprecated and will be removed in Rails
6.1. Please use MailDeliveryJob instead. (called from call at
/home/travis/build/rubygems/rubygems.org/lib/clearance_backdoor.rb:9)
```
Change is not backward compatible. This could be deployed during off
peak hours, when no mail is pending in queue.
If some job does fail, we can queue it again with same args manually.