### PR TITLE
Rescue the versioned "no such file" error from S3

### DIFF
--- a/lib/rubygem_fs.rb
+++ b/lib/rubygem_fs.rb
@@ -84,7 +84,7 @@ module RubygemFs
 
     def restore(key)
       s3.head_object(key: key, bucket: bucket)
-    rescue Aws::S3::Errors::NoSuchKey => e
+    rescue Aws::S3::Errors::NotFound => e
       version_id = e.context.http_response.headers["x-amz-version-id"]
       s3.delete_object(key: key, bucket: bucket, version_id: version_id)
     end


### PR DESCRIPTION
It turns out that when the bucket is versioned, and the latest version
of that key is a deletion marker, the error raised is not `NoSuchKey`,
but instead `NotFound`. I needed to apply this patch live in production
to successfully run `Deletion#restore!` for this ticket:
https://github.com/rubygems/rubygems.org/issues/2400