### PR TITLE
Check if profile exists in DeleteUser job

### DIFF
--- a/app/jobs/delete_user.rb
+++ b/app/jobs/delete_user.rb
@@ -6,7 +6,10 @@ class DeleteUser
   end
 
   def perform
-    profile = User.find(user["id"])
+    profile = User.find_by(id: user["id"])
+
+    return unless profile
+
     email = profile.email
     if profile.destroy
       Mailer.deletion_complete(email)

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -137,6 +137,23 @@ class ProfileTest < SystemTest
       " We will send you a confirmation mail when your request has been processed."
   end
 
+  test "deleting profile multiple times" do
+    sign_in
+    visit delete_profile_path
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Confirm"
+
+    sign_in
+    visit delete_profile_path
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Confirm"
+
+    Delayed::Worker.new.work_off
+    assert_empty Delayed::Job.all
+  end
+
   test "enabling multifactor authentication with valid otp" do
     sign_in
     visit profile_path("nick1")


### PR DESCRIPTION
yanking multiple versions of the profile before deletion takes time,
it could be possible that user has submitted another request to delete
profile in the mean time.
Fixes:
```
Couldn't find User with 'id'=<user_id>
/usr/local/bundle/gems/activerecord-6.0.2.2/lib/active_record/core.rb:177:in `find'
/app/app/jobs/delete_user.rb:9:in `perform'
```