### PR TITLE
Add validation to metadata key being empty

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -383,6 +383,7 @@ class Version < ApplicationRecord
     metadata.each do |key, value|
       errors.add(:metadata, "metadata key ['#{key}'] is too large (maximum is #{max_key_size} bytes)") if key.size > max_key_size
       errors.add(:metadata, "metadata value ['#{value}'] is too large (maximum is #{max_value_size} bytes)") if value.size > max_value_size
+      errors.add(:metadata, "metadata key is empty") if key.empty?
     end
   end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -780,6 +780,12 @@ class VersionTest < ActiveSupport::TestCase
         @version.validate
         assert_equal @version.errors.messages[:metadata], ["metadata key ['#{large_key}'] is too large (maximum is 128 bytes)"]
       end
+
+      should "be invalid with empty key" do
+        @version.metadata = { "" => "value" }
+        @version.validate
+        assert_equal @version.errors.messages[:metadata], ["metadata key is empty"]
+      end
     end
   end
 


### PR DESCRIPTION
Elasticsearch indexing is breaking as it does allow empty key names
(`metatadata.<key_name>`). ex gem: randomsnumbers
Fixes:
```
[400] {"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"failed to parse"}],"type":"mapper_parsing_exception","reason":"failed to
parse","caused_by": {"type":"illegal_argument_exception","reason":"name cannot be empty string"}},"status":400}
/usr/local/bundle/gems/elasticsearch-transport-5.0.5/lib/elasticsearch/transport/transport/base.rb:202:in `__raise_transport_error'
/usr/local/bundle/gems/elasticsearch-transport-5.0.5/lib/elasticsearch/transport/transport/base.rb:319:in `perform_request'
/usr/local/bundle/gems/elasticsearch-transport-5.0.5/lib/elasticsearch/transport/transport/http/faraday.rb:20:in `perform_request'
/usr/local/bundle/gems/elasticsearch-transport-5.0.5/lib/elasticsearch/transport/client.rb:131:in `perform_request'
/usr/local/bundle/gems/elasticsearch-api-5.0.5/lib/elasticsearch/api/actions/index.rb:100:in `index'
/usr/local/bundle/gems/elasticsearch-model-5.0.2/lib/elasticsearch/model/indexing.rb:346:in `index_document'
/app/app/models/concerns/rubygem_searchable.rb:9:in `index_document'
```