### PR TITLE
Implement #find_rubygem_by_name inside WebhooksController

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,8 @@
 class Api::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  private
+
   def gem_name
     params[:gem_name] || params[:rubygem_name]
   end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,12 +1,13 @@
 class Api::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  private
+  def gem_name
+    params[:gem_name] || params[:rubygem_name]
+  end
 
   def find_rubygem_by_name
-    @gem_name = params[:gem_name] || params[:rubygem_name]
-    @rubygem  = Rubygem.find_by_name(@gem_name)
-    return if @rubygem || @gem_name == WebHook::GLOBAL_PATTERN
+    @rubygem  = Rubygem.find_by name: gem_name
+    return if @rubygem
     render plain: "This gem could not be found", status: :not_found
   end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,7 @@ class Api::BaseController < ApplicationController
   end
 
   def find_rubygem_by_name
-    @rubygem  = Rubygem.find_by name: gem_name
+    @rubygem = Rubygem.find_by name: gem_name
     return if @rubygem
     render plain: "This gem could not be found", status: :not_found
   end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::WebHooksController < Api::BaseController
   private
 
   def find_rubygem_by_name
-    @rubygem  = Rubygem.find_by name: gem_name
+    @rubygem = Rubygem.find_by name: gem_name
     return if @rubygem || gem_name == WebHook::GLOBAL_PATTERN
     render plain: "This gem could not be found", status: :not_found
   end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -41,6 +41,12 @@ class Api::V1::WebHooksController < Api::BaseController
 
   private
 
+  def find_rubygem_by_name
+    @rubygem  = Rubygem.find_by name: gem_name
+    return if @rubygem || gem_name == WebHook::GLOBAL_PATTERN
+    render plain: "This gem could not be found", status: :not_found
+  end
+
   def set_url
     render plain: "URL was not provided", status: :bad_request unless params[:url]
     @url = params[:url]


### PR DESCRIPTION
There's some creeping logic in the `find_rubygem_by_name` method inside the API BaseController:

https://github.com/rubygems/rubygems.org/blob/97b1703bdabf53e46a0b78115fbda3f8103dbb80/app/controllers/api/base_controller.rb#L6-L11

specifically on line 9:
 
    @rubygem || @gem_name == WebHook::GLOBAL_PATTERN

`WebHook::GLOBAL_PATTERN` is the character `*`, which none of the gem, or versions controllers expects or handles. To fix this, I decided to implement `find_rubygem_by_name` inside the WebhooksController  with the `WebHook::GLOBAL_PATTERN` and remove it from the Base Controller.

I also cleaned up a couple of things, like removing the `private` keyword from the Base Controller because none of the method in the BaseController are not really private methods.

Resolves https://app.honeybadger.io/projects/40972/faults/64833892