### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+This issue tracker for bug reports and feature requests only.
+
+  * Please open a support ticket on https://help.rubygems.org if your issue is related your rubygems.org
+    account or you need help using the site.
+  * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
+--->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Environment
+Browser and its version:
+RubyGems version:
+
+## Additional Context
+<!--- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+<!--
+This issue tracker for bug reports and feature requests only.
+
+  * Please open a support ticket on https://help.rubygems.org if your issue is related your rubygems.org
+    account or you need help using the site.
+  * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
+--->
+
+## Is your feature request related to a problem?
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen.  -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here.-->


### PR DESCRIPTION
Some of the issues open here are unnecessarily lengthy. I am hoping a formal format will inspire to the point reports.
Templates taken from https://github.com/stevemao/github-issue-templates