### PR TITLE
Fix unreachable branch in api/v1/owners/gem endpoint when owner is not found

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -36,11 +36,15 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def gems
-    user = User.find_by_slug!(params[:handle])
-    rubygems = user.rubygems.with_versions
-    respond_to do |format|
-      format.json { render json: rubygems }
-      format.yaml { render yaml: rubygems }
+    user = User.find_by_slug(params[:handle])
+    if user
+      rubygems = user.rubygems.with_versions
+      respond_to do |format|
+        format.json { render json: rubygems }
+        format.yaml { render yaml: rubygems }
+      end
+    else
+      render plain: "Owner could not be found.", status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -37,14 +37,10 @@ class Api::V1::OwnersController < Api::BaseController
 
   def gems
     user = User.find_by_slug!(params[:handle])
-    if user
-      rubygems = user.rubygems.with_versions
-      respond_to do |format|
-        format.json { render json: rubygems }
-        format.yaml { render yaml: rubygems }
-      end
-    else
-      render plain: "Owner could not be found.", status: :not_found
+    rubygems = user.rubygems.with_versions
+    respond_to do |format|
+      format.json { render json: rubygems }
+      format.yaml { render yaml: rubygems }
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ApplicationRecord
     find_by(id: slug) || find_by!(handle: slug)
   end
 
+  def self.find_by_slug(slug)
+    find_by(id: slug) || find_by(handle: slug)
+  end
+
   def self.find_by_name(name)
     find_by(email: name) || find_by(handle: name)
   end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -62,8 +62,8 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       get :gems, params: { handle: "imaginary_handler" }, format: :json
     end
 
-    should "return JSON with error message" do
-      assert_equal JSON.parse(@response.body), { "error" => "Not Found" }
+    should "return plaintext with error message" do
+      assert_equal @response.body, "Owner could not be found."
     end
 
     should respond_with :not_found
@@ -84,8 +84,8 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       get :gems, params: { handle: -9999 }, format: :json
     end
 
-    should "return JSON with error message" do
-      assert_equal JSON.parse(@response.body), { "error" => "Not Found" }
+    should "return plain text with error message" do
+      assert_equal @response.body, "Owner could not be found."
     end
 
     should respond_with :not_found

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -57,6 +57,18 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     should respond_with :success
   end
 
+  context "on GET to owner gems with nonexistent handle" do
+    setup do
+      get :gems, params: { handle: "imaginary_handler" }, format: :json
+    end
+
+    should "return JSON with error message" do
+      assert_equal JSON.parse(@response.body), { "error" => "Not Found" }
+    end
+
+    should respond_with :not_found
+  end
+
   context "on GET to owner gems with id" do
     setup do
       @user = create(:user)
@@ -64,6 +76,19 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
+  end
+
+  context "on GET to owner gems with nonexistent id" do
+    setup do
+      @user = create(:user)
+      get :gems, params: { handle: -9999 }, format: :json
+    end
+
+    should "return JSON with error message" do
+      assert_equal JSON.parse(@response.body), { "error" => "Not Found" }
+    end
+
+    should respond_with :not_found
   end
 
   should "route POST" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -453,4 +453,27 @@ class UserTest < ActiveSupport::TestCase
       assert @user.remember_me?
     end
   end
+
+  context ".find_by_slug" do
+    should "return nil if using a falsy value" do
+      refute User.find_by_slug(nil)
+    end
+    context "foundable" do
+      setup { @user = create(:user, handle: 'findable') }
+      should "return an AR when founded by id" do
+        assert User.find_by_slug(@user.id)
+      end
+      should "return an AR when founded by handle" do
+        assert User.find_by_slug(@user.handle)
+      end
+    end
+    context "not founded" do
+      should "return nil when using id" do
+        refute User.find_by_slug(-9999)
+      end
+      should "return nil when not founded by handle" do
+        refute User.find_by_slug("notfoundable")
+      end
+    end
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -458,19 +458,24 @@ class UserTest < ActiveSupport::TestCase
     should "return nil if using a falsy value" do
       refute User.find_by_slug(nil)
     end
+
     context "foundable" do
       setup { @user = create(:user, handle: "findable") }
+      
       should "return an AR when founded by id" do
-        assert User.find_by_slug(@user.id)
+        assert_equal User.find_by_slug(@user.id), @user
       end
+
       should "return an AR when founded by handle" do
-        assert User.find_by_slug(@user.handle)
+        assert_equal User.find_by_slug(@user.handle), @user
       end
     end
+
     context "not founded" do
       should "return nil when using id" do
         refute User.find_by_slug(-9999)
       end
+
       should "return nil when not founded by handle" do
         refute User.find_by_slug("notfoundable")
       end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -459,7 +459,7 @@ class UserTest < ActiveSupport::TestCase
       refute User.find_by_slug(nil)
     end
     context "foundable" do
-      setup { @user = create(:user, handle: 'findable') }
+      setup { @user = create(:user, handle: "findable") }
       should "return an AR when founded by id" do
         assert User.find_by_slug(@user.id)
       end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -461,7 +461,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "foundable" do
       setup { @user = create(:user, handle: "findable") }
-      
+
       should "return an AR when founded by id" do
         assert_equal User.find_by_slug(@user.id), @user
       end


### PR DESCRIPTION
The gem method is currently using User.find_by_slug! to find the user fromthe :handle parameter. #find_by_slug will trigger a AR::NotFound exception if is not able to find by id nor handle. Since is an exception the now-removed branch is not reachable, ergo not needed.

Added some functional test to cover this case.