### PR TITLE
Extracted mailer partial to make code DRY

### DIFF
--- a/app/views/mailer/_compromised_instructions.html.erb
+++ b/app/views/mailer/_compromised_instructions.html.erb
@@ -1,0 +1,11 @@
+<ol>
+  <li>If you suspect your account was compromised:
+    <ul>
+      <li><%= link_to("Change your password", new_password_url) %></li>
+      <li><%= link_to("Reset your API key", edit_profile_url) %></li>
+      <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
+    </ul>
+  </li>
+  <%= yield %>
+  <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
+</ol>

--- a/app/views/mailer/gem_pushed.html.erb
+++ b/app/views/mailer/gem_pushed.html.erb
@@ -28,17 +28,11 @@
           <strong>Only if this push is unexpected</strong>
           please take immediate steps to secure your account and gems:
         </p>
-        <ol>
-          <li>If you suspect your account was compromised:
-            <ul>
-              <li><%= link_to("Change your password", new_password_url) %></li>
-              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
-              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
-            </ul>
-          </li>
+
+        <%= render "compromised_instructions" do %>
           <li>Yank the version of the gem reported in this email</li>
-          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
-        </ol>
+        <% end %>
+
         <p>
           <em>
             To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.

--- a/app/views/mailer/gem_yanked.html.erb
+++ b/app/views/mailer/gem_yanked.html.erb
@@ -28,16 +28,11 @@
           <strong>Only if this yank is unexpected</strong>
           please take immediate steps to secure your account and gems:
         </p>
-        <ol>
-          <li>If you suspect your account was compromised:
-            <ul>
-              <li><%= link_to("Change your password", new_password_url) %></li>
-              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
-              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
-            </ul>
-          </li>
-          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
-        </ol>
+
+        <%= render "compromised_instructions" do %>
+          <li>Yank the version of the gem reported in this email</li>
+        <% end %>
+
         <p>
           <em>
             To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.

--- a/app/views/mailer/notifiers_changed.html.erb
+++ b/app/views/mailer/notifiers_changed.html.erb
@@ -30,18 +30,11 @@
           <strong>Only if this change to your settings is unexpected</strong>
           please take immediate steps to secure your account and gems:
         </p>
-        <ol>
-          <li>If you suspect your account was compromised:
-            <ul>
-              <li><%= link_to("Change your password", new_password_url) %></li>
-              <li><%= link_to("Reset your API key", edit_profile_url) %></li>
-              <li><%= link_to("Enable multifactor authentication", edit_profile_url) %></li>
-              <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
-            </ul>
-          </li>
+
+        <%= render "compromised_instructions" do %>
           <li>Look out for unexpected changes to your gems on RubyGems.org</li>
-          <li><%= link_to("Report this", page_url("security")) %> incident to RubyGems.org</li>
-        </ol>
+        <% end %>
+
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/mailer/notifiers_changed.html.erb
+++ b/app/views/mailer/notifiers_changed.html.erb
@@ -32,6 +32,7 @@
         </p>
 
         <%= render "compromised_instructions" do %>
+          <li><%= link_to("Renable email notification for your gem", notifier_url) %></li>
           <li>Look out for unexpected changes to your gems on RubyGems.org</li>
         <% end %>
 


### PR DESCRIPTION
As suggested by @sonalkr132 in this [PR comment](https://github.com/rubygems/rubygems.org/pull/2357#discussion_r440662487), extracted common instructions in the mailer views to a partial.