### PR TITLE
Fix broken rubycentral logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Ruby community's gem host.
 ## Support
 
 <a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a>
-<a href="https://rubycentral.org/"><img src="http://rubycentral.org/images/logo.png" width=200></a><br/>
+<a href="https://rubycentral.org/"><img src="https://gist.githubusercontent.com/sonalkr132/52a23481c0765b36ce1e909ba678c51a/raw/78e47c9ec77b690322040d4b9b8f460f58196182/Ruby-Central-Logo.png" width=160></a><br/>
 
 [RubyGems.org](https://rubygems.org) is managed by [Ruby Central](http://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](https://railsconf.org) and [RubyConf](https://rubyconf.org) through tickets and sponsorships.
 


### PR DESCRIPTION
This has been broken since rubycentral updated its site.
I tagged @evanphx in slack and asked for the updated logo but didn't get any response. Reverting this back to old logo until someone from rubycentral get back to us with the updated logo.

https://github.com/sonalkr132/rubygems.org/tree/rc-logo