### PR TITLE
Increase Strict-Transport-Security max age to 24 hours

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.ssl_options = {
-    hsts: { expires: 2.minutes, subdomains: false },
+    hsts: { expires: 24.hours, subdomains: false },
     redirect: {
       exclude: ->(request) { request.path.start_with?('/internal') }
     }


### PR DESCRIPTION
We have been using 2 minutes for quite a while. No one has complained
so far. Ideally, we should set max-age greater than 180 days, which will
be done in a follow-up PR if this goes well.

Related: #2069