### PR TITLE
[skip ci] Change hardcoded URLs to https on views, *.md + 500.html

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -19,4 +19,4 @@ This code of conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers, or emailing [conduct@rubygems.org](mailto:conduct@rubygems.org).
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://contributor-covenant.org), version 1.2.0, available at [https://contributor-covenant.org/version/1/2/0/](https://contributor-covenant.org/version/1/2/0/)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Ruby community's gem host.
 <a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a>
 <a href="https://rubycentral.org/"><img src="https://gist.githubusercontent.com/sonalkr132/52a23481c0765b36ce1e909ba678c51a/raw/78e47c9ec77b690322040d4b9b8f460f58196182/Ruby-Central-Logo.png" width=160></a><br/>
 
-[RubyGems.org](https://rubygems.org) is managed by [Ruby Central](http://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](https://railsconf.org) and [RubyConf](https://rubyconf.org) through tickets and sponsorships.
+[RubyGems.org](https://rubygems.org) is managed by [Ruby Central](https://rubycentral.org), a community-funded organization supported by conference participation for [RailsConf](https://railsconf.org) and [RubyConf](https://rubyconf.org) through tickets and sponsorships.
 
 Hosting fees are paid by Ruby Central and CDN fees are generously donated by [Fastly](https://fastly.com).
 
@@ -31,7 +31,7 @@ Additionally, [RubyTogether](https://rubytogether.org) sponsors individuals to w
 * [Trello Board][]
 
 [mailing list]: https://groups.google.com/group/rubygems-org
-[faq]: http://help.rubygems.org/kb/gemcutter/faq
+[faq]: https://help.rubygems.org/kb/gemcutter/faq
 [irc]: https://webchat.freenode.net/?channels=rubygems
 [travis]: https://travis-ci.org/rubygems/rubygems.org
 [code climate]: https://codeclimate.com/github/rubygems/rubygems.org

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -38,7 +38,7 @@
       <% if @my_gems.empty? %>
         <div class="t-body push--bottom">
           <p>
-            <%= t('.no_owned_html', :creating_link => link_to(t('.creating_link_text'), "http://guides.rubygems.org/make-your-own-gem/"),
+            <%= t('.no_owned_html', :creating_link => link_to(t('.creating_link_text'), "https://guides.rubygems.org/make-your-own-gem/"),
                                     :migrating_link => link_to(t('.migrating_link_text'), page_path("migrate"))) %>
           </p>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
             <% end %>
 
             <%= link_to "Releases", news_url, class: "header__nav-link #{active?(news_path)}" %>
-            <%= link_to t('.footer.blog'), "http://blog.rubygems.org", class: "header__nav-link" %>
+            <%= link_to t('.footer.blog'), "https://blog.rubygems.org", class: "header__nav-link" %>
 
             <%- if request.path_info == '/gems' %>
               <%= link_to "Gems", rubygems_path, class: "header__nav-link is-active" %>
@@ -59,7 +59,7 @@
               <%= link_to "Gems", rubygems_path, class: "header__nav-link" %>
             <%- end %>
 
-            <%= link_to t('.footer.guides'), "http://guides.rubygems.org", class: "header__nav-link" %>
+            <%= link_to t('.footer.guides'), "https://guides.rubygems.org", class: "header__nav-link" %>
 
             <% if signed_in? %>
               <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
@@ -135,14 +135,14 @@
             <%= link_to t('.footer.data'), page_path("data"), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.discussion_forum'), "https://groups.google.com/group/rubygems-org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.statistics'), stats_path, class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.contribute'), "http://guides.rubygems.org/contributing/", class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.contribute'), "https://guides.rubygems.org/contributing/", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/about' %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer is-active" %>
             <%- else %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer" %>
             <%- end %>
             <%= link_to t('.footer.help'), t(:help_url), class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.api'), "http://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.api'), "https://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/security' %>
               <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer is-active" %>
             <%- else %>
@@ -153,11 +153,11 @@
             <div class="footer__about">
               <p>
                 <%= t('footer_about_html',
-                  publish_docs: "http://guides.rubygems.org/publishing/",
-                  install_docs: "http://guides.rubygems.org/command-reference/#gem-install",
-                  api_docs: "http://guides.rubygems.org/rubygems-org-api/",
+                  publish_docs: "https://guides.rubygems.org/publishing/",
+                  install_docs: "https://guides.rubygems.org/command-reference/#gem-install",
+                  api_docs: "https://guides.rubygems.org/rubygems-org-api/",
                   gem_list: rubygems_path,
-                  contributing_docs: "http://guides.rubygems.org/contributing/"
+                  contributing_docs: "https://guides.rubygems.org/contributing/"
                   ) %>
               </p>
               <p>
@@ -172,7 +172,7 @@
       </div>
       <div class="footer__sponsors-wrap">
         <div class="footer__sponsors">
-          <a class="footer__sponsor" href="http://rubycentral.org/" target="_blank">
+          <a class="footer__sponsor" href="https://rubycentral.org/" target="_blank">
             <%= t("layouts.application.footer.supported_by") %>
             <span class="t-hidden">Ruby Central</span>
           </a>
@@ -192,7 +192,7 @@
             <%= t("layouts.application.footer.optimized_by") %>
             <span class="t-hidden">New Relic</span>
           </a>
-          <a class="footer__sponsor" href="http://get.gaug.es/" target="_blank">
+          <a class="footer__sponsor" href="https://get.gaug.es/" target="_blank">
             <%= t("layouts.application.footer.tracking_by") %>
             <span class="t-hidden">Gauges</span>
           </a>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -317,7 +317,7 @@
 												&nbsp;&nbsp;|&nbsp;&nbsp;
 												<a href="https://blog.rubygems.org/" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">BLOG</span></a>
 												&nbsp;&nbsp;|&nbsp;&nbsp;
-												<a href="http://help.rubygems.org/" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">CONTACT US</span></a>
+												<a href="https://help.rubygems.org/" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">CONTACT US</span></a>
 											</div>
 											<table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="20" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/app/views/mailer/deletion_failed.html.erb
+++ b/app/views/mailer/deletion_failed.html.erb
@@ -11,7 +11,7 @@
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
-        <%= t('.body_html', contact: link_to('contact', "http://help.rubygems.org")) %><br />
+        <%= t('.body_html', contact: link_to('contact', "https://help.rubygems.org")) %><br />
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -20,11 +20,11 @@
                            :aws => link_to("AWS", "https://aws.amazon.com")) %>
   </p>
   <p>
-    <%= t('.technical_html', :rails => link_to("Rails", "http://rubyonrails.org"),
+    <%= t('.technical_html', :rails => link_to("Rails", "https://rubyonrails.org"),
                              :s3 => link_to("Amazon S3", "https://aws.amazon.com/s3/"),
                              :fastly => link_to("Fastly", "https://www.fastly.com"),
                              :source_code => link_to("please check out the code", "https://github.com/rubygems/rubygems.org"),
-                             :license => link_to("MIT licensed", "http://www.opensource.org/licenses/mit-license.php")
+                             :license => link_to("MIT licensed", "https://www.opensource.org/licenses/mit-license.php")
                              ) %>
   </p>
 

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -2,6 +2,6 @@
 
 <div class="t-body">
   <p>
-    <%= link_to "This page has been moved onto #{t(:title)}’s new support site.", "http://help.rubygems.org/faqs/gemcutter/faq" %>
+    <%= link_to "This page has been moved onto #{t(:title)}’s new support site.", "https://help.rubygems.org/kb/gemcutter/faq" %>
   </p>
 </div>

--- a/app/views/pages/security.html.erb
+++ b/app/views/pages/security.html.erb
@@ -11,9 +11,9 @@
   <p>
     Before continuing, please ensure this is a security issue for the RubyGems
     client or the RubyGems.org service. For all vulnerabilities with individual
-    gems, follow our guide on <a href="http://guides.rubygems.org/security/#reporting-security-vulnerabilities">
+    gems, follow our guide on <a href="https://guides.rubygems.org/security/#reporting-security-vulnerabilities">
       reporting security issues</a> with others' gems. If it's a security issue
-    with the Ruby on Rails framework, see the <a href="http://rubyonrails.org/security/">
+    with the Ruby on Rails framework, see the <a href="https://rubyonrails.org/security/">
       Rails Security</a> guide.
   </p>
 
@@ -55,7 +55,7 @@
   <h2>Reporting RubyGems.org Website Problems</h2>
   <p>
     If you're having trouble pushing a gem, or otherwise need help with your
-    RubyGems.org account, please <a href="http://help.rubygems.org">
+    RubyGems.org account, please <a href="https://help.rubygems.org">
       open a new help issue</a>.
   </p>
 
@@ -94,7 +94,7 @@
       include patches for all versions still under support. The changes are
       pushed to the public repository and new gems released to rubygems. At
       least 6 hours after the mailing list is notified, a copy of the advisory
-      will be published on the <a href="http://blog.rubygems.org/"> RubyGems.org
+      will be published on the <a href="https://blog.rubygems.org/"> RubyGems.org
       blog</a>.
     </li>
   </ol>

--- a/app/views/profiles/delete.html.erb
+++ b/app/views/profiles/delete.html.erb
@@ -2,7 +2,7 @@
 
 <% if @only_owner_gems.any? %>
   <div class="t-body">
-    <p class="page__subheading"><%= (t '.list_only_owner_html', command_link: link_to('gem owner', 'http://guides.rubygems.org/command-reference/#gem-owner')) %></p>
+    <p class="page__subheading"><%= (t '.list_only_owner_html', command_link: link_to('gem owner', 'https://guides.rubygems.org/command-reference/#gem-owner')) %></p>
   </div>
   <div id="profile">
     <div class="profile-list">

--- a/public/500.html
+++ b/public/500.html
@@ -15,7 +15,7 @@
         <h1>Server error.</h1>
         <p>
           Looks like something blew up on our end. We&rsquo;ve been alerted of the problem, but feel free to open up an
-          <a href="http://help.rubygems.org/">issue</a>
+          <a href="https://help.rubygems.org/">issue</a>
           if you want it fixed faster.
         </p>
         <a href="/">Back to RubyGems.org →</a>


### PR DESCRIPTION
- app/views
- README.md
- CODE_OF_CONDUCT.md
- 500.html

Note: the secure version of uptime.rubygems.org is currently not configured correctly and will prompt browser warning with  a `SSL_ERROR_BAD_CERT_DOMAIN` message, which would made the other way around impact (as insecure); so I kept it as it is for now.