### PR TITLE
Remove unreacheable code on Redirector middleware

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -13,12 +13,6 @@ class Redirector
       redirect_to(fake_request.url)
     elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)} && request.host !~ /docs/
       redirect_to("https://docs.rubygems.org#{request.path}")
-    elsif %r{^/pages/docs$}.match?(request.path)
-      redirect_to("https://guides.rubygems.org")
-    elsif %r{^/pages/gem_docs$}.match?(request.path)
-      redirect_to("https://guides.rubygems.org/command-reference")
-    elsif %r{^/pages/api_docs$}.match?(request.path)
-      redirect_to("https://guides.rubygems.org/rubygems-org-api")
     else
       @app.call(env)
     end

--- a/test/unit/redirector_test.rb
+++ b/test/unit/redirector_test.rb
@@ -61,27 +61,6 @@ class RedirectorTest < ActiveSupport::TestCase
     assert_equal 200, last_response.status
   end
 
-  should "redirect request to docs to guides " do
-    get "/pages/docs", {}, "HTTP_HOST" => Gemcutter::HOST
-
-    assert_equal 301, last_response.status
-    assert_equal "https://guides.rubygems.org", last_response.headers["Location"]
-  end
-
-  should "redirect request to gem docs to guides " do
-    get "/pages/gem_docs", {}, "HTTP_HOST" => Gemcutter::HOST
-
-    assert_equal 301, last_response.status
-    assert_equal "https://guides.rubygems.org/command-reference", last_response.headers["Location"]
-  end
-
-  should "redirect request to api docs to guides " do
-    get "/pages/api_docs", {}, "HTTP_HOST" => Gemcutter::HOST
-
-    assert_equal 301, last_response.status
-    assert_equal "https://guides.rubygems.org/rubygems-org-api", last_response.headers["Location"]
-  end
-
   should "allow fastly domains" do
     get "/", {}, "HTTP_HOST" => "index.rubygems.org"
     assert_equal 200, last_response.status


### PR DESCRIPTION
In commit 37c4ed2b4807fda1 the following views were removed from the code base

- app/views/pages/api_docs.html.erb
- app/views/pages/docs.html.erb
- app/views/pages/gem_docs.html.erb

And later, on f4c33aa522a83739e1 a new constraint was added.

    get 'pages/*id' => 'high_voltage/pages#show',
     constraints: { id:/(#{HighVoltage.page_ids.join("|")})/ }, as: :page

Currently the routes are restrictive enough so now Rails raises an `ActionController::RoutingError` on the following routes way before the middleware is called:

- pages/api_docs
- pages/docs
- pages/gem_docs

All of this made the branches on the middleware unreachable because are never checked at all.

Removing these now superfluos conditions would make every single request to the app a little bit faster.