### PR TITLE
User.block! should not use Unpwn

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,8 +223,8 @@ class User < ApplicationRecord
       update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{id}-#{handle}@rubygems.org")
       confirm_email!
       disable_mfa!
+      update_attribute(:password, SecureRandom.alphanumeric)
       update!(
-        password: SecureRandom.alphanumeric,
         remember_token: nil,
         remember_token_expires_at: nil,
         api_key: nil


### PR DESCRIPTION
There's an small chance a SecureRandom.alphanumeric returns an already leaked password on HIBP. Since the goal is just
use another password as a measure to block the user we can just bypass the Unpwn validation.