### PR TITLE
Fix SimpleCov for correct coverage report 

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start "rails"
+
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 
@@ -11,9 +14,6 @@ require "helpers/gem_helpers"
 require "helpers/email_helpers"
 require "helpers/es_helper"
 require "helpers/password_helpers"
-require "simplecov"
-
-SimpleCov.start "rails"
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true


### PR DESCRIPTION
According to the documentation of SimpleCov

> If SimpleCov starts after your application code is already loaded (via require), it won't be able to track your files and their coverage! The SimpleCov.start must be issued before any of your application code is required!

Earlier coverage report looked like this
![Screenshot from 2020-07-04 19-06-23](https://user-images.githubusercontent.com/29918760/86513651-902c9980-be29-11ea-9534-94c16a40b4cb.png)


This change reports the code coverage correctly.
![Screenshot from 2020-07-04 18-59-34](https://user-images.githubusercontent.com/29918760/86513582-f7961980-be28-11ea-8cf8-76040a95fd15.png)
