### PR TITLE
Removed unnecessary ES cookie from tests

### DIFF
--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -62,7 +62,6 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
       import_and_refresh
-      @request.cookies["new_search"] = "true"
       get :show, params: { query: "sinatra" }
     end
 
@@ -104,7 +103,6 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra_redux)
       create(:version, rubygem: @brando)
       import_and_refresh
-      @request.cookies["new_search"] = "true"
       get :show, params: { query: "sinatre" }
     end
 
@@ -152,7 +150,6 @@ class SearchesControllerTest < ActionController::TestCase
     should "fallback to legacy search" do
       requires_toxiproxy
       Toxiproxy[:elasticsearch].down do
-        @request.cookies["new_search"] = "true"
         get :show, params: { query: "sinatra" }
         assert_response :success
         assert page.has_content?("Advanced search is currently unavailable. Falling back to legacy search.")


### PR DESCRIPTION
Cookie based ES toggle was introduced [here](https://github.com/rubygems/rubygems.org/commit/5f0ba2b32ec59adc9cebed237e51e933fb94ed01#) which was then removed as ES search for fully enabled [here](https://github.com/rubygems/rubygems.org/commit/8265fbb5a35536bcfecfdba301a7ac65074b1666#diff-66694174e90422724c8c508d12a0f225)

We can remove it from the tests too :smile: 