### PR TITLE
update api versions used for k8s resources

### DIFF
--- a/config/deploy/delayed_job_statsd.yaml.erb
+++ b/config/deploy/delayed_job_statsd.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: delayed-jobs-statsd

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jobs

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shoryuken

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: unicorn


### PR DESCRIPTION
This is to prepare for Kubernetes 1.16.
Ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/