### PR TITLE
Remove unused dependencies from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,12 @@ FROM ruby:2.6-alpine as build
 RUN apk add --no-cache \
   ruby \
   nodejs \
-  postgresql-client \
   postgresql-dev \
   ca-certificates \
-  ruby-dev \
   build-base \
   bash \
   linux-headers \
   zlib-dev \
-  libxml2-dev \
-  libxslt-dev \
   tzdata \
   && rm -rf /var/cache/apk/*
 
@@ -27,7 +23,7 @@ ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/version
 
 RUN mv /app/config/database.yml.example /app/config/database.yml
 
-RUN gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without deploy
+RUN gem install bundler io-console --no-ri --no-rdoc && bundle install --jobs 20 --retry 5 --without development test
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=1234 bin/rails assets:precompile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM ruby:2.6-alpine
 RUN apk add --no-cache \
   ruby \
   nodejs \
-  postgresql-client \
+  libpq \
   ca-certificates \
   bash \
   tzdata \


### PR DESCRIPTION
pg only needs postgresql-dev (equavalent of libpq-dev in debian), postgresql-client was removable.
nokorigi only needs build-base[1], ruby-dev, libxml2-dev and libxslt-dev was removable.

bundle install --without flag was changed as we don't have deploy group any more and we don't need to install test and development groups.

[1] https://nokogiri.org/tutorials/installing_nokogiri.html#ruby-on-alpine-linux-docker