### PR TITLE
Increase Strict-Transport-Security max-age to one year

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.ssl_options = {
-    hsts: { expires: 24.hours, subdomains: false },
+    hsts: { expires: 365.days, subdomains: false },
     redirect: {
       exclude: ->(request) { request.path.start_with?('/internal') }
     }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.ssl_options = {
-    hsts: { expires: 2.minutes, subdomains: false },
+    hsts: { expires: 365.days, subdomains: false },
     redirect: {
       exclude: ->(request) { request.path.start_with?('/internal') }
     }


### PR DESCRIPTION
using one year as it is one of requirements of HSTS preload list. It also
needs includeSubDomains which we have disabled as of now. I don't think
adding includeSubDomains should be an issue either since gem clients
don't really this header or its values.

Related: #2423