### PR TITLE
Fix rack_attack test failing on travis with 429

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ class ActiveSupport::TestCase
   setup do
     I18n.locale = :en
     Rails.cache.clear
+    Rack::Attack.cache.store.clear
 
     # Don't connect to the Pwned Passwords API in tests
     Pwned.stubs(:pwned?).returns(false)


### PR DESCRIPTION
Previously, [travis build was failing](https://travis-ci.org/github/sonalkr132/rubygems.org/jobs/707339379#L1253) for `--seed 27888` on test for `Api::V1::RubygemsTest#test_request_has_remote_addr_present`:
```
Expected response to be a <2XX: success>, but was a <429: Too Many
Requests>
Response body: Retry later
```
Interestingly, the test suite passed locally when running with the same seed.

We noticed rack_attack throttle key was not resetting between tests on travis:
```
api/push/ip:1.2.3.4 : 502
```

We had added `Rails.cache.clear` for very purpose on [recommendation of the gem author](https://github.com/rubygems/rubygems.org/pull/1414#discussion_r77869334).
I suppose things have changed since then and [rack_attack doc recommends](https://github.com/kickstarter/rack-attack#testing) using `Rack::Attack.reset!` for isolated tests, unfortunately [it doesn't support MemCacheStore](https://travis-ci.org/github/sonalkr132/rubygems.org/jobs/707355621#L631).
Using `Rack::Attack.cache.store.clear` [fixes this issue for us](https://travis-ci.org/github/sonalkr132/rubygems.org/jobs/707340350#L1247). I am not sure why Rack::Attack.cache and Rails.cache are not the same on travis.