### PR TITLE
Fix TypeError on sign_up page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < Clearance::UsersController
   def new
-    redirect_to sign_up_path
+    @user = user_from_params
   end
 
   def create
@@ -14,7 +14,9 @@ class UsersController < Clearance::UsersController
     end
   end
 
+  private
+
   def user_params
-    params.require(:user).permit(*User::PERMITTED_ATTRS)
+    params.permit(user: [*User::PERMITTED_ATTRS]).fetch(:user, {})
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Rails.application.routes.draw do
     get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
-    get '/sign_up' => 'clearance/users#new', as: 'sign_up' if Clearance.configuration.allow_sign_up?
+    get '/sign_up' => 'users#new', as: 'sign_up' if Clearance.configuration.allow_sign_up?
   end
 
   ################################################################################

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -6,7 +6,7 @@ class UsersControllerTest < ActionController::TestCase
       get :new
     end
 
-    should redirect_to("sign up page") { sign_up_path }
+    render_template(:new)
   end
 
   context "on POST to create" do
@@ -19,9 +19,11 @@ class UsersControllerTest < ActionController::TestCase
 
     context "when missing a parameter" do
       should "raises parameter missing" do
-        post :create
-        assert_response :bad_request
-        assert page.has_content?("Request is missing param 'user'")
+        assert_no_changes -> { User.count } do
+          post :create
+        end
+        assert_response :ok
+        assert page.has_content?("Email address is not a valid email")
       end
     end
 

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -56,6 +56,12 @@ class SignUpTest < SystemTest
     end
   end
 
+  test "sign up when user param is string" do
+    assert_nothing_raised do
+      get "/sign_up?user=JJJ12QQQ"
+    end
+  end
+
   test "email confirmation" do
     visit sign_up_path
 


### PR DESCRIPTION
`user_params.delete(:email)` in clearance raises following error when
user requests `/sign_up?user=JJJ12QQQ`:
```
TypeError:
       no implicit conversion of Symbol into String
     # ./app/controllers/clearance/users_controller.rb:34:in `delete'
     # ./app/controllers/clearance/users_controller.rb:34:in
`user_from_params'
     # ./app/controllers/clearance/users_controller.rb:6:in `new'
```

This patch overrides `new` action and updates `user_params` to requires
(optional) nested user params.
Removing `require` means that `create` won't raise 400, however overall
effect will remain the same (of not creating new user).

Related: https://github.com/thoughtbot/clearance/issues/900