### PR TITLE
Remove ruby from prod and build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6-alpine as build
 
 RUN apk add --no-cache \
-  ruby \
   nodejs \
   postgresql-dev \
   ca-certificates \
@@ -33,7 +32,6 @@ RUN RAILS_ENV=production SECRET_KEY_BASE=1234 bin/rails assets:precompile
 FROM ruby:2.6-alpine
 
 RUN apk add --no-cache \
-  ruby \
   nodejs \
   libpq \
   ca-certificates \


### PR DESCRIPTION
The image is already based on ruby:2.6-alpine, we shouldn't have to install ruby again.

cc: @simi 