### PR TITLE
Enable new cops of rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,6 +165,31 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+
+Performance/AncestorsInclude:
+  Enabled: true
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: true
 

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -12,24 +12,24 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
     should "forbid access when creating a web hook" do
       rubygem = create(:rubygem)
       post :create, params: { gem_name: rubygem.name, url: "http://example.com" }
-      assert @response.body =~ /Access Denied/
+      assert @response.body.include? "Access Denied"
       assert WebHook.count.zero?
     end
 
     should "forbid access when listing hooks" do
       get :index
-      assert @response.body =~ /Access Denied/
+      assert @response.body.include? "Access Denied"
     end
 
     should "forbid access when firing hooks" do
       post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN, url: "http://example.com" }
-      assert @response.body =~ /Access Denied/
+      assert @response.body.include? "Access Denied"
     end
 
     should "forbid access when removing a web hook" do
       hook = create(:web_hook)
       delete :remove, params: { gem_name: hook.rubygem.name, url: hook.url }
-      assert @response.body =~ /Access Denied/
+      assert @response.body.include? "Access Denied"
       assert_equal 1, WebHook.count
     end
   end


### PR DESCRIPTION
Fixes following warning:
```
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Performance/AncestorsInclude (1.7)
 - Performance/BigDecimalWithNumericArgument (1.7)
 - Performance/RedundantSortBlock (1.7)
 - Performance/RedundantStringChars (1.7)
 - Performance/ReverseFirst (1.7)
 - Performance/SortReverse (1.7)
 - Performance/Squeeze (1.7)
 - Performance/StringInclude (1.7)
For more information: https://docs.rubocop.org/rubocop/versioning.html
```

webhook test change is to fix:
```
Performance/StringInclude: Use String#include? instead of a regex match
with literal-only pattern.
```