### PR TITLE
Make API key reset mailer view generic

### DIFF
--- a/app/views/mailer/reset_api_key.erb
+++ b/app/views/mailer/reset_api_key.erb
@@ -10,7 +10,7 @@
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
         <p>
-          Unfortunately, your RubyGems.org API key was published in a public gem. To protect your account, we have reset your API key to a new, random value.
+          Unfortunately, your RubyGems.org API key was leaked. To protect your account, we have reset your API key to a new, random value.
           Please check the gems you own to ensure that they were not modified without your permission while your API key was public.
         </p>
         <p>


### PR DESCRIPTION
> your RubyGems.org API key was published in a public gem.

This may not always be the case. while it would be nice to add more details, it can be communicated through the blog if needed.