### PR TITLE
Increase gem limit for v1 dependencies controller

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::DependenciesController < Api::BaseController
   before_action :check_gem_count
-  GEM_REQUEST_LIMIT = 200
+  GEM_REQUEST_LIMIT = 275
 
   def index
     deps = GemDependent.new(gem_names).to_a


### PR DESCRIPTION
Installing `aws-sdk` takes extremely long - related issue https://github.com/aws/aws-sdk-ruby/issues/2377

I suspect that, because there are >200 `aws-sdk-<service>` gems, the `gem install` command is attempting to resolve dependencies itself. Output of `gem install aws-sdk -V` shows an unprocessable entity error from rubygems.org, and there are multiple version downloads of .gemspec.rz files for each gem.

If it's allowable (and your server can handle it), can this limit be increased?

Tested with `docker-compose up`, setup the DB (https://github.com/rubygems/rubygems.org/blob/master/CONTRIBUTING.md), and tests pass.