### PR TITLE
Update backfill required_rubygems_version task to required_ruby_version

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -82,18 +82,18 @@ namespace :gemcutter do
     end
   end
 
-  namespace :required_rubygems_version do
+  namespace :required_ruby_version do
     desc "Backfill gem versions with rubygems_version."
     task backfill: :environment do
-      without_required_rubygems_version = Version.where(required_rubygems_version: nil)
+      without_required_ruby_version = Version.where("created_at < '2014-03-21' and required_ruby_version is null")
       mod = ENV["shard"]
-      without_required_rubygems_version = without_required_rubygems_version.where("id % 4 = ?", mod.to_i) if mod
+      without_required_ruby_version = without_required_ruby_version.where("id % 4 = ?", mod.to_i) if mod
 
-      total = without_required_rubygems_version.count
+      total = without_required_ruby_version.count
       i = 0
       puts "Total: #{total}"
-      without_required_rubygems_version.find_each do |version|
-        GemcutterTaskshelper.assign_required_rubygems_version!(version)
+      without_required_ruby_version.find_each do |version|
+        GemcutterTaskshelper.assign_required_ruby_version!(version)
         i += 1
         print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
       end

--- a/lib/tasks/helpers/gemcutter_tasks_helper.rb
+++ b/lib/tasks/helpers/gemcutter_tasks_helper.rb
@@ -17,9 +17,9 @@ module GemcutterTaskshelper
     version.update(metadata: metadata || {})
   end
 
-  def assign_required_rubygems_version!(version)
-    required_rubygems_version = get_spec_attribute(version.full_name, "required_rubygems_version")
-    version.update_column(:required_rubygems_version, required_rubygems_version.to_s)
+  def assign_required_ruby_version!(version)
+    required_ruby_version = get_spec_attribute(version.full_name, "required_ruby_version")
+    version.update_column(:required_ruby_version, required_ruby_version.to_s)
   end
 
   def get_spec_attribute(version_full_name, attribute_name)


### PR DESCRIPTION
We started storing required_ruby_version since 20 March, 2014. At
the time it was only used in UI and considered not as important to
backfill.
rubygems pre installation checks uses gemspec to verify ruby requirements,
and bundle install fails when it tries to install a version with
incompatible requirements.
Now that bundler uses required_ruby_version in dependency resolution
it would be nicer if older versions reported their required ruby
version on the compact index endpoint.

440314 versions match the `where` criteria.

Related: https://github.com/rubygems/rubygems/issues/3870