### PR TITLE
Replace sass-rails with sassc-rails and don't install in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,13 @@ RUN mv /app/config/database.yml.example /app/config/database.yml
 
 
 RUN gem install bundler io-console --no-ri --no-rdoc && \
-  bundle config set without 'development test' && \
+  bundle config set --local without 'development test' && \
   bundle install --jobs 20 --retry 5
 
-RUN RAILS_ENV=production RAILS_GROUPS=js SECRET_KEY_BASE=1234 bin/rails assets:precompile
+RUN RAILS_ENV=production RAILS_GROUPS=assets SECRET_KEY_BASE=1234 bin/rails assets:precompile
+
+RUN bundle config set --local without 'development test assets' && \
+  bundle clean --force
 
 
 FROM ruby:2.6-alpine

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "rbtrace", "~> 0.4.8"
 gem "rdoc"
 gem "rest-client", require: "rest_client"
 gem "roadie-rails"
-gem "sass-rails"
+gem "sassc-rails"
 gem "shoryuken", "~> 2.1.0", require: false
 gem "statsd-instrument", "~> 2.3.0"
 gem "unicorn", "~> 5.5.0.1.g6836"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "rbtrace", "~> 0.4.8"
 gem "rdoc"
 gem "rest-client", require: "rest_client"
 gem "roadie-rails"
-gem "sassc-rails"
 gem "shoryuken", "~> 2.1.0", require: false
 gem "statsd-instrument", "~> 2.3.0"
 gem "unicorn", "~> 5.5.0.1.g6836"
@@ -46,7 +45,8 @@ gem "unpwn", "~> 0.3.0"
 # Logging
 gem "lograge"
 
-group :js do
+group :assets do
+  gem "sassc-rails"
   gem "uglifier", ">= 1.0.3"
   gem "autoprefixer-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,9 +337,7 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -458,7 +456,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
-  sass-rails
+  sassc-rails
   selenium-webdriver
   shoryuken (~> 2.1.0)
   shoulda


### PR DESCRIPTION
We precompile assets in build state and don't assets group installed in prod container.
`bundle clean --force` ensures gem not enabled are not installed on the host.

Reduces docker image size by almost 100 MB
```
$ sudo docker images | grep ruby
rubygems                latest              8b8dab70e1a1        19 minutes ago      273MB
rubygems-old            latest              f8777bb38d38        2 hoursago         371MB
```

Tested with force SSL config and Redirector middleware disabled
```
sudo docker run --net host  -e DATABASE_URL=postgresql://localhost -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e RAILS_SERVE_STATIC_FILES=true rubygems -- unicorn_rails -E production -c /app/config/unicorn.conf
```

cc: @simi 