### PR TITLE
Prophylactic measures on /dashboard endpoint

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -19,7 +19,9 @@ class DashboardsController < ApplicationController
   private
 
   def authenticate_with_api_key
-    api_key   = request.headers["Authorization"] || params.permit(:api_key).fetch(:api_key, "")
+    api_key = request.headers["Authorization"] || params.permit(:api_key).fetch(:api_key, "")
+    return head(:not_acceptable) if api_key.size > 32
+
     @api_user = User.find_by_api_key(api_key)
   end
 

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -8,6 +8,20 @@ class DashboardTest < ActionDispatch::IntegrationTest
     create(:rubygem, name: "arrakis", number: "1.0.0")
   end
 
+  test "request with long api_key should be rejected" do
+    cookies[:remember_token] = nil
+    get dashboard_path(api_key: ("x" * 40))
+
+    assert_response 406
+  end
+
+  test "request with long Authorization header should be rejected" do
+    cookies[:remember_token] = nil
+    get dashboard_path, headers: { "Authorization" => ("x" * 40) }
+
+    assert_response 406
+  end
+
   test "request with array of api keys does not pass autorization" do
     cookies[:remember_token] = nil
     rubygem = create(:rubygem, name: "sandworm", number: "1.0.0")


### PR DESCRIPTION
The /dashboard endpoint is an open endpoint with the ability to authenticate the user via and Authorization header
or the usage of api_key parameter, so the users are able to get the dashboard via RSS/Atom. This openness also open
the opportunity to have DoS or DDoS affecting the internal network because the above headers or parameters will be
sent as a parameter to the database, the size of these parameter will be limited only by the limits on nginx or unicorn before they issue a 414 response (URI Too Long).

As a prophylactic measure we should reject post with an API key longer than expected, so no bad actors(s) would have
the chance to do more harm sending big/long request and expect rubygems.org to have a bad time working on this
unnecessary task.

Note: I'm returning a 406 'Not Acceptable' in order to let administrator to instrument and take actions via their
sysops tools such as HoneyBadger or similar when seeing an elevate number of responses of this kind.