### PR TITLE
Use marshal gemspec file in require ruby backfill and update info checksum

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -85,7 +85,9 @@ namespace :gemcutter do
   namespace :required_ruby_version do
     desc "Backfill gem versions with rubygems_version."
     task backfill: :environment do
-      without_required_ruby_version = Version.where("created_at < '2014-03-21' and required_ruby_version is null")
+      ActiveRecord::Base.logger.level = 1 if Rails.env.development?
+
+      without_required_ruby_version = Version.where("created_at < '2014-03-21' and required_ruby_version is null and indexed = true")
       mod = ENV["shard"]
       without_required_ruby_version = without_required_ruby_version.where("id % 4 = ?", mod.to_i) if mod
 

--- a/lib/tasks/helpers/gemcutter_tasks_helper.rb
+++ b/lib/tasks/helpers/gemcutter_tasks_helper.rb
@@ -19,16 +19,24 @@ module GemcutterTaskshelper
 
   def assign_required_ruby_version!(version)
     required_ruby_version = get_spec_attribute(version.full_name, "required_ruby_version")
+
+    return if required_ruby_version.nil? || required_ruby_version.to_s == ">= 0"
+    Rails.logger.info("[gemcutter:required_ruby_version:backfill] updating version: #{version.full_name} "\
+      " with required_ruby_version: #{required_ruby_version}")
+
     version.update_column(:required_ruby_version, required_ruby_version.to_s)
+    CompactIndexTasksHelper.update_last_checksum(version.rubygem, "gemcutter:required_ruby_version:backfill")
   end
 
   def get_spec_attribute(version_full_name, attribute_name)
-    key = "gems/#{version_full_name}.gem"
+    key = "quick/Marshal.4.8/#{version_full_name}.gemspec.rz"
     file = RubygemFs.instance.get(key)
     return nil unless file
-    spec = Gem::Package.new(StringIO.new(file)).spec
+    spec = Marshal.load(Gem::Util.inflate(file))
     spec.send(attribute_name)
-  rescue Gem::Package::FormatError
+  rescue StandardError => e
+    Rails.logger.info("[gemcutter:required_ruby_version:backfill] could not get required_ruby_version for version: #{version.full_name}"\
+      " error: #{e.inspect}")
     nil
   end
 end


### PR DESCRIPTION
I am hoping using marshal gemspec will be slightly faster than the entire gem file. 
Also, added check for not updating versions where spec.required_ruby_version is `>= 0`. This is the default value for `required_ruby_version` if one not set in gemspec and current versions have this default value in the table, however updating old versions with this would mean all 403797 versions (matching where clause) will updated and info_checksum of almost half of the rubygems would change.
As far as I understand, not setting default of `>= 0` would not make any difference to current behaviour (in resolution or installation) of the cli.