### PR TITLE
Add basic auth to staging ui

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -99,6 +99,10 @@ data:
         }
 
         location / {
+        <% if environment == 'staging' %>
+          auth_basic           "Restricted Access!";
+          auth_basic_user_file /etc/nginxbasicauth/.htpasswd;
+        <% end %>
           limit_req zone=abusers burst=10;
           proxy_pass http://127.0.0.1:3000;
         }

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -24,6 +24,12 @@
         "sendgrid_webhook_username": "EJ[1:KAN7c51q2VWDrnvvVz2B0EuxBXk67FXswztYOJHRdm0=:elop/93FDinCvVXMwDT9eRNVkQkNe3Cg:VHnaUh3gqhrkbTW76SetCcDQjCFTxtviu+bbYcMFoTPb60QQH3131dmgV2zSWA==]",
         "sendgrid_webhook_password": "EJ[1:KAN7c51q2VWDrnvvVz2B0EuxBXk67FXswztYOJHRdm0=:Jc7/IHv1SPsVn1pje8OZFpyI0+sRI9FQ:79/96QQJ3kfET2h2eM2eSUh0ZI1e/odfGzo61HaafHIgNeanDK3HmlDClJczhFr4kfjBimjeaab9Cp8=]"
       }
+    },
+    "nginx-basic-auth": {
+      "_type": "Opaque",
+      "data": {
+        ".htpasswd": "EJ[1:MVylFycMlDK6oU5Jje1iXf6AMMiHkYAD5RnXlXfg5Fs=:YcD96nyUoPoeK9fJgh5Uj9oaKtx69HqV:tL7FPskgJqmU5hTYrL5kPwnTzC0gITPxGpswSrS4AihF5/96GbPqS97Fz/qNr6YUsO3d4IcfClvbHapUzc7mYeW4dTlf3Q==]"
+      }
     }
   }
 }

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -203,6 +203,11 @@ spec:
             mountPath: /var/log/nginx
           - name: nginxcache
             mountPath: /var/lib/nginx/cache
+          <% if environment == 'staging' %>
+          - name: nginxbasicauth
+            mountPath: /etc/nginxbasicauth
+            readOnly: true
+          <% end %>
         livenessProbe:
           httpGet:
             path: /nginx_health
@@ -230,3 +235,8 @@ spec:
           emptyDir: {}
         - name: nginxcache
           emptyDir: {}
+        <% if environment == 'staging' %>
+        - name: nginxbasicauth
+          secret:
+            secretName: nginx-basic-auth
+        <% end %>


### PR DESCRIPTION
I would very much prefer to load data-dump from prod in staging env. This would be very helpful in running rake tasks which need access to things like s3.

Some users seem to get confused when they see same gem on multiple site (rubgems.org and staging.rubygems.org). Adding basic auth to avoid this confusion.