### PR TITLE
Set dependabot to ignore rubocop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
   - dependency-name: aws-sdk
     versions:
     - "> 2.11.473, < 2.12"
+  - dependency-name: "rubocop*"


### PR DESCRIPTION
Rubocop has been making lots of releases lately but the value of working on merging those PRs doesn't seem to offer much benefit to the project. This PR sets dependant to ignore any gem matching `rubocop*`. Going forward we will perform updates to rubocop on an as-needed basis.