### PR TITLE
Introduce a review changes button to a gem version diff against a previous release

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Metrics/ModuleLength:
   Exclude:
     - lib/patterns.rb
     - app/models/concerns/rubygem_searchable.rb
+    - app/helpers/rubygems_helper.rb
 
 Metrics/PerceivedComplexity:
   Max: 10 # TODO: Lower to 7

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -62,7 +62,7 @@ module RubygemsHelper
 
     diff_url = "https://my.diffend.io/gems/#{rubygem.name}/prev/#{latest_version.slug}"
 
-    link_to t(".links.review_changes"), diff_url,
+    link_to t("rubygems.aside.links.review_changes"), diff_url,
       class: "gem__link t-list__item"
   end
 

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -57,6 +57,15 @@ module RubygemsHelper
       method: :delete, remote: true
   end
 
+  def change_diff_link(rubygem, latest_version)
+    return if latest_version.yanked?
+
+    diff_url = "https://my.diffend.io/gems/#{rubygem.name}/prev/#{latest_version.slug}"
+
+    link_to t(".links.review_changes"), diff_url,
+      class: "gem__link t-list__item"
+  end
+
   def atom_link(rubygem)
     link_to t(".links.rss"), rubygem_versions_path(rubygem, format: "atom"),
       class: "gem__link t-list__item", id: :rss

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -66,6 +66,7 @@
     <%- @versioned_links.each do |name, link| %>
       <%= link_to_page name, link %>
     <%- end %>
+    <%= change_diff_link(@rubygem, @latest_version) %>
     <%= badge_link(@rubygem) %>
     <%= subscribe_link(@rubygem) if @latest_version.indexed %>
     <%= atom_link(@rubygem) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -294,6 +294,7 @@ de:
         mail: Mailingliste
         report_abuse: Missbrauch melden
         reverse_dependencies: Reverse dependencies
+        review_changes:
         rss: RSS
         subscribe: Abonniere
         unsubscribe: Storniere

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
         mail: Mailing List
         report_abuse: Report Abuse
         reverse_dependencies: Reverse dependencies
+        review_changes: Review changes
         rss: RSS
         subscribe: Subscribe
         unsubscribe: Unsubscribe

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -304,6 +304,7 @@ es:
         mail: Lista de Correo
         report_abuse: Reportar abusos
         reverse_dependencies: Dependencias inversas
+        review_changes:
         rss: RSS
         subscribe: Suscribirse
         unsubscribe: Desuscribirse

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -294,6 +294,7 @@ fr:
         mail: Liste de diffusion
         report_abuse: Signaler un abus
         reverse_dependencies:
+        review_changes:
         rss: RSS
         subscribe: Abonnement
         unsubscribe: Désabonement

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -294,6 +294,7 @@ ja:
         mail: メーリングリスト
         report_abuse: 悪用報告
         reverse_dependencies: 被依存性
+        review_changes:
         rss: RSS
         subscribe: 購読
         unsubscribe: 購読を解除

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -294,6 +294,7 @@ nl:
         mail: Mailing-list
         report_abuse:
         reverse_dependencies:
+        review_changes:
         rss: RSS
         subscribe:
         unsubscribe:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -294,6 +294,7 @@ pt-BR:
         mail: Lista de Emails
         report_abuse: Denunciar Abuso
         reverse_dependencies: Dependências Reversas
+        review_changes:
         rss: RSS
         subscribe: Inscrever-se
         unsubscribe: Desinscrever-se

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -294,6 +294,7 @@ zh-CN:
         mail: 邮件列表
         report_abuse: 举报投诉
         reverse_dependencies: 反向依赖
+        review_changes:
         rss: RSS
         subscribe: 订阅
         unsubscribe: 取消订阅

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -294,6 +294,7 @@ zh-TW:
         mail: 郵件群組
         report_abuse: 舉報投訴
         reverse_dependencies: 反向依賴
+        review_changes:
         rss: RSS
         subscribe: 訂閱
         unsubscribe: 取消訂閱

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -195,4 +195,37 @@ class RubygemsHelperTest < ActionView::TestCase
       end
     end
   end
+
+  context "change_diff_link" do
+    setup do
+      @virtual_path = "rubygems.aside"
+    end
+
+    context "with yanked version" do
+      setup do
+        @version = create(:version, indexed: false)
+        @rubygem = @version.rubygem
+      end
+
+      should "return nil" do
+        assert_nil change_diff_link(@rubygem, @version)
+      end
+    end
+
+    context "with available version" do
+      setup do
+        @version = create(:version)
+        @rubygem = @version.rubygem
+      end
+
+      should "generate a correct link to the gem versions diff" do
+        diff_url = "https://my.diffend.io/gems/#{@rubygem.name}/prev/#{@version.slug}"
+
+        expected_link = link_to "Review changes", diff_url,
+                          class: "gem__link t-list__item"
+
+        assert_equal expected_link, change_diff_link(@rubygem, @version)
+      end
+    end
+  end
 end

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -210,7 +210,6 @@ class RubygemsHelperTest < ActionView::TestCase
 
     context "with available version" do
       setup do
-        @virtual_path = "rubygems.aside"
         @version = create(:version)
         @rubygem = @version.rubygem
       end

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -197,10 +197,6 @@ class RubygemsHelperTest < ActionView::TestCase
   end
 
   context "change_diff_link" do
-    setup do
-      @virtual_path = "rubygems.aside"
-    end
-
     context "with yanked version" do
       setup do
         @version = create(:version, indexed: false)
@@ -214,6 +210,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
     context "with available version" do
       setup do
+        @virtual_path = "rubygems.aside"
         @version = create(:version)
         @rubygem = @version.rubygem
       end


### PR DESCRIPTION
This PR includes a link to the diffend.io page that calculates diff of a gem version against a previous one.

In order to simplify the design on the rubygems side the format is as followed:

```
my.diffend.io/gems/GEM_NAME/prev/GEM_VERSION
```

the `prev` is then calculated on the diffend side to redirect back to a proper version.

Example:

```
my.diffend.io/gems/puma/prev/4.3.5-java

# redirects to

https://my.diffend.io/gems/puma/4.3.4-java/4.3.5-java
```

```
my.diffend.io/gems/puma/prev/4.3.5

# redirects to

https://my.diffend.io/gems/puma/4.3.4/4.3.5
```

A bit of info about this PR and the functionality:

- it is free and will remain free (diffend reviewing)
- it does not require log in or anything else to review the full scope of changes
- it is platform aware thus the `prev` refers to the platform-specific previous version
- the method from the PR  does not display the link for yanked versions
- in case there's only a single release of a gem or it's the first version, it will show diff against empty exposing all the code introduced to the gem (example: https://my.diffend.io/gems/puma/0.8.0
- it indicates the CVEs for the target version as well (if any) as well as any known memory issues or issues with the license (missing, non-spdx, missing but in the source code)
- I excluded the helper file from the Rubocop length report on the module
- Appropriate tests are added
- Translation for other languages was not added per @sonalkr132 request

How it looks:

![Zrzut ekranu z 2020-09-09 11-14-12](https://user-images.githubusercontent.com/392754/92579682-c81ee580-f28d-11ea-8f91-4557bc2e18d6.png)

This button has been discussed at least with:

- evanphx 
- colby-swandale 
- indirect 
- sonalkr132 

