### PR TITLE
Enable new cops from rubocop update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,6 +156,21 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/StringConcatenation:
+  Enabled: true
+
 Lint/DuplicateElsifCondition:
   Enabled: true
 
@@ -171,6 +186,32 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
 
 Performance/AncestorsInclude:
   Enabled: true

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::WebHooksController < Api::BaseController
     @rubygem ||= Rubygem.find_by_name("gemcutter")
 
     if webhook.fire(request.protocol.delete("://"), request.host_with_port, @rubygem,
-      @rubygem.versions.most_recent, false)
+      @rubygem.versions.most_recent, delayed: false)
       render plain: webhook.deployed_message(@rubygem)
     else
       render plain: webhook.failed_message(@rubygem), status: :bad_request

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -16,7 +16,7 @@ class WebHook < ApplicationRecord
     where.not(rubygem_id: nil)
   end
 
-  def fire(protocol, host_with_port, deploy_gem, version, delayed = true)
+  def fire(protocol, host_with_port, deploy_gem, version, delayed: true)
     job = Notifier.new(url, protocol, host_with_port, deploy_gem, version, user.api_key)
     if delayed
       Delayed::Job.enqueue job, priority: PRIORITIES[:web_hook]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
     config.cache_classes = true
     config.eager_load = true
 
-    config.logger = ActiveSupport::Logger.new(STDOUT)
+    config.logger = ActiveSupport::Logger.new($stdout)
     config.log_level = :info
 
     config.public_file_server.enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,13 +93,13 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   # if ENV["RAILS_LOG_TO_STDOUT"].present?
-  #   logger           = ActiveSupport::Logger.new(STDOUT)
+  #   logger           = ActiveSupport::Logger.new($stdout)
   #   logger.formatter = config.log_formatter
   #   config.logger    = ActiveSupport::TaggedLogging.new(logger)
   # end
 
   # Custom logging config.
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -97,13 +97,13 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   # if ENV["RAILS_LOG_TO_STDOUT"].present?
-  #   logger           = ActiveSupport::Logger.new(STDOUT)
+  #   logger           = ActiveSupport::Logger.new($stdout)
   #   logger.formatter = config.log_formatter
   #   config.logger    = ActiveSupport::TaggedLogging.new(logger)
   # end
 
   # Custom logging config.
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -7,7 +7,7 @@ class Net::HTTP::Purge < Net::HTTPRequest
 end
 
 class Fastly
-  def self.purge(path, soft = false)
+  def self.purge(path, soft: false)
     return unless ENV["FASTLY_DOMAINS"]
     ENV["FASTLY_DOMAINS"].split(",").each do |domain|
       url = "https://#{domain}/#{path}"
@@ -22,7 +22,7 @@ class Fastly
     end
   end
 
-  def self.purge_key(key, soft = false)
+  def self.purge_key(key, soft: false)
     headers = { "Fastly-Key" => ENV["FASTLY_API_KEY"] }
     headers["Fastly-Soft-Purge"] = 1 if soft
     url = "https://api.fastly.com/service/#{ENV['FASTLY_SERVICE_ID']}/purge/#{key}"

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -3,10 +3,10 @@ class GemCachePurger
     # We need to purge from Fastly and from Memcached
     ["info/#{gem_name}", "names"].each do |path|
       Rails.cache.delete(path)
-      Fastly.delay.purge(path, true)
+      Fastly.delay.purge(path, soft: true)
     end
 
     Rails.cache.delete("deps/v1/#{gem_name}")
-    Fastly.delay.purge("versions", true)
+    Fastly.delay.purge("versions", soft: true)
   end
 end

--- a/script/yank_gem
+++ b/script/yank_gem
@@ -7,7 +7,7 @@ if ARGV.empty?
 end
 
 gemname, version = *ARGV
-puts "Yanking #{gemname} #{' ' + version if version}"
+puts "Yanking #{gemname} #{version}"
 
 ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
   end
 
   def authorize_with(str)
-    @request.env["HTTP_AUTHORIZATION"] = "Basic " + Base64.encode64(str)
+    @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64.encode64(str)}"
   end
 
   context "on GET to show with bad credentials" do

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -15,9 +15,9 @@ class GemCachePurgerTest < ActiveSupport::TestCase
     end
 
     should "purge cdn cache" do
-      Fastly.expects(:purge).with("info/#{@gem_name}", true)
-      Fastly.expects(:purge).with("names", true)
-      Fastly.expects(:purge).with("versions", true)
+      Fastly.expects(:purge).with("info/#{@gem_name}", soft: true)
+      Fastly.expects(:purge).with("names", soft: true)
+      Fastly.expects(:purge).with("versions", soft: true)
 
       GemCachePurger.call(@gem_name)
       Delayed::Worker.new.work_off

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -56,7 +56,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "email" do
       should "be less than 255 characters" do
-        user = build(:user, email: ("a" * 255) + "@example.com")
+        user = build(:user, email: format("%s@example.com", "a" * 255))
         refute user.valid?
         assert_contains user.errors[:email], "is too long (maximum is 255 characters)"
       end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -197,7 +197,7 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "limit the character length" do
-      @version.required_rubygems_version = ">=" + "0" * 2 * 1024 * 1024 * 100
+      @version.required_rubygems_version = format(">=%s", "0" * 2 * 1024 * 1024 * 100)
       @version.validate
       assert_equal @version.errors.messages[:required_rubygems_version], ["is too long (maximum is 255 characters)"]
     end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -186,11 +186,11 @@ class WebHookTest < ActiveSupport::TestCase
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number + @hook.user.api_key)
       RestClient.expects(:post).with(anything, anything, has_entries("Authorization" => authorization))
 
-      @hook.fire("https", "rubygems.org", @rubygem, @version, false)
+      @hook.fire("https", "rubygems.org", @rubygem, @version, delayed: false)
     end
 
     should "not increment failure count for hook" do
-      @hook.fire("https", "rubygems.org", @rubygem, @version, false)
+      @hook.fire("https", "rubygems.org", @rubygem, @version, delayed: false)
 
       assert @hook.failure_count.zero?
     end
@@ -216,7 +216,7 @@ class WebHookTest < ActiveSupport::TestCase
        Net::ProtocolError].each_with_index do |exception, index|
         RestClient.stubs(:post).raises(exception)
 
-        @hook.fire("https", "rubygems.org", @rubygem, @version, false)
+        @hook.fire("https", "rubygems.org", @rubygem, @version, delayed: false)
 
         assert_equal index + 1, @hook.reload.failure_count
         assert @hook.global?


### PR DESCRIPTION
Fixes following warning:
```
The following cops were added to RuboCop, but are not configured. Please
set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Lint/BinaryOperatorWithIdenticalOperands (0.89)
 - Lint/DuplicateRescueException (0.89)
 - Lint/EmptyConditionalBody (0.89)
 - Lint/FloatComparison (0.89)
 - Lint/MissingSuper (0.89)
 - Lint/OutOfRangeRegexpRef (0.89)
 - Lint/SelfAssignment (0.89)
 - Lint/TopLevelReturnWithArgument (0.89)
 - Lint/UnreachableLoop (0.89)
 - Style/ExplicitBlockArgument (0.89)
 - Style/GlobalStdStream (0.89)
 - Style/OptionalBooleanParameter (0.89)
 - Style/SingleArgumentDig (0.89)
 - Style/StringConcatenation (0.89)
For more information: https://docs.rubocop.org/rubocop/versioning.html
```