### PR TITLE
Add expiry notice to email confirmation mail

### DIFF
--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -73,6 +73,12 @@
         </tr>
       </table>
       <!-- END Button -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        <%= t('mailer.link_expiration_explanation_html') %><br />
+      </div>
+
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -45,7 +45,7 @@
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
-        <%= t('.link_expiration_explanation') %><br />
+        <%= t('mailer.link_expiration_explanation_html') %><br />
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -113,6 +113,7 @@ de:
   mailer:
     confirm_your_email:
     confirmation_subject:
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ de:
       title:
       subtitle:
       visit_link_instructions:
-      link_expiration_explanation:
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,8 +119,9 @@ en:
         sign_out: Sign out
         sign_up: Sign up
   mailer:
-    confirm_your_email: Please confirm your email address with the link sent to you email.
+    confirm_your_email: Please confirm your email address with the link sent to your email.
     confirmation_subject: Please confirm your email address with RubyGems.org
+    link_expiration_explanation_html: Please keep in mind that this link is valid for only 3 hours. You can request the updated link using <a href='https://rubygems.org/email_confirmations/new'>resend confirmation mail</a> page.
     email_confirmation:
       title: EMAIL CONFIRMATION
       subtitle: Almost done!
@@ -130,7 +131,6 @@ en:
       title: EMAIL RESET
       subtitle: Hi %{handle}!
       visit_link_instructions: You changed your email address on RubyGems.org. Please visit the following url to re-activate your account.
-      link_expiration_explanation: Please keep in mind that this link is only valid for 3 hours.
     deletion_complete:
       title: DELETION COMPLETE
       subtitle: Bye!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -121,6 +121,7 @@ es:
   mailer:
     confirm_your_email: Por favor confirma tu dirección de correo con el enlace enviado.
     confirmation_subject: Por favor confirma tu dirección de correo con RubyGems.org
+    link_expiration_explanation_html:
     email_confirmation:
       title: CONFIRMACIÓN DE EMAIL
       subtitle: ¡Último paso!
@@ -130,7 +131,6 @@ es:
       title: CAMBIO DE EMAIL
       subtitle: ¡Hola %{handle}!
       visit_link_instructions: Cambiaste tu dirección de correo en RubyGems.org. Por favor visita el siguiente enlace para re-activar tu cuenta.
-      link_expiration_explanation: Por favor ten en cuenta que el enlace tiene una validez de 3 horas.
     deletion_complete:
       title: ELIMINACIÓN COMPLETADA
       subtitle: ¡Adiós!

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -113,6 +113,7 @@ fr:
   mailer:
     confirm_your_email: Veuillez confirmer votre adresse email avec le lien qui vous a été envoyé par email.
     confirmation_subject: Veuillez confirmer votre adresse email pour RubyGems.org
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ fr:
       title:
       subtitle:
       visit_link_instructions: Vous avez changé d'adresse email sur RubyGems.org. Veuillez suivre l'URL suivant pour réactiver votre compte.
-      link_expiration_explanation: Veuillez noter que ce lien n'est valide que pendant 3 heures.
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -113,6 +113,7 @@ ja:
   mailer:
     confirm_your_email: あなたのメールアドレスに送信されたURLを確認してください。
     confirmation_subject: RubyGems.orgに登録されたあなたのメールアドレスを確認してください
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ ja:
       title:
       subtitle:
       visit_link_instructions: RubyGems.orgでのあなたのメールアドレスが変更されました。以下のURLからメールアドレスを確認してください。
-      link_expiration_explanation: このリンクは15分間のみ有効です。
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -113,6 +113,7 @@ nl:
   mailer:
     confirm_your_email:
     confirmation_subject:
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ nl:
       title:
       subtitle:
       visit_link_instructions:
-      link_expiration_explanation: Deze link is 3 uur geldig.
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -113,6 +113,7 @@ pt-BR:
   mailer:
     confirm_your_email:
     confirmation_subject:
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ pt-BR:
       title:
       subtitle:
       visit_link_instructions:
-      link_expiration_explanation:
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -113,6 +113,7 @@ zh-CN:
   mailer:
     confirm_your_email:
     confirmation_subject:
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ zh-CN:
       title:
       subtitle:
       visit_link_instructions:
-      link_expiration_explanation:
     deletion_complete:
       title:
       subtitle:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -113,6 +113,7 @@ zh-TW:
   mailer:
     confirm_your_email:
     confirmation_subject:
+    link_expiration_explanation_html:
     email_confirmation:
       title:
       subtitle:
@@ -122,7 +123,6 @@ zh-TW:
       title:
       subtitle:
       visit_link_instructions:
-      link_expiration_explanation:
     deletion_complete:
       title:
       subtitle:

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < SystemTest
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
-    assert page.has_content? "Please confirm your email address with the link sent to you email."
+    assert page.has_content? "Please confirm your email address with the link sent to your email."
   end
 
   test "signing in with current valid otp when mfa enabled" do


### PR DESCRIPTION
Some users get confused when they see link is invalid.