### PR TITLE
Update help site links to use zendesk email

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,7 @@ assignees: ''
 <!--
 This issue tracker for bug reports and feature requests only.
 
-  * Please open a support ticket on https://help.rubygems.org if your issue is related your rubygems.org
-    account or you need help using the site.
+  * Please open a support ticket by sending mail to support@rubygems.org if your issue is related your rubygems.org account or you need help using the site.
   * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
 --->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,7 @@ assignees: ''
 <!--
 This issue tracker for bug reports and feature requests only.
 
-  * Please open a support ticket on https://help.rubygems.org if your issue is related your rubygems.org
-    account or you need help using the site.
+  * Please open a support ticket by sending mail to support@rubygems.org  if your issue is related your rubygems.org account or you need help using the site.
   * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
 --->
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -141,7 +141,7 @@
             <%- else %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer" %>
             <%- end %>
-            <%= link_to t('.footer.help'), t(:help_url), class: "nav--v__link--footer" %>
+            <%= mail_to "support@rubygems.org", t('.footer.help'), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.api'), "https://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
             <%- if request.path_info == '/pages/security' %>
               <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer is-active" %>

--- a/app/views/pages/migrate.html.erb
+++ b/app/views/pages/migrate.html.erb
@@ -4,5 +4,5 @@
   <p>
     <code>gem migrate</code> has been deprecated, all of the RubyForge accounts and ownerships have been transferred over to Gemcutter.
   </p>
-  <p>If you’re having problems with your gems and pushing, <%= link_to "please open a support request", t(:help_url) %>.</p>
+  <p>If you’re having problems with your gems and pushing, <%= mail_to "support@rubygems.org", "please open a support request" %>.</p>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,7 +7,6 @@ de:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: Bitte warten...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: Deutsch
   none:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,6 @@ en:
   footer_join_rt_html: We need your help to fund the developer time that keeps RubyGems.org running smoothly for everyone.
     <a href="https://rubytogether.org/join?source=rubygems">Join Ruby Together today</a>.
   form_disable_with: Please wait...
-  help_url: https://help.rubygems.org
   invalid_page: Page number is out of range. Redirected to default page.
   locale_name: English
   none: None

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -15,7 +15,6 @@ es:
   footer_join_rt_html: Necesitamos tu ayuda para financiar el tiempo de los desarrolladores que mantienen RubyGems.org funcionando correctamente para todo el mundo.
     <a href="https://rubytogether.org/join?source=rubygems">Únete a Ruby Together hoy</a>.
   form_disable_with: Un momento por favor...
-  help_url: https://help.rubygems.org
   invalid_page: Número de página inexistente. Redireccionando a la página por defecto.
   locale_name: Español
   none: Ninguno

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -7,7 +7,6 @@ fr:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: Veuillez patienter...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: Français
   none:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,7 +7,6 @@ ja:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: お待ち下さい...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: 日本語
   none: なし

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -7,7 +7,6 @@ nl:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: Een moment geduld...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: Nederlands
   none: Geen

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,7 +7,6 @@ pt-BR:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: Atualizando...
-  help_url: https://help.rubygems.org
   invalid_page: Número da página está fora do limite. Redirecionado para página padrão.
   locale_name: Português do Brasil
   none: Nenhum

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -7,7 +7,6 @@ zh-CN:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: 请稍后...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: 简体中文
   none: 无

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -7,7 +7,6 @@ zh-TW:
   footer_sponsors_html:
   footer_join_rt_html:
   form_disable_with: 請稍候...
-  help_url: https://help.rubygems.org
   invalid_page:
   locale_name: 正體中文
   none: 無


### PR DESCRIPTION
tenderapp (provider of help.rubygems.org) has a very bad spamming issue. it is tolerable that some of the spam gets through but their spam filter is so bad that it blocks genuine users as well, which is not acceptable.
on zendesk we have `team` subscription, which means no webform/site for tickets or help site (/knowledge base). we don't need them per se.

help.rubygems.org will continue to exist (with deprecated notice) but zendesk will be the primary portal for support. some links still point to help.rubygems.org for docs, they are not that critical and are very old/outdated. I will move them to guides if similar ones don't exist.