### PR TITLE
Skip set_unconfirmed_email callback in change_email script

### DIFF
--- a/script/change_email
+++ b/script/change_email
@@ -8,7 +8,16 @@ ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 from_user = User.find_by_email!(from_email)
+from_user.class.skip_callback(:validation, :after, :set_unconfirmed_email)
 from_user.email = to_email
-from_user.save!
+from_user.email_confirmed = false
+from_user.generate_confirmation_token
 
-puts "#{from_user.name}'s email is now: #{to_email}"
+if from_user.save
+  puts "#{from_user.name}'s email is now: #{to_email}"
+  Delayed::Job.enqueue(EmailConfirmationMailer.new(from_user.id))
+  puts "enqueued email confirmation mail."
+else
+  puts "could not save user"
+  puts from_user.errors.full_messages.to_sentence
+end


### PR DESCRIPTION
The callback doesn't change email but uncofirmed_email column (used in
edit profiel). In this script we don't want to set unconfirmed_email,
as locked out users don't have access to send confirmation for unconfirmed_email.