### PR TITLE
Add funding links to sidebar

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -35,6 +35,7 @@ module RubygemSearchable
         source_code_uri:   versioned_links&.source_code_uri,
         bug_tracker_uri:   versioned_links&.bug_tracker_uri,
         changelog_uri:     versioned_links&.changelog_uri,
+        funding_uri:       versioned_links&.funding_uri,
         yanked:            versions.none?(&:indexed?),
         summary:           latest_version&.summary,
         description:       latest_version&.description,

--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -8,7 +8,8 @@ class Links
     "wiki"      => "wiki_uri",
     "mail"      => "mailing_list_uri",
     "bugs"      => "bug_tracker_uri",
-    "download"  => "download_uri"
+    "download"  => "download_uri",
+    "funding"   => "funding_uri"
   }.freeze
 
   # Links available for non-indexed gems

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -187,6 +187,7 @@ class Rubygem < ApplicationRecord
       "source_code_uri"   => versioned_links.source_code_uri,
       "bug_tracker_uri"   => versioned_links.bug_tracker_uri,
       "changelog_uri"     => versioned_links.changelog_uri,
+      "funding_uri"       => versioned_links.funding_uri,
       "dependencies"      => {
         "development" => deps.select { |r| r.rubygem && r.scope == "development" },
         "runtime"     => deps.select { |r| r.rubygem && r.scope == "runtime" }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -36,6 +36,7 @@ de:
         docs: Dokumentation URL
         mail: Mailingliste URL
         wiki: Wiki URL
+        funding:
       session:
         password: Passwort
         who: E-Mail oder Benutzername

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
         docs: Documentation URL
         mail: Mailing List URL
         wiki: Wiki URL
+        funding: Funding URL
       session:
         password: Password
         who: Email or Username

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -44,6 +44,7 @@ es:
         docs: URL de la documentación
         mail: URL de la lista de correo
         wiki: URL de la Wiki
+        funding:
       session:
         password: Contraseña
         who: Correo electrónico o usuario

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -36,6 +36,7 @@ fr:
         docs: URL de la documentation
         mail: URL de la liste de diffusion
         wiki: URL du wiki
+        funding:
       session:
         password: Mot de passe
         who: Email ou pseudonyme

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,6 +36,7 @@ ja:
         docs: ドキュメントのURL
         mail: メーリングリストのURL
         wiki: WikiのURL
+        funding:
       session:
         password: パスワード
         who: Email又はユーザー名

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -36,6 +36,7 @@ nl:
         docs: Documentatie-URL
         mail: Mailing-list-URL
         wiki: Wiki URL
+        funding:
       session:
         password: Wachtwoord
         who: E-mail of Gebruikersnaam

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -36,6 +36,7 @@ pt-BR:
         docs: URL da Documentação
         mail: URL da Lista de Emails
         wiki: URL da Wiki
+        funding:
       session:
         password: Senha
         who: Email ou Usuário

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -36,6 +36,7 @@ zh-CN:
         docs: 文档 URL
         mail: 邮件列表 URL
         wiki: Wiki URL
+        funding:
       session:
         password: 密码
         who: Email / 账号

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -36,6 +36,7 @@ zh-TW:
         docs: 文件 URL
         mail: 郵件群組 URL
         wiki: Wiki URL
+        funding:
       session:
         password: 密碼
         who: Email / 帳號

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -99,6 +99,7 @@ class ElasticSearcher
        wiki_uri
        documentation_uri
        mailing_list_uri
+       funding_uri
        source_code_uri
        bug_tracker_uri
        changelog_uri]

--- a/test/unit/links_test.rb
+++ b/test/unit/links_test.rb
@@ -55,4 +55,35 @@ class LinksTest < ActiveSupport::TestCase
 
     assert links.homepage_uri
   end
+
+  context "metadata includes non whitelisted uri key" do
+    setup do
+      metadata = {
+        "homepage_uri"        => "https://example.com",
+        "source_code_uri"     => "https://example.com",
+        "wiki_uri"            => "https://example.com",
+        "mailing_list_uri"    => "https://example.com",
+        "bug_tracker_uri"     => "https://example.com",
+        "funding_uri"         => "https://example.com",
+        "documentation_uri"   => "https://example.com",
+        "changelog_uri"       => "https://example.com",
+        "non_whitelisted_uri" => "https://example.com"
+      }
+
+      version = build(:version, metadata: metadata)
+      rubygem = build(:rubygem, versions: [version])
+      @links = rubygem.links(version)
+    end
+
+    should "create method for whitelisted keys" do
+      whitelisted_keys = Links::LINKS.values.reject! { |k| k == "download_uri" }
+      whitelisted_keys.each do |key|
+        assert_equal "https://example.com", @links.send(key), "value doesn't match for method: #{key}"
+      end
+    end
+
+    should "not create method for non whitelisted key" do
+      refute @links.respond_to?("non_whitelisted_uri")
+    end
+  end
 end

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -317,6 +317,7 @@ class PusherTest < ActiveSupport::TestCase
           "source_code_uri"   => "http://example.com",
           "bug_tracker_uri"   => "http://example.com",
           "changelog_uri"     => nil,
+          "funding_uri"       => nil,
           "yanked"            => false,
           "summary"           => "old summary",
           "description"       => "Some awesome gem",

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -15,7 +15,15 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         number: "1.0.1",
         rubygem: @rubygem,
         summary: "some summary",
-        description: "some description")
+        description: "some description",
+        metadata: {
+          "homepage_uri" => "http://example.com",
+          "source_code_uri" => "http://example.com",
+          "wiki_uri" => "http://example.com",
+          "mailing_list_uri" => "http://example.com",
+          "bug_tracker_uri" => "http://example.com",
+          "funding_uri" => "http://example.com"
+        })
     end
 
     should "return a hash" do
@@ -35,7 +43,14 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         authors:           "Joe User",
         info:              "some description",
         licenses:          "MIT",
-        metadata:          { "foo" => "bar" },
+        metadata:          {
+          "homepage_uri" => "http://example.com",
+          "source_code_uri" => "http://example.com",
+          "wiki_uri" => "http://example.com",
+          "mailing_list_uri" => "http://example.com",
+          "bug_tracker_uri" => "http://example.com",
+          "funding_uri" => "http://example.com"
+        },
         sha:               "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
         project_uri:       "http://localhost/gems/example_gem",
         gem_uri:           "http://localhost/gems/example_gem-1.0.1.gem",

--- a/test/unit/rubygem_searchable_test.rb
+++ b/test/unit/rubygem_searchable_test.rb
@@ -17,12 +17,13 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         summary: "some summary",
         description: "some description",
         metadata: {
-          "homepage_uri" => "http://example.com",
-          "source_code_uri" => "http://example.com",
-          "wiki_uri" => "http://example.com",
-          "mailing_list_uri" => "http://example.com",
-          "bug_tracker_uri" => "http://example.com",
-          "funding_uri" => "http://example.com"
+          "homepage_uri"      => "http://example.com",
+          "source_code_uri"   => "http://example.com",
+          "wiki_uri"          => "http://example.com",
+          "mailing_list_uri"  => "http://example.com",
+          "bug_tracker_uri"   => "http://example.com",
+          "funding_uri"       => "http://example.com",
+          "documentation_uri" => "http://example.com"
         })
     end
 
@@ -44,12 +45,13 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         info:              "some description",
         licenses:          "MIT",
         metadata:          {
-          "homepage_uri" => "http://example.com",
-          "source_code_uri" => "http://example.com",
-          "wiki_uri" => "http://example.com",
-          "mailing_list_uri" => "http://example.com",
-          "bug_tracker_uri" => "http://example.com",
-          "funding_uri" => "http://example.com"
+          "homepage_uri"      => "http://example.com",
+          "source_code_uri"   => "http://example.com",
+          "wiki_uri"          => "http://example.com",
+          "mailing_list_uri"  => "http://example.com",
+          "bug_tracker_uri"   => "http://example.com",
+          "funding_uri"       => "http://example.com",
+          "documentation_uri" => "http://example.com"
         },
         sha:               "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
         project_uri:       "http://localhost/gems/example_gem",
@@ -60,6 +62,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
         mailing_list_uri:  "http://example.com",
         source_code_uri:   "http://example.com",
         bug_tracker_uri:   "http://example.com",
+        funding_uri:       "http://example.com",
         yanked:            false,
         summary:           "some summary",
         description:       "some description",
@@ -68,7 +71,7 @@ class RubygemSearchableTest < ActiveSupport::TestCase
       }
 
       expected_hash.each do |k, v|
-        assert_equal v, json[k]
+        assert_equal v, json[k], "value doesn't match for key: #{k}"
       end
     end
   end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -458,7 +458,8 @@ class RubygemTest < ActiveSupport::TestCase
             "mailing_list_uri" => "http://example.com/mail",
             "source_code_uri" => "http://example.com/code",
             "bug_tracker_uri" => "http://example.com/bugs",
-            "changelog_uri" => "http://example.com/change"
+            "changelog_uri" => "http://example.com/change",
+            "funding_uri" => "http://example.com/funding"
           }
         )
 
@@ -471,6 +472,7 @@ class RubygemTest < ActiveSupport::TestCase
         assert_equal "http://example.com/code", hash["source_code_uri"]
         assert_equal "http://example.com/bugs", hash["bug_tracker_uri"]
         assert_equal "http://example.com/change", hash["changelog_uri"]
+        assert_equal "http://example.com/funding", hash["funding_uri"]
       end
 
       should "return version documentation url if metadata and linkset docs is empty" do


### PR DESCRIPTION
Building off of https://github.com/rubygems/rubygems/pull/3060 and https://github.com/rubygems/rubygems/pull/3390, this adds the `funding_uri` information to a gem's page on rubygems.org. 

