### PR TITLE
Better: Allow to set host in load-pg-dump script

### DIFF
--- a/script/load-pg-dump
+++ b/script/load-pg-dump
@@ -22,7 +22,7 @@ public_tar=
 pg_database=rubygems
 pg_user=postgres
 download=false
-
+host=
 
 ## For downloading
 base_url="https://s3-us-west-2.amazonaws.com/rubygems-dumps/"
@@ -39,13 +39,14 @@ Load a rubygems.org postgresql dump into a datatbase.
     -c          download the latest file to FILE
     -d DATABASE load the data into this database (default: rubygems)
     -u USER     connect to postgresql using this username (default: postgres)
+    -H HOSTNAME connect to postgresql using this hostname (default: Unix-domain socket)
 
 Example: ./load-pg-dump -d rubygems_development ~/Downloads/public_postgresql.tar
 EOF
 }
 
 OPTIND=1
-while getopts "hcd:u:" opt; do
+while getopts "hcd:u:H:" opt; do
     case "$opt" in
         h)
             show_help
@@ -57,6 +58,8 @@ while getopts "hcd:u:" opt; do
             ;;
         u)  pg_user=$OPTARG
             ;;
+        H)  host=$OPTARG
+            ;;
         '?')
             show_help >&2
             exit 1
@@ -64,6 +67,12 @@ while getopts "hcd:u:" opt; do
     esac
 done
 shift "$((OPTIND-1))" # Shift off the options and optional
+
+pg_host=
+if [ -n "$host" ]; then
+  pg_host="-h $host"
+fi
+
 
 public_tar=$1
 if [ -z "$public_tar" ]; then
@@ -81,25 +90,25 @@ fi
 printf 'Loading "%s" into database "%s" as user "%s"\n', "$public_tar", "$pg_database", "$pg_user"
 
 echo "Droppping database $pg_database"
-dropdb -U $pg_user $pg_database
+dropdb $pg_host -U $pg_user $pg_database
 
 echo "Creating database $pg_database"
-createdb -U $pg_user $pg_database
+createdb $pg_host -U $pg_user $pg_database
 
 echo "Adding hstore extension"
-psql -q -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+psql -q $pg_host -U $pg_user -d $pg_database -c "CREATE EXTENSION IF NOT EXISTS hstore;"
 
 echo "Running migrations"
 rake db:migrate
 
 echo "Droppping tables in $pg_database that we're going to load in"
-psql -q -U $pg_user -d $pg_database -c "DROP TABLE IF EXISTS dependencies, gem_downloads, linksets, rubygems, versions CASCADE;"
+psql -q $pg_host -U $pg_user -d $pg_database -c "DROP TABLE IF EXISTS dependencies, gem_downloads, linksets, rubygems, versions CASCADE;"
 
 # Extract the single PostgresSQL.sql.gz file from the tar file, pass it through gunzip
 # and load it as quietly as possible into the database
 echo "Loading the data from $public_tar"
 tar xOf "$public_tar" public_postgresql/databases/PostgreSQL.sql.gz | \
   gunzip -c | \
-  psql --username $pg_user --dbname $pg_database
+  psql $pg_host --username $pg_user --dbname $pg_database
 
 echo "Done."


### PR DESCRIPTION
In CONTRIBUTING.md, one installation method is with docker but the load-pg-dump script defaults to using postgresql locally with the unix socket.

I have added the -H option to set the hostname for postgresql commands. It still works as before is no -H option is given