### PR TITLE
Limit total pages on search result not total count

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,8 +4,8 @@ class SearchesController < ApplicationController
   def show
     return unless params[:query]&.is_a?(String)
     @error_msg, @gems = ElasticSearcher.new(params[:query], page: @page).search
-    limit_total_count if @gems.total_count > Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
 
+    set_total_pages if @gems.total_count > Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
     exact_match = Rubygem.name_is(params[:query]).first
     @yanked_gem = exact_match unless exact_match&.indexed_versions?
     @yanked_filter = true if params[:yanked] == "true"
@@ -16,10 +16,10 @@ class SearchesController < ApplicationController
 
   private
 
-  def limit_total_count
+  def set_total_pages
     class << @gems
-      def total_count
-        Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
+      def total_pages
+        Gemcutter::SEARCH_MAX_PAGES
       end
     end
   end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -68,4 +68,26 @@ class SearchTest < SystemTest
     assert page.has_link?("Next", href: "/search?page=2&query=ruby")
     Kaminari.configure { |c| c.default_per_page = 30 }
   end
+
+  test "total result count more than (max pages x default per page) shows max pages and accurate total count" do
+    silence_warnings do
+      Kaminari.configure { |c| c.default_per_page = 1 }
+      orignal_val = Gemcutter::SEARCH_MAX_PAGES
+      Gemcutter::SEARCH_MAX_PAGES = 2
+
+      create(:rubygem, name: "ruby-ruby", number: "1.0.0")
+      create(:rubygem, name: "ruby-gems", number: "1.0.0")
+      create(:rubygem, name: "ruby-thing", number: "1.0.0")
+      import_and_refresh
+
+      visit "/search?query=ruby"
+      assert page.has_content? "Displaying gem 1 - 1 of 3 in total"
+
+      click_link "Last"
+      assert page.has_content? "Displaying gem 2 - 2 of 3 in total"
+
+      Gemcutter::SEARCH_MAX_PAGES = orignal_val
+      Kaminari.configure { |c| c.default_per_page = 30 }
+    end
+  end
 end


### PR DESCRIPTION
On search result page we should filters for name, desc etc:
> FILTER: NAME (5357) DESCRIPTION (12592) SUMMARY (12755) UPDATED LAST
WEEK (88) UPDATED LAST MONTH (265)

After clicking on name filter, the page info show to user was:
> DISPLAYING GEMS 1 - 30 OF 3000 IN TOTAL

This was a bit confusing in the sense that filter originally said there
were 5357 matches for the filter per page info later said 3000 total.

This patch will show following page info, while still limiting at 100
pages.
> DISPLAYING GEMS 1 - 30 OF 5357 IN TOTAL

closes: #2501