### PR TITLE
Bulk update rubygem downloads

### DIFF
--- a/test/helpers/es_helper.rb
+++ b/test/helpers/es_helper.rb
@@ -1,12 +1,17 @@
 module ESHelper
   def import_and_refresh
     Rubygem.import force: true
+    refresh_index
+  end
+
+  def refresh_index
     Rubygem.__elasticsearch__.refresh_index!
     # wait for indexing to finish
     Rubygem.__elasticsearch__.client.cluster.health wait_for_status: "yellow"
   end
 
   def es_downloads(id)
+    refresh_index
     response = Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
                                                     type: "rubygem",
                                                     id: id


### PR DESCRIPTION
Updating all rubygems in any log ticket in one query is much faster
than updating each record seperately. We could be doing the same
for versions, which may be taken up in future.

index refresh was needed in tests for es downloads as using raw sql
meant Rubygem hooks for elasticsearch-rails were not triggered.

Related: #1457