### PR TITLE
Increase memory limit of staging jobs

### DIFF
--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -38,7 +38,7 @@ spec:
             memory: 250Mi
           limits:
             cpu: 500m
-            memory: 300Mi
+            memory: 1.2Gi
           <% end %>
         env:
           - name: RAILS_ENV


### PR DESCRIPTION
The pod starts crashing with OOM whenever I push a gem to staging.