### PR TITLE
Don't show filter text if no result was found

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -33,4 +33,8 @@ module SearchesHelper
     path = search_path(params: { query: params[:query], yanked: true })
     link_to t("searches.show.yanked", count: 1), path, class: "t-link--black"
   end
+
+  def not_empty?(response)
+    response["hits"]["total"] != 0
+  end
 end

--- a/app/views/searches/_aggregations.html.erb
+++ b/app/views/searches/_aggregations.html.erb
@@ -1,6 +1,6 @@
 <% if gems.respond_to?(:response) && aggregations = gems.response['aggregations'] %>
   <div class="aggregations">
-    <%= t('searches.show.filter')%>
+    <%= t('searches.show.filter') if not_empty?(gems.response) %>
     <%= aggregation_match_count aggregations['matched_field'], 'name' %>
     <%= aggregation_match_count aggregations['matched_field'], 'description' %>
     <%= aggregation_match_count aggregations['matched_field'], 'summary' %>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -34,7 +34,7 @@
     <% if suggestions %>
       <div class='search__suggestions'>
         <p>
-          Maybe you mean
+          <%= t(".suggestion") %>
           <%= suggestions.map do |term|
             link_to term, search_path(params: { query: term }), only_path: true
           end.to_sentence(last_word_connector: ' or ').html_safe %>?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -369,6 +369,7 @@ de:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: Passwort vergessen?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -404,6 +404,7 @@ en:
       week_update: Updated last week (%{count})
       filter: "Filter:"
       yanked: Yanked (%{count})
+      suggestion: Did you mean
   sessions:
     new:
       forgot_password: Forgot password?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -377,6 +377,7 @@ es:
       week_update: Actualizadas en la última semana (%{count})
       filter: "Filtro:"
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: ¿Olvidaste tu contraseña?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -369,6 +369,7 @@ fr:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: Mot de passe oublié ?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -369,6 +369,7 @@ ja:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: パスワードをお忘れですか?

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -369,6 +369,7 @@ nl:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: Wachtwoord vergeten?

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -369,6 +369,7 @@ pt-BR:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: Esqueceu sua Senha?

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -369,6 +369,7 @@ zh-CN:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: 忘记了密码？

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -394,6 +394,7 @@ zh-TW:
       week_update:
       filter:
       yanked:
+      suggestion:
   sessions:
     new:
       forgot_password: 忘記密碼？

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -78,7 +78,7 @@ class SearchesControllerTest < ActionController::TestCase
       page.assert_text("all 2 gems")
     end
     should "not see suggestions" do
-      page.assert_no_text("Maybe you mean")
+      page.assert_no_text("Did you mean")
       page.assert_no_selector(".search-suggestions")
     end
   end
@@ -108,7 +108,7 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the suggestions" do
-      page.assert_text("Maybe you mean")
+      page.assert_text("Did you mean")
       assert page.find(".search__suggestions").has_content?(@sinatra.name)
       assert page.has_selector?("a[href='#{search_path(query: @sinatra.name)}']")
     end
@@ -118,6 +118,9 @@ class SearchesControllerTest < ActionController::TestCase
     should "not see brando on the page in the results" do
       page.assert_no_text(@brando.name)
       page.assert_no_selector("a[href='#{rubygem_path(@brando)}']")
+    end
+    should "not see filters" do
+      page.assert_no_text("Filter")
     end
   end
 


### PR DESCRIPTION
Remove unnecessary empty filter when no match is found:
```
Filter:
```