### PR TITLE
Set version_downloads in ES with most_recent version downloads

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -152,18 +152,22 @@ class Rubygem < ApplicationRecord
   end
 
   def to_s
-    versions.most_recent&.to_title || name
+    most_recent_version&.to_title || name
   end
 
   def downloads
     gem_download&.count || 0
   end
 
-  def links(version = versions.most_recent)
+  def most_recent_version
+    versions.most_recent
+  end
+
+  def links(version = most_recent_version)
     Links.new(self, version)
   end
 
-  def payload(version = versions.most_recent, protocol = Gemcutter::PROTOCOL, host_with_port = Gemcutter::HOST)
+  def payload(version = most_recent_version, protocol = Gemcutter::PROTOCOL, host_with_port = Gemcutter::HOST)
     versioned_links = links(version)
     deps = version.dependencies.to_a
     {

--- a/test/helpers/es_helper.rb
+++ b/test/helpers/es_helper.rb
@@ -11,10 +11,19 @@ module ESHelper
   end
 
   def es_downloads(id)
+    response = get_response(id)
+    response["_source"]["downloads"]
+  end
+
+  def es_version_downloads(id)
+    response = get_response(id)
+    response["_source"]["version_downloads"]
+  end
+
+  def get_response(id)
     refresh_index
-    response = Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
+    Rubygem.__elasticsearch__.client.get index: "rubygems-#{Rails.env}",
                                                     type: "rubygem",
                                                     id: id
-    response["_source"]["downloads"]
   end
 end


### PR DESCRIPTION
most search results have incorrect `version_downloads` because we were not updating this field in ES in log processor job:
```
$ curl https://rubygems.org/api/v1/search.json?query=time_diff | jq '.[0].version_downloads'
1087380

$ curl https://rubygems.org/api/v1/gems/time_diff.json | jq .version_downloads
1228562
```

versions_downloads value comes from `rubygems.versions.most_recent.downloads_count`. it would have been very
inefficient to use `most_recent` with it's `||` logic as it necessitates query per version. we moved the latest version by platform a separate query and used that as a condition for join on version (and gem_downloads). In few cases where the gem doesn't have any version marked `latest` (all existing versions are prerelease), we will find downloads for those separately.

originally reported at: https://mail.google.com/mail/u/1/#search/google+group+rubygems/FMfcgxwJZJZkFdjsLvQdtxvPfjNRwNnC