### PR TITLE
Use display_id for setting mfa_user in session

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < Clearance::SessionsController
     @user = find_user(params.require(:session))
 
     if @user&.mfa_enabled?
-      session[:mfa_user] = @user.handle
+      session[:mfa_user] = @user.display_id
       render "sessions/otp_prompt"
     else
       do_login
@@ -13,7 +13,7 @@ class SessionsController < Clearance::SessionsController
   end
 
   def mfa_create
-    @user = User.find_by_name(session[:mfa_user])
+    @user = User.find_by_slug(session[:mfa_user])
     session.delete(:mfa_user)
 
     if @user&.mfa_enabled? && @user&.otp_verified?(params[:otp])

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SessionsControllerTest < ActionController::TestCase
   context "when user has mfa enabled" do
     setup do
-      @user = User.new(email_confirmed: true)
+      @user = User.new(email_confirmed: true, handle: "test")
       @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
       @request.cookies[:mfa_feature] = "true"
     end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -3,8 +3,6 @@ require "test_helper"
 class ProfileTest < SystemTest
   setup do
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
-
-    page.driver.browser.set_cookie("mfa_feature=true")
   end
 
   def sign_in

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -2,12 +2,10 @@ require "test_helper"
 
 class SignInTest < SystemTest
   setup do
-    create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD)
-    create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
+    create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
-
-    page.driver.browser.set_cookie("mfa_feature=true")
   end
 
   test "signing in" do
@@ -119,6 +117,23 @@ class SignInTest < SystemTest
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
+  end
+
+  test "siging in when user does not have handle" do
+    @mfa_user.update_attribute(:handle, nil)
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Multifactor authentication"
+
+    fill_in "OTP code", with: ROTP::TOTP.new("thisisonemfaseed").now
+    click_button "Sign in"
+
+    assert page.has_content? "john@example.com"
+    assert page.has_content? "Sign out"
   end
 
   test "signing out" do


### PR DESCRIPTION
some users don't have handle. this meant `find_by_name(nil)` was fetching the first user whose handle was `nil`.