### PR TITLE
Remove unconfirmed user ownerships on destroy as well.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,9 @@ class User < ApplicationRecord
   has_many :deletions, dependent: :nullify
   has_many :web_hooks, dependent: :destroy
 
+  # used for deleting unconfirmed ownerships as well on user destroy
+  has_many :unconfirmed_ownerships, -> { unconfirmed }, dependent: :destroy, inverse_of: :user, class_name: "Ownership"
+
   after_validation :set_unconfirmed_email, if: :email_changed?, on: :update
   before_create :generate_api_key, :generate_confirmation_token
 

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -177,6 +177,14 @@ class OwnerTest < SystemTest
     assert page.has_selector?("a[href='#{resend_confirmation_rubygem_owners_path(@rubygem)}']")
   end
 
+  test "deleting unconfirmed owner user" do
+    create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
+    @other_user.destroy
+    visit_ownerships_page
+
+    refute page.has_content? @other_user.handle
+  end
+
   private
 
   def owner_row(owner)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -8,6 +8,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   should have_many(:ownerships).dependent(:destroy)
+  should have_many(:unconfirmed_ownerships).dependent(:destroy)
   should have_many(:rubygems).through(:ownerships)
   should have_many(:subscribed_gems).through(:subscriptions)
   should have_many(:deletions)


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40972/faults/68202479

As followup one-timer I think it would make sense to remove all unconfirmed ownerships having `user_id` `nil` and check if all ownerships do have `user_id` again.