### PR TITLE
Strip username in API login to filter out null bytes.

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::ApiKeysController < Api::BaseController
 
   def show
     authenticate_or_request_with_http_basic do |username, password|
-      user = User.authenticate(username, password)
+      # strip username mainly to remove null bytes
+      user = User.authenticate(username.strip, password)
       otp = request.headers["HTTP_OTP"]
       if user&.mfa_api_authorized?(otp)
         respond_to do |format|

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -35,6 +35,18 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to show with invalid credentials" do
+    setup do
+      @user = create(:user)
+      authorize_with("bad\0:creds")
+      get :show
+    end
+    should "deny access" do
+      assert_response 401
+      assert_match "HTTP Basic: Access denied.", @response.body
+    end
+  end
+
   context "when user has enabled MFA for API" do
     setup do
       @user = create(:user)


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40972/faults/66993119#notice-context

Alt. it would be possible to reuse [user_name_and_password](https://github.com/rails/rails/blob/de0f59f1ce2443964948a0504d0cf897765d2886/actionpack/lib/action_controller/metal/http_authentication.rb#L109-L111) in prepended before action and assign username and password to `params` and let it handle in app helper controller https://github.com/rubygems/rubygems.org/blob/3b2770de784c161df95375f87edf50bd3ef88e2c/app/controllers/application_controller.rb#L111-L113

But `authenticate_or_request_with_http_basic` would be needed anyway so I decided to go with this simple solution.


