### PR TITLE
Use build-arg to set rubygems version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - script/build_docker.sh
 
 env:
-  - RUBYGEMS_VERSION=2.6.10
+  - RUBYGEMS_VERSION=3.0.3
   - RUBYGEMS_VERSION=latest
 
 matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 #### Environment (OS X)
 
 * Use Ruby 2.6.x (`.ruby-version` is present and can be used)
-* Use Rubygems 2.6.10
+* Use Rubygems 3.0.3
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`
@@ -84,7 +84,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 
 * Use Ruby 2.6.x `apt-get install ruby2.6`
   * Or install via [alternate methods](https://www.ruby-lang.org/en/downloads/)
-* Use Rubygems 2.6.10
+* Use Rubygems 3.0.3
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.6-alpine as build
 
+ARG RUBYGEMS_VERSION
+
 RUN apk add --no-cache \
   nodejs \
   postgresql-dev \
@@ -14,7 +16,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /app /app/config /app/log/
 WORKDIR /app
 
-RUN gem update --system 2.6.10
+RUN gem update --system $RUBYGEMS_VERSION
 
 COPY . /app
 
@@ -23,7 +25,7 @@ ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/version
 RUN mv /app/config/database.yml.example /app/config/database.yml
 
 
-RUN gem install bundler io-console --no-ri --no-rdoc && \
+RUN gem install bundler io-console --no-document && \
   bundle config set --local without 'development test' && \
   bundle install --jobs 20 --retry 5
 
@@ -35,6 +37,8 @@ RUN bundle config set --local without 'development test assets' && \
 
 FROM ruby:2.6-alpine
 
+ARG RUBYGEMS_VERSION
+
 RUN apk add --no-cache \
   libpq \
   ca-certificates \
@@ -43,10 +47,11 @@ RUN apk add --no-cache \
   xz-libs \
   && rm -rf /var/cache/apk/*
 
+RUN gem update --system $RUBYGEMS_VERSION
+
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY --from=build /usr/local/bin/gem /usr/local/bin/gem
 COPY --from=build /usr/local/bundle/ /usr/local/bundle/
 COPY --from=build /app/ /app/
 


### PR DESCRIPTION
Fixes mismatch between expected gem version and installed gem version.
As of now installed version of gem in prod is `3.0.3`, when we expect
it to be 2.6.10.
In Dockerfile in we were copying `/usr/local/bin/gem`, which is just
a loader and doesn't decide rubygems version.
Copying `/usr/local/lib/ruby/2.6.0/rubygem` from builder would most likely
work but this seems unconventional and doesn't really save as much build time.