### PR TITLE
Disallow publishing of same canonical version numbers

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -76,6 +76,7 @@ class Pusher
     sha256 = Digest::SHA2.base64digest(body.string)
 
     @version = @rubygem.versions.new number: spec.version.to_s,
+                                     canonical_number: spec.version.canonical_segments.join("."),
                                      platform: spec.original_platform.to_s,
                                      size: size,
                                      sha256: sha256,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -17,13 +17,13 @@ class Version < ApplicationRecord
   serialize :requirements
 
   validates :number, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: /\A#{Gem::Version::VERSION_PATTERN}\z/ }
-  validates :canonical_number, uniqueness: { scope: %i[rubygem_id platform] }
   validates :platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }
   validates :full_name, presence: true, uniqueness: { case_sensitive: false }
   validates :rubygem, presence: true
   validates :required_rubygems_version, :licenses, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_blank: true
   validates :description, :summary, :authors, :requirements, length: { minimum: 0, maximum: MAX_TEXT_FIELD_LENGTH }, allow_blank: true
 
+  validate :unique_canonical_number, on: :create
   validate :platform_and_number_are_unique, on: :create
   validate :authors_format, on: :create
   validate :metadata_links_format
@@ -393,5 +393,10 @@ class Version < ApplicationRecord
       errors.add(:metadata, "metadata value ['#{value}'] is too large (maximum is #{max_value_size} bytes)") if value.size > max_value_size
       errors.add(:metadata, "metadata key is empty") if key.empty?
     end
+  end
+
+  def unique_canonical_number
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
+    errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -17,6 +17,7 @@ class Version < ApplicationRecord
   serialize :requirements
 
   validates :number, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: /\A#{Gem::Version::VERSION_PATTERN}\z/ }
+  validates :canonical_number, uniqueness: { scope: %i[rubygem_id platform] }
   validates :platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }
   validates :full_name, presence: true, uniqueness: { case_sensitive: false }
   validates :rubygem, presence: true

--- a/db/migrate/20201130040817_add_canonical_number_to_versions.rb
+++ b/db/migrate/20201130040817_add_canonical_number_to_versions.rb
@@ -1,0 +1,5 @@
+class AddCanonicalNumberToVersions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :versions, :canonical_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_071636) do
+ActiveRecord::Schema.define(version: 2020_11_30_040817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 2020_05_16_071636) do
     t.string "info_checksum"
     t.string "yanked_info_checksum"
     t.bigint "pusher_id"
+    t.string "canonical_number"
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["created_at"], name: "index_versions_on_created_at"

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -136,4 +136,23 @@ namespace :gemcutter do
       puts "Done."
     end
   end
+
+  namespace :versions do
+    desc "Backfill canonical_number field of versions table"
+    task backfill_canonical_number: :environment do
+      versions = Version.all
+
+      total = versions.count
+      processed = 0
+      puts "Total: #{total}"
+      versions.find_each do |version|
+        canonical_number = Gem::Version.new(version.number).canonical_segments.join(".")
+        version.update_attribute(:canonical_number, canonical_number)
+        processed += 1
+        print format("\r%.2f%% (%d/%d) complete", processed.to_f / total * 100.0, processed, total)
+      end
+      puts
+      puts "Done."
+    end
+  end
 end

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -140,13 +140,21 @@ namespace :gemcutter do
   namespace :versions do
     desc "Backfill canonical_number field of versions table"
     task backfill_canonical_number: :environment do
-      versions = Version.all
+      versions = Version.order(:created_at).all
 
       total = versions.count
       processed = 0
       puts "Total: #{total}"
       versions.find_each do |version|
         canonical_number = Gem::Version.new(version.number).canonical_segments.join(".")
+
+        loop do
+          conflicting_version = Version.find_by(canonical_number: canonical_number, rubygem_id: version.rubygem_id, platform: version.platform)
+          break unless conflicting_version
+
+          canonical_number += ".dedup"
+        end
+
         version.update_attribute(:canonical_number, canonical_number)
         processed += 1
         print format("\r%.2f%% (%d/%d) complete", processed.to_f / total * 100.0, processed, total)

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -100,6 +100,7 @@ FactoryBot.define do
     indexed { true }
     metadata { { "foo" => "bar" } }
     number
+    canonical_number { Gem::Version.new(number).canonical_segments.join(".") }
     platform { "ruby" }
     required_rubygems_version { ">= 2.6.3" }
     required_ruby_version { ">= 2.0.0" }

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -146,7 +146,7 @@ class PusherTest < ActiveSupport::TestCase
     setup do
       spec = mock
       spec.expects(:name).returns "some name"
-      spec.expects(:version).returns "1.3.3.7"
+      spec.expects(:version).times(2).returns Gem::Version.new("1.3.3.7")
       spec.expects(:original_platform).returns "ruby"
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:size).returns 5
@@ -178,7 +178,7 @@ class PusherTest < ActiveSupport::TestCase
       @rubygem = create(:rubygem)
       spec = mock
       spec.stubs(:name).returns @rubygem.name
-      spec.stubs(:version).returns "1.3.3.7"
+      spec.stubs(:version).returns Gem::Version.new("1.3.3.7")
       spec.stubs(:original_platform).returns "ruby"
       @cutter.stubs(:spec).returns spec
       @cutter.find
@@ -195,7 +195,7 @@ class PusherTest < ActiveSupport::TestCase
 
       spec = mock
       spec.expects(:name).returns @rubygem.name.upcase
-      spec.expects(:version).returns "1.3.3.7"
+      spec.expects(:version).returns Gem::Version.new("1.3.3.7")
       spec.expects(:original_platform).returns "ruby"
       @cutter.stubs(:spec).returns spec
       refute @cutter.find
@@ -209,7 +209,7 @@ class PusherTest < ActiveSupport::TestCase
 
       spec = mock
       spec.stubs(:name).returns @rubygem.name.upcase
-      spec.stubs(:version).returns "1.3.3.7"
+      spec.stubs(:version).returns Gem::Version.new("1.3.3.7")
       spec.stubs(:original_platform).returns "ruby"
       @cutter.stubs(:spec).returns spec
       @cutter.find

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -310,19 +310,19 @@ class VersionTest < ActiveSupport::TestCase
     should "be invalid with trailing zero in segments" do
       version = build(:version, rubygem: @rubygem, number: "1.0.0.0")
       refute version.valid?
-      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken. Existing version: 1.0.0"]
     end
 
     should "be invalid with fewer zero in segments" do
       version = build(:version, rubygem: @rubygem, number: "1.0")
       refute version.valid?
-      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken. Existing version: 1.0.0"]
     end
 
     should "be invalid with leading zero in significant segments" do
       version = build(:version, rubygem: @rubygem, number: "01.0.0")
       refute version.valid?
-      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken. Existing version: 1.0.0"]
     end
 
     should "be valid in a different platform" do

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -304,6 +304,38 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context "with canonical number" do
+    setup { @rubygem = create(:rubygem, number: "1.0.0") }
+
+    should "be invalid with trailing zero in segments" do
+      version = build(:version, rubygem: @rubygem, number: "1.0.0.0")
+      refute version.valid?
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+    end
+
+    should "be invalid with fewer zero in segments" do
+      version = build(:version, rubygem: @rubygem, number: "1.0")
+      refute version.valid?
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+    end
+
+    should "be invalid with leading zero in significant segments" do
+      version = build(:version, rubygem: @rubygem, number: "01.0.0")
+      refute version.valid?
+      assert_equal version.errors.messages[:canonical_number], ["has already been taken"]
+    end
+
+    should "be valid in a different platform" do
+      version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "win32")
+      assert version.valid?
+    end
+
+    should "be valid with prerelease" do
+      version = build(:version, rubygem: @rubygem, number: "1.0.0.pre")
+      assert version.valid?
+    end
+  end
+
   context "with a version" do
     setup do
       @version = build(:version)


### PR DESCRIPTION
rubygem considers following vesions to be same for all purposes:
```
Gem::Version.new("1.0") == Gem::Version.new("1.0.0")
Gem::Version.new("1") == Gem::Version.new("1.0.0")
Gem::Version.new("0.01") == Gem::Version.new("0.1")
```

This means a malicious actor can potentially release `0.01`, and users depending on `0.1` would end up installing it.

IMHO, the root cause of the issue that we don't have a standard for version numbers. For example, npm cli inforces semvar and errors on versions like `1.0` or `0.01.0` during build. A similar change on gem would require a well thought out solution and current behavior can't be changed right now.
Disallowing duplicate (canonical) versions from the server side is something that would be needed even if the gem was enforcing a standard version numbering.

We can't add DB level as we have existing versions that have duplicate canonical version numbers.
https://gist.github.com/sonalkr132/acaee9a8ea86b2beb9e0f39e1b0dad14

Issue reported on Hackerone.