### PR TITLE
Revert to extract unicord_normalize

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -22,6 +22,7 @@ module Patterns
     rbconfig
     socket
     thread
+    unicode_normalize
     ubygems
 
     jruby


### PR DESCRIPTION
I missed to remove `unicord_normalize` from reserved names at https://github.com/rubygems/rubygems.org/pull/2560. But `unicord_normalize` couldn't use the old version of Ruby.