### PR TITLE
Improve german translation for “home” (homepage)

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -316,7 +316,7 @@ de:
         docs: Dokumentation
         download: Download
         header: Links
-        home: Startseite
+        home: Homepage
         mail: Mailingliste
         report_abuse: Missbrauch melden
         reverse_dependencies: Reverse dependencies


### PR DESCRIPTION
“Startseite” is rather unusual in this context. It either refers to the root page within a website, or to the home page configured in the browser.

Both “Homepage” and “Website” would be a better fit, see https://de.wikipedia.org/wiki/Homepage and https://de.wikipedia.org/wiki/Website. I’d slightly prefer “Homepage”, but that’s definitely a matter of individual taste.