### PR TITLE
Remove update hook to email to set unconfirmed_email

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -44,7 +44,9 @@ class ProfilesController < ApplicationController
   private
 
   def params_user
-    params.require(:user).permit(*User::PERMITTED_ATTRS)
+    params.require(:user).permit(:handle, :twitter_username, :unconfirmed_email, :hide_email).tap do |hash|
+      hash.delete(:unconfirmed_email) if hash[:unconfirmed_email] == current_user.email
+    end
   end
 
   def verify_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -227,7 +227,7 @@ class User < ApplicationRecord
 
   def block!
     transaction do
-      update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{id}-#{handle}@rubygems.org")
+      update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{display_handle.downcase}@rubygems.org")
       confirm_email!
       disable_mfa!
       update_attribute(:password, SecureRandom.alphanumeric)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   has_many :unconfirmed_ownerships, -> { unconfirmed }, dependent: :destroy, inverse_of: :user, class_name: "Ownership"
   has_many :api_keys, dependent: :destroy
 
-  after_validation :set_unconfirmed_email, if: :email_changed?, on: :update
+  before_save :generate_confirmation_token, if: :will_save_change_to_unconfirmed_email?
   before_create :generate_confirmation_token
 
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
@@ -130,11 +130,6 @@ class User < ApplicationRecord
     coder.tag = nil
     coder.implicit = true
     coder.map = payload
-  end
-
-  def set_unconfirmed_email
-    self.attributes = { unconfirmed_email: email, email: email_was }
-    generate_confirmation_token
   end
 
   def generate_api_key
@@ -263,7 +258,7 @@ class User < ApplicationRecord
   end
 
   def unconfirmed_email_exists?
-    User.where(unconfirmed_email: email).exists?
+    User.where(email: unconfirmed_email).exists?
   end
 
   def yank_gems

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -46,7 +46,7 @@
 
   <div class="text_field">
     <%= form.label :email, :class => 'form__label' %>
-    <%= form.email_field :email, :class => 'form__input' %>
+    <%= form.email_field :email, name: 'user[unconfirmed_email]', class: 'form__input' %>
   </div>
 
   <p class='form__field__instructions'>

--- a/script/block_user
+++ b/script/block_user
@@ -14,7 +14,7 @@ require_relative "../config/environment"
 
 begin
   user = User.find_by!(handle: handle)
-  puts "Found user: #{user}"
+  puts "Found user: #{user.handle} #{user.email}"
   user.block!
   puts "Done."
 rescue ActiveRecord::RecordNotFound

--- a/script/change_email
+++ b/script/change_email
@@ -8,7 +8,6 @@ ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 from_user = User.find_by_email!(from_email)
-from_user.class.skip_callback(:validation, :after, :set_unconfirmed_email)
 from_user.email = to_email
 from_user.email_confirmed = false
 from_user.generate_confirmation_token

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -149,7 +149,7 @@ class ProfilesControllerTest < ActionController::TestCase
       context "updating email with existing email" do
         setup do
           create(:user, email: "cannotchange@tothis.com")
-          put :update, params: { user: { email: "cannotchange@tothis.com", password: @user.password } }
+          put :update, params: { user: { unconfirmed_email: "cannotchange@tothis.com", password: @user.password } }
         end
 
         should "not set unconfirmed_email" do
@@ -161,12 +161,11 @@ class ProfilesControllerTest < ActionController::TestCase
       context "updating email with existing unconfirmed_email" do
         setup do
           create(:user, unconfirmed_email: "cannotchange@tothis.com")
-          put :update, params: { user: { email: "cannotchange@tothis.com", password: @user.password } }
+          put :update, params: { user: { unconfirmed_email: "cannotchange@tothis.com", password: @user.password } }
         end
 
-        should "not set unconfirmed_email" do
-          assert page.has_content? "Email address has already been taken"
-          refute_equal "cannotchange@tothis.com", @user.unconfirmed_email
+        should "set unconfirmed_email" do
+          assert_equal "cannotchange@tothis.com", @user.unconfirmed_email
         end
       end
 
@@ -180,13 +179,13 @@ class ProfilesControllerTest < ActionController::TestCase
           end
 
           should "set unconfirmed email and confirmation token" do
-            put :update, params: { user: { email: @new_email, password: @user.password } }
+            put :update, params: { user: { unconfirmed_email: @new_email, password: @user.password } }
             assert_equal @new_email, @user.unconfirmed_email
             assert @user.confirmation_token
           end
 
           should "not update the current email" do
-            put :update, params: { user: { email: @new_email, password: @user.password } }
+            put :update, params: { user: { unconfirmed_email: @new_email, password: @user.password } }
             assert_equal @current_email, @user.email
           end
 
@@ -196,7 +195,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
             Mailer.expects(:email_reset).returns(mailer).times(1)
             Mailer.expects(:email_reset_update).returns(mailer).times(1)
-            put :update, params: { user: { email: @new_email, password: @user.password } }
+            put :update, params: { user: { unconfirmed_email: @new_email, password: @user.password } }
             Delayed::Worker.new.work_off
           end
         end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -460,4 +460,14 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "block when handle has uppercase" do
+    setup { @user = create(:user, handle: "MikeJudge") }
+
+    should "not raise ActiveRecord::RecordInvalid for email address already taken" do
+      assert_changed(@user, :email, :password, :api_key, :mfa_seed, :remember_token) do
+        @user.block!
+      end
+    end
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,12 +1,6 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  def assert_resetting_email_changes(attr_name)
-    assert_changed(@user, attr_name) do
-      @user.update(email: "some@one.com")
-    end
-  end
-
   should have_many(:ownerships).dependent(:destroy)
   should have_many(:unconfirmed_ownerships).dependent(:destroy)
   should have_many(:rubygems).through(:ownerships)
@@ -187,17 +181,11 @@ class UserTest < ActiveSupport::TestCase
       assert_equal [my_rubygem], @user.rubygems
     end
 
-    context "email change" do
-      should "reset confirmation token" do
-        assert_resetting_email_changes :confirmation_token
-      end
-
-      should "store unconfirm email" do
-        assert_resetting_email_changes :unconfirmed_email
-      end
-
-      should "reset token_expires_at" do
-        assert_resetting_email_changes :token_expires_at
+    context "unconfirmed_email update" do
+      should "set confirmation token and token_expires_at" do
+        assert_changed(@user, :confirmation_token, :token_expires_at) do
+          @user.update(unconfirmed_email: "some@one.com")
+        end
       end
     end
 


### PR DESCRIPTION
This was creating issue with scripts to update email and block accounts. Setting unconfirmed_email directly is much easier to reason than using an update hook on email.
allowing duplicates in unconfirmed_email is intentional. we shouldn't block email address until they are confirmed.