### PR TITLE
Backfill not nil canonical_number rows only

### DIFF
--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -140,7 +140,7 @@ namespace :gemcutter do
   namespace :versions do
     desc "Backfill canonical_number field of versions table"
     task backfill_canonical_number: :environment do
-      versions = Version.order(:created_at).all
+      versions = Version.where.not(canonical_number: nil).order(:created_at).all
 
       total = versions.count
       processed = 0


### PR DESCRIPTION
The rake task takes a couple of hours to complete. The versions published during this period will have their canonical_number set.
Setting it again would end up adding `.dedup` for the self match.