### PR TITLE
Remove very old instructions to update rubygems

### DIFF
--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -16,10 +16,6 @@
   </p>
   <pre><code>$ gem update --system          # may need to be administrator or root</code></pre>
   <p>
-  <strong>NOTE:</strong> RubyGems 1.1 and 1.2 have problems upgrading when there is no rubygems-update installed.  You will need to use the following instructions if you see <code>Nothing to update</code>. If you have an older version of RubyGems installed, then you can still do it in two steps:
-  </p>
-  <pre><code>$ gem install rubygems-update  # again, might need to be admin/root&#x000A;$ update_rubygems              # ... here too</code></pre>
-  <p>
     If you don't have any RubyGems installed, there is still the pre-gem approach to getting software, doing it manually:
   </p>
   <ol class="manual">


### PR DESCRIPTION
They are no longer useful for anyone.