### PR TITLE
Block throw-away domains from signup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN gem update --system $RUBYGEMS_VERSION
 COPY . /app
 
 ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions.list /app/config/versions.list
+ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/stopforumspam/toxic_domains_whole.txt /app/vendor/toxic_domains_whole.txt
 
 RUN mv /app/config/database.yml.example /app/config/database.yml
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ApplicationRecord
     allow_nil: true,
     unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness
+  validate :toxic_email_domain, on: :create
 
   enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2 }, _prefix: :mfa
 
@@ -266,5 +267,13 @@ class User < ApplicationRecord
     versions_to_yank.each do |v|
       deletions.create(version: v)
     end
+  end
+
+  def toxic_email_domain
+    domain             = email.split("@").last
+    toxic_domains_path = Pathname.new(Gemcutter::Application.config.toxic_domains_filepath)
+    toxic = toxic_domains_path.exist? && toxic_domains_path.readlines.grep(/^#{domain}$/).any?
+
+    errors.add(:email, I18n.t("activerecord.errors.messages.blocked", domain: domain)) if toxic
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module Gemcutter
     config.plugins = [:dynamic_form]
 
     config.eager_load_paths << Rails.root.join("lib")
+    config.toxic_domains_filepath = Rails.root.join("vendor", "toxic_domains_whole.txt")
   end
 
   def self.config

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -48,6 +48,7 @@ de:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     errors:
       messages:
         unpwn: has previously appeared in a data breach and should not be used
+        blocked: "domain '%{domain}' has been blocked for spamming. Please use a valid personal email."
   api_keys:
     create:
       success: "Created new API key"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -56,6 +56,7 @@ es:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -48,6 +48,7 @@ fr:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,6 +48,7 @@ ja:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -48,6 +48,7 @@ nl:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -48,6 +48,7 @@ pt-BR:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -48,6 +48,7 @@ zh-CN:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -48,6 +48,7 @@ zh-TW:
     errors:
       messages:
         unpwn:
+        blocked:
   api_keys:
     create:
       success:

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -66,6 +66,18 @@ class UserTest < ActiveSupport::TestCase
         refute user.valid?
         assert_contains user.errors[:email], "is invalid"
       end
+
+      should "be invalid with toxic domains in email" do
+        Tempfile.create("toxic_domains_whole.txt") do |f|
+          f.write "thing.com"
+          f.rewind
+          Gemcutter::Application.config.stubs(:toxic_domains_filepath).returns(f.path)
+
+          user = build(:user, email: "mail@thing.com")
+          refute user.valid?
+          assert_contains user.errors[:email], "domain 'thing.com' has been blocked for spamming. Please use a valid personal email."
+        end
+      end
     end
 
     context "twitter_username" do


### PR DESCRIPTION
More often than not, malicious accounts use throw-away email accounts for signup.
For example, both accounts we locked this month had `yektara.com` in email.
https://check-mail.org/domain/yektara.com/

Current list is taken from: https://www.stopforumspam.com/downloads
we will add a cron to keep s3 file updated.

As of now ~1k users have these domains in email and they collectly own ~50 gems.