### PR TITLE
Remove gem install bundler from Dockerfile and update rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
   - git submodule update --init
   - sh -c "if [ '$RUBYGEMS_VERSION' != 'latest' ]; then gem update --system $RUBYGEMS_VERSION; fi"
   - gem --version
+  - bundle -v
   - script/install_toxiproxy.sh
 
 before_script:
@@ -47,7 +48,7 @@ script:
   - script/build_docker.sh
 
 env:
-  - RUBYGEMS_VERSION=3.0.3
+  - RUBYGEMS_VERSION=3.1.5
   - RUBYGEMS_VERSION=latest
 
 matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 #### Environment (OS X)
 
 * Use Ruby 2.6.x (`.ruby-version` is present and can be used)
-* Use Rubygems 3.0.3
+* Use Rubygems 3.1.5
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`
@@ -84,7 +84,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 
 * Use Ruby 2.6.x `apt-get install ruby2.6`
   * Or install via [alternate methods](https://www.ruby-lang.org/en/downloads/)
-* Use Rubygems 3.0.3
+* Use Rubygems 3.1.5
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * Pull ElasticSearch `5.6.16` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.16`

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/version
 RUN mv /app/config/database.yml.example /app/config/database.yml
 
 
-RUN gem install bundler io-console --no-document && \
-  bundle config set --local without 'development test' && \
+RUN bundle config set --local without 'development test' && \
   bundle install --jobs 20 --retry 5
 
 RUN RAILS_ENV=production RAILS_GROUPS=assets SECRET_KEY_BASE=1234 bin/rails assets:precompile


### PR DESCRIPTION
It was installing the latest bundler. It didn't match the version we are running our test suite with and updating `BUNDLED WITH` in
Gemfile.lock of the image. rubygems 3.1.5 comes with bundler 2.1.4, we don't need to install bundler separately.