### PR TITLE
Don't redirect dependency api endpoints to https on host insecure.rubygems.org

### DIFF
--- a/app/middleware/redirector.rb
+++ b/app/middleware/redirector.rb
@@ -6,7 +6,7 @@ class Redirector
   def call(env)
     request = Rack::Request.new(env)
 
-    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "ipv6.rubygems.org"]
+    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "insecure.rubygems.org"]
 
     if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,10 @@ Rails.application.configure do
   config.ssl_options = {
     hsts: { expires: 365.days, subdomains: false },
     redirect: {
-      exclude: ->(request) { request.path.start_with?('/internal') }
+      exclude: lambda do |request|
+        insecure_dependency_api = (request.host == "insecure.rubygems.org" && request.path =~ %r{^/(info|versions|api/v1/dependencies)})
+        request.path.start_with?('/internal') or insecure_dependency_api
+      end
     }
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,10 @@ Rails.application.configure do
   config.ssl_options = {
     hsts: { expires: 365.days, subdomains: false },
     redirect: {
-      exclude: ->(request) { request.path.start_with?('/internal') }
+      exclude: lambda do |request|
+        insecure_dependency_api = (request.host == "insecure.rubygems.org" && request.path =~ %r{^/(info|versions|api/v1/dependencies)})
+        request.path.start_with?('/internal') or insecure_dependency_api
+      end
     }
   }
 


### PR DESCRIPTION
We want to allow users to use `--source 'http://insecure.rubygems.org'` in cli (if they must) and not have it redirect to https. It can be possible that user's host doesn't have openssl installed, which is required for https source.
We use to support this on all domains before migrating to `config.ssl = true`.

Related: #1083, https://github.com/rubygems/rubygems/pull/4192