### PR TITLE
Replace errors[:base] << with errors.add(:base, ..)

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -354,7 +354,7 @@ class Version < ApplicationRecord
 
   def platform_and_number_are_unique
     return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)
-    errors[:base] << "A version already exists with this number or platform."
+    errors.add(:base, "A version already exists with this number or platform.")
   end
 
   def authors_format

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -85,16 +85,16 @@ class WebHook < ApplicationRecord
       if WebHook.exists?(user_id: user.id,
                          rubygem_id: rubygem.id,
                          url: url)
-        errors[:base] << "A hook for #{url} has already been registered for #{rubygem.name}"
+        errors.add(:base, "A hook for #{url} has already been registered for #{rubygem.name}")
       end
     elsif user
       if WebHook.exists?(user_id: user.id,
                          rubygem_id: nil,
                          url: url)
-        errors[:base] << "A global hook for #{url} has already been registered"
+        errors.add(:base, "A global hook for #{url} has already been registered")
       end
     else
-      errors[:base] << "A user is required for this hook"
+      errors.add(:base, "A user is required for this hook")
     end
   end
 end


### PR DESCRIPTION
Fixes deprecation on rails 6.1
```
Calling `<<` to an ActiveModel::Errors message array in order to add an
error is deprecated. Please call `ActiveModel::Errors#add` instead.
```

Related: #2584