### PR TITLE
Remove format validation from api-key name

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -5,10 +5,7 @@ class ApiKey < ApplicationRecord
   validates :user, :name, :hashed_key, presence: true
   validate :exclusive_show_dashboard_scope, if: :can_show_dashboard?
   validate :scope_presence
-  validates :name, format: {
-    with: /\A[a-zA-Z0-9_-]*\z/,
-    message: "can only contain letters, numbers, dash and underscores"
-  }, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validates :name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
 
   def enabled_scopes
     API_SCOPES.map { |scope| scope if send(scope) }.compact

--- a/app/views/mailer/api_key_created.html.erb
+++ b/app/views/mailer/api_key_created.html.erb
@@ -25,7 +25,7 @@
             Note that we are in the process of migration from a single API key per account to multiple API keys with minimum scopes enabled.
             <strong>GET /api/v1/api_key</strong>, used in <strong>gem signin</strong> before rubygems 3.2.0 has been updated
             to create a new API key on every request. Please update your rubygems with <strong>gem --update system</strong> to start using the
-            new <strong>POST /api/v1/api_key</strong> endpoint (<%= link_to("Read more", "https://github.com/rubygems/rubygems.org/pull/1962", target: :_blank) %>).
+            new <strong>POST /api/v1/api_key</strong> endpoint (<%= link_to("Read more", "https://guides.rubygems.org/api-key-scopes/", target: :_blank) %>).
           </p>
 
           <br/>

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -22,12 +22,6 @@ class ApiKeyTest < ActiveSupport::TestCase
     assert_contains api_key.errors[:name], "is too long (maximum is 255 characters)"
   end
 
-  should "be invalid when name has invalid characters" do
-    api_key = build(:api_key, name: "aa'")
-    refute api_key.valid?
-    assert_contains api_key.errors[:name], "can only contain letters, numbers, dash and underscores"
-  end
-
   context "#scope" do
     setup do
       @api_key = create(:api_key, index_rubygems: true, push_rubygem: true)


### PR DESCRIPTION
we use hostname and whoami in default key name. Limiting the format when we aren't making users always pick the name was not feasible.

Alternatively, we can ask the user to run `gem signin` in error message which would allow them to pick key name.
Rather misleading error message on failed gem push was:
> Name can only contain letters, numbers, dash and underscores