### PR TITLE
Adds a new "UI and gem signin" mfa_level to allow API Keys to skip MFA check

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::ApiKeysController < Api::BaseController
   private
 
   def check_mfa(user)
-    if user&.mfa_api_authorized?(otp)
+    if user&.mfa_gem_signin_authorized?(otp)
       yield
     elsif user&.mfa_enabled?
       prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
     unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness
 
-  enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2 }, _prefix: :mfa
+  enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2, ui_and_gem_signin: 3 }, _prefix: :mfa
 
   def self.authenticate(who, password)
     user = find_by(email: who.downcase) || find_by(handle: who)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -213,6 +213,11 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
+  def mfa_gem_signin_authorized?(otp)
+    return true unless mfa_ui_and_gem_signin? || mfa_ui_and_api?
+    otp_verified?(otp)
+  end
+
   def mfa_api_authorized?(otp)
     return true unless mfa_ui_and_api?
     otp_verified?(otp)

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -8,6 +8,7 @@
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
       <%= select_tag :level, options_for_select([
         [t(".mfa.level.ui_and_api"), "ui_and_api"],
+        [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
         [t(".mfa.level.ui_only"), "ui_only"],
         [t(".mfa.level.disabled"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
       <div class="text_field">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -305,6 +305,7 @@ de:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
           disabled: Disabled
           ui_only: UI Only
           ui_and_api: UI and API
+          ui_and_gem_signin: UI and gem signin
   profiles:
     edit:
       change_avatar: Change Avatar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -313,6 +313,7 @@ es:
           disabled: Desactivada
           ui_only: Solo Interfaz de Usuario
           ui_and_api: Interfaz de Usuario y API
+          ui_and_gem_signin: Interfaz de Usario y gem signin
   profiles:
     edit:
       change_avatar:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -305,6 +305,7 @@ fr:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -305,6 +305,7 @@ ja:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -305,6 +305,7 @@ nl:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -305,6 +305,7 @@ pt-BR:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -305,6 +305,7 @@ zh-CN:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -330,6 +330,7 @@ zh-TW:
           disabled:
           ui_only:
           ui_and_api:
+          ui_and_gem_signin:
   profiles:
     edit:
       change_avatar:

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -50,7 +50,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     end
   end
 
-  def should_return_api_key_successfully
+  def self.should_return_api_key_successfully
     should respond_with :success
     should "return API key" do
       hashed_key = @user.api_keys.first.hashed_key

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -50,6 +50,110 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     end
   end
 
+  def self.should_expect_otp_for_show
+    context "without OTP" do
+      setup { get :show }
+      should_deny_access_missing_otp
+    end
+
+    context "with incorrect OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = "11111"
+        get :show
+      end
+
+      should_deny_access_incorrect_otp
+    end
+
+    context "with correct OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+        get :show
+        Delayed::Worker.new.work_off
+      end
+
+      should respond_with :success
+      should "return API key" do
+        hashed_key = @user.api_keys.first.hashed_key
+        assert_equal hashed_key, Digest::SHA256.hexdigest(@response.body)
+      end
+
+      should "deliver api key created email" do
+        refute ActionMailer::Base.deliveries.empty?
+        email = ActionMailer::Base.deliveries.last
+        assert_equal [@user.email], email.to
+        assert_equal ["no-reply@mailer.rubygems.org"], email.from
+        assert_equal "New API key created for rubygems.org", email.subject
+        assert_match "legacy-key", email.body.to_s
+      end
+
+      should "not sign in user" do
+        refute @controller.request.env[:clearance].signed_in?
+      end
+    end
+  end
+
+  def self.should_expect_otp_for_create
+    context "without OTP" do
+      setup { post :create }
+      should_deny_access_missing_otp
+    end
+
+    context "with incorrect OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = "11111"
+        post :create
+      end
+
+      should_deny_access_incorrect_otp
+    end
+
+    context "with correct OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+        post :create, params: { name: "test", index_rubygems: "true" }
+      end
+
+      should respond_with :success
+      should "return API key" do
+        hashed_key = @user.api_keys.first.hashed_key
+        assert_equal hashed_key, Digest::SHA256.hexdigest(@response.body)
+      end
+    end
+  end
+
+  def self.should_expect_otp_for_update
+    context "without OTP" do
+      setup { put :update }
+      should_deny_access_missing_otp
+    end
+
+    context "with incorrect OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = "11111"
+        put :update
+      end
+
+      should_deny_access_incorrect_otp
+    end
+
+    context "with correct OTP" do
+      setup do
+        @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+        @api_key = create(:api_key, user: @user, key: "12345", push_rubygem: true)
+
+        put :update, params: { api_key: "12345", index_rubygems: "true" }
+        @api_key.reload
+      end
+
+      should respond_with :success
+      should "keep current scope enabled and update scope in params" do
+        assert @api_key.can_index_rubygems?
+        assert @api_key.can_push_rubygem?
+      end
+    end
+  end
+
   context "on GET to show with invalid credentials" do
     setup do
       @user = create(:user)
@@ -113,53 +217,24 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       end
     end
 
-    context "when user has enabled MFA for API" do
+    context "when user has enabled MFA for UI and API" do
       setup do
         @user = create(:user)
         @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "without OTP" do
-        setup { get :show }
-        should_deny_access_missing_otp
+      should_expect_otp_for_show
+    end
+
+    context "when user has enabled MFA for UI and gem signin" do
+      setup do
+        @user = create(:user)
+        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "with incorrect OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = "11111"
-          get :show
-        end
-
-        should_deny_access_incorrect_otp
-      end
-
-      context "with correct OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
-          get :show
-          Delayed::Worker.new.work_off
-        end
-
-        should respond_with :success
-        should "return API key" do
-          hashed_key = @user.api_keys.first.hashed_key
-          assert_equal hashed_key, Digest::SHA256.hexdigest(@response.body)
-        end
-
-        should "deliver api key created email" do
-          refute ActionMailer::Base.deliveries.empty?
-          email = ActionMailer::Base.deliveries.last
-          assert_equal [@user.email], email.to
-          assert_equal ["no-reply@mailer.rubygems.org"], email.from
-          assert_equal "New API key created for rubygems.org", email.subject
-          assert_match "legacy-key", email.body.to_s
-        end
-
-        should "not sign in user" do
-          refute @controller.request.env[:clearance].signed_in?
-        end
-      end
+      should_expect_otp_for_show
     end
 
     context "when user has old sha1 password" do
@@ -216,38 +291,22 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       end
     end
 
-    context "when user has enabled MFA for API" do
+    context "when user has enabled MFA for UI and API" do
       setup do
         @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "without OTP" do
-        setup { post :create }
-        should_deny_access_missing_otp
+      should_expect_otp_for_create
+    end
+
+    context "when user has enabled MFA for UI and gem signin" do
+      setup do
+        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "with incorrect OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = "11111"
-          post :create
-        end
-
-        should_deny_access_incorrect_otp
-      end
-
-      context "with correct OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
-          post :create, params: { name: "test", index_rubygems: "true" }
-        end
-
-        should respond_with :success
-        should "return API key" do
-          hashed_key = @user.api_keys.first.hashed_key
-          assert_equal hashed_key, Digest::SHA256.hexdigest(@response.body)
-        end
-      end
+      should_expect_otp_for_create
     end
   end
 
@@ -282,41 +341,22 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       end
     end
 
-    context "when user has enabled MFA for API" do
+    context "when user has enabled MFA for UI and API" do
       setup do
         @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "without OTP" do
-        setup { put :update }
-        should_deny_access_missing_otp
+      should_expect_otp_for_update
+    end
+
+    context "when user has enabled MFA for UI and gem signin" do
+      setup do
+        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "with incorrect OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = "11111"
-          put :update
-        end
-
-        should_deny_access_incorrect_otp
-      end
-
-      context "with correct OTP" do
-        setup do
-          @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
-          @api_key = create(:api_key, user: @user, key: "12345", push_rubygem: true)
-
-          put :update, params: { api_key: "12345", index_rubygems: "true" }
-          @api_key.reload
-        end
-
-        should respond_with :success
-        should "keep current scope enabled and update scope in params" do
-          assert @api_key.can_index_rubygems?
-          assert @api_key.can_push_rubygem?
-        end
-      end
+      should_expect_otp_for_update
     end
   end
 end

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -99,6 +99,18 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             assert @user.reload.mfa_ui_and_api?
           end
         end
+
+        context "on updating to ui_and_gem_signin" do
+          setup do
+            put :update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now, level: "ui_and_gem_signin" }
+          end
+
+          should respond_with :redirect
+          should redirect_to("the settings page") { edit_settings_path }
+          should "update make mfa level to mfa_ui_and_gem_signin now" do
+            assert @user.reload.mfa_ui_and_gem_signin?
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Adds a new "UI and gem signin" mfa_level to allow API Keys to skip MFA check
Fixes #2500

# Additional Notes
Apologies for the auto-formatting, my IDE decided indentation was better this way but since Rubocop didn't complain I left it that way, I hope that's fine