### PR TITLE
Add missing pt-BR translations on Signup page

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -9,6 +9,6 @@
   <%= form.text_field :handle, :class => 'form__input' %>
 </div>
 <div class="password_field">
-  <%= form.label :password, :class => 'form__label' %>
+  <%= form.label :password, t('activerecord.attributes.user.password'), :class => 'form__label' %>
   <%= form.password_field :password, :class => 'form__input' %>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -49,6 +49,8 @@ de:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,8 @@ en:
       messages:
         unpwn: has previously appeared in a data breach and should not be used
         blocked: "domain '%{domain}' has been blocked for spamming. Please use a valid personal email."
+    models:
+      user: User
   api_keys:
     create:
       success: "Created new API key"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -57,6 +57,8 @@ es:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -49,6 +49,8 @@ fr:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,6 +49,8 @@ ja:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -49,6 +49,8 @@ nl:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -47,8 +47,10 @@ pt-BR:
         password: Senha
     errors:
       messages:
-        unpwn:
+        unpwn: já apareceu anteriormente em um vazamento de dados e não deve ser utilizada
         blocked:
+    models:
+      user: Usuário
   api_keys:
     create:
       success:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -49,6 +49,8 @@ zh-CN:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -49,6 +49,8 @@ zh-TW:
       messages:
         unpwn:
         blocked:
+    models:
+      user:
   api_keys:
     create:
       success:


### PR DESCRIPTION
This commit adds three missing translations for pt-BR on the Signup
page:
- User model name
- password previously appeared in a data breach error
- Password field label

Before: (3 translations missing)

![Screen Shot 2021-01-12 at 17 40 25](https://user-images.githubusercontent.com/771411/104370333-761cf380-54fd-11eb-9b33-61f78c72a17a.png)

After:
![image](https://user-images.githubusercontent.com/771411/104370381-87660000-54fd-11eb-8cd7-16869d0af9ea.png)


To fix the password label translation this commit manually adds the
translation of the attribute instead of relying on the action-view auto
translation. This happens because action-view looks before for a
helpers.label.password translation before trying to use the
human_attribute_name of it and Clearance defines this translation key in
their Gem on english and we fallback to it since we don't have it
defined on other idioms.