### PR TITLE
set surrogate key on versions and add info/gem-name key to info compact index

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -8,6 +8,7 @@ class Api::CompactIndexController < Api::BaseController
   end
 
   def versions
+    set_surrogate_key "versions"
     versions_path = Rails.application.config.rubygems["versions_file_location"]
     versions_file = CompactIndex::VersionsFile.new(versions_path)
     from_date = versions_file.updated_at

--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -17,7 +17,7 @@ class Api::CompactIndexController < Api::BaseController
   end
 
   def info
-    set_surrogate_key "info/* gem/#{@rubygem.name}"
+    set_surrogate_key "info/* gem/#{@rubygem.name} info/#{@rubygem.name}"
     return unless stale?(@rubygem)
     info_params = GemInfo.new(@rubygem.name).compact_index_info
     render_range CompactIndex.info(info_params)

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -139,7 +139,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
 
   test "/info has surrogate key header" do
     get info_path(gem_name: "gemA")
-    assert_equal "info/* gem/gemA", @response.headers["Surrogate-Key"]
+    assert_equal "info/* gem/gemA info/gemA", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -115,6 +115,11 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal expected, @response.body
   end
 
+  test "/version has surrogate key header" do
+    get versions_path
+    assert_equal "versions", @response.headers["Surrogate-Key"]
+  end
+
   test "/info with existing gem" do
     expected = <<~VERSIONS_FILE
       ---


### PR DESCRIPTION
we are using `POST /service/service_id/purge/surrogate_key` in Fastly.purge_key. This POST endpoint is only for surrograte-key purging. We can use `PURGE /versions` for url purging, but setting surrogate-key on versions endpoint is more uniform.


Related: https://github.com/rubygems/rubygems.org/issues/1877
https://developer.fastly.com/reference/api/purging/