### PR TITLE
Reduce Fastly cache time for versions

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -1,14 +1,15 @@
 class Api::CompactIndexController < Api::BaseController
   before_action :find_rubygem_by_name, only: [:info]
-  before_action :set_compact_index_cache_headers
 
   def names
+    set_compact_index_cache_headers
     names = GemInfo.ordered_names
     render_range CompactIndex.names(names)
   end
 
   def versions
     set_surrogate_key "versions"
+    set_compact_index_cache_headers(fastly_expiry: 30)
     versions_path = Rails.application.config.rubygems["versions_file_location"]
     versions_file = CompactIndex::VersionsFile.new(versions_path)
     from_date = versions_file.updated_at
@@ -18,6 +19,7 @@ class Api::CompactIndexController < Api::BaseController
 
   def info
     set_surrogate_key "info/* gem/#{@rubygem.name} info/#{@rubygem.name}"
+    set_compact_index_cache_headers
     return unless stale?(@rubygem)
     info_params = GemInfo.new(@rubygem.name).compact_index_info
     render_range CompactIndex.info(info_params)
@@ -25,9 +27,9 @@ class Api::CompactIndexController < Api::BaseController
 
   private
 
-  def set_compact_index_cache_headers
+  def set_compact_index_cache_headers(fastly_expiry: 3600)
     expires_in 60, public: true
-    fastly_expires_in 3600
+    fastly_expires_in fastly_expiry
   end
 
   def render_range(response_body)

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -118,6 +118,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   test "/version has surrogate key header" do
     get versions_path
     assert_equal "versions", @response.headers["Surrogate-Key"]
+    assert_equal "max-age=30", @response.headers["Surrogate-Control"]
   end
 
   test "/info with existing gem" do


### PR DESCRIPTION
we have set nginx cache to 60s with update in backgroud. This
meant the first resquest returned `STALE` response (outdated response)
to Fastly after 60s, while cache was updated in backgroup for subsequent
requests. This outdated response was getting cached by Fastly for
Surrogate-Control: max-age=3600 period.

Worst case delay in version being available for download is
nginx cache period + fastly cache period (previously 3660s, now 90s).

method name was renamed because rubocop was complaining (futile):
```
app/controllers/api/compact_index_controller.rb:30:7: C:
Naming/AccessorMethodName: Do not prefix writer method names with set_.
(https://rubystyle.guide#accessor_mutator_method_names)
```