### PR TITLE
Add index on versions indexed and yanked_at

### DIFF
--- a/db/migrate/20210124062231_add_index_to_versions_indexed_yanked_at.rb
+++ b/db/migrate/20210124062231_add_index_to_versions_indexed_yanked_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToVersionsIndexedYankedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_index :versions, [:indexed, :yanked_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_24_105545) do
+ActiveRecord::Schema.define(version: 2021_01_24_062231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -221,6 +221,7 @@ ActiveRecord::Schema.define(version: 2020_12_24_105545) do
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
+    t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
     t.index ["indexed"], name: "index_versions_on_indexed"
     t.index ["number"], name: "index_versions_on_number"
     t.index ["position"], name: "index_versions_on_position"


### PR DESCRIPTION
Makes SQL query on compact_index versions 1400x times faster.

Before: https://explain.depesz.com/s/DqiJ9
total: 192ms, major time spent on seq scan for ((indexed IS FALSE) AND (yanked_at > '2021-12-01
00:00:24')

After: https://explain.depesz.com/s/hyC2
total: 0.12 ms, uses index_versions_on_indexed_and_yanked_at index.