### PR TITLE
Remove nginx cache from versions endpoint

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -1,15 +1,14 @@
 class Api::CompactIndexController < Api::BaseController
   before_action :find_rubygem_by_name, only: [:info]
+  before_action :cache_expiry_headers
 
   def names
-    cache_expiry_headers
     names = GemInfo.ordered_names
     render_range CompactIndex.names(names)
   end
 
   def versions
     set_surrogate_key "versions"
-    cache_expiry_headers(fastly_expiry: 30)
     versions_path = Rails.application.config.rubygems["versions_file_location"]
     versions_file = CompactIndex::VersionsFile.new(versions_path)
     from_date = versions_file.updated_at
@@ -19,7 +18,6 @@ class Api::CompactIndexController < Api::BaseController
 
   def info
     set_surrogate_key "info/* gem/#{@rubygem.name} info/#{@rubygem.name}"
-    cache_expiry_headers
     return unless stale?(@rubygem)
     info_params = GemInfo.new(@rubygem.name).compact_index_info
     render_range CompactIndex.info(info_params)

--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -28,7 +28,6 @@ data:
       limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=100r/s;
       limit_req_zone  $binary_remote_addr  zone=dependencyapi:10m  rate=100r/s;
 
-      proxy_cache_path  /var/lib/nginx/cache  levels=1:2 keys_zone=cache-versions:10m inactive=24h  max_size=100m;
 
       include /etc/nginx/conf.d/logging.conf;
       include /etc/nginx/sites-enabled/*;
@@ -84,22 +83,12 @@ data:
           proxy_busy_buffers_size    256k;
         }
 
-        location /versions {
-          proxy_cache cache-versions;
-          proxy_cache_background_update on;
-          proxy_cache_key "/versions";
-          proxy_cache_lock on;
-          proxy_cache_use_stale updating;
-          proxy_cache_valid 200 60s;
-          proxy_pass http://127.0.0.1:3000/versions;
-        }
-
         location /info {
           proxy_pass http://127.0.0.1:3000;
         }
 
          <% if environment == 'staging' %>
-        location ~ ^/(api|internal) {
+        location ~ ^/(api|internal|versions) {
           limit_req zone=abusers burst=10;
           proxy_pass http://127.0.0.1:3000;
         }

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -201,8 +201,6 @@ spec:
             readOnly: true
           - name: nginxlog
             mountPath: /var/log/nginx
-          - name: nginxcache
-            mountPath: /var/lib/nginx/cache
           <% if environment == 'staging' %>
           - name: nginxbasicauth
             mountPath: /etc/nginxbasicauth
@@ -232,8 +230,6 @@ spec:
               - key: rubygems
                 path: sites-enabled/<%= environment %>.ruybgems.conf
         - name: nginxlog
-          emptyDir: {}
-        - name: nginxcache
           emptyDir: {}
         <% if environment == 'staging' %>
         - name: nginxbasicauth

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -118,7 +118,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   test "/version has surrogate key header" do
     get versions_path
     assert_equal "versions", @response.headers["Surrogate-Key"]
-    assert_equal "max-age=30", @response.headers["Surrogate-Control"]
+    assert_equal "max-age=3600", @response.headers["Surrogate-Control"]
   end
 
   test "/info with existing gem" do


### PR DESCRIPTION
The response time on this endpoint is under 200ms and doesn't nee nginx caching anymore.
Using fixed duration cache on nginx meant version updates were delayed by that period (60s).

https://github.com/rubygems/rubygems.org/pull/2615 didn't reduce response time by 1400x but by 3x
![Screenshot-20210124175159-704x472](https://user-images.githubusercontent.com/7680662/105631348-1bc45100-5e74-11eb-8ff8-4b9110719311.png)

Single pod on staging (with same resource limits as prod) is able to serve 70 rps without issue:
```
bash-5.1# vegeta attack -targets targets.txt -duration 120s -rate 70  | tee results.bin | vegeta report                                               
Requests      [total, rate, throughput]         8400, 70.01, 69.98                                                                                    
Duration      [total, attack, wait]             2m0s, 2m0s, 52.589ms                                                                                  
Latencies     [min, mean, 50, 90, 95, 99, max]  44.772ms, 54.627ms, 53.096ms, 58.256ms, 62.39ms, 132.982ms, 196.42ms                                  
Bytes In      [total, mean]                     1680000, 200.00                                                                                       
Bytes Out     [total, mean]                     0, 0.00                                                                                               
Success       [ratio]                           100.00%                                                                                               
Status Codes  [code:count]                      206:8400                                                                                              
Error Set: 
```
Related: #1877