### PR TITLE
Add index on gem_downloads.count with order by

### DIFF
--- a/db/migrate/20210125153619_add_index_to_gem_downloads_count_desc.rb
+++ b/db/migrate/20210125153619_add_index_to_gem_downloads_count_desc.rb
@@ -1,0 +1,5 @@
+class AddIndexToGemDownloadsCountDesc < ActiveRecord::Migration[6.1]
+  def change
+    add_index :gem_downloads, [:count], order: {count: :desc}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_24_062231) do
+ActiveRecord::Schema.define(version: 2021_01_25_153619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2021_01_24_062231) do
     t.integer "rubygem_id", null: false
     t.integer "version_id", null: false
     t.bigint "count"
+    t.index ["count"], name: "index_gem_downloads_on_count", order: :desc
     t.index ["rubygem_id", "version_id"], name: "index_gem_downloads_on_rubygem_id_and_version_id", unique: true
     t.index ["version_id", "rubygem_id", "count"], name: "index_gem_downloads_on_version_id_and_rubygem_id_and_count"
   end


### PR DESCRIPTION
Although `by_downloads` is used at quite a few places, this index is specially helpful in reducing the response time of
`ReverseDependenciesController#index`. This endpoint was causing major cpu spike on postgres with just above 100rpm.

I tried adding other kinds of indices (without order by) but postgres was always choosing Bitmap heap scan + Bitmap index scan over plain. Index scan: https://explain.depesz.com/s/qguj

Before:
```
Rubygem Load (1977.0ms)  SELECT "rubygems".* FROM "rubygems" inner join
versions as v on v.rubygem_id = rubygems.id
      inner join dependencies as d on d.version_id = v.id INNER JOIN
"gem_downloads" ON "gem_downloads"."version_id" = $1 AND
"gem_downloads"."rubygem_id" = "rubygems"."id" WHERE (v.indexed = 't'
      and v.position = 0 and d.rubygem_id = 19969) ORDER BY
gem_downloads.count DESC LIMIT $2 OFFSET $3  [["version_id", 0],
["LIMIT", 31], ["OFFSET",
 0]]
```

After:
```
Rubygem Load (23.4ms)  SELECT "rubygems".* FROM "rubygems" inner join
versions as v on v.rubygem_id = rubygems.id
      inner join dependencies as d on d.version_id = v.id INNER JOIN
"gem_downloads" ON "gem_downloads"."version_id" = $1 AND
"gem_downloads"."rubygem
_id" = "rubygems"."id" WHERE (v.indexed = 't'
      and v.position = 0 and d.rubygem_id = 19969) ORDER BY
gem_downloads.count DESC LIMIT $2 OFFSET $3  [["version_id", 0],
["LIMIT", 31], ["OFFSET",
 0]]
```
https://www.postgresql.org/docs/9.3/indexes-ordering.html

what I am unsure about is the impact it may have on our fastly log processor jobs for updating downloads count.