### PR TITLE
Escape regexp in toxic email domain validation.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,7 +279,7 @@ class User < ApplicationRecord
   def toxic_email_domain
     domain             = email.split("@").last
     toxic_domains_path = Pathname.new(Gemcutter::Application.config.toxic_domains_filepath)
-    toxic = toxic_domains_path.exist? && toxic_domains_path.readlines.grep(/^#{domain}$/).any?
+    toxic = toxic_domains_path.exist? && toxic_domains_path.readlines.grep(/^#{Regexp.escape(domain)}$/).any?
 
     errors.add(:email, I18n.t("activerecord.errors.messages.blocked", domain: domain)) if toxic
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -78,6 +78,18 @@ class UserTest < ActiveSupport::TestCase
           assert_contains user.errors[:email], "domain 'thing.com' has been blocked for spamming. Please use a valid personal email."
         end
       end
+
+      should "be invalid with regexp-like email address and toxic email check enabled" do
+        Tempfile.create("toxic_domains_whole.txt") do |f|
+          f.write "thing.com"
+          f.rewind
+          Gemcutter::Application.config.stubs(:toxic_domains_filepath).returns(f.path)
+
+          user = build(:user, email: "${10000263+9999729}")
+          refute user.valid?
+          assert_contains user.errors[:email], "is not a valid email"
+        end
+      end
     end
 
     context "twitter_username" do


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40972/faults/74517899