### PR TITLE
Set document_type to rubygems

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -5,6 +5,7 @@ module RubygemSearchable
     include Elasticsearch::Model
 
     index_name "rubygems-#{Rails.env}"
+    document_type "rubygems"
 
     delegate :index_document, to: :__elasticsearch__
     delegate :update_document, to: :__elasticsearch__


### PR DESCRIPTION
ES 6 (at least the client library) has changed default document type
to `_doc`. However our existing document are in rubygems type. we
want to continue using our current document type.