### PR TITLE
Reduce abusers rate limit to 40 rps and add rate limit on versions

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -25,8 +25,9 @@ data:
       }
 
       limit_req_status 429;
-      limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=100r/s;
+      limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=40r/s;
       limit_req_zone  $binary_remote_addr  zone=dependencyapi:10m  rate=100r/s;
+      limit_req_zone  $binary_remote_addr  zone=versions:10m  rate=100r/m;
 
       proxy_cache_path  /var/lib/nginx/cache  levels=1:2 keys_zone=cache-versions:10m inactive=24h  max_size=100m;
 
@@ -85,6 +86,7 @@ data:
         }
 
         location /versions {
+          limit_req zone=versions burst=10 nodelay;
           proxy_cache cache-versions;
           proxy_cache_background_update on;
           proxy_cache_key "/versions";


### PR DESCRIPTION
We had increased limits to 100 rps when we were having issues with info endpoint. we don't rate limit info at the moment, there limit need not be this high. Further, we had 100 rps at the time when we were running single nginx. With nginx on every pod, our rate limit was 100 * number of pods (replicas).

versions was missing rate limit. added it for good measure.

I have verified that our normal traffic doesn't need this high limits.
Our original rate limits were 10 rps:
https://github.com/rubygems/rubygems-chef/blob/master/cookbooks/rubygems-balancer/templates/default/site.conf.erb#L14