### PR TITLE
Enable return_only_media_type_on_content_type rails 6.0 default

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -17,7 +17,7 @@ Rails.application.config.action_view.default_enforce_utf8 = false
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
 # Return false instead of self when enqueuing is aborted from a callback.
 Rails.application.config.active_job.return_false_on_aborted_enqueue = true


### PR DESCRIPTION
As far as I understand if we or the clients are not checking
content-type values specifically, this won't affect us.