### PR TITLE
Reset ApiKeys for the user on block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,6 +244,7 @@ class User < ApplicationRecord
         remember_token_expires_at: nil,
         api_key: nil
       )
+      api_keys.update_all(hashed_key: "--locked--")
     end
   end
 


### PR DESCRIPTION
Using --locked-- value since we have validation of presence on hashed_key. dash (-) is not a valid hex symbol, hexdigest would
never return this for any string.