### PR TITLE
Revert "Don't redirect dependency api endpoints to https on host insecure.rubygems.org"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,10 +51,7 @@ Rails.application.configure do
   config.ssl_options = {
     hsts: { expires: 365.days, subdomains: false },
     redirect: {
-      exclude: lambda do |request|
-        insecure_dependency_api = (request.host == "insecure.rubygems.org" && request.path =~ %r{^/(info|versions|api/v1/dependencies)})
-        request.path.start_with?('/internal') or insecure_dependency_api
-      end
+      exclude: ->(request) { request.path.start_with?('/internal') }
     }
   }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -56,10 +56,7 @@ Rails.application.configure do
   config.ssl_options = {
     hsts: { expires: 365.days, subdomains: false },
     redirect: {
-      exclude: lambda do |request|
-        insecure_dependency_api = (request.host == "insecure.rubygems.org" && request.path =~ %r{^/(info|versions|api/v1/dependencies)})
-        request.path.start_with?('/internal') or insecure_dependency_api
-      end
+      exclude: ->(request) { request.path.start_with?('/internal') }
     }
   }
 

--- a/lib/middleware/redirector.rb
+++ b/lib/middleware/redirector.rb
@@ -6,7 +6,7 @@ class Redirector
   def call(env)
     request = Rack::Request.new(env)
 
-    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "insecure.rubygems.org"]
+    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "ipv6.rubygems.org"]
 
     if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))

--- a/lib/middleware/redirector.rb
+++ b/lib/middleware/redirector.rb
@@ -6,7 +6,7 @@ class Redirector
   def call(env)
     request = Rack::Request.new(env)
 
-    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "ipv6.rubygems.org"]
+    allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org"]
 
     if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
       fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))


### PR DESCRIPTION
This reverts commit df14d9d87463d17810860baa668b2d5cf872f956.

We decided that we don't want to add support for install over HTTP.