### PR TITLE
Update nginx to 1.14.2

### DIFF
--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -171,7 +171,7 @@ spec:
             exec:
               command: ["sleep", "25"]
       - name: nginx
-        image: nginx:1.11.10
+        image: nginx:1.14.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:


### PR DESCRIPTION
Technically, 1.14 is also not supported, however I am trying to
catch up to latest stable in steps.

Hoping to fix:
```
cache file "/var/lib/nginx/cache/8/83/6718be1951d67827d718066f8af18838"
has too long header, client: -, server: _, request: "GET
/versions
```