### PR TITLE
Update nginx to 1.19.7, latest mainline

### DIFF
--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -171,7 +171,7 @@ spec:
             exec:
               command: ["sleep", "25"]
       - name: nginx
-        image: nginx:1.18.0
+        image: nginx:1.19.7
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:


### PR DESCRIPTION
`cache file .. has too long header` issue landed in 1.19.3

https://trac.nginx.org/nginx/ticket/2029