### PR TITLE
Delete all api_keys of the user on block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,7 +244,7 @@ class User < ApplicationRecord
         remember_token_expires_at: nil,
         api_key: nil
       )
-      api_keys.update_all(hashed_key: "--locked--")
+      api_keys.delete_all
     end
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -327,7 +327,7 @@ class UserTest < ActiveSupport::TestCase
           should "reset api key" do
             @user.block!
             assert @user.api_key.nil?
-            assert(@user.api_keys.pluck(:hashed_key).all? { |key| key == "--locked--" })
+            assert @user.api_keys.empty?
           end
         end
       end


### PR DESCRIPTION
Fixes:
```
/usr/local/bundle/gems/activerecord-6.1.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:676:in
`exec_params': PG::UniqueViolation: ERR
OR:  duplicate key value violates unique constraint
"index_api_keys_on_hashed_key" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (hashed_key)=(--locked--) already exists.
``