### PR TITLE
Hide email address of profiles by default

### DIFF
--- a/db/migrate/20210307101812_change_users_hide_email_default.rb
+++ b/db/migrate/20210307101812_change_users_hide_email_default.rb
@@ -1,0 +1,5 @@
+class ChangeUsersHideEmailDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :users, :hide_email, from: nil, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_25_153619) do
+ActiveRecord::Schema.define(version: 2021_03_07_101812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -175,7 +175,7 @@ ActiveRecord::Schema.define(version: 2021_01_25_153619) do
     t.datetime "updated_at"
     t.boolean "email_reset"
     t.string "handle"
-    t.boolean "hide_email"
+    t.boolean "hide_email", default: true
     t.string "twitter_username"
     t.string "unconfirmed_email"
     t.datetime "remember_token_expires_at"

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -25,16 +25,12 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         assert_kind_of Array, response
       end
 
-      should "return correct owner email" do
-        assert_equal @user.email, yield(@response.body)[0]["email"]
-      end
-
       should "return correct owner handle" do
         assert_equal @user.handle, yield(@response.body)[0]["handle"]
       end
 
-      should "not return other owner email" do
-        assert yield(@response.body).map { |owner| owner["email"] }.exclude?(@other_user.email)
+      should "not return other owner handle" do
+        assert yield(@response.body).map { |owner| owner["handle"] }.exclude?(@other_user.handle)
       end
     end
   end

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -38,21 +38,22 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
         end
 
         should respond_with :success
-        should "include the user email" do
-          assert response_body.key?("email")
-          assert_equal @user.email, response_body["email"]
+        should "hide the user email by default" do
+          refute response_body.key?("email")
         end
       end
 
-      context "on GET to show when hide email" do
+      context "on GET to show when hide email is disabled" do
         setup do
-          @user.update(hide_email: true)
+          @user.update(hide_email: false)
           get :show, params: { id: @user.handle }, format: format
         end
 
         should respond_with :success
-        should "hide the user email" do
-          refute response_body.key?("email")
+
+        should "include the user email" do
+          assert response_body.key?("email")
+          assert_equal @user.email, response_body["email"]
         end
 
         should "shows the handle" do

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -15,9 +15,8 @@ class ProfilesControllerTest < ActionController::TestCase
       setup { get :show, params: { id: @user.id } }
 
       should respond_with :success
-      should "render Email link" do
-        assert page.has_content?("Email Me")
-        assert page.has_selector?("a[href='mailto:#{@user.email}']")
+      should "not render Email link by defaulr" do
+        refute page.has_selector?("a[href='mailto:#{@user.email}']")
       end
     end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -167,22 +167,21 @@ class UserTest < ActiveSupport::TestCase
       assert_nil User.authenticate(@user.email, "bad")
     end
 
-    should "have email and handle on JSON" do
+    should "have handle on JSON" do
       json = JSON.parse(@user.to_json)
-      hash = { "id" => @user.id, "email" => @user.email, "handle" => @user.handle }
+      hash = { "id" => @user.id, "handle" => @user.handle }
       assert_equal hash, json
     end
 
-    should "have email and handle on XML" do
+    should "have handle on XML" do
       xml = Nokogiri.parse(@user.to_xml)
       assert_equal "user", xml.root.name
-      assert_equal %w[id handle email], xml.root.children.select(&:element?).map(&:name)
-      assert_equal @user.email, xml.at_css("email").content
+      assert_equal %w[id handle], xml.root.children.select(&:element?).map(&:name)
     end
 
-    should "have email and handle on YAML" do
+    should "have handle on YAML" do
       yaml = YAML.safe_load(@user.to_yaml)
-      hash = { "id" => @user.id, "email" => @user.email, "handle" => @user.handle }
+      hash = { "id" => @user.id, "handle" => @user.handle }
       assert_equal hash, yaml
     end
 
@@ -207,8 +206,8 @@ class UserTest < ActiveSupport::TestCase
       assert_equal @user.handle, @user.name
     end
 
-    should "setup a field to toggle showing email" do
-      assert_nil @user.hide_email
+    should "setup a field to toggle showing email with default true" do
+      assert @user.hide_email
     end
 
     should "only return rubygems" do


### PR DESCRIPTION
We will run update_all for all existing profiles to set `hide_email` to true.

Github issue tracker or gem help site are more appropriate means for contacting owners. gem metadata can used to set link for these.