### PR TITLE
Add stricter rate limit on search API

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -27,7 +27,7 @@ data:
       limit_req_status 429;
       limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=40r/s;
       limit_req_zone  $binary_remote_addr  zone=dependencyapi:10m  rate=100r/s;
-      limit_req_zone  $binary_remote_addr  zone=versions:10m  rate=100r/m;
+      limit_req_zone  $binary_remote_addr  zone=minutely:10m  rate=100r/m;
 
       proxy_cache_path  /var/lib/nginx/cache  levels=1:2 keys_zone=cache-versions:10m inactive=24h  max_size=100m;
 
@@ -86,7 +86,7 @@ data:
         }
 
         location /versions {
-          limit_req zone=versions burst=10 nodelay;
+          limit_req zone=minutely burst=10 nodelay;
           proxy_cache cache-versions;
           proxy_cache_background_update on;
           proxy_cache_key "/versions";
@@ -94,6 +94,11 @@ data:
           proxy_cache_use_stale updating;
           proxy_cache_valid 200 10s;
           proxy_pass http://127.0.0.1:3000/versions;
+        }
+
+        location /api/v1/search {
+          limit_req zone=minutely  burst=10 nodelay;
+          proxy_pass http://127.0.0.1:3000;
         }
 
         location /info {


### PR DESCRIPTION
Majority of requests[1] on this endpoint is coming from a single IP and
it is degrading performance of search for everyone else.

[1] it is same request for "updated:[2021-03-09 TO *}". we have
dedicated api for time based query, search api need not be used for
this.