### PR TITLE
Add cc-test-reporter to upload coverage to codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       RUBYGEMS_VERSION: ${{ matrix.rubygems_version }}
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
     - uses: actions/checkout@v2
     - name: Install and start services
@@ -32,5 +33,14 @@ jobs:
       run: |
         cp config/database.yml.example config/database.yml
         bundle exec rake db:setup
+    - name: Install cc-test-reporter and prebuild notification
+      if: matrix.rubygems_version == '3.1.5' && github.event_name != 'pull_request'
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+        ./cc-test-reporter before-build
     - name: Tests
       run: bin/rails test
+    - name: CodeClimate Post-build upload
+      run: ./cc-test-reporter -d -t simplecov after-build
+      if: matrix.rubygems_version == '3.1.5' && github.event_name != 'pull_request'


### PR DESCRIPTION
CC_TEST_REPORTER_ID is required on rails test step as well to enable
[JsonFormatter](https://github.com/simplecov-ruby/simplecov/blob/efbb12ecc9cd41912803ede0f0c4b20153b0afac/README.md#json-formatter)

Report was not being uploaded to codecoverage because of https://github.com/codeclimate/test-reporter/issues/413 which has been fixed.
Report from coverage branch: https://codeclimate.com/repos/4fdb7b4c7e00a4097900071b/settings/test_reports/6056e2df1e25ce01b50021ec

closes #2671