### PR TITLE
Remove redirect to non-existent docs.rubygems.org

### DIFF
--- a/lib/gemcutter/middleware/redirector.rb
+++ b/lib/gemcutter/middleware/redirector.rb
@@ -12,8 +12,6 @@ module Gemcutter::Middleware
       if !allowed_hosts.include?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
         fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))
         redirect_to(fake_request.url)
-      elsif request.path =~ %r{^/(book|chapter|export|read|shelf|syndicate)} && request.host !~ /docs/
-        redirect_to("https://docs.rubygems.org#{request.path}")
       else
         @app.call(env)
       end

--- a/test/unit/gemcutter/middleware/redirector_test.rb
+++ b/test/unit/gemcutter/middleware/redirector_test.rb
@@ -40,27 +40,6 @@ class Gemcutter::Middleware::RedirectorTest < ActiveSupport::TestCase
     assert last_response.ok?
   end
 
-  %w[/book
-     /book/42
-     /chapter/58
-     /read/book/2
-     /export
-     /shelf/9000
-     /syndicate.xml].each do |uri|
-    should "redirect to docs.rubygems.org when #{uri} is hit" do
-      get uri, {}, "HTTP_HOST" => Gemcutter::HOST
-
-      assert_equal 301, last_response.status
-      assert_equal "https://docs.rubygems.org#{uri}", last_response.headers["Location"]
-    end
-  end
-
-  should "not redirect docs.rubygems.org to a url that redirects back to docs.rubygems.org" do
-    get "/read/book/2", {}, "HTTP_HOST" => "docs.rubygems.org"
-
-    assert_equal 200, last_response.status
-  end
-
   should "allow fastly domains" do
     get "/", {}, "HTTP_HOST" => "index.rubygems.org"
     assert_equal 200, last_response.status


### PR DESCRIPTION
docs.rubygems.org record does not exist. going through internet
archieve briefly, I concluded that content is mostly same as guides.rubygems.org

http://web.archive.org/web/20070407232155/http://docs.rubygems.org/read/chapter/1#page1