### PR TITLE
Remove outdated links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,16 @@ Additionally, [RubyTogether](https://rubytogether.org) sponsors individuals to w
 
 ## Links
 
-* [Mailing List][]
-* [FAQ][]
-* [IRC][]: #rubygems on Freenode
+* [Slack][]: #rubygems-org
+* [RFCs](https://github.com/rubygems/rfcs)
+* [Support](mailto:support@rubygems.org)
 * [GitHub Workflow][]: [![test workflow](https://github.com/rubygems/rubygems.org/actions/workflows/test.yml/badge.svg)](https://github.com/rubygems/rubygems.org/actions/workflows/test.yml) [![lint workflow](https://github.com/rubygems/rubygems.org/actions/workflows/lint.yml/badge.svg)](https://github.com/rubygems/rubygems.org/actions/workflows/lint.yml) [![docker workflow](https://github.com/rubygems/rubygems.org/actions/workflows/docker.yml/badge.svg)](https://github.com/rubygems/rubygems.org/actions/workflows/docker.yml)
 * [Code Climate][]: [![Maintainability](https://api.codeclimate.com/v1/badges/7110bb3f9b765042d604/maintainability)](https://codeclimate.com/github/rubygems/rubygems.org/maintainability)
 * [Code Climate][]: [![Test Coverage](https://api.codeclimate.com/v1/badges/7110bb3f9b765042d604/test_coverage)](https://codeclimate.com/github/rubygems/rubygems.org/test_coverage)
-* [Trello Board][]
 
-[mailing list]: https://groups.google.com/group/rubygems-org
-[faq]: https://help.rubygems.org/kb/gemcutter/faq
-[irc]: https://webchat.freenode.net/?channels=rubygems
+[Slack]: https://bundler.slack.com/
 [github workflow]: https://github.com/rubygems/rubygems.org/actions/
 [code climate]: https://codeclimate.com/github/rubygems/rubygems.org
-[trello board]: https://trello.com/board/rubygems-org/513f9634a7ed906115000755
 
 ## Contributions
 


### PR DESCRIPTION
We no longer use irc, trello or google group. use slack for IM and
support@rubygems.org for help.