### PR TITLE
Don't abbreviate MFA when you don't need to

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -65,7 +65,7 @@ class Mailer < ApplicationMailer
     @user = User.find(user_id)
 
     mail to: @user.email,
-      subject: "Please consider enabling MFA for your account"
+      subject: "Please consider enabling multifactor authentication for your account"
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/views/mailer/honeycomb_reset_api_key.erb
+++ b/app/views/mailer/honeycomb_reset_api_key.erb
@@ -16,7 +16,7 @@
           We do not have any record of your key being abused. However, we have reset your key
           as a precautionary step. To be completely sure, please double-check any gems published
           by your RubyGems.org account between 6 November 2018 and 19 July 2019.
-          Note that if you had enabled MFA for  <%= link_to("UI and API", "https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels") %>
+          Note that if you had enabled multifactor authentication (MFA) for <%= link_to("UI and API", "https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels") %>
           gem push, yank, owner (-a/r) operations were not compromised.
           For complete information about the issue, please  <%= link_to("read our blog post", "https://blog.rubygems.org") %>.
         </p>

--- a/app/views/mailer/mfa_notification.html.erb
+++ b/app/views/mailer/mfa_notification.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Please enable MFA" %>
+<% @title = "Please enable multifactor authentication (MFA)" %>
 <% @sub_title = "Hi #{@user.handle}" %>
 
 <!-- Body -->
@@ -12,11 +12,11 @@
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
         We care about keeping your RubyGems.org account secure and recommend enabling multifactor authentication for <b>both UI and API</b>.
-        Setting up MFA only takes a few minutes and goes a long way towards protecting your account and the Ruby ecosystem.
+        Setting up multifactor authentication (MFA) only takes a few minutes and goes a long way towards protecting your account and the Ruby ecosystem.
         <br/>
         Once enabled, we will ask you for an OTP for actions like <b>sign in</b> and <b>gem push</b>.
         <br/>
-        Please click on the Enable MFA button below to register a new device. You may be asked to first log in to your account. You can also find the same link on your <%= link_to("Edit Profile", "https://rubygems.org/profile/edit") %> page.
+        Please click on the Enable Multifactor Authentication (MFA) button below to register a new device. You may be asked to first log in to your account. You can also find the same link on your <%= link_to("Edit Profile", "https://rubygems.org/profile/edit") %> page.
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
@@ -34,7 +34,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MFA</span></a>
+                          <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTIFACTOR AUTHENTICATION (MFA)</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
@@ -50,7 +50,7 @@
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
-        Check our guides for more details on <%= link_to("setting up MFA", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using MFA with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+        Check our guides for more details on <%= link_to("setting up multifactor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multifactor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,7 +279,7 @@ en:
     destroy:
       success: You have successfully disabled multifactor authentication.
     update:
-      success: You have successfully updated your MFA level.
+      success: You have successfully updated your multifactor authentication level.
   notifiers:
     update:
       success: You have successfully updated your email notification settings.
@@ -404,12 +404,12 @@ en:
       header: "%{title} Dependencies"
     gem_members:
       authors_header: Authors
-      self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling MFA</a> to keep your account secure.
-      not_using_mfa_warning_show: "* Some owners are not using MFA. Click for the complete list."
-      not_using_mfa_warning_hide: "* The following owners are not using MFA. Click to hide."
+      self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling multifactor authentication (MFA)</a> to keep your account secure.
+      not_using_mfa_warning_show: "* Some owners are not using multifactor authentication (MFA). Click for the complete list."
+      not_using_mfa_warning_hide: "* The following owners are not using multifactor authentication (MFA). Click to hide."
       owners_header: Owners
       pushed_by: Pushed by
-      using_mfa_info: "* All owners are using MFA."
+      using_mfa_info: "* All owners are using multifactor authentication (MFA)."
       yanked_by: Yanked by
       sha_256_checksum: SHA 256 checksum
     index:


### PR DESCRIPTION
MFA is complex and confusing enough without making it sound esoteric as well.

This PR spells out "multifactor authentication" the same way as it's been spelled in
existing localization files (although it should be spelled `multi-factor authentication`)
so that people who don't understand what the hell `MFA` means aren't instantly turned away
by the initialism.

Since MFA is also referred to as `Two Factor Authentication` or `2FA` by many other systems, spelling it allows
users who are at least familiar with that to pattern-match the words.

Yes, it's a bit pedantic, but we need every arrow in our quiver to get people on board with more secure authentication methods.

I'm aware some locales others than English will need to be updated as a result of this PR, but I think it's a good first step. 🤗 