### PR TITLE
default revoke format to json

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :api_key, only: %i[show create update] do
         collection do
-          post :revoke, to: "github_secret_scanning#revoke"
+          post :revoke, to: "github_secret_scanning#revoke", defaults: { format: :json }
         end
       end
       resource :multifactor_auth, only: :show


### PR DESCRIPTION
That is the format we expect and handle the response.

I tested this from GitHub side, and it is returning a 406 status back, and looking at DD logs I found it was doing a: `ActionController::UnknownFormat: ActionController::UnknownFormat`