### PR TITLE
fix api key revoke email

### DIFF
--- a/app/controllers/api/v1/github_secret_scanning_controller.rb
+++ b/app/controllers/api/v1/github_secret_scanning_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::GithubSecretScanningController < Api::BaseController
     tokens.each do |t|
       api_key = ApiKey.find_by(hashed_key: hashed_key(t[:token]))
       label = if api_key&.destroy
-                Mailer.delay.api_key_revoked(api_key, t[:url])
+                Mailer.delay.api_key_revoked(api_key.user_id, api_key.name, api_key.enabled_scopes.join(", "), t[:url])
                 "true_positive"
               else
                 "false_positive"

--- a/app/controllers/api/v1/github_secret_scanning_controller.rb
+++ b/app/controllers/api/v1/github_secret_scanning_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::GithubSecretScanningController < Api::BaseController
     tokens.each do |t|
       api_key = ApiKey.find_by(hashed_key: hashed_key(t[:token]))
       label = if api_key&.destroy
-                Mailer.delay.api_key_revoked(api_key.user_id, api_key.name, api_key.enabled_scopes.join(", "), t[:url])
+                schedule_revoke_email(api_key, t[:url])
                 "true_positive"
               else
                 "false_positive"
@@ -48,6 +48,10 @@ class Api::V1::GithubSecretScanningController < Api::BaseController
   end
 
   private
+
+  def schedule_revoke_email(api_key, url)
+    Mailer.delay.api_key_revoked(api_key.user_id, api_key.name, api_key.enabled_scopes.join(", "), url)
+  end
 
   def secret_scanning_key(key_id)
     GithubSecretScanning.new(key_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -91,10 +91,12 @@ class Mailer < ApplicationMailer
       subject: I18n.t("mail.api_key_created.subject", default: "New API key created for rubygems.org")
   end
 
-  def api_key_revoked(api_key, commit_url)
-    @api_key = api_key
+  def api_key_revoked(user_id, api_key_name, enabled_scopes, commit_url)
     @commit_url = commit_url
-    mail to: @api_key.user.email,
+    @user = User.find(user_id)
+    @api_key_name = api_key_name
+    @enabled_scopes = enabled_scopes
+    mail to: @user.email,
       subject: I18n.t("mail.api_key_revoked.subject", default: "One of your API keys was revoked on rubygems.org")
   end
 end

--- a/app/views/mailer/api_key_revoked.html.erb
+++ b/app/views/mailer/api_key_revoked.html.erb
@@ -1,5 +1,5 @@
 <% @title = "API KEY REVOKED" %>
-<% @sub_title = "Hi #{@api_key.user.handle}" %>
+<% @sub_title = "Hi #{@user.handle}" %>
 
 <!-- Body -->
 <table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
@@ -13,9 +13,9 @@
           One of your API keys was revoked on rubygems.org.
         </p>
         <p>
-          Name: <strong><%= @api_key.name %></strong>
+          Name: <strong><%= @api_key_name %></strong>
           <br />
-          Scope: <strong><%= @api_key.enabled_scopes.join(", ") %></strong>
+          Scope: <strong><%= @enabled_scopes %></strong>
         </p>
         <br/>
           <p>

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -78,6 +78,6 @@ class MailerPreview < ActionMailer::Preview
 
   def api_key_revoked
     api_key = ApiKey.last
-    Mailer.api_key_revoked(api_key, "https://example.com")
+    Mailer.api_key_revoked(api_key.user.id, api_key.name, api_key.enabled_scopes.join(", "), "https://example.com")
   end
 end


### PR DESCRIPTION
it would not work as the api_key was deleted, and when
executing the job, it would not be able to reload it

cc @greysteil 