### PR TITLE
Update secret scanning email text

### DIFF
--- a/app/views/mailer/api_key_revoked.html.erb
+++ b/app/views/mailer/api_key_revoked.html.erb
@@ -19,12 +19,7 @@
         </p>
         <br/>
           <p>
-            This API key was compromised and revoked by <a href="https://docs.github.com/en/code-security/secret-security/about-secret-scanning">GitHub Secret Scanning</a>.
-            We automatically revoke API keys that are pushed to a public repository, as that can be accessed by anyone.
-            <br />
-            We have revoked that key right away.
-             <br/>
-            <a href="<%= @commit_url %>">Public commit url</a>
+            This API key was <a href="<%= @commit_url %>">detected in a public repository</a> by GitHub Secret Scanning. As a result we consider it compromised and have automatically revoked it to prevent any unauthorized access to your account.
           </p>
 
 


### PR DESCRIPTION
Tweaks the wording in the emails we send when an API key is leaked to the following:

> This API key was [detected in a public repository](https://github.com/greysteil/test/blob/98cf9098f6b1ac8b22d06df8de2c65e5ce21af5f/README.md) by GitHub Secret Scanning. As a result we consider it compromised and have automatically revoked it to prevent any unauthorized access to your account.