### PR TITLE
Validate unconfirmed_email regex

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   before_create :generate_confirmation_token
 
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
+  validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 
   validates :handle, uniqueness: true, allow_nil: true
   validates :handle, format: {

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -104,6 +104,14 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    context "unconfirmed_email" do
+      should "be invalid when it doesn't match URI mail email regex" do
+        user = build(:user, unconfirmed_email: ">\"<script>alert(document.cookie)</script>@gmail.com")
+        refute user.valid?
+        assert_contains user.errors[:unconfirmed_email], "is invalid"
+      end
+    end
+
     context "twitter_username" do
       should validate_length_of(:twitter_username)
       should allow_value("user123_32").for(:twitter_username)


### PR DESCRIPTION
Previously we were using hook to update email before saving, however we changed that in #2570