### PR TITLE
Don't raise RecordNotFound in OwnershipConfirmation mailer

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::OwnersController < Api::BaseController
     if owner
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
-        OwnersMailer.delay.ownership_confirmation(ownership.id)
+        Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
         render plain: "#{owner.display_handle} was added as an unconfirmed owner. "\
          "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email."
       else

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -17,7 +17,7 @@ class OwnersController < ApplicationController
   def resend_confirmation
     ownership = @rubygem.unconfirmed_ownerships.find_by!(user: current_user)
     if ownership.generate_confirmation_token && ownership.save
-      OwnersMailer.delay.ownership_confirmation(ownership.id)
+      Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
       flash[:notice] = t(".resent_notice")
     else
       flash[:alert] = t("try_again")
@@ -33,7 +33,7 @@ class OwnersController < ApplicationController
     owner = User.find_by_name(handle_params)
     ownership = @rubygem.ownerships.new(user: owner, authorizer: current_user)
     if ownership.save
-      OwnersMailer.delay.ownership_confirmation(ownership.id)
+      Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
       redirect_to rubygem_owners_path(@rubygem), notice: t(".success_notice", handle: owner.name)
     else
       index_with_error ownership.errors.full_messages.to_sentence, :unprocessable_entity

--- a/app/jobs/ownership_confirmation_mailer.rb
+++ b/app/jobs/ownership_confirmation_mailer.rb
@@ -1,0 +1,10 @@
+OwnershipConfirmationMailer = Struct.new(:ownership_id) do
+  def perform
+    ownership = Ownership.find_by(id: ownership_id)
+    if ownership
+      OwnersMailer.ownership_confirmation(ownership).deliver
+    else
+      Rails.logger.info("[jobs:ownership_confirmation_mailer] owernship not found. skipping sending mail for #{ownership_id}")
+    end
+  end
+end

--- a/app/mailers/owners_mailer.rb
+++ b/app/mailers/owners_mailer.rb
@@ -9,8 +9,8 @@ class OwnersMailer < ApplicationMailer
   default_url_options[:host] = Gemcutter::HOST
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
-  def ownership_confirmation(ownership_id)
-    @ownership = Ownership.find(ownership_id)
+  def ownership_confirmation(ownership)
+    @ownership = ownership
     @user = @ownership.user
     @rubygem = @ownership.rubygem
     mail to: @user.email,


### PR DESCRIPTION
if the unconfirmed owner was removed before we could send confirmation mail, the background job was raising error.