### PR TITLE
Initial commit for a verified user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -248,6 +248,10 @@ class User < ApplicationRecord
     end
   end
 
+  def verify!
+    update!(verified: true)
+  end
+
   private
 
   def verify_digit_otp(seed, otp)

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -20,6 +20,15 @@
             class: "t-link--black"
           )
         %>
+        <% if @user.verified %>
+          <%=
+            image_tag(
+              "rubygems_logo_black.png",
+              size: 40,
+              title: 'Verified User'
+            )
+          %>
+        <% end %>
       </h1>
 
       <% if @user == current_user %>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -2,6 +2,15 @@
   <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= rubygem.name %>
+      <% if rubygem.owners.any?(&:verified) %>
+        <%=
+          image_tag(
+            "rubygems_logo_black.png",
+            title: 'Verified User',
+            width: 20
+          )
+        %>
+      <% end %>
       <span class="gems__gem__version"><%= latest_version_number(rubygem) %></span>
     </h2>
     <p class="gems__gem__desc t-text"><%= short_info(rubygem) %></p>

--- a/db/migrate/20210419212254_add_verified_to_users.rb
+++ b/db/migrate/20210419212254_add_verified_to_users.rb
@@ -1,0 +1,5 @@
+class AddVerifiedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :verified, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_07_101812) do
+ActiveRecord::Schema.define(version: 2021_04_19_212254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define(version: 2021_03_07_101812) do
     t.integer "mfa_level", default: 0
     t.string "mfa_recovery_codes", default: [], array: true
     t.integer "mail_fails", default: 0
+    t.boolean "verified", default: false, null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"

--- a/script/verify_user
+++ b/script/verify_user
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+if ARGV.empty?
+  puts "Verify user account to have an official status and also avoid some limitations."
+  puts "USAGE: script/verify_user USERNAME"
+  exit
+end
+
+handle = ARGV.first
+puts "Verifying user #{handle}..."
+
+ENV["RAILS_ENV"] ||= "production"
+require_relative "../config/environment"
+
+begin
+  user = User.find_by!(handle: handle)
+  puts "Found user: #{user.handle}"
+  user.verify!
+  puts "Done."
+rescue ActiveRecord::RecordNotFound
+  puts "User #{handle} not found."
+  exit 1 # return non-zero on fail
+end


### PR DESCRIPTION
Hello Rubygems team! This pull request adds a simple "verified" flag to a user. It is inspired by [this original issue](https://github.com/rubygems/rubygems.org/pull/2163). First, let me preface this request with: I am not a web developer. I opened this pull request as an initial starting point and hopefully we can iterate on it and improve it!

Why have a verified status? Organizations such as AWS, Rails, Ruby stdlib developers, etc, could benefit from a verified user status. A verified user would have an image/checkmark to indicate that the gems they own are official, in good form, or otherwise not malicious. This will thwart [imitation/typo-squatting gems](https://blog.reversinglabs.com/blog/mining-for-malicious-ruby-gems) to some degree, giving developers confidence in gems that appear on the website. In the future, the verified feature can be expanded to bypass limitations such as the ability to unyank gems or bypass typo restrictions. In short, verified users should be in good standing with the Ruby community.

Implementation wise, I've done the following:
* Added a verified column to User.
* Added a method to verify a user, as well as a script.
* Re-purposed the "rubygems_logo_black" image with some title text to indicate verified status.
* The verified image shows on gems when searching or attached to the owner's profile. You can view samples here: https://imgur.com/a/HOqFTgV

What is missing/Improvements:
* Tests - I can add a test for the verify! method, but other than that, are there any tests on views or partials? I'm open to writing tests with some guidance on what you're looking for and where.
* Better image/styling for the verified status. I chose an image already in the code base. We could select a different image if you want, or the same image with color (perhaps a Red RubyGem, as opposed to the standard Blue Checkmark)
* Are there any other locations where the verified status should be shown?

Thanks.