### PR TITLE
Reduce abusers rate limit to 30 rps

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -25,7 +25,7 @@ data:
       }
 
       limit_req_status 429;
-      limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=40r/s;
+      limit_req_zone  $binary_remote_addr  zone=abusers:10m  rate=30r/s;
       limit_req_zone  $binary_remote_addr  zone=dependencyapi:10m  rate=100r/s;
       limit_req_zone  $binary_remote_addr  zone=minutely:10m  rate=100r/m;
 


### PR DESCRIPTION
Follow up to https://github.com/rubygems/rubygems.org/pull/2634
We were using a combined rate limit of 20 rps before migrating to side-car
nginx.