### PR TITLE
Add guide link to MFA prompt

### DIFF
--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="t-body">
   <h2><%= t ".mfa.multifactor_auth" %></h2>
   <% if @user.mfa_enabled? %>
-    <p><%= t ".mfa.enabled" %></p>
+    <p><%= t(".mfa.enabled").html_safe %></p>
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
       <%= select_tag :level, options_for_select([
@@ -19,7 +19,7 @@
     <% end %>
   <% else %>
     <p>
-      <%= t ".mfa.disabled" %>
+      <%= t(".mfa.disabled").html_safe %>
       <%= button_to t(".mfa.go_settings"), new_multifactor_auth_path, method: "get", class: "form__submit" %>
     </p>
   <% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="t-body">
   <h2><%= t ".mfa.multifactor_auth" %></h2>
   <% if @user.mfa_enabled? %>
-    <p><%= t(".mfa.enabled").html_safe %></p>
+    <p><%= t(".mfa.enabled_html") %></p>
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
       <%= select_tag :level, options_for_select([
@@ -19,7 +19,7 @@
     <% end %>
   <% else %>
     <p>
-      <%= t(".mfa.disabled").html_safe %>
+      <%= t(".mfa.disabled_html") %>
       <%= button_to t(".mfa.go_settings"), new_multifactor_auth_path, method: "get", class: "form__submit" %>
     </p>
   <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -300,9 +300,9 @@ de:
         title: Zurücksetzen des Passworts
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,9 +335,9 @@ en:
         title: Reset password
       mfa:
         multifactor_auth: Multifactor authentication
-        disabled: You have not yet enabled multifactor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
+        disabled_html: You have not yet enabled multifactor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         go_settings: Register a new device
-        enabled: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
+        enabled_html: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
           Refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         update: Update
         level:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,15 +335,16 @@ en:
         title: Reset password
       mfa:
         multifactor_auth: Multifactor authentication
-        disabled: You have not yet enabled multifactor authentication.
+        disabled: You have not yet enabled multifactor authentication. Please refer to <a href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         go_settings: Register a new device
         enabled: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
+          Refer to <a href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         update: Update
         level:
           title: MFA Level
           disabled: Disabled
           ui_only: UI Only
-          ui_and_api: UI and API
+          ui_and_api: UI and API (Recommended)
           ui_and_gem_signin: UI and gem signin
   profiles:
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,10 +335,10 @@ en:
         title: Reset password
       mfa:
         multifactor_auth: Multifactor authentication
-        disabled: You have not yet enabled multifactor authentication. Please refer to <a href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
+        disabled: You have not yet enabled multifactor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         go_settings: Register a new device
         enabled: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
-          Refer to <a href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
+          Refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         update: Update
         level:
           title: MFA Level

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -308,9 +308,9 @@ es:
         title: Reestablecer contraseña
       mfa:
         multifactor_auth: Autenticación de múltiples factores
-        disabled: Todavía no activaste la Autenticación de Múltiples Factores.
+        disabled_html:
         go_settings: Registrar un nuevo dispositivo
-        enabled: Has activado la Autenticación de Múltiples Factores. Por favor ingresa el código OTP desde tu autenticador o alguna de tus claves de recuperación para cambiar tu nivel de Autenticación de Múltiples Factores para desactivarla.
+        enabled_html:
         update: Actualizar
         level:
           title: Nivel de Autenticación de Múltiples Factores

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,9 +300,9 @@ fr:
         title: Renvoi de mot de passe
       mfa:
         multifactor_auth: Authentification Multifacteur
-        disabled: Vous n'avez pas encore activé l'authentification multifacteur.
+        disabled_html:
         go_settings: Enregistrer un nouvel appareil
-        enabled: Vous avez activé l'authentification multifacteur. Veuillez entrer l'OTP de votre authentificateur ou un de vos codes de récupération pour le désactiver.
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -300,9 +300,9 @@ ja:
         title: パスワードのリセット
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -300,9 +300,9 @@ nl:
         title: Reset wachtwoord
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -305,9 +305,9 @@ pt-BR:
         title: Resetar senha
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -300,9 +300,9 @@ zh-CN:
         title: 重置密码
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -325,9 +325,9 @@ zh-TW:
         title: 重設密碼
       mfa:
         multifactor_auth:
-        disabled:
+        disabled_html:
         go_settings:
-        enabled:
+        enabled_html:
         update:
         level:
           title:

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -45,6 +45,7 @@ class SettingsTest < SystemTest
     click_link "Continue"
 
     assert page.has_content? "You have enabled multifactor authentication."
+    assert page.has_content? "https://guides.rubygems.org/setting-up-multifactor-authentication"
   end
 
   test "enabling multifactor authentication with invalid otp" do
@@ -70,6 +71,7 @@ class SettingsTest < SystemTest
     change_auth_level "Disabled"
 
     assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert page.has_content? "https://guides.rubygems.org/setting-up-multifactor-authentication"
   end
 
   test "disabling multifactor authentication with invalid otp" do

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -45,7 +45,8 @@ class SettingsTest < SystemTest
     click_link "Continue"
 
     assert page.has_content? "You have enabled multifactor authentication."
-    assert page.has_content? "https://guides.rubygems.org/setting-up-multifactor-authentication"
+    css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
+    assert page.has_css?(css, visible: true)
   end
 
   test "enabling multifactor authentication with invalid otp" do
@@ -71,7 +72,8 @@ class SettingsTest < SystemTest
     change_auth_level "Disabled"
 
     assert page.has_content? "You have not yet enabled multifactor authentication."
-    assert page.has_content? "https://guides.rubygems.org/setting-up-multifactor-authentication"
+    css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
+    assert page.has_css?(css)
   end
 
   test "disabling multifactor authentication with invalid otp" do


### PR DESCRIPTION
This change is to address #2686, adding '_(recommended)_ ' to 'UI and API' MFA option and link to MFA guide to settings page.

Screenshot: <img width="978" alt="Screenshot" src="https://user-images.githubusercontent.com/10329663/117180387-b682e300-ae06-11eb-8ab1-8d53ddd32b14.png">