### PR TITLE
Fix fsevent_watch error in ARM64

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Rubygems.org checks for the presence of an env variable called PROFILE that
   # switches several settings to a more "production-like" value for profiling


### PR DESCRIPTION
I think this is NOT a pull-request that really needs to be merged, but notification for anyone using an ARM64 laptop (e.g. Apple M1) and trying running this project. Since [rb-fsevent](https://github.com/thibaudgg/rb-fsevent) hasn't merged support yet, you can change the file watch in development as workaround.