### PR TITLE
Add copy link to recovery code page and disable continue link 

### DIFF
--- a/app/assets/javascripts/multifactor_auths.js
+++ b/app/assets/javascripts/multifactor_auths.js
@@ -1,6 +1,28 @@
+function popUp (e) {
+  e.preventDefault();
+  e.returnValue = "";
+};
+
 if($("#recovery-code-list").length){
-  window.addEventListener("beforeunload", function (e) {
-    e.preventDefault();
-    e.returnValue = '';
+  new Clipboard(".recovery__copy__icon");
+
+  $(".recovery__copy__icon").on("click", function(e){
+    $(this).text("[ copied ]");
+
+    if( !$(this).is(".clicked") ) {
+      e.preventDefault();
+      $(this).addClass("clicked");
+      window.removeEventListener("beforeunload", popUp);
+    }
+  });
+
+  window.addEventListener("beforeunload", popUp);
+
+  $(".form__checkbox__input").change(function() {
+    if(this.checked) {
+      $(".form__submit").prop('disabled', false);
+    } else {
+      $(".form__submit").prop('disabled', true);
+    }
   });
 }

--- a/app/assets/stylesheets/modules/button.css
+++ b/app/assets/stylesheets/modules/button.css
@@ -64,6 +64,13 @@
   .form__submit:hover {
     opacity: .7; }
 
+.form__submit:disabled {
+  opacity: .7; }
+
+.form__submit--no-hover:enabled:hover {
+  opacity: 1;
+}
+
 .form__submit--small {
     margin: auto;
     padding: 4px 25px 4px 25px;

--- a/app/assets/stylesheets/modules/form.css
+++ b/app/assets/stylesheets/modules/form.css
@@ -173,8 +173,8 @@
   margin-right: 10px;
   height: 26px;
   width: 26px;
-  border: 1px solid #f2f3f4;
-  border: 0 none #f2f3f4 \0;
+  border: 1px solid #7c7e80;
+  border: 0 none #7c7e80 \0;
   border-radius: 4px;
   border-radius: 0\0;
   box-shadow: inset 0 1px 1px -1px #c1c4ca;

--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -187,7 +187,7 @@ span#github-btn {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
-.t-link--arrow {
+.t-link--arrow, .t-link--bold {
   font-weight: bold;
 }
 
@@ -202,4 +202,8 @@ span#github-btn {
 
 .t-link--arrow:hover:after {
   box-shadow: 3px -3px 0 0 rgba(233, 87, 63, 0.7) inset;
+}
+
+.t-body strong.recovery__bold {
+  font-weight: 800;
 }

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -1,11 +1,18 @@
-<% @title = t('.title') %>
+<% @title = t(".title") %>
 
 <div class="t-body">
+  <p><%= t ".note_html" %></p>
+
   <ul id="recovery-code-list">
     <% current_user.mfa_recovery_codes.each do |code| %>
       <li class="recovery-code-list__item"><%= code %></li>
     <% end %>
   </ul>
-  <p><%= t '.note' %></p>
-  <p><%= link_to t('.continue'), edit_settings_path, class: "t-link--arrow" %></p>
+
+  <p><%= link_to t(".copy"), "#/", class: "t-link--bold recovery__copy__icon", data: { "clipboard-target": "#recovery-code-list" } %></p>
+  <div class = "form__checkbox__item">
+    <%= check_box_tag "ack", "ack", false, class: "form__checkbox__input" %>
+    <%= label_tag "checked", t(".saved"), class: "form__checkbox__label" %>
+  </div>
+  <%= button_to t(".continue"), edit_settings_path, method: "get", class: "form__submit form__submit--no-hover", disabled: true %>
 </div>

--- a/app/views/sessions/otp_prompt.html.erb
+++ b/app/views/sessions/otp_prompt.html.erb
@@ -1,5 +1,9 @@
 <% @title = t('multifactor_authentication') %>
 
+<div class="t-body">
+  <p><%= t("multifactor_auths.recovery_code_html") %></p>
+</div>
+
 <%= form_tag mfa_create_session_path, method: :post do %>
   <div class="text_field">
     <%= label_tag :otp, t('multifactor_auths.otp_code'), class: 'form__label' %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -250,6 +250,7 @@ de:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -269,7 +269,9 @@ de:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
     otp_prompt:
       authenticate: Authenticate
   multifactor_auths:
-    recovery_code: recovery code
+    recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your MFA device.'
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
     require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
     otp_prompt:
       authenticate: Authenticate
   multifactor_auths:
+    recovery_code: recovery code
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
     require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.
@@ -277,7 +278,9 @@ en:
     recovery:
       continue: Continue
       title: Recovery codes
-      note: "You MUST keep the recovery codes safe to prevent losing your account. Each of the code can be used once if you lose your authenticator."
+      copy: "[ copy ]"
+      saved: I acknowledge that I have saved my recovery codes.
+      note_html: "Please <strong class='recovery__bold'>copy and save</strong> these recovery codes. You can use these codes to login and reset your MFA if your lose your authentication device. Each of the code can be used once."
     destroy:
       success: You have successfully disabled multifactor authentication.
     update:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -277,7 +277,9 @@ es:
     recovery:
       continue: Continuar
       title: Códigos de recuperación
-      note: "DEBES mantener seguros los códigos de recuperación para prevenir la pérdida de tu cuenta. Cada código puede ser usado una vez si pierdes tu Autenticador."
+      copy:
+      saved:
+      note_html:
     destroy:
       success: Has desactivado exitosamente la autenticación de múltiples factores.
     update:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -258,6 +258,7 @@ es:
     otp_prompt:
       authenticate: Autenticar
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp: Tu código OTP no es correcto.
     otp_code: código OTP
     require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Primero tienes que desactivarla.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -269,7 +269,9 @@ fr:
     recovery:
       continue: Continuer
       title: Codes de récupération
-      note: "Vous DEVEZ garder les codes de récupération en sécurité pour ne pas perdre votre compte. Chacun des codes peut être utilisé une fois si vous perdez votre authentificateur"
+      copy:
+      saved:
+      note_html:
     destroy:
       success: Vous avez désactivé l'authentification multifacteur.
     update:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -250,6 +250,7 @@ fr:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp: Votre clé OTP est incorrecte.
     otp_code: clé OTP
     require_mfa_disabled: Votre authentification multifacteur a été activée. Vous devez d'abord la désactiver.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -250,6 +250,7 @@ ja:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -269,7 +269,9 @@ ja:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -250,6 +250,7 @@ nl:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -269,7 +269,9 @@ nl:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -274,7 +274,9 @@ pt-BR:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -255,6 +255,7 @@ pt-BR:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -269,7 +269,9 @@ zh-CN:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -250,6 +250,7 @@ zh-CN:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -250,6 +250,7 @@ zh-TW:
     otp_prompt:
       authenticate:
   multifactor_auths:
+    recovery_code_html:
     incorrect_otp:
     otp_code:
     require_mfa_disabled:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -269,7 +269,9 @@ zh-TW:
     recovery:
       continue:
       title:
-      note:
+      copy:
+      saved:
+      note_html:
     destroy:
       success:
     update:

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class SettingsTest < SystemTest
   setup do
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
-
-    page.driver.browser.set_cookie("mfa_feature=true")
+    headless_chrome_driver
   end
 
   def sign_in
@@ -42,7 +41,9 @@ class SettingsTest < SystemTest
 
     assert page.has_content? "Recovery codes"
 
-    click_link "Continue"
+    click_link "[ copy ]"
+    check "ack"
+    click_button "Continue"
 
     assert page.has_content? "You have enabled multifactor authentication."
   end
@@ -96,10 +97,18 @@ class SettingsTest < SystemTest
     assert page.has_content? "Recovery codes"
 
     recoveries = page.find_by_id("recovery-code-list").text.split
-    click_link "Continue"
+
+    click_link "[ copy ]"
+    check "ack"
+    click_button "Continue"
     page.fill_in "otp", with: recoveries.sample
     change_auth_level "Disabled"
 
     assert page.has_content? "You have not yet enabled multifactor authentication."
+  end
+
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
   end
 end


### PR DESCRIPTION
We get quite a few help tickets where users didn't know that they had to copy and save the recovery codes.
![Screenshot-20210523165131-787x570](https://user-images.githubusercontent.com/7680662/119258419-2951d380-bbe7-11eb-8929-a29eb5b7d703.png)
