### PR TITLE
Add CSP for form_action and frame_ancestors

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,6 +13,8 @@ Rails.application.config.content_security_policy do |policy|
     policy.script_src  :self, "https://secure.gaug.es", "https://www.fastly-insights.com"
     policy.style_src   :self, "https://fonts.googleapis.com"
     policy.connect_src :self, "https://s3-us-west-2.amazonaws.com/rubygems-dumps/", "https://*.fastly-insights.com", "https://fastly-insights.com", "https://api.github.com"
+    policy.form_action :self
+    policy.frame_ancestors :self
   end
 
   # Specify URI for violation reports


### PR DESCRIPTION
We received a report that `X-Frame-Options` can be bypassed if
rubygems.org was behind a proxy. This is not really an issue since this is not our setup. Regardless best practice to set these. These don't fallback to default-src.