### PR TITLE
Enable rails 6.1 default preload_links_header

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -64,4 +64,4 @@ Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
-# Rails.application.config.action_view.preload_links_header = true
+Rails.application.config.action_view.preload_links_header = true


### PR DESCRIPTION
Sets Link header with preload info:
```
Link: </assets/application.debug-61b209aae17c22b051405dfe8296b7ba5e730e852bb60084ab4d759c57b4e09e.css>; rel=preload; as=style; nopush,</assets/application.debug-2bc39b633cf4b6123274bf60487a5f62e750810d48c22ae59a4823756676fba8.js>; rel=preload; as=script; nopush
```