### PR TITLE
Remove page entries info from gems index page

### DIFF
--- a/app/views/rubygems/index.html.erb
+++ b/app/views/rubygems/index.html.erb
@@ -4,12 +4,6 @@
   <%= link_to_directory %>
 </div>
 
-<header class="gems__header">
-  <p class="gems__meter">
-    <%= page_entries_info @gems, :entry_name => 'gem'%>
-  </p>
-</header>
-
 <%= render @gems %>
 
 <%= paginate @gems %>

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -84,9 +84,6 @@ class RubygemsControllerTest < ActionController::TestCase
         assert page.has_selector?("a[href='#{rubygem_path(g)}']")
       end
     end
-    should "display 'gems' in pagination summary" do
-      assert page.has_content?("all #{@gems.count} gems")
-    end
   end
 
   context "On GET to index as an atom feed" do


### PR DESCRIPTION
We are removing info like following from gem index page:
> DISPLAYING GEMS 1 - 30 OF 11172 IN TOTAL

Showing count means we need to run a select count(*), which becomes
expensive (upwards of 400ms) if DB is already under load. The query is
already using index.
For past few days, we are receiving traffic for all of index pages
being scraped once a day. This is triggering CPU alerts on RDS.
Caching won't really help here unless we use an exceptionally large
expiry time. IMO, the above info doesn't add any significant value
and removing it should be fine.