### PR TITLE
Update clipboard.js from 1.5.5 to 2.0.8

### DIFF
--- a/app/assets/javascripts/clipboard_buttons.js
+++ b/app/assets/javascripts/clipboard_buttons.js
@@ -1,5 +1,5 @@
 $(function() {
-  var clipboard = new Clipboard('.gem__code__icon');
+  var clipboard = new ClipboardJS('.gem__code__icon');
   var copyTooltip = $('.gem__code__tooltip--copy');
   var copiedTooltip = $('.gem__code__tooltip--copied');
   var copyButtons = $('.gem__code__icon');

--- a/app/assets/javascripts/multifactor_auths.js
+++ b/app/assets/javascripts/multifactor_auths.js
@@ -4,7 +4,7 @@ function popUp (e) {
 };
 
 if($("#recovery-code-list").length){
-  new Clipboard(".recovery__copy__icon");
+  new ClipboardJS(".recovery__copy__icon");
 
   $(".recovery__copy__icon").on("click", function(e){
     $(this).text("[ copied ]");

--- a/vendor/assets/javascripts/clipboard.js
+++ b/vendor/assets/javascripts/clipboard.js
@@ -1,745 +1,864 @@
 /*!
- * clipboard.js v1.5.5
- * https://zenorocha.github.io/clipboard.js
+ * clipboard.js v2.0.8
+ * https://clipboardjs.com/
  *
  * Licensed MIT © Zeno Rocha
  */
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Clipboard = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-  var matches = require('matches-selector')
-  
-  module.exports = function (element, selector, checkYoSelf) {
-    var parent = checkYoSelf ? element : element.parentNode
-  
-    while (parent && parent !== document) {
-      if (matches(parent, selector)) return parent;
-      parent = parent.parentNode
-    }
-  }
-  
-  },{"matches-selector":2}],2:[function(require,module,exports){
-  
-  /**
-   * Element prototype.
-   */
-  
-  var proto = Element.prototype;
-  
-  /**
-   * Vendor function.
-   */
-  
-  var vendor = proto.matchesSelector
-    || proto.webkitMatchesSelector
-    || proto.mozMatchesSelector
-    || proto.msMatchesSelector
-    || proto.oMatchesSelector;
-  
-  /**
-   * Expose `match()`.
-   */
-  
-  module.exports = match;
-  
-  /**
-   * Match `el` to `selector`.
-   *
-   * @param {Element} el
-   * @param {String} selector
-   * @return {Boolean}
-   * @api public
-   */
-  
-  function match(el, selector) {
-    if (vendor) return vendor.call(el, selector);
-    var nodes = el.parentNode.querySelectorAll(selector);
-    for (var i = 0; i < nodes.length; ++i) {
-      if (nodes[i] == el) return true;
-    }
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["ClipboardJS"] = factory();
+	else
+		root["ClipboardJS"] = factory();
+})(this, function() {
+return /******/ (function() { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 747:
+/***/ (function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  "default": function() { return /* binding */ clipboard; }
+});
+
+// EXTERNAL MODULE: ./node_modules/tiny-emitter/index.js
+var tiny_emitter = __webpack_require__(279);
+var tiny_emitter_default = /*#__PURE__*/__webpack_require__.n(tiny_emitter);
+// EXTERNAL MODULE: ./node_modules/good-listener/src/listen.js
+var listen = __webpack_require__(370);
+var listen_default = /*#__PURE__*/__webpack_require__.n(listen);
+// EXTERNAL MODULE: ./node_modules/select/src/select.js
+var src_select = __webpack_require__(817);
+var select_default = /*#__PURE__*/__webpack_require__.n(src_select);
+;// CONCATENATED MODULE: ./src/common/command.js
+/**
+ * Executes a given operation type.
+ * @param {String} type
+ * @return {Boolean}
+ */
+function command(type) {
+  try {
+    return document.execCommand(type);
+  } catch (err) {
     return false;
   }
-  },{}],3:[function(require,module,exports){
-  var closest = require('closest');
-  
-  /**
-   * Delegates event to a selector.
-   *
-   * @param {Element} element
-   * @param {String} selector
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Object}
-   */
-  function delegate(element, selector, type, callback) {
-      var listenerFn = listener.apply(this, arguments);
-  
-      element.addEventListener(type, listenerFn);
-  
-      return {
-          destroy: function() {
-              element.removeEventListener(type, listenerFn);
-          }
-      }
-  }
-  
-  /**
-   * Finds closest match and invokes callback.
-   *
-   * @param {Element} element
-   * @param {String} selector
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Function}
-   */
-  function listener(element, selector, type, callback) {
-      return function(e) {
-          e.delegateTarget = closest(e.target, selector, true);
-  
-          if (e.delegateTarget) {
-              callback.call(element, e);
-          }
-      }
-  }
-  
-  module.exports = delegate;
-  
-  },{"closest":1}],4:[function(require,module,exports){
-  /**
-   * Check if argument is a HTML element.
-   *
-   * @param {Object} value
-   * @return {Boolean}
-   */
-  exports.node = function(value) {
-      return value !== undefined
-          && value instanceof HTMLElement
-          && value.nodeType === 1;
+}
+;// CONCATENATED MODULE: ./src/clipboard-action-cut.js
+
+
+/**
+ * Cut action wrapper.
+ * @param {HTMLElement} target
+ * @return {String}
+ */
+
+var ClipboardActionCut = function ClipboardActionCut(target) {
+  var selectedText = select_default()(target);
+  command('cut');
+  return selectedText;
+};
+
+/* harmony default export */ var clipboard_action_cut = (ClipboardActionCut);
+;// CONCATENATED MODULE: ./src/common/create-fake-element.js
+/**
+ * Creates a fake textarea element with a value.
+ * @param {String} value
+ * @return {HTMLElement}
+ */
+function createFakeElement(value) {
+  var isRTL = document.documentElement.getAttribute('dir') === 'rtl';
+  var fakeElement = document.createElement('textarea'); // Prevent zooming on iOS
+
+  fakeElement.style.fontSize = '12pt'; // Reset box model
+
+  fakeElement.style.border = '0';
+  fakeElement.style.padding = '0';
+  fakeElement.style.margin = '0'; // Move element out of screen horizontally
+
+  fakeElement.style.position = 'absolute';
+  fakeElement.style[isRTL ? 'right' : 'left'] = '-9999px'; // Move element to the same position vertically
+
+  var yPosition = window.pageYOffset || document.documentElement.scrollTop;
+  fakeElement.style.top = "".concat(yPosition, "px");
+  fakeElement.setAttribute('readonly', '');
+  fakeElement.value = value;
+  return fakeElement;
+}
+;// CONCATENATED MODULE: ./src/clipboard-action-copy.js
+
+
+
+/**
+ * Copy action wrapper.
+ * @param {String|HTMLElement} target
+ * @param {Object} options
+ * @return {String}
+ */
+
+var ClipboardActionCopy = function ClipboardActionCopy(target) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {
+    container: document.body
   };
-  
-  /**
-   * Check if argument is a list of HTML elements.
-   *
-   * @param {Object} value
-   * @return {Boolean}
-   */
-  exports.nodeList = function(value) {
-      var type = Object.prototype.toString.call(value);
-  
-      return value !== undefined
-          && (type === '[object NodeList]' || type === '[object HTMLCollection]')
-          && ('length' in value)
-          && (value.length === 0 || exports.node(value[0]));
-  };
-  
-  /**
-   * Check if argument is a string.
-   *
-   * @param {Object} value
-   * @return {Boolean}
-   */
-  exports.string = function(value) {
-      return typeof value === 'string'
-          || value instanceof String;
-  };
-  
-  /**
-   * Check if argument is a function.
-   *
-   * @param {Object} value
-   * @return {Boolean}
-   */
-  exports.function = function(value) {
-      var type = Object.prototype.toString.call(value);
-  
-      return type === '[object Function]';
-  };
-  
-  },{}],5:[function(require,module,exports){
-  var is = require('./is');
-  var delegate = require('delegate');
-  
-  /**
-   * Validates all params and calls the right
-   * listener function based on its target type.
-   *
-   * @param {String|HTMLElement|HTMLCollection|NodeList} target
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Object}
-   */
-  function listen(target, type, callback) {
-      if (!target && !type && !callback) {
-          throw new Error('Missing required arguments');
-      }
-  
-      if (!is.string(type)) {
-          throw new TypeError('Second argument must be a String');
-      }
-  
-      if (!is.function(callback)) {
-          throw new TypeError('Third argument must be a Function');
-      }
-  
-      if (is.node(target)) {
-          return listenNode(target, type, callback);
-      }
-      else if (is.nodeList(target)) {
-          return listenNodeList(target, type, callback);
-      }
-      else if (is.string(target)) {
-          return listenSelector(target, type, callback);
-      }
-      else {
-          throw new TypeError('First argument must be a String, HTMLElement, HTMLCollection, or NodeList');
-      }
+  var selectedText = '';
+
+  if (typeof target === 'string') {
+    var fakeElement = createFakeElement(target);
+    options.container.appendChild(fakeElement);
+    selectedText = select_default()(fakeElement);
+    command('copy');
+    fakeElement.remove();
+  } else {
+    selectedText = select_default()(target);
+    command('copy');
   }
-  
-  /**
-   * Adds an event listener to a HTML element
-   * and returns a remove listener function.
-   *
-   * @param {HTMLElement} node
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Object}
-   */
-  function listenNode(node, type, callback) {
-      node.addEventListener(type, callback);
-  
-      return {
-          destroy: function() {
-              node.removeEventListener(type, callback);
-          }
+
+  return selectedText;
+};
+
+/* harmony default export */ var clipboard_action_copy = (ClipboardActionCopy);
+;// CONCATENATED MODULE: ./src/clipboard-action-default.js
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+
+
+/**
+ * Inner function which performs selection from either `text` or `target`
+ * properties and then executes copy or cut operations.
+ * @param {Object} options
+ */
+
+var ClipboardActionDefault = function ClipboardActionDefault() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  // Defines base properties passed from constructor.
+  var _options$action = options.action,
+      action = _options$action === void 0 ? 'copy' : _options$action,
+      container = options.container,
+      target = options.target,
+      text = options.text; // Sets the `action` to be performed which can be either 'copy' or 'cut'.
+
+  if (action !== 'copy' && action !== 'cut') {
+    throw new Error('Invalid "action" value, use either "copy" or "cut"');
+  } // Sets the `target` property using an element that will be have its content copied.
+
+
+  if (target !== undefined) {
+    if (target && _typeof(target) === 'object' && target.nodeType === 1) {
+      if (action === 'copy' && target.hasAttribute('disabled')) {
+        throw new Error('Invalid "target" attribute. Please use "readonly" instead of "disabled" attribute');
       }
-  }
-  
-  /**
-   * Add an event listener to a list of HTML elements
-   * and returns a remove listener function.
-   *
-   * @param {NodeList|HTMLCollection} nodeList
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Object}
-   */
-  function listenNodeList(nodeList, type, callback) {
-      Array.prototype.forEach.call(nodeList, function(node) {
-          node.addEventListener(type, callback);
-      });
-  
-      return {
-          destroy: function() {
-              Array.prototype.forEach.call(nodeList, function(node) {
-                  node.removeEventListener(type, callback);
-              });
-          }
+
+      if (action === 'cut' && (target.hasAttribute('readonly') || target.hasAttribute('disabled'))) {
+        throw new Error('Invalid "target" attribute. You can\'t cut text from elements with "readonly" or "disabled" attributes');
       }
-  }
-  
-  /**
-   * Add an event listener to a selector
-   * and returns a remove listener function.
-   *
-   * @param {String} selector
-   * @param {String} type
-   * @param {Function} callback
-   * @return {Object}
-   */
-  function listenSelector(selector, type, callback) {
-      return delegate(document.body, selector, type, callback);
-  }
-  
-  module.exports = listen;
-  
-  },{"./is":4,"delegate":3}],6:[function(require,module,exports){
-  function select(element) {
-      var selectedText;
-  
-      if (element.nodeName === 'INPUT' || element.nodeName === 'TEXTAREA') {
-          element.focus();
-          element.setSelectionRange(0, element.value.length);
-  
-          selectedText = element.value;
-      }
-      else {
-          if (element.hasAttribute('contenteditable')) {
-              element.focus();
-          }
-  
-          var selection = window.getSelection();
-          var range = document.createRange();
-  
-          range.selectNodeContents(element);
-          selection.removeAllRanges();
-          selection.addRange(range);
-  
-          selectedText = selection.toString();
-      }
-  
-      return selectedText;
-  }
-  
-  module.exports = select;
-  
-  },{}],7:[function(require,module,exports){
-  function E () {
-    // Keep this empty so it's easier to inherit from
-    // (via https://github.com/lipsmack from https://github.com/scottcorgan/tiny-emitter/issues/3)
-  }
-  
-  E.prototype = {
-    on: function (name, callback, ctx) {
-      var e = this.e || (this.e = {});
-  
-      (e[name] || (e[name] = [])).push({
-        fn: callback,
-        ctx: ctx
-      });
-  
-      return this;
-    },
-  
-    once: function (name, callback, ctx) {
-      var self = this;
-      function listener () {
-        self.off(name, listener);
-        callback.apply(ctx, arguments);
-      };
-  
-      listener._ = callback
-      return this.on(name, listener, ctx);
-    },
-  
-    emit: function (name) {
-      var data = [].slice.call(arguments, 1);
-      var evtArr = ((this.e || (this.e = {}))[name] || []).slice();
-      var i = 0;
-      var len = evtArr.length;
-  
-      for (i; i < len; i++) {
-        evtArr[i].fn.apply(evtArr[i].ctx, data);
-      }
-  
-      return this;
-    },
-  
-    off: function (name, callback) {
-      var e = this.e || (this.e = {});
-      var evts = e[name];
-      var liveEvents = [];
-  
-      if (evts && callback) {
-        for (var i = 0, len = evts.length; i < len; i++) {
-          if (evts[i].fn !== callback && evts[i].fn._ !== callback)
-            liveEvents.push(evts[i]);
-        }
-      }
-  
-      // Remove event from queue to prevent memory leak
-      // Suggested by https://github.com/lazd
-      // Ref: https://github.com/scottcorgan/tiny-emitter/commit/c6ebfaa9bc973b33d110a84a307742b7cf94c953#commitcomment-5024910
-  
-      (liveEvents.length)
-        ? e[name] = liveEvents
-        : delete e[name];
-  
-      return this;
+    } else {
+      throw new Error('Invalid "target" value, use a valid Element');
     }
-  };
-  
-  module.exports = E;
-  
-  },{}],8:[function(require,module,exports){
-  'use strict';
-  
-  exports.__esModule = true;
-  
-  var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-  
-  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-  
-  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-  
-  var _select = require('select');
-  
-  var _select2 = _interopRequireDefault(_select);
-  
-  /**
-   * Inner class which performs selection from either `text` or `target`
-   * properties and then executes copy or cut operations.
-   */
-  
-  var ClipboardAction = (function () {
-      /**
-       * @param {Object} options
-       */
-  
-      function ClipboardAction(options) {
-          _classCallCheck(this, ClipboardAction);
-  
-          this.resolveOptions(options);
-          this.initSelection();
-      }
-  
-      /**
-       * Defines base properties passed from constructor.
-       * @param {Object} options
-       */
-  
-      ClipboardAction.prototype.resolveOptions = function resolveOptions() {
-          var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-  
-          this.action = options.action;
-          this.emitter = options.emitter;
-          this.target = options.target;
-          this.text = options.text;
-          this.trigger = options.trigger;
-  
-          this.selectedText = '';
-      };
-  
-      /**
-       * Decides which selection strategy is going to be applied based
-       * on the existence of `text` and `target` properties.
-       */
-  
-      ClipboardAction.prototype.initSelection = function initSelection() {
-          if (this.text && this.target) {
-              throw new Error('Multiple attributes declared, use either "target" or "text"');
-          } else if (this.text) {
-              this.selectFake();
-          } else if (this.target) {
-              this.selectTarget();
-          } else {
-              throw new Error('Missing required attributes, use either "target" or "text"');
-          }
-      };
-  
-      /**
-       * Creates a fake textarea element, sets its value from `text` property,
-       * and makes a selection on it.
-       */
-  
-      ClipboardAction.prototype.selectFake = function selectFake() {
-          var _this = this;
-  
-          this.removeFake();
-  
-          this.fakeHandler = document.body.addEventListener('click', function () {
-              return _this.removeFake();
-          });
-  
-          this.fakeElem = document.createElement('textarea');
-          this.fakeElem.style.position = 'absolute';
-          this.fakeElem.style.left = '-9999px';
-          this.fakeElem.style.top = (window.pageYOffset || document.documentElement.scrollTop) + 'px';
-          this.fakeElem.setAttribute('readonly', '');
-          this.fakeElem.value = this.text;
-  
-          document.body.appendChild(this.fakeElem);
-  
-          this.selectedText = _select2['default'](this.fakeElem);
-          this.copyText();
-      };
-  
-      /**
-       * Only removes the fake element after another click event, that way
-       * a user can hit `Ctrl+C` to copy because selection still exists.
-       */
-  
-      ClipboardAction.prototype.removeFake = function removeFake() {
-          if (this.fakeHandler) {
-              document.body.removeEventListener('click');
-              this.fakeHandler = null;
-          }
-  
-          if (this.fakeElem) {
-              document.body.removeChild(this.fakeElem);
-              this.fakeElem = null;
-          }
-      };
-  
-      /**
-       * Selects the content from element passed on `target` property.
-       */
-  
-      ClipboardAction.prototype.selectTarget = function selectTarget() {
-          this.selectedText = _select2['default'](this.target);
-          this.copyText();
-      };
-  
-      /**
-       * Executes the copy operation based on the current selection.
-       */
-  
-      ClipboardAction.prototype.copyText = function copyText() {
-          var succeeded = undefined;
-  
-          try {
-              succeeded = document.execCommand(this.action);
-          } catch (err) {
-              succeeded = false;
-          }
-  
-          this.handleResult(succeeded);
-      };
-  
-      /**
-       * Fires an event based on the copy operation result.
-       * @param {Boolean} succeeded
-       */
-  
-      ClipboardAction.prototype.handleResult = function handleResult(succeeded) {
-          if (succeeded) {
-              this.emitter.emit('success', {
-                  action: this.action,
-                  text: this.selectedText,
-                  trigger: this.trigger,
-                  clearSelection: this.clearSelection.bind(this)
-              });
-          } else {
-              this.emitter.emit('error', {
-                  action: this.action,
-                  trigger: this.trigger,
-                  clearSelection: this.clearSelection.bind(this)
-              });
-          }
-      };
-  
-      /**
-       * Removes current selection and focus from `target` element.
-       */
-  
-      ClipboardAction.prototype.clearSelection = function clearSelection() {
-          if (this.target) {
-              this.target.blur();
-          }
-  
-          window.getSelection().removeAllRanges();
-      };
-  
-      /**
-       * Sets the `action` to be performed which can be either 'copy' or 'cut'.
-       * @param {String} action
-       */
-  
-      /**
-       * Destroy lifecycle.
-       */
-  
-      ClipboardAction.prototype.destroy = function destroy() {
-          this.removeFake();
-      };
-  
-      _createClass(ClipboardAction, [{
-          key: 'action',
-          set: function set() {
-              var action = arguments.length <= 0 || arguments[0] === undefined ? 'copy' : arguments[0];
-  
-              this._action = action;
-  
-              if (this._action !== 'copy' && this._action !== 'cut') {
-                  throw new Error('Invalid "action" value, use either "copy" or "cut"');
-              }
-          },
-  
-          /**
-           * Gets the `action` property.
-           * @return {String}
-           */
-          get: function get() {
-              return this._action;
-          }
-  
-          /**
-           * Sets the `target` property using an element
-           * that will be have its content copied.
-           * @param {Element} target
-           */
-      }, {
-          key: 'target',
-          set: function set(target) {
-              if (target !== undefined) {
-                  if (target && typeof target === 'object' && target.nodeType === 1) {
-                      this._target = target;
-                  } else {
-                      throw new Error('Invalid "target" value, use a valid Element');
-                  }
-              }
-          },
-  
-          /**
-           * Gets the `target` property.
-           * @return {String|HTMLElement}
-           */
-          get: function get() {
-              return this._target;
-          }
-      }]);
-  
-      return ClipboardAction;
-  })();
-  
-  exports['default'] = ClipboardAction;
-  module.exports = exports['default'];
-  
-  },{"select":6}],9:[function(require,module,exports){
-  'use strict';
-  
-  exports.__esModule = true;
-  
-  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-  
-  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-  
-  function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-  
-  var _clipboardAction = require('./clipboard-action');
-  
-  var _clipboardAction2 = _interopRequireDefault(_clipboardAction);
-  
-  var _tinyEmitter = require('tiny-emitter');
-  
-  var _tinyEmitter2 = _interopRequireDefault(_tinyEmitter);
-  
-  var _goodListener = require('good-listener');
-  
-  var _goodListener2 = _interopRequireDefault(_goodListener);
-  
-  /**
-   * Base class which takes one or more elements, adds event listeners to them,
-   * and instantiates a new `ClipboardAction` on each click.
-   */
-  
-  var Clipboard = (function (_Emitter) {
-      _inherits(Clipboard, _Emitter);
-  
-      /**
-       * @param {String|HTMLElement|HTMLCollection|NodeList} trigger
-       * @param {Object} options
-       */
-  
-      function Clipboard(trigger, options) {
-          _classCallCheck(this, Clipboard);
-  
-          _Emitter.call(this);
-  
-          this.resolveOptions(options);
-          this.listenClick(trigger);
-      }
-  
-      /**
-       * Helper function to retrieve attribute value.
-       * @param {String} suffix
-       * @param {Element} element
-       */
-  
-      /**
-       * Defines if attributes would be resolved using internal setter functions
-       * or custom functions that were passed in the constructor.
-       * @param {Object} options
-       */
-  
-      Clipboard.prototype.resolveOptions = function resolveOptions() {
-          var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-  
-          this.action = typeof options.action === 'function' ? options.action : this.defaultAction;
-          this.target = typeof options.target === 'function' ? options.target : this.defaultTarget;
-          this.text = typeof options.text === 'function' ? options.text : this.defaultText;
-      };
-  
-      /**
-       * Adds a click event listener to the passed trigger.
-       * @param {String|HTMLElement|HTMLCollection|NodeList} trigger
-       */
-  
-      Clipboard.prototype.listenClick = function listenClick(trigger) {
-          var _this = this;
-  
-          this.listener = _goodListener2['default'](trigger, 'click', function (e) {
-              return _this.onClick(e);
-          });
-      };
-  
-      /**
-       * Defines a new `ClipboardAction` on each click event.
-       * @param {Event} e
-       */
-  
-      Clipboard.prototype.onClick = function onClick(e) {
-          var trigger = e.delegateTarget || e.currentTarget;
-  
-          if (this.clipboardAction) {
-              this.clipboardAction = null;
-          }
-  
-          this.clipboardAction = new _clipboardAction2['default']({
-              action: this.action(trigger),
-              target: this.target(trigger),
-              text: this.text(trigger),
-              trigger: trigger,
-              emitter: this
-          });
-      };
-  
-      /**
-       * Default `action` lookup function.
-       * @param {Element} trigger
-       */
-  
-      Clipboard.prototype.defaultAction = function defaultAction(trigger) {
-          return getAttributeValue('action', trigger);
-      };
-  
-      /**
-       * Default `target` lookup function.
-       * @param {Element} trigger
-       */
-  
-      Clipboard.prototype.defaultTarget = function defaultTarget(trigger) {
-          var selector = getAttributeValue('target', trigger);
-  
-          if (selector) {
-              return document.querySelector(selector);
-          }
-      };
-  
-      /**
-       * Default `text` lookup function.
-       * @param {Element} trigger
-       */
-  
-      Clipboard.prototype.defaultText = function defaultText(trigger) {
-          return getAttributeValue('text', trigger);
-      };
-  
-      /**
-       * Destroy lifecycle.
-       */
-  
-      Clipboard.prototype.destroy = function destroy() {
-          this.listener.destroy();
-  
-          if (this.clipboardAction) {
-              this.clipboardAction.destroy();
-              this.clipboardAction = null;
-          }
-      };
-  
-      return Clipboard;
-  })(_tinyEmitter2['default']);
-  
-  function getAttributeValue(suffix, element) {
-      var attribute = 'data-clipboard-' + suffix;
-  
-      if (!element.hasAttribute(attribute)) {
-          return;
-      }
-  
-      return element.getAttribute(attribute);
+  } // Define selection strategy based on `text` property.
+
+
+  if (text) {
+    return clipboard_action_copy(text, {
+      container: container
+    });
+  } // Defines which selection strategy based on `target` property.
+
+
+  if (target) {
+    return action === 'cut' ? clipboard_action_cut(target) : clipboard_action_copy(target, {
+      container: container
+    });
   }
-  
-  exports['default'] = Clipboard;
-  module.exports = exports['default'];
-  
-  },{"./clipboard-action":8,"good-listener":5,"tiny-emitter":7}]},{},[9])(9)
-  });
+};
+
+/* harmony default export */ var clipboard_action_default = (ClipboardActionDefault);
+;// CONCATENATED MODULE: ./src/clipboard.js
+function clipboard_typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { clipboard_typeof = function _typeof(obj) { return typeof obj; }; } else { clipboard_typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return clipboard_typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (clipboard_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+
+
+
+
+
+/**
+ * Helper function to retrieve attribute value.
+ * @param {String} suffix
+ * @param {Element} element
+ */
+
+function getAttributeValue(suffix, element) {
+  var attribute = "data-clipboard-".concat(suffix);
+
+  if (!element.hasAttribute(attribute)) {
+    return;
+  }
+
+  return element.getAttribute(attribute);
+}
+/**
+ * Base class which takes one or more elements, adds event listeners to them,
+ * and instantiates a new `ClipboardAction` on each click.
+ */
+
+
+var Clipboard = /*#__PURE__*/function (_Emitter) {
+  _inherits(Clipboard, _Emitter);
+
+  var _super = _createSuper(Clipboard);
+
+  /**
+   * @param {String|HTMLElement|HTMLCollection|NodeList} trigger
+   * @param {Object} options
+   */
+  function Clipboard(trigger, options) {
+    var _this;
+
+    _classCallCheck(this, Clipboard);
+
+    _this = _super.call(this);
+    _this.ClipboardActionCut = clipboard_action_cut.bind(_assertThisInitialized(_this));
+    _this.ClipboardActionCopy = clipboard_action_copy.bind(_assertThisInitialized(_this));
+
+    _this.resolveOptions(options);
+
+    _this.listenClick(trigger);
+
+    return _this;
+  }
+  /**
+   * Defines if attributes would be resolved using internal setter functions
+   * or custom functions that were passed in the constructor.
+   * @param {Object} options
+   */
+
+
+  _createClass(Clipboard, [{
+    key: "resolveOptions",
+    value: function resolveOptions() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      this.action = typeof options.action === 'function' ? options.action : this.defaultAction;
+      this.target = typeof options.target === 'function' ? options.target : this.defaultTarget;
+      this.text = typeof options.text === 'function' ? options.text : this.defaultText;
+      this.container = clipboard_typeof(options.container) === 'object' ? options.container : document.body;
+    }
+    /**
+     * Adds a click event listener to the passed trigger.
+     * @param {String|HTMLElement|HTMLCollection|NodeList} trigger
+     */
+
+  }, {
+    key: "listenClick",
+    value: function listenClick(trigger) {
+      var _this2 = this;
+
+      this.listener = listen_default()(trigger, 'click', function (e) {
+        return _this2.onClick(e);
+      });
+    }
+    /**
+     * Defines a new `ClipboardAction` on each click event.
+     * @param {Event} e
+     */
+
+  }, {
+    key: "onClick",
+    value: function onClick(e) {
+      var trigger = e.delegateTarget || e.currentTarget;
+      var selectedText = clipboard_action_default({
+        action: this.action(trigger),
+        container: this.container,
+        target: this.target(trigger),
+        text: this.text(trigger)
+      }); // Fires an event based on the copy operation result.
+
+      this.emit(selectedText ? 'success' : 'error', {
+        action: this.action,
+        text: selectedText,
+        trigger: trigger,
+        clearSelection: function clearSelection() {
+          if (trigger) {
+            trigger.focus();
+          }
+
+          document.activeElement.blur();
+          window.getSelection().removeAllRanges();
+        }
+      });
+    }
+    /**
+     * Default `action` lookup function.
+     * @param {Element} trigger
+     */
+
+  }, {
+    key: "defaultAction",
+    value: function defaultAction(trigger) {
+      return getAttributeValue('action', trigger);
+    }
+    /**
+     * Default `target` lookup function.
+     * @param {Element} trigger
+     */
+
+  }, {
+    key: "defaultTarget",
+    value: function defaultTarget(trigger) {
+      var selector = getAttributeValue('target', trigger);
+
+      if (selector) {
+        return document.querySelector(selector);
+      }
+    }
+  }, {
+    key: "defaultText",
+
+    /**
+     * Default `text` lookup function.
+     * @param {Element} trigger
+     */
+    value: function defaultText(trigger) {
+      return getAttributeValue('text', trigger);
+    }
+    /**
+     * Destroy lifecycle.
+     */
+
+  }, {
+    key: "destroy",
+    value: function destroy() {
+      this.listener.destroy();
+    }
+  }], [{
+    key: "copy",
+    value: function copy(target) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {
+        container: document.body
+      };
+      return clipboard_action_copy(target, options);
+    }
+  }, {
+    key: "cut",
+    value: function cut(target) {
+      return clipboard_action_cut(target);
+    }
+    /**
+     * Returns the support of the given action, or all actions if no action is
+     * given.
+     * @param {String} [action]
+     */
+
+  }, {
+    key: "isSupported",
+    value: function isSupported() {
+      var action = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : ['copy', 'cut'];
+      var actions = typeof action === 'string' ? [action] : action;
+      var support = !!document.queryCommandSupported;
+      actions.forEach(function (action) {
+        support = support && !!document.queryCommandSupported(action);
+      });
+      return support;
+    }
+  }]);
+
+  return Clipboard;
+}((tiny_emitter_default()));
+
+/* harmony default export */ var clipboard = (Clipboard);
+
+/***/ }),
+
+/***/ 828:
+/***/ (function(module) {
+
+var DOCUMENT_NODE_TYPE = 9;
+
+/**
+ * A polyfill for Element.matches()
+ */
+if (typeof Element !== 'undefined' && !Element.prototype.matches) {
+    var proto = Element.prototype;
+
+    proto.matches = proto.matchesSelector ||
+                    proto.mozMatchesSelector ||
+                    proto.msMatchesSelector ||
+                    proto.oMatchesSelector ||
+                    proto.webkitMatchesSelector;
+}
+
+/**
+ * Finds the closest parent that matches a selector.
+ *
+ * @param {Element} element
+ * @param {String} selector
+ * @return {Function}
+ */
+function closest (element, selector) {
+    while (element && element.nodeType !== DOCUMENT_NODE_TYPE) {
+        if (typeof element.matches === 'function' &&
+            element.matches(selector)) {
+          return element;
+        }
+        element = element.parentNode;
+    }
+}
+
+module.exports = closest;
+
+
+/***/ }),
+
+/***/ 438:
+/***/ (function(module, __unused_webpack_exports, __webpack_require__) {
+
+var closest = __webpack_require__(828);
+
+/**
+ * Delegates event to a selector.
+ *
+ * @param {Element} element
+ * @param {String} selector
+ * @param {String} type
+ * @param {Function} callback
+ * @param {Boolean} useCapture
+ * @return {Object}
+ */
+function _delegate(element, selector, type, callback, useCapture) {
+    var listenerFn = listener.apply(this, arguments);
+
+    element.addEventListener(type, listenerFn, useCapture);
+
+    return {
+        destroy: function() {
+            element.removeEventListener(type, listenerFn, useCapture);
+        }
+    }
+}
+
+/**
+ * Delegates event to a selector.
+ *
+ * @param {Element|String|Array} [elements]
+ * @param {String} selector
+ * @param {String} type
+ * @param {Function} callback
+ * @param {Boolean} useCapture
+ * @return {Object}
+ */
+function delegate(elements, selector, type, callback, useCapture) {
+    // Handle the regular Element usage
+    if (typeof elements.addEventListener === 'function') {
+        return _delegate.apply(null, arguments);
+    }
+
+    // Handle Element-less usage, it defaults to global delegation
+    if (typeof type === 'function') {
+        // Use `document` as the first parameter, then apply arguments
+        // This is a short way to .unshift `arguments` without running into deoptimizations
+        return _delegate.bind(null, document).apply(null, arguments);
+    }
+
+    // Handle Selector-based usage
+    if (typeof elements === 'string') {
+        elements = document.querySelectorAll(elements);
+    }
+
+    // Handle Array-like based usage
+    return Array.prototype.map.call(elements, function (element) {
+        return _delegate(element, selector, type, callback, useCapture);
+    });
+}
+
+/**
+ * Finds closest match and invokes callback.
+ *
+ * @param {Element} element
+ * @param {String} selector
+ * @param {String} type
+ * @param {Function} callback
+ * @return {Function}
+ */
+function listener(element, selector, type, callback) {
+    return function(e) {
+        e.delegateTarget = closest(e.target, selector);
+
+        if (e.delegateTarget) {
+            callback.call(element, e);
+        }
+    }
+}
+
+module.exports = delegate;
+
+
+/***/ }),
+
+/***/ 879:
+/***/ (function(__unused_webpack_module, exports) {
+
+/**
+ * Check if argument is a HTML element.
+ *
+ * @param {Object} value
+ * @return {Boolean}
+ */
+exports.node = function(value) {
+    return value !== undefined
+        && value instanceof HTMLElement
+        && value.nodeType === 1;
+};
+
+/**
+ * Check if argument is a list of HTML elements.
+ *
+ * @param {Object} value
+ * @return {Boolean}
+ */
+exports.nodeList = function(value) {
+    var type = Object.prototype.toString.call(value);
+
+    return value !== undefined
+        && (type === '[object NodeList]' || type === '[object HTMLCollection]')
+        && ('length' in value)
+        && (value.length === 0 || exports.node(value[0]));
+};
+
+/**
+ * Check if argument is a string.
+ *
+ * @param {Object} value
+ * @return {Boolean}
+ */
+exports.string = function(value) {
+    return typeof value === 'string'
+        || value instanceof String;
+};
+
+/**
+ * Check if argument is a function.
+ *
+ * @param {Object} value
+ * @return {Boolean}
+ */
+exports.fn = function(value) {
+    var type = Object.prototype.toString.call(value);
+
+    return type === '[object Function]';
+};
+
+
+/***/ }),
+
+/***/ 370:
+/***/ (function(module, __unused_webpack_exports, __webpack_require__) {
+
+var is = __webpack_require__(879);
+var delegate = __webpack_require__(438);
+
+/**
+ * Validates all params and calls the right
+ * listener function based on its target type.
+ *
+ * @param {String|HTMLElement|HTMLCollection|NodeList} target
+ * @param {String} type
+ * @param {Function} callback
+ * @return {Object}
+ */
+function listen(target, type, callback) {
+    if (!target && !type && !callback) {
+        throw new Error('Missing required arguments');
+    }
+
+    if (!is.string(type)) {
+        throw new TypeError('Second argument must be a String');
+    }
+
+    if (!is.fn(callback)) {
+        throw new TypeError('Third argument must be a Function');
+    }
+
+    if (is.node(target)) {
+        return listenNode(target, type, callback);
+    }
+    else if (is.nodeList(target)) {
+        return listenNodeList(target, type, callback);
+    }
+    else if (is.string(target)) {
+        return listenSelector(target, type, callback);
+    }
+    else {
+        throw new TypeError('First argument must be a String, HTMLElement, HTMLCollection, or NodeList');
+    }
+}
+
+/**
+ * Adds an event listener to a HTML element
+ * and returns a remove listener function.
+ *
+ * @param {HTMLElement} node
+ * @param {String} type
+ * @param {Function} callback
+ * @return {Object}
+ */
+function listenNode(node, type, callback) {
+    node.addEventListener(type, callback);
+
+    return {
+        destroy: function() {
+            node.removeEventListener(type, callback);
+        }
+    }
+}
+
+/**
+ * Add an event listener to a list of HTML elements
+ * and returns a remove listener function.
+ *
+ * @param {NodeList|HTMLCollection} nodeList
+ * @param {String} type
+ * @param {Function} callback
+ * @return {Object}
+ */
+function listenNodeList(nodeList, type, callback) {
+    Array.prototype.forEach.call(nodeList, function(node) {
+        node.addEventListener(type, callback);
+    });
+
+    return {
+        destroy: function() {
+            Array.prototype.forEach.call(nodeList, function(node) {
+                node.removeEventListener(type, callback);
+            });
+        }
+    }
+}
+
+/**
+ * Add an event listener to a selector
+ * and returns a remove listener function.
+ *
+ * @param {String} selector
+ * @param {String} type
+ * @param {Function} callback
+ * @return {Object}
+ */
+function listenSelector(selector, type, callback) {
+    return delegate(document.body, selector, type, callback);
+}
+
+module.exports = listen;
+
+
+/***/ }),
+
+/***/ 817:
+/***/ (function(module) {
+
+function select(element) {
+    var selectedText;
+
+    if (element.nodeName === 'SELECT') {
+        element.focus();
+
+        selectedText = element.value;
+    }
+    else if (element.nodeName === 'INPUT' || element.nodeName === 'TEXTAREA') {
+        var isReadOnly = element.hasAttribute('readonly');
+
+        if (!isReadOnly) {
+            element.setAttribute('readonly', '');
+        }
+
+        element.select();
+        element.setSelectionRange(0, element.value.length);
+
+        if (!isReadOnly) {
+            element.removeAttribute('readonly');
+        }
+
+        selectedText = element.value;
+    }
+    else {
+        if (element.hasAttribute('contenteditable')) {
+            element.focus();
+        }
+
+        var selection = window.getSelection();
+        var range = document.createRange();
+
+        range.selectNodeContents(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        selectedText = selection.toString();
+    }
+
+    return selectedText;
+}
+
+module.exports = select;
+
+
+/***/ }),
+
+/***/ 279:
+/***/ (function(module) {
+
+function E () {
+  // Keep this empty so it's easier to inherit from
+  // (via https://github.com/lipsmack from https://github.com/scottcorgan/tiny-emitter/issues/3)
+}
+
+E.prototype = {
+  on: function (name, callback, ctx) {
+    var e = this.e || (this.e = {});
+
+    (e[name] || (e[name] = [])).push({
+      fn: callback,
+      ctx: ctx
+    });
+
+    return this;
+  },
+
+  once: function (name, callback, ctx) {
+    var self = this;
+    function listener () {
+      self.off(name, listener);
+      callback.apply(ctx, arguments);
+    };
+
+    listener._ = callback
+    return this.on(name, listener, ctx);
+  },
+
+  emit: function (name) {
+    var data = [].slice.call(arguments, 1);
+    var evtArr = ((this.e || (this.e = {}))[name] || []).slice();
+    var i = 0;
+    var len = evtArr.length;
+
+    for (i; i < len; i++) {
+      evtArr[i].fn.apply(evtArr[i].ctx, data);
+    }
+
+    return this;
+  },
+
+  off: function (name, callback) {
+    var e = this.e || (this.e = {});
+    var evts = e[name];
+    var liveEvents = [];
+
+    if (evts && callback) {
+      for (var i = 0, len = evts.length; i < len; i++) {
+        if (evts[i].fn !== callback && evts[i].fn._ !== callback)
+          liveEvents.push(evts[i]);
+      }
+    }
+
+    // Remove event from queue to prevent memory leak
+    // Suggested by https://github.com/lazd
+    // Ref: https://github.com/scottcorgan/tiny-emitter/commit/c6ebfaa9bc973b33d110a84a307742b7cf94c953#commitcomment-5024910
+
+    (liveEvents.length)
+      ? e[name] = liveEvents
+      : delete e[name];
+
+    return this;
+  }
+};
+
+module.exports = E;
+module.exports.TinyEmitter = E;
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		if(__webpack_module_cache__[moduleId]) {
+/******/ 			return __webpack_module_cache__[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	!function() {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = function(module) {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				function() { return module['default']; } :
+/******/ 				function() { return module; };
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	}();
+/******/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	!function() {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = function(exports, definition) {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	}();
+/******/
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	!function() {
+/******/ 		__webpack_require__.o = function(obj, prop) { return Object.prototype.hasOwnProperty.call(obj, prop); }
+/******/ 	}();
+/******/
+/************************************************************************/
+/******/ 	// module exports must be returned from runtime so entry inlining is disabled
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(747);
+/******/ })()
+.default;
+});


### PR DESCRIPTION
> Changes constructor from new Clipboard() to new ClipboardJS() #468
There are no new features on this release. This breaking change was only introduced due to a name conflict with the new window.Clipboard native API.

https://github.com/zenorocha/clipboard.js/releases