### PR TITLE
Reset session in system test teardown

### DIFF
--- a/test/integration/locale_test.rb
+++ b/test/integration/locale_test.rb
@@ -15,6 +15,4 @@ class LocaleTest < SystemTest
     click_link "Deutsch"
     assert_equal "de", page.find("html")[:lang]
   end
-
-  teardown { reset_session! }
 end

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -13,8 +13,6 @@ class OwnerTest < SystemTest
     ActionMailer::Base.deliveries.clear
   end
 
-  teardown { reset_session! }
-
   test "adding owner via UI with email" do
     visit_ownerships_page
 

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -13,9 +13,6 @@ class PasswordResetTest < SystemTest
     @user = create(:user, handle: nil)
   end
 
-  # clears session[:password_reset_token] set in edit action
-  teardown { reset_session! }
-
   def forgot_password_with(email)
     visit sign_in_path
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,8 @@ Capybara.always_include_port = true
 
 class SystemTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
+
+  teardown { reset_session! }
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
fixes:
```
Run options: --seed 47181

Failure:
OwnerTest#test_incorrect_password_on_verify_shows_error [/home/runner/work/rubygems.org/rubygems.org/test/integration/owner_test.rb:122]:
Expected false to be truthy.

rails test test/integration/owner_test.rb:119
```