### PR TITLE
Add rate limit to reverse_dependencies page

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,14 +24,15 @@ class Rack::Attack
   # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
 
   protected_ui_actions = [
-    { controller: "sessions",            action: "create" },
-    { controller: "users",               action: "create" },
-    { controller: "passwords",           action: "edit" },
-    { controller: "sessions",            action: "authenticate" },
-    { controller: "passwords",           action: "create" },
-    { controller: "profiles",            action: "update" },
-    { controller: "profiles",            action: "destroy" },
-    { controller: "email_confirmations", action: "create" }
+    { controller: "sessions",             action: "create" },
+    { controller: "users",                action: "create" },
+    { controller: "passwords",            action: "edit" },
+    { controller: "sessions",             action: "authenticate" },
+    { controller: "passwords",            action: "create" },
+    { controller: "profiles",             action: "update" },
+    { controller: "profiles",             action: "destroy" },
+    { controller: "email_confirmations",  action: "create" },
+    { controller: "reverse_dependencies", action: "index" }
   ]
 
   protected_ui_mfa_actions = [

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -173,6 +173,14 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
           assert_response :ok
         end
+
+        should "allow reverse_dependencies index" do
+          rubygem = create(:rubygem, name: "test", number: "0.0.1")
+          get "/gems/#{rubygem.name}/reverse_dependencies",
+            headers: { REMOTE_ADDR: @ip_address }
+
+          assert_response :ok
+        end
       end
 
       context "api requests" do
@@ -274,6 +282,15 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
       exceed_limit_for("clearance/ip")
       delete "/profile",
+        headers: { REMOTE_ADDR: @ip_address }
+
+      assert_response :too_many_requests
+    end
+
+    should "throttle reverse_dependencies index" do
+      exceed_limit_for("clearance/ip")
+      rubygem = create(:rubygem, name: "test", number: "0.0.1")
+      get "/gems/#{rubygem.name}/reverse_dependencies",
         headers: { REMOTE_ADDR: @ip_address }
 
       assert_response :too_many_requests


### PR DESCRIPTION
avg req is under 100 rpm. 400-500 rpm creates load on db.