### PR TITLE
Cache bundle install in docker build setup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,16 @@ jobs:
       RUBY_VERSION: 2.7.4
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-rubygems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-rubygems-org
     - name: Install and start services (needed for image test)
       run: docker-compose up -d
     - name: build, test and optionally push docker image
@@ -20,4 +30,10 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,17 @@ WORKDIR /app
 
 RUN gem update --system $RUBYGEMS_VERSION
 
+COPY Gemfile* /app
+
+RUN bundle config set --local without 'development test' && \
+  bundle install --jobs 20 --retry 5
+
 COPY . /app
 
 ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions.list /app/config/versions.list
 ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/stopforumspam/toxic_domains_whole.txt /app/vendor/toxic_domains_whole.txt
 
 RUN mv /app/config/database.yml.example /app/config/database.yml
-
-
-RUN bundle config set --local without 'development test' && \
-  bundle install --jobs 20 --retry 5
 
 RUN RAILS_ENV=production RAILS_GROUPS=assets SECRET_KEY_BASE=1234 bin/rails assets:precompile
 

--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -18,7 +18,11 @@ echo "$GITHUB_SHA" > REVISION
 # and must be lowercase
 GITHUB_REPOSITORY=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
 
-docker build -t quay.io/$GITHUB_REPOSITORY:$GITHUB_SHA --build-arg RUBYGEMS_VERSION=$RUBYGEMS_VERSION .
+docker buildx build --cache-from=type=local,src=/tmp/.buildx-cache \
+  --cache-to=mode=max,type=local,dest=/tmp/.buildx-cache-new \
+  --output type=docker \
+  -t quay.io/$GITHUB_REPOSITORY:$GITHUB_SHA \
+  --build-arg RUBYGEMS_VERSION=$RUBYGEMS_VERSION .
 
 docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
   --net host quay.io/$GITHUB_REPOSITORY:$GITHUB_SHA \


### PR DESCRIPTION
saves almost 5 min from build time. also enables us to run docker build
even if rubygems.org is down.
uses buildx --cache-from and --cache-to options for caching all docker
layers. similar to https://github.com/docker/build-push-action

we are moving cache from new dir location in last step because buildkit
by default doesn't delete old caches. it would have meant that 5GB limit
of github action cache was reached very soon.