### PR TITLE
Increase request limit in line with #2765

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::DependenciesController < Api::BaseController
   before_action :check_gem_count
-  GEM_REQUEST_LIMIT = 275
+  GEM_REQUEST_LIMIT = 300
 
   def index
     deps = GemDependent.new(gem_names).to_a


### PR DESCRIPTION
#2765 
The current request limit prevents the installation of the aws-sdk gem. While the ideal is to not use the umbrella gems of aws-sdk and aws-sdk-resources, such are currently required to deploy the aws cookbook through Chef (https://github.com/sous-chefs/aws/issues/441). The overhaul required for the latter to use the aforementioned approach of not using the aws-sdk and aws-sdk-resources gems is extensive and unlikely to be undertaken in short order.
