### PR TITLE
Fix a Dutch translation string

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -352,7 +352,7 @@ nl:
         badge: Badge
         bugs: Bug-tracker
         changelog:
-        code: source code
+        code: Broncode
         docs: Documentatie
         download: Download
         header: Links


### PR DESCRIPTION
Changed "source code" (no capitalization) to "Broncode" (correct translation, with capitalization) in the gem/show aside partial. 

This word is already present in `activerecord.attributes.linkset.code` where it means the same. 

Before:
![image](https://user-images.githubusercontent.com/1312973/131538433-b197269f-1ac3-436a-83e8-ea633ff85495.png)

After:
![image](https://user-images.githubusercontent.com/1312973/131538447-cd57ff47-b71d-4fe0-b3a1-e457c1e0536a.png)

Would you like me to submit more Pull Requests? I can see a couple of missing translations as well. 

Looking forward to hearing from you!