### PR TITLE
Refactor the ES search suggestions

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -1,12 +1,13 @@
 module SearchesHelper
-  def es_suggestions(gems)
-    return false if gems.size >= 1
-    return false unless gems.respond_to?(:response)
+  def search_suggestions(gems)
     suggestions = gems.response["suggest"]
-    return false if suggestions.blank?
-    return false if suggestions["suggest_name"].blank?
-    return false if suggestions["suggest_name"][0]["options"].empty?
+
+    options = suggestions["suggest_name"][0]["options"]
+    return if options.empty?
+
     suggestions.map { |_k, v| v.first["options"] }.flatten.map { |v| v["text"] }.uniq
+  rescue NoMethodError
+    return
   end
 
   def aggregation_match_count(aggregration, field)

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -30,7 +30,7 @@
 
     <%= render partial: 'aggregations', locals: { gems: @gems } %>
 
-    <% suggestions = es_suggestions(@gems) %>
+    <% suggestions = search_suggestions(@gems) %>
     <% if suggestions %>
       <div class='search__suggestions'>
         <p>


### PR DESCRIPTION
This is my attempt at refactoring the `es_suggestions` function in `app/helpers/searches_helper.rb` to make developers and Code Climate happier.

![image](https://user-images.githubusercontent.com/1312973/131563202-8257045d-6f1c-4083-8537-9005e87f23fb.png)

Let me explain my changes:

- I changed the function name to `search_suggestions` to be more decriptive. I don't think we have to mention ElasticSearch, but if you disagree I would suggest `elasticsearch_suggestions`. 
- I dropped line 3 because the function is only used within an `<% if @gems %>` statement in `app/views/searches/show.html.erb`.
- Instead of using `respond_to?(:response)` I preferred to use a `rescue NoMethodError` here. By the way, are there scenarios where we have gems but none that respond to `response`? If not, there is more room for improvement.
- I dropped line 6 and 7 because I think there is no point in returning `false` there, as `map` will just return an empty array in the end regadless. 
- I split up line 8 to make it more readable. 

This is my first stab at improving this codebase so please take a close look at these changes and correct me where I'm wrong. Thank you!! ^~^