### PR TITLE
Use new args flags for shoryuken

### DIFF
--- a/bin/shoryuken-worker
+++ b/bin/shoryuken-worker
@@ -8,4 +8,4 @@ then
   exit 1
 fi
 
-exec bin/shoryuken --rails --require ./lib/shoryuken/sqs_worker.rb --queue "$SQS_QUEUE"
+exec bin/shoryuken -R -r ./lib/shoryuken/sqs_worker.rb -q "$SQS_QUEUE"


### PR DESCRIPTION
Fixes:
```
ERROR: "shoryuken start" was called with arguments ["--queue", "some"]
```

Related: https://github.com/ruby-shoryuken/shoryuken/pull/330 #2774