### PR TITLE
Update setup script to prepare database config

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,9 +18,9 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  unless File.exist?('config/database.yml')
+    FileUtils.cp 'config/database.yml.example', 'config/database.yml'
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # puts "\n== Copying sample files =="
+  puts "\n== Copying sample files =="
   unless File.exist?('config/database.yml')
     FileUtils.cp 'config/database.yml.example', 'config/database.yml'
   end


### PR DESCRIPTION
Resolves error when running `bin/setup` for the first time.


```
$ bin/setup
== Installing dependencies ==
The Gemfile's dependencies are satisfied

== Preparing database ==
rails aborted!
Cannot load database configuration:
Could not load database configuration. No such file - ["config/database.yml"]
/Users/colby/Github/rubygems.org/config/environment.rb:5:in `<main>'

Caused by:
Could not load database configuration. No such file - ["config/database.yml"]
/Users/colby/Github/rubygems.org/config/environment.rb:5:in `<main>'
Tasks: TOP => db:prepare => db:load_config => environment
(See full trace by running task with --trace)
```