### PR TITLE
Make form text input padding even

### DIFF
--- a/app/assets/stylesheets/modules/form.css
+++ b/app/assets/stylesheets/modules/form.css
@@ -46,7 +46,7 @@
 
 .form__input, .form__textarea {
   -webkit-appearance: none;
-  padding: 12px 50px 12px 16px;
+  padding: 12px 16px;
   display: block;
   width: 100%;
   font-weight: 300;


### PR DESCRIPTION
Nitpicky PR. The padding on the `.form__input` class on the right side is extensive. Maybe to accommodate an icon, but I can't find any instance of this (the search fields are a separate CSS class) from what I can tell. This is causing password manager icons like 1Password & MS Edge to show up in an odd place.

### Before

![Screen Shot 2021-09-05 at 1 02 49 am](https://user-images.githubusercontent.com/996377/132099880-326bc998-e90d-4107-b853-71d8da978817.png)

### After 

![Screen Shot 2021-09-05 at 1 22 12 am](https://user-images.githubusercontent.com/996377/132099881-3511b2ca-b355-4a37-8105-00613a3bf3e6.png)