### PR TITLE
Purge gem/name cache key on faslty after gem push/yank

### DIFF
--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -8,5 +8,6 @@ class GemCachePurger
 
     Rails.cache.delete("deps/v1/#{gem_name}")
     Fastly.delay.purge("versions", soft: true)
+    Fastly.delay.purge("gem/#{gem_name}", soft: true)
   end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -297,7 +297,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           assert_equal "Successfully registered gem: test (1.0.0)", @response.body
         end
         should "enqueue jobs" do
-          assert_difference "Delayed::Job.count", 7 do
+          assert_difference "Delayed::Job.count", 8 do
             post :create, body: gem_file("test-1.0.0.gem").read
           end
         end

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -74,7 +74,7 @@ class DeletionTest < ActiveSupport::TestCase
   end
 
   should "enque job for updating ES index, spec index and purging cdn" do
-    assert_difference "Delayed::Job.count", 8 do
+    assert_difference "Delayed::Job.count", 9 do
       delete_gem
     end
 

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -16,6 +16,7 @@ class GemCachePurgerTest < ActiveSupport::TestCase
 
     should "purge cdn cache" do
       Fastly.expects(:purge).with("info/#{@gem_name}", soft: true)
+      Fastly.expects(:purge).with("gem/#{@gem_name}", soft: true)
       Fastly.expects(:purge).with("names", soft: true)
       Fastly.expects(:purge).with("versions", soft: true)
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -339,7 +339,7 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
-      assert_difference "Delayed::Job.count", 6 do
+      assert_difference "Delayed::Job.count", 7 do
         @cutter.save
       end
     end


### PR DESCRIPTION
we set gem/name surrogate key on v1/deps and v1/versions endpoints.
before this they were valid until expiry (60s).