### PR TITLE
Update rubygems to 3.2.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     name: Docker build (and optional push)
     runs-on: ubuntu-18.04
     env:
-      RUBYGEMS_VERSION: 3.1.5
+      RUBYGEMS_VERSION: 3.2.3
       RUBY_VERSION: 2.7.4
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rubygems_version: ['3.1.5', 'latest']
+        rubygems_version: ['3.2.3', 'latest']
         ruby_version: ['2.7.4']
     name: Rails tests (Ruby ${{ matrix.ruby_version }}, RubyGems ${{ matrix.rubygems_version }})
     runs-on: ubuntu-18.04
@@ -38,7 +38,7 @@ jobs:
     - name: Tests
       run: bin/rails test
     - name: archive coverage
-      if: matrix.rubygems_version == '3.1.5'
+      if: matrix.rubygems_version == '3.2.3'
       uses: actions/upload-artifact@v2
       with:
         name: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,15 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby_version }}
         bundler-cache: true
+    - name: set rubygems version
+      run: |
+        if [ "$RUBYGEMS_VERSION" != "latest" ]; then
+          gem update --system $RUBYGEMS_VERSION;
+        else
+          gem update --system
+        fi
+        gem --version
+        bundle --version
     - name: Prepare environment
       run: |
         cp config/database.yml.example config/database.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 #### Environment (OS X)
 
 * Use Ruby 2.6.x (`.ruby-version` is present and can be used)
-* Use Rubygems 3.1.5
+* Use Rubygems 3.2.3
 * Install bundler: `gem install bundler`
 * Install Elastic Search:
   * Pull ElasticSearch `7.10.1` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:7.10.1`
@@ -84,7 +84,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 
 * Use Ruby 2.6.x `apt-get install ruby2.6`
   * Or install via [alternate methods](https://www.ruby-lang.org/en/downloads/)
-* Use Rubygems 3.1.5
+* Use Rubygems 3.2.3
 * Install bundler: `gem install bundler`
 * Install Elastic Search (see the docker installation instructions above):
   * Pull ElasticSearch `7.10.1` : `docker pull docker.elastic.co/elasticsearch/elasticsearch:7.10.1`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,4 +474,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -85,7 +85,12 @@ class PusherTest < ActiveSupport::TestCase
     should "not be able to pull spec with metadata containing bad ruby objects" do
       @gem = gem_file("exploit.gem")
       @cutter = Pusher.new(@user, @gem)
-      @cutter.pull_spec
+      out, err = capture_io do
+        @cutter.pull_spec
+      end
+
+      assert_equal "", out
+      assert_equal("Exception while verifying \n", err)
       assert_nil @cutter.spec
       assert_match(/RubyGems\.org cannot process this gem/, @cutter.message)
       assert_match(/ActionController::Routing::RouteSet::NamedRouteCollection/, @cutter.message)
@@ -108,8 +113,13 @@ class PusherTest < ActiveSupport::TestCase
     should "not be able to save a gem if the date is not valid" do
       @gem = gem_file("bad-date-1.0.0.gem")
       @cutter = Pusher.new(@user, @gem)
-      @cutter.process
-      assert_match(/exception while verifying: mon out of range/, @cutter.message)
+      out, err = capture_io do
+        @cutter.process
+      end
+
+      assert_equal "", out
+      assert_equal("Exception while verifying \n", err)
+      assert_match(/mon out of range/, @cutter.message)
       assert_equal @cutter.code, 422
     end
 
@@ -117,7 +127,12 @@ class PusherTest < ActiveSupport::TestCase
       ["1.0.0", "2.0.0", "3.0.0", "4.0.0"].each do |version|
         @gem = gem_file("dos-#{version}.gem")
         @cutter = Pusher.new(@user, @gem)
-        @cutter.pull_spec
+        out, err = capture_io do
+          @cutter.pull_spec
+        end
+
+        assert_equal "", out
+        assert_equal("Exception while verifying \n", err)
         assert_nil @cutter.spec
         assert_includes @cutter.message, %(RubyGems.org cannot process this gem)
         assert_includes @cutter.message, %(Tried to load unspecified class: Symbol)


### PR DESCRIPTION
Add supress warning to some tests since 3.2.0 remove kenrel warn
supression. it makes test look dirty.

error message for mon out of range has changed.