### PR TITLE
Convert optional keyword arg to options

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -62,8 +62,8 @@ class Deletion < ApplicationRecord
   end
 
   def purge_fastly
-    Fastly.delay.purge("gems/#{@version.full_name}.gem")
-    Fastly.delay.purge("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    Fastly.delay.purge(path: "gems/#{@version.full_name}.gem")
+    Fastly.delay.purge(path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
   end
 
   def update_search_index

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -7,11 +7,11 @@ class Net::HTTP::Purge < Net::HTTPRequest
 end
 
 class Fastly
-  def self.purge(path, soft: false)
+  def self.purge(options = {})
     return unless ENV["FASTLY_DOMAINS"]
     ENV["FASTLY_DOMAINS"].split(",").each do |domain|
-      url = "https://#{domain}/#{path}"
-      headers = soft ? { "Fastly-Soft-Purge" => 1 } : {}
+      url = "https://#{domain}/#{options[:path]}"
+      headers = options[:soft] ? { "Fastly-Soft-Purge" => 1 } : {}
       headers["Fastly-Key"] = ENV["FASTLY_API_KEY"]
 
       response = RestClient::Request.execute(method: :purge,

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -3,11 +3,11 @@ class GemCachePurger
     # We need to purge from Fastly and from Memcached
     ["info/#{gem_name}", "names"].each do |path|
       Rails.cache.delete(path)
-      Fastly.delay.purge(path, soft: true)
+      Fastly.delay.purge(path: path, soft: true)
     end
 
     Rails.cache.delete("deps/v1/#{gem_name}")
-    Fastly.delay.purge("versions", soft: true)
-    Fastly.delay.purge("gem/#{gem_name}", soft: true)
+    Fastly.delay.purge(path: "versions", soft: true)
+    Fastly.delay.purge(path: "gem/#{gem_name}", soft: true)
   end
 end

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -120,8 +120,8 @@ class DeletionTest < ActiveSupport::TestCase
       end
 
       should "purge fastly" do
-        Fastly.expects(:purge).with("gems/#{@version.full_name}.gem").times(2)
-        Fastly.expects(:purge).with("quick/Marshal.4.8/#{@version.full_name}.gemspec.rz").times(2)
+        Fastly.expects(:purge).with(path: "gems/#{@version.full_name}.gem").times(2)
+        Fastly.expects(:purge).with(path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz").times(2)
 
         Delayed::Worker.new.work_off
       end

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -12,7 +12,7 @@ class FastlyTest < ActiveSupport::TestCase
   context ".purge" do
     should "purge for each domain" do
       RestClient::Request.expects(:execute).times(2).returns("{}")
-      Fastly.purge("some-url")
+      Fastly.purge(path: "some-url")
     end
   end
 end

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -15,10 +15,10 @@ class GemCachePurgerTest < ActiveSupport::TestCase
     end
 
     should "purge cdn cache" do
-      Fastly.expects(:purge).with("info/#{@gem_name}", soft: true)
-      Fastly.expects(:purge).with("gem/#{@gem_name}", soft: true)
-      Fastly.expects(:purge).with("names", soft: true)
-      Fastly.expects(:purge).with("versions", soft: true)
+      Fastly.expects(:purge).with(path: "info/#{@gem_name}", soft: true)
+      Fastly.expects(:purge).with(path: "gem/#{@gem_name}", soft: true)
+      Fastly.expects(:purge).with(path: "names", soft: true)
+      Fastly.expects(:purge).with(path: "versions", soft: true)
 
       GemCachePurger.call(@gem_name)
       Delayed::Worker.new.work_off


### PR DESCRIPTION
Fixes:
/usr/local/bundle/gems/delayed_job-4.1.9/lib/delayed/performable_method.rb:26: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/lib/fastly.rb:10: warning: The called method `purge' is defined here

The warning is being raised because delayed_job does not support ruby 3. https://github.com/collectiveidea/delayed_job/issues/1134