### PR TITLE
Update unpawn from 0.3.0 to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "sprockets-rails"
 gem "rack-attack"
 gem "rqrcode"
 gem "rotp"
-gem "unpwn", "~> 0.3.0"
+gem "unpwn"
 
 # Logging
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    pwned (1.2.1)
+    pwned (2.3.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-attack (6.5.0)
@@ -386,9 +386,9 @@ GEM
     unicorn (5.8.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    unpwn (0.3.0)
+    unpwn (1.0.0)
       bloomer (~> 1.0)
-      pwned (~> 1.2)
+      pwned (~> 2.0)
     validates_formatting_of (0.9.0)
       activemodel
     webdrivers (4.6.1)
@@ -467,7 +467,7 @@ DEPENDENCIES
   toxiproxy (~> 1.0.0)
   uglifier (>= 1.0.3)
   unicorn (~> 5.8.0)
-  unpwn (~> 0.3.0)
+  unpwn
   validates_formatting_of
   webdrivers
   webrick

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,8 +32,7 @@ class ActiveSupport::TestCase
     Rails.cache.clear
     Rack::Attack.cache.store.clear
 
-    # Don't connect to the Pwned Passwords API in tests
-    Pwned.stubs(:pwned?).returns(false)
+    Unpwn.offline = true
   end
 
   def page


### PR DESCRIPTION
Fixes:
/usr/local/bundle/gems/pwned-1.2.1/lib/pwned/password.rb:109: warning: Splitting the last argument into positional and keyword parameters is deprecated
/usr/local/lib/ruby/2.7.0/open-uri.rb:13: warning: The called method `open' is defined here
/usr/local/bundle/gems/pwned-1.2.1/lib/pwned/password.rb:109: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open