### PR TITLE
Change docker base image from dockhub official to bitnami

### DIFF
--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -27,12 +27,13 @@ docker buildx build --cache-from=type=local,src=/tmp/.buildx-cache \
 docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
   --net host quay.io/$GITHUB_REPOSITORY:$GITHUB_SHA \
   -- rake db:create db:migrate
-docker run -d -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
+docker run -d --name vindictive_applejack -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
   --net host quay.io/$GITHUB_REPOSITORY:$GITHUB_SHA \
   -- unicorn_rails -E production -c /app/config/unicorn.conf
 
-sleep 5
+sleep 20
 curl -m 5 http://localhost:3000/internal/ping | grep PONG
+docker logs vindictive_applejack
 
 if [ $? -eq 1 ]; then
   echo "Internal ping api test didn't pass."


### PR DESCRIPTION
dockerhub official is maintained by docker community. after migration
to ruby 3.0 we are facing memory leak issue with it.
bitnami/ruby had consistent memory usage in local testing.