### PR TITLE
Display whether a gem version is signed on show page

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -195,6 +195,10 @@ class Version < ApplicationRecord
     !indexed
   end
 
+  def signed?
+    cert_chain.present?
+  end
+
   def size
     self[:size] || "N/A"
   end

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -6,6 +6,11 @@
   <% end %>
 
   <span class="gem__version__date">(<%= number_to_human_size(version.size) %>)</span>
+
+  <% if version.signed? %>
+    <span class="gem__version__date"><%= t '.signed' %></span>
+  <% end %>
+
   <% if version.yanked? -%>
     <span class="gem__version__date"><%= t '.yanked' %></span>
   <% end -%>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -446,6 +446,7 @@ de:
       title: Alle Versionen von %{name}
       versions_since: "%{count} Versionen seit %{since}"
     version:
+      signed:
       yanked:
   will_paginate:
     next_label: Nächstes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,6 +482,7 @@ en:
       title: All versions of %{name}
       versions_since: "%{count} versions since %{since}"
     version:
+      signed: signed
       yanked: yanked
   will_paginate:
     next_label: Next

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -454,6 +454,7 @@ es:
       title: Todas las versiones de %{name}
       versions_since: "%{count} versiones desde %{since}"
     version:
+      signed:
       yanked: borrada
   will_paginate:
     next_label: Siguiente

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -446,6 +446,7 @@ fr:
       title: Toutes les versions de %{name}
       versions_since: "%{count} versions depuis %{since}"
     version:
+      signed:
       yanked: retiré
   will_paginate:
     next_label: Suivant

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -454,6 +454,7 @@ ja:
       title: '%{name}の全バージョン履歴'
       versions_since: "%{since}からの%{count}項目"
     version:
+      signed:
       yanked: yanked
   will_paginate:
     next_label: 次

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -446,6 +446,7 @@ nl:
       title: Alle versies van %{name}
       versions_since: "%{count} versies sinds %{since}"
     version:
+      signed:
       yanked: verwijderd
   will_paginate:
     next_label: Volgende

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -451,6 +451,7 @@ pt-BR:
       title: Todas as versões para %{name}
       versions_since: "%{count} versões desde %{since}"
     version:
+      signed:
       yanked: removida
   will_paginate:
     next_label:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -446,6 +446,7 @@ zh-CN:
       title: "%{name} 的所有版本"
       versions_since: 自 %{since} 以来有 %{count} 个版本
     version:
+      signed:
       yanked: 已废弃
   will_paginate:
     next_label: 下一页

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -471,6 +471,7 @@ zh-TW:
       title: "%{name} 的所有版本"
       versions_since: 自從 %{since} 以來，有 %{count} 個版本
     version:
+      signed:
       yanked: 已被移除
   will_paginate:
     next_label: 下一頁

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -67,6 +67,15 @@ class PushTest < ActionDispatch::IntegrationTest
     assert page.has_content?("> 1")
   end
 
+  test "pushing a signed gem" do
+    push_gem gem_file("valid_signature-0.0.0.gem")
+
+    get rubygem_path("valid_signature")
+    assert_response :success
+    assert page.find("li.gem__version-wrap").has_content?("0.0.0")
+    assert page.find("li.gem__version-wrap").has_content?("signed")
+  end
+
   test "push errors bubble out" do
     push_gem Rails.root.join("test", "gems", "bad-characters-1.0.0.gem")
 


### PR DESCRIPTION
Relevant Issue: https://github.com/rubygems/rubygems.org/issues/2079

Recently, https://github.com/rubygems/rubygems.org/pull/2444 was merged that allows the `cert_chain` to be stored in the versions table.

I figured it would be great to surface if a gem is signed on the site by seeing if there is a `cert_chain` available for such version. For now, I just added a `signed` tag beside the version if it is signed (similar to yanked). I'm open to suggestions on how we can display this information.

### Additional Ideas
- In the gem members partial where it displays more information about the latest version, a section can be added to display when the cert is valid and whether it is expired
- Add a signed badge (if applicable) beside the gem name and version on the show page, and search result

### Signed

<img width="719" alt="Screen Shot 2021-10-06 at 10 35 05 AM" src="https://user-images.githubusercontent.com/42748004/136224695-8aa7ce9c-6b85-4686-ad65-94845b5e3705.png">

### Signed and yanked
<img width="760" alt="Screen Shot 2021-10-06 at 10 04 09 AM" src="https://user-images.githubusercontent.com/42748004/136222529-0b8ee6a1-6b1e-43f8-87e7-267549799bf4.png">

