### PR TITLE
Tweak download page

### DIFF
--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -16,7 +16,7 @@
   </p>
   <pre><code>$ gem update --system</code></pre>
   <p>
-    If you don't have any RubyGems installed, there is still the pre-gem approach to getting software, doing it manually:
+    You might be running into some bug that prevents you from upgrading rubygems the standard way. In that case, you can try upgrading manually:
   </p>
   <ol class="manual">
     <li><%=link_to "Download from above", "#formats" %></li>

--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -14,14 +14,14 @@
   <p>
   Or, to upgrade to the latest RubyGems:
   </p>
-  <pre><code>$ gem update --system          # may need to be administrator or root</code></pre>
+  <pre><code>$ gem update --system</code></pre>
   <p>
     If you don't have any RubyGems installed, there is still the pre-gem approach to getting software, doing it manually:
   </p>
   <ol class="manual">
     <li><%=link_to "Download from above", "#formats" %></li>
     <li>Unpack into a directory and <code>cd</code> there</li>
-    <li>Install with: <code>ruby setup.rb</code> (you may need admin/root privilege)</li>
+    <li>Install with: <code>ruby setup.rb</code></li>
   </ol>
   <p>
   For more details and other options, see:


### PR DESCRIPTION
Just two small changes.

* We don't really recommend installing rubygems using `sudo`, so I'm removing mentions to that.
* The manual upgrade mentions ruby setups without rubygems installed. That's never the case these days, so I changed the motivation to a use case that does come up sometimes.