### PR TITLE
Fix time now changing between function calls

### DIFF
--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -9,8 +9,10 @@ class UpdateVersionsFileTest < ActiveSupport::TestCase
   end
 
   def update_versions_file
-    @created_at = Time.now.iso8601
-    Rake::Task["compact_index:update_versions_file"].invoke
+    freeze_time do
+      @created_at = Time.now.iso8601
+      Rake::Task["compact_index:update_versions_file"].invoke
+    end
   end
 
   teardown do


### PR DESCRIPTION
This was unintentially removed in #2811. causes different times for
@created_at and version file header occasionally.