### PR TITLE
Add listener to advanced search inputs to submit

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -18,5 +18,9 @@ if($("#advanced-search").length){
       var updated     = $updated.val().length > 0 ? 'updated: ' + $updated.val() : '';
 
       $main.val($.trim(name + ' ' + summary + ' ' + description + ' ' + downloads + ' ' + updated));
+  }).on('keypress', function(e) {
+    if (e.key === 'Enter') {
+      $("input#advanced_search_submit").click();
+    }
   });
 }

--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -6,7 +6,7 @@
     <%= label_tag :home_query do %>
       <span class="t-hidden"><%= t("layouts.application.header.search_gem_html") %></span>
     <% end %>
-    <%= submit_tag "⌕", name: nil, class: "home__search__icon" %>
+    <%= submit_tag "⌕", id: "advanced_search_submit", name: nil, class: "home__search__icon" %>
   <% end %>
 
   <dl id="search-fields">

--- a/test/integration/advanced_search_test.rb
+++ b/test/integration/advanced_search_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "capybara/minitest"
+
+class AdvancedSearchTest < SystemTest
+  include ESHelper
+
+  setup do
+    headless_chrome_driver
+
+    visit advanced_search_path
+  end
+
+  test "enter inside any field will submit form" do
+    ["#name", "#summary", "#description", "#downloads", "#updated"].each do |el|
+      visit advanced_search_path
+      find(el).send_keys(:return)
+      assert current_path == search_path
+    end
+  end
+
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+end


### PR DESCRIPTION
Addresses part of #2724

This PR adds some functionality to the Advanced Search page to submit the form if "enter" is clicked inside any of the input fields. It addresses the second item in https://github.com/rubygems/rubygems.org/issues/2724. 

@sonalkr132 I saw that you had initially created this JavaScript, could you please let me know how to write tests to execute this new codepath? I wasn't able to find any patterns in the `test/` directory that tested client JS, so I'd appreciate some pointers. 