### PR TITLE
Add integration tests for advanced search

### DIFF
--- a/test/integration/advanced_search_test.rb
+++ b/test/integration/advanced_search_test.rb
@@ -10,12 +10,35 @@ class AdvancedSearchTest < SystemTest
     visit advanced_search_path
   end
 
+  test "searches for a gem while scoping advanced attributes" do
+    rubygem = create(:rubygem, name: "LDAP", number: "1.0.0", downloads: 3)
+    create(:version, summary: "some summary", description: "Hello World", rubygem: rubygem)
+
+    import_and_refresh
+
+    fill_in "Search Gems…", with: "downloads: <5"
+    click_button "advanced_search_submit"
+
+    assert current_path == search_path
+    assert has_content? "LDAP"
+  end
+
   test "enter inside any field will submit form" do
     ["#name", "#summary", "#description", "#downloads", "#updated"].each do |el|
       visit advanced_search_path
       find(el).send_keys(:return)
       assert current_path == search_path
     end
+  end
+
+  test "forms search query out of advanced attributes" do
+    fill_in "name", with: "hello"
+    fill_in "summary", with: "world"
+    fill_in "description", with: "foo"
+    fill_in "downloads", with: ">69"
+    fill_in "updated", with: ">2021-05-05"
+
+    page.find("#home_query").assert_text "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
   end
 
   teardown do

--- a/test/integration/advanced_search_test.rb
+++ b/test/integration/advanced_search_test.rb
@@ -19,7 +19,7 @@ class AdvancedSearchTest < SystemTest
     fill_in "Search Gems…", with: "downloads: <5"
     click_button "advanced_search_submit"
 
-    assert current_path == search_path
+    assert_current_path(search_path, ignore_query: true)
     assert has_content? "LDAP"
   end
 
@@ -27,7 +27,7 @@ class AdvancedSearchTest < SystemTest
     ["#name", "#summary", "#description", "#downloads", "#updated"].each do |el|
       visit advanced_search_path
       find(el).send_keys(:return)
-      assert current_path == search_path
+      assert_current_path(search_path, ignore_query: true)
     end
   end
 
@@ -38,7 +38,7 @@ class AdvancedSearchTest < SystemTest
     fill_in "downloads", with: ">69"
     fill_in "updated", with: ">2021-05-05"
 
-    page.find("#home_query").assert_text "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
+    has_field? "Search Gems…", with: "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
   end
 
   teardown do

--- a/test/integration/advanced_search_test.rb
+++ b/test/integration/advanced_search_test.rb
@@ -38,7 +38,7 @@ class AdvancedSearchTest < SystemTest
     fill_in "downloads", with: ">69"
     fill_in "updated", with: ">2021-05-05"
 
-    has_field? "Search Gems…", with: "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
+    assert has_field? "Search Gems…", with: "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
   end
 
   teardown do


### PR DESCRIPTION
This PR adds integration tests for the Advanced Search UI. 

These were initially proposed in https://github.com/rubygems/rubygems.org/pull/2833#issuecomment-952607749, however were moved to a separate PR to separate concerns and to be able to better diagnose why one of these tests is no working. 

TODO: 
- [x] Figure out why second test is failing. 