### PR TITLE
Enable MFA on specific API keys

### DIFF
--- a/app/assets/stylesheets/modules/form.css
+++ b/app/assets/stylesheets/modules/form.css
@@ -41,7 +41,7 @@
 .form__input__addon-left .form__input {
   padding-left: 45px; }
 
-.form__input, .form__textarea, .form__select {
+.form__input, .form__textarea, .form__select, .form__group {
   margin-bottom: 30px; }
 
 .form__input, .form__textarea {

--- a/app/assets/stylesheets/modules/owners.css
+++ b/app/assets/stylesheets/modules/owners.css
@@ -27,6 +27,13 @@ span.owners__icon img {
     padding-right: 2px;
 }
 
+.owners__cell[data-title="MFA"] img {
+    margin: auto 0;
+    height: 23px;
+    width: 23px;
+    border-radius: 50%;
+}
+
 @media screen and (max-width: 640px) {
     .owners__tbody {
         display: block;

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -27,7 +27,7 @@ class Api::BaseController < ApplicationController
 
   def verify_with_otp
     otp = request.headers["HTTP_OTP"]
-    return if @api_key.user.mfa_api_authorized?(otp)
+    return if @api_key.mfa_authorized?(otp)
     prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)
     render plain: prompt_text, status: :unauthorized
   end

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -79,10 +79,10 @@ class Api::V1::ApiKeysController < Api::BaseController
   end
 
   def api_key_create_params
-    params.permit(:name, *ApiKey::API_SCOPES)
+    params.permit(:name, *ApiKey::API_SCOPES, :mfa)
   end
 
   def api_key_update_params
-    params.permit(*ApiKey::API_SCOPES)
+    params.permit(*ApiKey::API_SCOPES, :mfa)
   end
 end

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -66,7 +66,7 @@ class ApiKeysController < ApplicationController
   private
 
   def api_key_params
-    params.require(:api_key).permit(:name, *ApiKey::API_SCOPES)
+    params.require(:api_key).permit(:name, *ApiKey::API_SCOPES, :mfa)
   end
 
   def redirect_to_verify

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -19,6 +19,16 @@ class ApiKey < ApplicationRecord
     end
   end
 
+  def mfa_authorized?(otp)
+    return true unless mfa_enabled?
+    user.otp_verified?(otp)
+  end
+
+  def mfa_enabled?
+    return false unless user.mfa_enabled?
+    user.mfa_ui_and_api? || mfa
+  end
+
   private
 
   def exclusive_show_dashboard_scope

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,11 +230,6 @@ class User < ApplicationRecord
     otp_verified?(otp)
   end
 
-  def mfa_api_authorized?(otp)
-    return true unless mfa_ui_and_api?
-    otp_verified?(otp)
-  end
-
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)

--- a/app/views/api_keys/edit.html.erb
+++ b/app/views/api_keys/edit.html.erb
@@ -5,11 +5,23 @@
     <%= label_tag :name, t("api_keys.index.name"), class: "form__label" %>
     <%= f.text_field :name, class: "form__input", autocomplete: :off %>
 
-    <%= label_tag :scope, t("api_keys.index.scope"), class: "form__label" %>
-    <% ApiKey::API_SCOPES.each do |api_scope| %>
-      <div class = "form__checkbox__item">
-        <%= f.check_box "#{api_scope}", { class: "form__checkbox__input", id: "#{api_scope}" } , "true", "false" %>
-        <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
+    <div class="form__group">
+      <%= label_tag :scope, t("api_keys.index.scope"), class: "form__label" %>
+      <% ApiKey::API_SCOPES.each do |api_scope| %>
+        <div class = "form__checkbox__item">
+          <%= f.check_box "#{api_scope}", { class: "form__checkbox__input", id: "#{api_scope}" } , "true", "false" %>
+          <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
+        </div>
+      <% end %>
+    </div>
+
+    <% unless current_user.mfa_disabled? || current_user.mfa_ui_and_api? %>
+      <div class="form__group">
+        <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>
+        <div class="form__checkbox__item">
+          <%= f.check_box :mfa, { class: "form__checkbox__input", id: :mfa } , "true", "false" %>
+          <%= label_tag :mfa, t(".enable_mfa"), class: "form__checkbox__label" %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -21,6 +21,11 @@
       <th class="owners__cell">
         <%= t(".age") %>
       </th>
+      <% if current_user.mfa_enabled? %>
+        <th class="owners__cell">
+          <%= t(".mfa") %>
+        </th>
+      <% end %>
       <th class="owners__cell">
         <%= t(".last_access") %>
       </th>
@@ -41,6 +46,11 @@
         <td class="owners__cell" data-title="Age">
           <%= time_ago_in_words(api_key.created_at) %>
         </td>
+        <% if current_user.mfa_enabled? %>
+          <td class="owners__cell" data-title="MFA">
+            <%= image_tag("/images/check.svg") if api_key.mfa_enabled? %>
+          </td>
+        <% end %>
         <td class="owners__cell" data-title="Last access">
           <%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %>
         </td>
@@ -70,6 +80,10 @@
       </td>
       <td class="owners__cell">
       </td>
+      <% if current_user.mfa_enabled? %>
+        <td class="owners__cell">
+        </td>
+      <% end %>
       <td class="owners__cell">
         <%= button_to t(".reset"),
                     reset_profile_api_keys_path,

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -48,7 +48,7 @@
         </td>
         <% if current_user.mfa_enabled? %>
           <td class="owners__cell" data-title="MFA">
-            <%= image_tag("/images/check.svg") if api_key.mfa_enabled? %>
+            <%= image_tag("/images/check.svg") if api_key.mfa? %>
           </td>
         <% end %>
         <td class="owners__cell" data-title="Last access">

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -5,11 +5,27 @@
     <%= label_tag :name, t("api_keys.index.name"), class: "form__label" %>
     <%= f.text_field :name, class: "form__input", autocomplete: :off %>
 
-    <%= label_tag :scope, t("api_keys.index.scope"), class: "form__label" %>
-    <% ApiKey::API_SCOPES.each do |api_scope| %>
-      <div class = "form__checkbox__item">
-        <%= f.check_box "#{api_scope}", { class: "form__checkbox__input", id: "#{api_scope}" } , "true", "false" %>
-        <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
+    <div class="form__group">
+      <%= label_tag :scope, t("api_keys.index.scope"), class: "form__label" %>
+      <% ApiKey::API_SCOPES.each do |api_scope| %>
+        <div class = "form__checkbox__item">
+          <%= f.check_box "#{api_scope}", { class: "form__checkbox__input", id: "#{api_scope}" } , "true", "false" %>
+          <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
+        </div>
+      <% end %>
+    </div>
+
+    <% if current_user.mfa_enabled? %>
+      <div class="form__group">
+        <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>
+        <% if current_user.mfa_ui_and_api? %>
+          <p><%= t(".mfa_api_enabled") %></p>
+        <% else %>
+          <div class="form__checkbox__item">
+            <%= f.check_box :mfa, { class: "form__checkbox__input", id: :mfa, checked: true } , "true", "false" %>
+            <%= label_tag :mfa, t(".enable_mfa"), class: "form__checkbox__label" %>
+          </div>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -18,14 +18,10 @@
     <% if current_user.mfa_enabled? %>
       <div class="form__group">
         <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>
-        <% if current_user.mfa_ui_and_api? %>
-          <p><%= t(".mfa_api_enabled") %></p>
-        <% else %>
-          <div class="form__checkbox__item">
-            <%= f.check_box :mfa, { class: "form__checkbox__input", id: :mfa, checked: true } , "true", "false" %>
-            <%= label_tag :mfa, t(".enable_mfa"), class: "form__checkbox__label" %>
-          </div>
-        <% end %>
+        <div class="form__checkbox__item">
+          <%= f.check_box :mfa, { class: "form__checkbox__input", id: :mfa, checked: true } , "true", "false" %>
+          <%= label_tag :mfa, t(".enable_mfa"), class: "form__checkbox__label" %>
+        </div>
       </div>
     <% end %>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -77,14 +77,20 @@ de:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -80,7 +80,6 @@ de:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,6 @@ en:
       mfa: MFA
     new:
       new_api_key: New API key
-      mfa_api_enabled: Your new key will have multifactor authentication turned on because you have enabled the UI and API MFA level.
       multifactor_auth: Multifactor authentication
       enable_mfa: Enable MFA
     reset:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,14 +85,20 @@ en:
       show_dashboard: Show dashboard
       reset: Reset
       save_key: "Note that we won't be able to show the key to you again. New API key:"
+      mfa: MFA
     new:
       new_api_key: New API key
+      mfa_api_enabled: Your new key will have multifactor authentication turned on because you have enabled the UI and API MFA level.
+      multifactor_auth: Multifactor authentication
+      enable_mfa: Enable MFA
     reset:
       success: "Deleted all API keys"
     update:
       success: "Successfully updated API key"
     edit:
       edit_api_key: "Edit API key"
+      multifactor_auth: Multifactor authentication
+      enable_mfa: Enable MFA
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -88,7 +88,6 @@ es:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -85,14 +85,20 @@ es:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title: CAMBIAR CONTRASEÑA

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -80,7 +80,6 @@ fr:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -77,14 +77,20 @@ fr:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -85,14 +85,20 @@ ja:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -88,7 +88,6 @@ ja:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -77,14 +77,20 @@ nl:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -80,7 +80,6 @@ nl:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -85,7 +85,6 @@ pt-BR:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -82,14 +82,20 @@ pt-BR:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -80,7 +80,6 @@ zh-CN:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -77,14 +77,20 @@ zh-CN:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -80,7 +80,6 @@ zh-TW:
       mfa:
     new:
       new_api_key:
-      mfa_api_enabled:
       multifactor_auth:
       enable_mfa:
     reset:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -77,14 +77,20 @@ zh-TW:
       show_dashboard:
       reset:
       save_key:
+      mfa:
     new:
       new_api_key:
+      mfa_api_enabled:
+      multifactor_auth:
+      enable_mfa:
     reset:
       success:
     update:
       success:
     edit:
       edit_api_key:
+      multifactor_auth:
+      enable_mfa:
   clearance_mailer:
     change_password:
       title:

--- a/db/migrate/20211027170037_add_mfa_column_to_api_keys.rb
+++ b/db/migrate/20211027170037_add_mfa_column_to_api_keys.rb
@@ -1,0 +1,5 @@
+class AddMfaColumnToApiKeys < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_keys, :mfa, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_050124) do
     t.datetime "last_accessed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "mfa", default: false, null: false
     t.index ["hashed_key"], name: "index_api_keys_on_hashed_key", unique: true
     t.index ["user_id"], name: "index_api_keys_on_user_id"
   end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -186,7 +186,8 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
   context "with index and push rubygem api key scope" do
     setup do
-      @user = create(:api_key, key: "12345", push_rubygem: true, index_rubygems: true).user
+      @api_key = create(:api_key, key: "12345", push_rubygem: true, index_rubygems: true)
+      @user = @api_key.user
 
       @request.env["HTTP_AUTHORIZATION"] = "12345"
     end
@@ -238,6 +239,15 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     context "When mfa for UI and gem signin is enabled" do
       setup do
         @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+      end
+
+      context "Api key has mfa enabled" do
+        setup do
+          @api_key.mfa = true
+          @api_key.save!
+          post :create, body: gem_file.read
+        end
+        should respond_with :unauthorized
       end
 
       context "On POST to create for new gem" do

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -15,10 +15,39 @@ class ApiKeysTest < SystemTest
 
     fill_in "api_key[name]", with: "test"
     check "api_key[index_rubygems]"
+    refute page.has_content? "Enable MFA"
     click_button "Create"
 
     assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
     assert @user.api_keys.last.can_index_rubygems?
+    refute @user.api_keys.last.mfa_enabled?
+  end
+
+  test "creating new api key with MFA UI enabled" do
+    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+
+    visit_profile_api_keys_path
+
+    fill_in "api_key[name]", with: "test"
+    check "api_key[index_rubygems]"
+    check "mfa"
+    click_button "Create"
+
+    assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert @user.api_keys.last.mfa_enabled?
+  end
+
+  test "creating new api key with MFA UI and API enabled" do
+    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+
+    visit_profile_api_keys_path
+
+    fill_in "api_key[name]", with: "test"
+    check "api_key[index_rubygems]"
+    click_button "Create"
+
+    assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert @user.api_keys.last.mfa_enabled?
   end
 
   test "update api key" do
@@ -29,9 +58,44 @@ class ApiKeysTest < SystemTest
 
     assert page.has_content? "Edit API key"
     check "api_key[add_owner]"
+    refute page.has_content? "Enable MFA"
     click_button "Update"
 
     assert api_key.reload.can_add_owner?
+  end
+
+  test "update api key with MFA UI enabled" do
+    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+
+    api_key = create(:api_key, user: @user)
+
+    visit_profile_api_keys_path
+    click_button "Edit"
+
+    assert page.has_content? "Edit API key"
+    check "api_key[add_owner]"
+    check "mfa"
+    click_button "Update"
+
+    assert api_key.reload.can_add_owner?
+    assert @user.api_keys.last.mfa_enabled?
+  end
+
+  test "update api key with MFA UI and API enabled" do
+    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+
+    api_key = create(:api_key, user: @user)
+
+    visit_profile_api_keys_path
+    click_button "Edit"
+
+    assert page.has_content? "Edit API key"
+    check "api_key[add_owner]"
+    refute page.has_content? "Enable MFA"
+    click_button "Update"
+
+    assert api_key.reload.can_add_owner?
+    assert @user.api_keys.last.mfa_enabled?
   end
 
   test "deleting api key" do


### PR DESCRIPTION
Part of: https://github.com/rubygems/rubygems.org/issues/2755

This PR allows users to enable or disable MFA requirement on owners that have MFA enabled for `UI` and `UI and gem signin`. Owners cannot disable MFA on keys if they have `UI and API` and cannot enable MFA if they didn't have MFA setup.

<details>
<summary> MFA disabled </summary>
Index
<img width="1057" alt="Screen Shot 2021-11-02 at 10 39 20 AM" src="https://user-images.githubusercontent.com/42748004/139868875-9348961f-a904-491f-b489-d4843db6dbc7.png">
</details>

<details>
<summary> MFA UI only </summary>
Index
<img width="1199" alt="Screen Shot 2021-11-02 at 10 38 27 AM" src="https://user-images.githubusercontent.com/42748004/139868695-c495e100-b947-4afa-b71b-0de57e26f295.png">

Edit
<img width="676" alt="Screen Shot 2021-11-02 at 10 38 13 AM" src="https://user-images.githubusercontent.com/42748004/139868636-048cf02d-eeda-4af1-a438-987c1675b8dc.png">

Create
<img width="782" alt="Screen Shot 2021-11-02 at 10 37 53 AM" src="https://user-images.githubusercontent.com/42748004/139868594-8a2d9075-f95f-432b-9520-8cccf3794b50.png">
</details>

<details>
<summary> MFA UI and API </summary>
Index
<img width="1144" alt="Screen Shot 2021-11-02 at 10 36 29 AM" src="https://user-images.githubusercontent.com/42748004/139868312-db7d229a-d8a5-4af6-a276-269de64d39c6.png">

Edit
<img width="631" alt="Screen Shot 2021-11-02 at 10 36 10 AM" src="https://user-images.githubusercontent.com/42748004/139868256-3450a629-2113-4432-818b-650809b17be6.png">

Create
<img width="1017" alt="Screen Shot 2021-11-02 at 2 12 19 PM" src="https://user-images.githubusercontent.com/42748004/139921741-d306f702-d743-4c6f-8e7e-c97bfd1366f3.png">

</details>
