### PR TITLE
Correct assert_equal assertions having flipped arguments

### DIFF
--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -23,6 +23,6 @@ class HomeControllerTest < ActionController::TestCase
 
   should "use default locale on GET using invalid one" do
     get :index, params: { locale: "foobar" }
-    assert_equal I18n.locale, I18n.default_locale
+    assert_equal I18n.default_locale, I18n.locale
   end
 end

--- a/test/functional/news_controller_test.rb
+++ b/test/functional/news_controller_test.rb
@@ -78,7 +78,7 @@ class NewsControllerTest < ActionController::TestCase
 
     should "display correct number of entries" do
       entries = assert_select("h2.gems__gem__name")
-      assert_equal(entries.size, 2)
+      assert_equal(2, entries.size)
     end
   end
 end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -5,7 +5,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "when missing email" do
       should "alerts about missing email" do
         post :create
-        assert_equal flash[:alert], "Email can't be blank."
+        assert_equal "Email can't be blank.", flash[:alert]
       end
     end
 
@@ -46,7 +46,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should redirect_to("the home page") { root_path }
       should "warn about invalid url" do
-        assert_equal flash[:alert], "Please double check the URL or try submitting it again."
+        assert_equal "Please double check the URL or try submitting it again.", flash[:alert]
       end
     end
 
@@ -90,7 +90,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
         should respond_with :unauthorized
         should "alert about otp being incorrect" do
-          assert_equal flash[:alert], "Your OTP code is incorrect."
+          assert_equal "Your OTP code is incorrect.", flash[:alert]
         end
       end
     end

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -26,7 +26,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }
     should "set flash error" do
-      assert_equal flash[:error], "Something went wrong. Please try again."
+      assert_equal "Something went wrong. Please try again.", flash[:error]
     end
   end
 
@@ -37,7 +37,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
 
     should redirect_to("rubygems show") { rubygem_path(@rubygem) }
     should "set flash error" do
-      assert_equal flash[:error], "Something went wrong. Please try again."
+      assert_equal "Something went wrong. Please try again.", flash[:error]
     end
   end
 

--- a/test/unit/dependency_test.rb
+++ b/test/unit/dependency_test.rb
@@ -22,7 +22,7 @@ class DependencyTest < ActiveSupport::TestCase
       long_requirement_suffix = ".0" * (Gemcutter::MAX_FIELD_LENGTH + 1)
       @dependency.gem_dependency = Gem::Dependency.new("holla", ["= 0#{long_requirement_suffix}"])
       refute @dependency.valid?
-      assert_equal @dependency.errors.messages[:requirements], ["is too long (maximum is 255 characters)"]
+      assert_equal ["is too long (maximum is 255 characters)"], @dependency.errors.messages[:requirements]
     end
 
     should "be invalid with unresolved_name longer than maximum field length" do
@@ -30,7 +30,7 @@ class DependencyTest < ActiveSupport::TestCase
       gem_dependency = Gem::Dependency.new(long_unresolved_name, ["= 0.0.0"])
       dependency = Dependency.create(gem_dependency: gem_dependency)
       refute dependency.valid?
-      assert_equal dependency.errors.messages[:unresolved_name], ["is too long (maximum is 255 characters)"]
+      assert_equal ["is too long (maximum is 255 characters)"], dependency.errors.messages[:unresolved_name]
     end
 
     should "return JSON" do


### PR DESCRIPTION
Follow up to #2847 and #2848, this time for several test suites.

I found a handful of `assert_equal` statements with _actual_ and _expected_ as the first and second arguments, respectively.  _expected_ should come first, otherwise the failing assertion message makes no sense.

```
Expected: wrong answer
  Actual: right answer
```