### PR TITLE
Add timelimit to just_updated query

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -140,10 +140,12 @@ class Version < ApplicationRecord
   end
 
   def self.just_updated(limit = 5)
+    six_months_ago_ts = 6.months.ago
     subquery = <<~SQL.squish
       versions.rubygem_id IN (SELECT versions.rubygem_id
                                 FROM versions
-                            WHERE versions.indexed = 'true'
+                            WHERE versions.indexed = 'true' AND
+                                  versions.created_at > '#{six_months_ago_ts}'
                             GROUP BY versions.rubygem_id
                               HAVING COUNT(versions.id) > 1
                               ORDER BY MAX(created_at) DESC LIMIT :limit)


### PR DESCRIPTION
/api/v1/just_updated endpoint is very slow and even 100rpm traffic overloads our database.
The issue with following query is that it needs to sort and filter
entire versions table:
```sql
                            SELECT versions.rubygem_id
                                FROM versions
                            WHERE versions.indexed = 'true' AND
                            GROUP BY versions.rubygem_id
                              HAVING COUNT(versions.id) > 1
                              ORDER BY MAX(created_at) DESC LIMIT :limit
```
It was doing sequential scan indexed column[1], which i was able to
change to index scan and save upto 2000ms by adding following index:
```
CREATE INDEX test2_mm_idx2s ON versions (created_at desc, rubygem_id)
where indexed = 'true';
```
However 4000ms query time after groupagg and index scan is still very expensive[2].
`Rows Removed by Filter: 1,152,502` in `group agg having count(id) > 1)`
step is real reason this query is slow. We can reduce this number if we
add a filter for created_at. We have 100-600 updates (releases of
existing gems) every day, adding a filter for 6 months will most
certainly cover us for the foreseeable future. It improves the query
cost by 8.3x times[3]

[1] https://explain.depesz.com/s/Z0XG
[2] https://explain.depesz.com/s/KN2b
[3] https://gist.github.com/sonalkr132/fd361e4e377f04035e74e6f6c0ac4fd3