### PR TITLE
factory bot linting and fix creating dependency factory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "toxiproxy", "~> 1.0.0"
   gem "webrick"
+  gem "factory_bot_rails"
 
   gem "brakeman", require: false
   gem "rubocop", "0.93.1", require: false
@@ -70,7 +71,6 @@ end
 group :test do
   gem "minitest", require: false
   gem "capybara", "~> 3.35"
-  gem "factory_bot_rails"
   gem "launchy"
   gem "rack-test", require: "rack/test"
   gem "mocha", require: false

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -16,7 +16,11 @@ FactoryBot.define do
   end
 
   factory :dependency do
-    gem_dependency { Gem::Dependency.new(Rubygem.last.name, "1.0.0") }
+    gem_dependency do
+      rubygem = Rubygem.last || create(:rubygem)
+      Gem::Dependency.new(rubygem.name, "1.0.0")
+    end
+
     rubygem
     version
 
@@ -24,7 +28,10 @@ FactoryBot.define do
     end
 
     trait :development do
-      gem_dependency { Gem::Dependency.new(Rubygem.last.name, "1.0.0", :development) }
+      gem_dependency do
+        rubygem = Rubygem.last || create(:rubygem)
+        Gem::Dependency.new(rubygem.name, "1.0.0", :development)
+      end
     end
 
     trait :unresolved do

--- a/test/unit/factories_test.rb
+++ b/test/unit/factories_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FactoriesTest < ActiveSupport::TestCase
+  test "can create factories including traits" do
+    FactoryBot.lint(traits: true)
+  end
+end


### PR DESCRIPTION
- puts factory bot in development too to easily create and test factories in development env
- adds linting for factories so we are sure we can easily create them
- fix dependency factories where there was no rubygem models so we need to create one