### PR TITLE
Rake task for seeding database with users and associating gems with owners 

### DIFF
--- a/lib/tasks/gem_owners.rake
+++ b/lib/tasks/gem_owners.rake
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#======================================================================================
+# HOW TO USE THIS
+# This task assumes that you have rubygems loaded into your database, but no users
+# The task will create users and assign them to the most downloaded gems
+#
+# To clear your database and load the latest rubygems data dump:
+# 💻 In your rubygems.org directory run ... (optional)
+#    rails db:reset
+# 💻 Navigate to Rubygems Data Dump and download one of the dumps (https://rubygems.org/pages/data)
+# 💻 In your rubygems.org direction run ...
+#    ./script/load-pg-dump -d rubygems_development ~/Downloads/public_postgresql.tar
+# 💻 In your rubygems.org direction run ...
+#    rake gem_owners:seed
+#======================================================================================
+
+namespace :gem_owners do
+  task seed: :environment do
+    people = [
+      {
+        email: "sandi@metz.com",
+        password: "yellow-bananas-111",
+        handle: "sandi",
+      },
+      {
+        email: "katrina@owen.com",
+        password: "red-bananas-111",
+        handle: "katrina",
+      },
+      {
+        email: "jen@shenny.com",
+        password: "black-berries-111",
+        handle: "jenshenny",
+      },
+      {
+        email: "betty@li.com",
+        password: "poop-berries-111",
+        handle: "betty",
+      },
+      {
+        email: "panda@bear.com",
+        password: "blue-berries-111",
+        handle: "panda",
+      },
+      {
+        email: "power@rangers.com",
+        password: "green-ranger-111",
+        handle: "greenranger",
+      },
+      {
+        email: "squid@games.com",
+        password: "so-squiddy-111",
+        handle: "squid",
+      },
+    ]
+
+    puts
+    puts "*" * 32
+    puts "Let's seed this database! 🌱 🚰"
+    puts "*" * 32
+    puts
+    print("Seeding Users")
+    puts
+
+    people.each do |person|
+      print "🧒"
+      User.create(
+        email: person[:email],
+        password: person[:password],
+        handle: person[:handle],
+        email_confirmed: true
+      )
+    end
+
+    users = User.all
+    rubygems = Rubygem.by_downloads.limit((users.count * 10) + 1)
+    count = 1
+
+    puts
+    puts
+    print("Assigning gem owners")
+    puts
+    users.each do |user|
+      # Assign all users to the same gem
+      print "💎"
+      Ownership.create_confirmed(rubygems[0], user)
+
+      10.times do
+        print "💎"
+        Ownership.create_confirmed(rubygems[count], user)
+
+        count += 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
## ✨ What problem does this solve?
It could be my naivety, but I haven't found any guidance around easily seeding our database with users. Once I painstakingly set up all my data manually, I feared losing it because it was so tedious to set up all the data 🙈 .  

So instead, I created this little rake task to make it easier for us to seed our db with users and associate them as gem owners. That way we don't need to be so precious about our local data.

I don't know if the rubygems.org community would benefit from this rake task. It might be overly specific to our needs 🤷‍♀️ ?

I'll just leave this task here for us to refer to for now 😊 .

## 🎩 How to use it
**1️⃣ Ensure you're starting off with a clean slate.**
_⚠️ This is a destructive command, so only run it if you're okay with losing all your data._ 
```shell
rails db:reset
```

**2️⃣ Download one of the data dumps from [Rubygems Data Dump](https://rubygems.org/pages/data)**
Navigate to [Rubygems Data Dump](https://rubygems.org/pages/data), download any of those dumps. Make sure it's save in your `Downloads` folder. 

**3️⃣ Seed your database with the data dump you just downloaded**
```shell
dev cd rubygems.org
./script/load-pg-dump -d rubygems_development ~/Downloads/public_postgresql.tar
```

**:four: Run the rake task to add users and gem ownership associations**
```shell
rails gem_owners:seed
```
