### PR TITLE
add Procfile.dev, bin/dev with foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem "toxiproxy", "~> 1.0.0"
   gem "webrick"
   gem "factory_bot_rails"
+  gem "foreman"
 
   gem "brakeman", require: false
   gem "rubocop", "~> 1.23", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    foreman (0.87.2)
     globalid (0.5.2)
       activesupport (>= 5.0)
     gravtastic (3.2.6)
@@ -430,6 +431,7 @@ DEPENDENCIES
   elasticsearch-rails (~> 7.0)
   factory_bot_rails
   faraday_middleware-aws-sigv4 (~> 0.3)
+  foreman
   gravtastic
   high_voltage
   honeybadger

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: rails server -p 3000
+cache: memcached
+search: docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:7.10.1

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+foreman start -f Procfile.dev


### PR DESCRIPTION
Having a simple `bin/dev` script to call to start the local environment makes developing locally much easier and not having to lookup the commands in `CONTRIBUTING.md` every time.

It's also the new recommended way for rails apps that is used by jsbundling-rails and cssbundling-rails for instance.

If you agree maybe I should also update `CONTRIBUTING.md` and I think it's fine to have the same elasticsearch command on linux and macOS but not sure (`-e "xpack.security.enabled=false"`).

What do you think?