### PR TITLE
add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "rubySingleQuote": false
+}


### PR DESCRIPTION
makes it easier to run `prettier --write` (e.g. `pw` with my `dorian-pw` gem) on files to format them automatically

it would be nice to have the whole codebase formatted though

```json
{
  "semi": false,
  "rubySingleQuote": false
}
```

`semi: false` is for not putting semicolons at the end of lines in js

`rubySingleQuote: false` is for using double quotes, I would be fine with single quote also but prefer double quote so I don't have to think about which quote to use if I ever need interpolation