### PR TITLE
Add forward slash to docker copy command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ WORKDIR /app
 
 RUN gem update --system $RUBYGEMS_VERSION
 
-COPY Gemfile* /app
+COPY Gemfile* /app/
 
 RUN bundle config set --local without 'development test' && \
   bundle install --jobs 20 --retry 5
 
-COPY . /app
+COPY . /app/
 
 ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions.list /app/config/versions.list
 ADD https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/stopforumspam/toxic_domains_whole.txt /app/vendor/toxic_domains_whole.txt


### PR DESCRIPTION
fails without it on newer docker versions