### PR TITLE
Disambiguate usage of `gem yank`

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -144,7 +144,7 @@ class Pusher
     if version.indexed?
       notify("Repushing of gem versions is not allowed.\n" \
              "Please bump the version number and push a new different release.\n" \
-             "See also `gem yank` if you want to get rid of the bad release.", 409)
+             "See also `gem yank` if you want to unpublish the bad release.", 409)
     else
       different_owner = "pushed by a previous owner of this gem " unless version.rubygem.owners.include?(@user)
       notify("A yanked version #{different_owner}already exists (#{version.full_name}).\n" \

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -142,8 +142,8 @@ class Pusher
 
   def republish_notification(version)
     if version.indexed?
-      notify("Repushing of gem versions is not allowed.\n" \
-             "Please use `gem yank` to remove bad gem releases.", 409)
+      notify("Repushing of gem versions is not allowed.\n"
+             "Please bump the version number and push a new different release.", 409)
     else
       different_owner = "pushed by a previous owner of this gem " unless version.rubygem.owners.include?(@user)
       notify("A yanked version #{different_owner}already exists (#{version.full_name}).\n" \

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -142,8 +142,9 @@ class Pusher
 
   def republish_notification(version)
     if version.indexed?
-      notify("Repushing of gem versions is not allowed.\n"
-             "Please bump the version number and push a new different release.", 409)
+      notify("Repushing of gem versions is not allowed.\n" \
+             "Please bump the version number and push a new different release.\n" \
+             "See also `gem yank` if you want to get rid of the bad release.", 409)
     else
       different_owner = "pushed by a previous owner of this gem " unless version.rubygem.owners.include?(@user)
       notify("A yanked version #{different_owner}already exists (#{version.full_name}).\n" \


### PR DESCRIPTION
Doing:

```
$ gem push my.gem
Pushing gem to https://rubygems.org...
Repushing of gem versions is not allowed.
Please use `gem yank` to remove bad gem releases.
```

May be interpreted as one should yank to be able to override. However,
wether the gem was yanked or not, it is not possible to override it.

Hence we'd rather advise to push a new version, yanking is rarely the
most appropriate option.

See https://github.com/rubygems/rubygems.org/issues/2400 for a
discussion on why _unyanking_ is not possible nowadays, and the reasons
that lead to this commit.

NOTE: I guessed tests were not appropriate there, correct me if I'm wrong 🙂 