### PR TITLE
Enable remaining rails 6.1 defaults

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -44,14 +44,8 @@ Rails.application.config.active_record.legacy_connection_handling = false
 # Make `form_with` generate non-remote forms by default.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
-# Set the default queue name for the incineration job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.incineration = nil
-
-# Set the default queue name for the routing job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.routing = nil
-
 # Set the default queue name for the mail deliver job to the queue adapter default.
-# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+Rails.application.config.action_mailer.deliver_later_queue_name = nil
 
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.


### PR DESCRIPTION
We don't use action_mailbox so it doesn't affect us. We don't use
callbacks in active job either.