### PR TITLE
Scope API keys to a gem

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,11 +107,12 @@ Rails/OutputSafety:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/rubygems_helper.rb'
 
-# Offense count: 6
+# Offense count: 7
 # This cop supports safe auto-correction (--auto-correct).
 Rails/RedundantPresenceValidationOnBelongsTo:
   Exclude:
     - 'app/models/api_key.rb'
+    - 'app/models/api_key_rubygem_scope.rb'
     - 'app/models/deletion.rb'
     - 'app/models/ownership_call.rb'
     - 'app/models/ownership_request.rb'

--- a/app/assets/javascripts/api_key_form.js
+++ b/app/assets/javascripts/api_key_form.js
@@ -1,0 +1,36 @@
+$(function() {
+  var enableGemScopeCheckboxes = $("#push_rubygem, #yank_rubygem, #add_owner, #remove_owner");
+  var hiddenRubygemId = "hidden_api_key_rubygem_id";
+  toggleGemSelector();
+
+  enableGemScopeCheckboxes.click(function() {
+    toggleGemSelector();
+  });
+
+  function toggleGemSelector() {
+    var isApplicableGemScopeSelected = enableGemScopeCheckboxes.is(":checked");
+    var gemScopeSelector = $("#api_key_rubygem_id");
+
+    if (isApplicableGemScopeSelected) {
+      gemScopeSelector.removeAttr("disabled");
+      removeHiddenRubygemField();
+    } else {
+      gemScopeSelector.val("");
+      gemScopeSelector.prop("disabled", true);
+      addHiddenRubygemField();
+    }
+  }
+
+  function addHiddenRubygemField() {
+    $("<input>").attr({
+      type: "hidden",
+      id: hiddenRubygemId,
+      name: "api_key[rubygem_id]",
+      value: ""
+    }).appendTo(".t-body form");
+  }
+
+  function removeHiddenRubygemField() {
+    $("#" + hiddenRubygemId + ":hidden").remove();
+  }
+});

--- a/app/assets/stylesheets/modules/owners.css
+++ b/app/assets/stylesheets/modules/owners.css
@@ -1,6 +1,9 @@
 .owners__row {
     background: #f6f6f6;
 }
+.owners__row__invalid {
+    color: #9A9A9A;
+}
 .owners__row:nth-of-type(odd) {
     background: #e9e9e9;
 }

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,6 +25,12 @@ class Api::BaseController < ApplicationController
     end
   end
 
+  def verify_api_key_gem_scope
+    return unless @api_key.rubygem && @api_key.rubygem != @rubygem
+
+    render plain: "This API key cannot perform the specified action on this gem.", status: :forbidden
+  end
+
   def verify_with_otp
     otp = request.headers["HTTP_OTP"]
     return if @api_key.mfa_authorized?(otp)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -41,7 +41,8 @@ class Api::BaseController < ApplicationController
     params_key = request.headers["Authorization"] || ""
     hashed_key = Digest::SHA256.hexdigest(params_key)
     @api_key   = ApiKey.find_by_hashed_key(hashed_key)
-    render_unauthorized unless @api_key
+    return render_unauthorized unless @api_key
+    render_soft_deleted_api_key if @api_key.soft_deleted?
   end
 
   def render_unauthorized
@@ -54,5 +55,9 @@ class Api::BaseController < ApplicationController
       format.json { render json: { error: t(:api_key_forbidden) }, status: :forbidden }
       format.yaml { render yaml: { error: t(:api_key_forbidden) }, status: :forbidden }
     end
+  end
+
+  def render_soft_deleted_api_key
+    render plain: "An invalid API key cannot be used. Please delete it and create a new one.", status: :forbidden
   end
 end

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::DeletionsController < Api::BaseController
   before_action :authenticate_with_api_key
   before_action :find_rubygem_by_name
+  before_action :verify_api_key_gem_scope
   before_action :validate_gem_and_version
   before_action :verify_with_otp
   before_action :render_api_key_forbidden, if: :api_key_unauthorized?

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::OwnersController < Api::BaseController
   before_action :authenticate_with_api_key, except: %i[show gems]
   before_action :find_rubygem, except: :gems
+  before_action :verify_api_key_gem_scope, except: %i[show gems]
   before_action :verify_gem_ownership, except: %i[show gems]
   before_action :verify_mfa_requirement, except: %i[show gems]
   before_action :verify_with_otp, except: %i[show gems]

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::RubygemsController < Api::BaseController
   def create
     return render_api_key_forbidden unless @api_key.can_push_rubygem?
 
-    gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip)
+    gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip, @api_key.rubygem)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
     render plain: gemcutter.message, status: gemcutter.code
   rescue StandardError => e

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -35,6 +35,10 @@ class ApiKeysController < ApplicationController
 
   def edit
     @api_key = current_user.api_keys.find(params.require(:id))
+    return unless @api_key.soft_deleted?
+
+    redirect_to profile_api_keys_path
+    flash[:error] = t(".invalid_key")
   end
 
   def update
@@ -46,6 +50,9 @@ class ApiKeysController < ApplicationController
       flash[:error] = @api_key.errors.full_messages.to_sentence
       render :edit
     end
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = t(".invalid_gem")
+    render :edit
   end
 
   def destroy

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -1,19 +1,19 @@
 module ApiKeysHelper
   def gem_scope(api_key)
-    return invalid_gem_tooltip if api_key.soft_deleted_by_ownership?
+    return invalid_gem_tooltip(api_key.soft_deleted_rubygem_name) if api_key.soft_deleted_by_ownership?
 
     api_key.rubygem ? api_key.rubygem.name : t("api_keys.all_gems")
   end
 
   private
 
-  def invalid_gem_tooltip
+  def invalid_gem_tooltip(name)
     content_tag(
       :span,
-      "[?]",
+      "#{name} [?]",
       class: "tooltip__text",
       style: "font-size:1em",
-      data: { tooltip: t("api_keys.gem_ownership_removed") }
+      data: { tooltip: t("api_keys.gem_ownership_removed", rubygem_name: name) }
     )
   end
 end

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -1,6 +1,6 @@
 module ApiKeysHelper
   def gem_scope(api_key)
-    return invalid_gem_tooltip if api_key.soft_deleted?
+    return invalid_gem_tooltip if api_key.soft_deleted_by_ownership?
 
     api_key.rubygem ? api_key.rubygem.name : t("api_keys.all_gems")
   end

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -1,7 +1,19 @@
 module ApiKeysHelper
   def gem_scope(api_key)
-    return if api_key.soft_deleted?
+    return invalid_gem_tooltip if api_key.soft_deleted?
 
     api_key.rubygem ? api_key.rubygem.name : t("api_keys.all_gems")
+  end
+
+  private
+
+  def invalid_gem_tooltip
+    content_tag(
+      :span,
+      "[?]",
+      class: "tooltip__text",
+      style: "font-size:1em",
+      data: { tooltip: t("api_keys.gem_ownership_removed") }
+    )
   end
 end

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -1,0 +1,7 @@
+module ApiKeysHelper
+  def gem_scope(api_key)
+    return if api_key.soft_deleted?
+
+    api_key.rubygem ? api_key.rubygem.name : t("api_keys.all_gems")
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,5 +1,6 @@
 class ApiKey < ApplicationRecord
   API_SCOPES = %i[index_rubygems push_rubygem yank_rubygem add_owner remove_owner access_webhooks show_dashboard].freeze
+  APPLICABLE_GEM_API_SCOPES = %i[push_rubygem yank_rubygem add_owner remove_owner].freeze
 
   belongs_to :user
   has_one :api_key_rubygem_scope, dependent: :destroy

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -9,6 +9,7 @@ class ApiKey < ApplicationRecord
   validate :exclusive_show_dashboard_scope, if: :can_show_dashboard?
   validate :scope_presence
   validates :name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validate :rubygem_scope_definition, if: :ownership
   validate :not_soft_deleted?
 
   delegate :rubygem_id, :rubygem, to: :ownership, allow_nil: true
@@ -59,6 +60,11 @@ class ApiKey < ApplicationRecord
 
   def scope_presence
     errors.add :base, "Please enable at least one scope" unless enabled_scopes.any?
+  end
+
+  def rubygem_scope_definition
+    return if (APPLICABLE_GEM_API_SCOPES & enabled_scopes).any?
+    errors.add :rubygem, "scope can only be set for push/yank rubygem, and add/remove owner scopes"
   end
 
   def not_soft_deleted?

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -2,10 +2,15 @@ class ApiKey < ApplicationRecord
   API_SCOPES = %i[index_rubygems push_rubygem yank_rubygem add_owner remove_owner access_webhooks show_dashboard].freeze
 
   belongs_to :user
+  has_one :api_key_rubygem_scope, dependent: :destroy
+  has_one :ownership, through: :api_key_rubygem_scope
   validates :user, :name, :hashed_key, presence: true
   validate :exclusive_show_dashboard_scope, if: :can_show_dashboard?
   validate :scope_presence
   validates :name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validate :not_soft_deleted?
+
+  delegate :rubygem_id, :rubygem, to: :ownership, allow_nil: true
 
   def enabled_scopes
     API_SCOPES.filter_map { |scope| scope if send(scope) }
@@ -29,6 +34,18 @@ class ApiKey < ApplicationRecord
     user.mfa_ui_and_api? || mfa
   end
 
+  def rubygem_id=(id)
+    self.ownership = id.blank? ? nil : user.ownerships.find_by!(rubygem_id: id)
+  end
+
+  def soft_delete!
+    update_attribute(:soft_deleted_at, Time.now.utc)
+  end
+
+  def soft_deleted?
+    soft_deleted_at?
+  end
+
   private
 
   def exclusive_show_dashboard_scope
@@ -41,5 +58,9 @@ class ApiKey < ApplicationRecord
 
   def scope_presence
     errors.add :base, "Please enable at least one scope" unless enabled_scopes.any?
+  end
+
+  def not_soft_deleted?
+    errors.add :base, "An invalid API key cannot be used. Please delete it and create a new one." if soft_deleted?
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -38,6 +38,8 @@ class ApiKey < ApplicationRecord
 
   def rubygem_id=(id)
     self.ownership = id.blank? ? nil : user.ownerships.find_by!(rubygem_id: id)
+  rescue ActiveRecord::RecordNotFound
+    errors.add :rubygem, "that is selected cannot be scoped to this key"
   end
 
   def soft_delete!

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -42,8 +42,9 @@ class ApiKey < ApplicationRecord
     errors.add :rubygem, "that is selected cannot be scoped to this key"
   end
 
-  def soft_delete!
+  def soft_delete!(ownership: nil)
     update_attribute(:soft_deleted_at, Time.now.utc)
+    update_attribute(:soft_deleted_rubygem_name, ownership.rubygem.name) if ownership
   end
 
   def soft_deleted?
@@ -51,7 +52,7 @@ class ApiKey < ApplicationRecord
   end
 
   def soft_deleted_by_ownership?
-    soft_deleted?
+    soft_deleted? && soft_deleted_rubygem_name.present?
   end
 
   private

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -50,6 +50,10 @@ class ApiKey < ApplicationRecord
     soft_deleted_at?
   end
 
+  def soft_deleted_by_ownership?
+    soft_deleted?
+  end
+
   private
 
   def exclusive_show_dashboard_scope

--- a/app/models/api_key_rubygem_scope.rb
+++ b/app/models/api_key_rubygem_scope.rb
@@ -1,0 +1,13 @@
+class ApiKeyRubygemScope < ApplicationRecord
+  belongs_to :api_key
+  belongs_to :ownership
+  validates :ownership_id, uniqueness: { scope: :api_key_id }
+  validates :api_key, :ownership, presence: true
+  before_destroy :soft_delete_api_key!, if: :destroyed_by_association
+
+  private
+
+  def soft_delete_api_key!
+    api_key.soft_delete!
+  end
+end

--- a/app/models/api_key_rubygem_scope.rb
+++ b/app/models/api_key_rubygem_scope.rb
@@ -8,6 +8,6 @@ class ApiKeyRubygemScope < ApplicationRecord
   private
 
   def soft_delete_api_key!
-    api_key.soft_delete!
+    api_key.soft_delete!(ownership: ownership)
   end
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -2,6 +2,7 @@ class Ownership < ApplicationRecord
   belongs_to :rubygem
   belongs_to :user
   belongs_to :authorizer, class_name: "User"
+  has_many :api_key_rubygem_scopes, dependent: :destroy
 
   validates :user_id, uniqueness: { scope: :rubygem_id }
 

--- a/app/views/api_keys/edit.html.erb
+++ b/app/views/api_keys/edit.html.erb
@@ -15,6 +15,12 @@
       <% end %>
     </div>
 
+    <div class="form__group">
+      <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
+      <p><%= t(".rubygem_scope_info") %></p>
+      <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t(".all_gems") }, selected: :rubygem_id, class: "form__input form__select" %>
+    </div>
+
     <% unless current_user.mfa_disabled? || current_user.mfa_ui_and_api? %>
       <div class="form__group">
         <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -19,6 +19,9 @@
         <%= t(".scopes") %>
       </th>
       <th class="owners__cell">
+        <%= t(".gem") %>
+      </th>
+      <th class="owners__cell">
         <%= t(".age") %>
       </th>
       <% if current_user.mfa_enabled? %>
@@ -36,7 +39,7 @@
     </tr>
 
     <% for api_key in @api_keys do %>
-      <tr class="owners__row">
+      <tr class="owners__row <%= 'owners__row__invalid' if api_key.soft_deleted? %>">
         <td class="owners__cell" data-title="Name">
           <%= api_key.name %>
         </td>
@@ -44,6 +47,9 @@
           <% api_key.enabled_scopes.each do |scope| %>
             <ul class="scopes__list"><%= t(".#{scope}") %></ul>
           <% end %>
+        </td>
+        <td class="owners__cell" data-title="Gem">
+          <%= api_key.rubygem&.name %>
         </td>
         <td class="owners__cell" data-title="Age">
           <%= time_ago_in_words(api_key.created_at) %>
@@ -57,10 +63,12 @@
           <%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %>
         </td>
         <td class="owners__cell">
-          <%= button_to t("edit"),
-                      edit_profile_api_key_path(id: api_key.id),
-                      method: :get,
-                      class: "form__submit form__submit--small" %>
+          <% unless api_key.soft_deleted? %>
+            <%= button_to t("edit"),
+                        edit_profile_api_key_path(id: api_key.id),
+                        method: :get,
+                        class: "form__submit form__submit--small" %>
+          <% end %>
         </td>
         <td class="owners__cell">
           <%= button_to t(".delete"),
@@ -72,6 +80,8 @@
       </tr>
     <% end %>
     <tr class="owners__row">
+      <td class="owners__cell">
+      </td>
       <td class="owners__cell">
       </td>
       <td class="owners__cell">

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -49,7 +49,7 @@
           <% end %>
         </td>
         <td class="owners__cell" data-title="Gem">
-          <%= api_key.rubygem&.name %>
+          <%= gem_scope(api_key) %>
         </td>
         <td class="owners__cell" data-title="Age">
           <%= time_ago_in_words(api_key.created_at) %>

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -15,6 +15,12 @@
       <% end %>
     </div>
 
+    <div class="form__group">
+      <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
+      <p><%= t(".rubygem_scope_info") %></p>
+      <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t(".all_gems") }, selected: :rubygem_id, class: "form__input form__select" %>
+    </div>
+
     <% unless current_user.mfa_disabled? || current_user.mfa_ui_and_api? %>
       <div class="form__group">
         <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -65,6 +65,7 @@ de:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -57,6 +57,7 @@ de:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -84,6 +85,9 @@ de:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -92,10 +92,15 @@ de:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -101,6 +101,7 @@ de:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -88,7 +88,6 @@ de:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -100,8 +99,8 @@ de:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,10 +98,15 @@ en:
       success: "Deleted all API keys"
     update:
       success: "Successfully updated API key"
+      invalid_gem: Selected gem cannot be scoped to this key
     edit:
       edit_api_key: "Edit API key"
       multifactor_auth: Multifactor authentication
       enable_mfa: Enable MFA
+      rubygem_scope: Gem Scope
+      rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
+      all_gems: All Gems
+      invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
   api_keys:
     create:
       success: "Created new API key"
+      invalid_gem: Selected gem cannot be scoped to this key
     destroy:
       success: "Successfully deleted API key: %{name}"
     index:
@@ -90,6 +91,9 @@ en:
       new_api_key: New API key
       multifactor_auth: Multifactor authentication
       enable_mfa: Enable MFA
+      rubygem_scope: Gem Scope
+      rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
+      all_gems: All Gems
     reset:
       success: "Deleted all API keys"
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
       api_keys: API keys
       name: Name
       scopes: Scopes
+      gem: Gem
       age: Age
       last_access: Last access
       action: Action

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
     all_gems: All Gems
-    gem_ownership_removed: Ownership of the gem has been removed after being scoped to this key.
+    gem_ownership_removed: Ownership of %{rubygem_name} has been removed after being scoped to this key.
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
     all_gems: All Gems
+    gem_ownership_removed: Ownership of the gem has been removed after being scoped to this key.
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,6 @@ en:
       enable_mfa: Enable MFA
       rubygem_scope: Gem Scope
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
-      all_gems: All Gems
     reset:
       success: "Deleted all API keys"
     update:
@@ -106,8 +105,8 @@ en:
       enable_mfa: Enable MFA
       rubygem_scope: Gem Scope
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
-      all_gems: All Gems
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
+    all_gems: All Gems
   clearance_mailer:
     change_password:
       title: CHANGE PASSWORD

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -68,6 +68,7 @@ es:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -95,6 +96,9 @@ es:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -76,6 +76,7 @@ es:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -103,10 +103,15 @@ es:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title: CAMBIAR CONTRASEÑA

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -99,7 +99,6 @@ es:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -111,8 +110,8 @@ es:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title: CAMBIAR CONTRASEÑA

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -112,6 +112,7 @@ es:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title: CAMBIAR CONTRASEÑA

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -94,10 +94,15 @@ fr:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -67,6 +67,7 @@ fr:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -59,6 +59,7 @@ fr:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -86,6 +87,9 @@ fr:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -103,6 +103,7 @@ fr:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -90,7 +90,6 @@ fr:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -102,8 +101,8 @@ fr:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -69,6 +69,7 @@ ja:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,7 @@ ja:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -88,6 +89,9 @@ ja:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -96,10 +96,15 @@ ja:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -105,6 +105,7 @@ ja:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -92,7 +92,6 @@ ja:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -104,8 +103,8 @@ ja:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -95,10 +95,15 @@ nl:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -68,6 +68,7 @@ nl:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -60,6 +60,7 @@ nl:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -87,6 +88,9 @@ nl:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -91,7 +91,6 @@ nl:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -103,8 +102,8 @@ nl:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -104,6 +104,7 @@ nl:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -75,6 +75,7 @@ pt-BR:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -102,10 +102,15 @@ pt-BR:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -67,6 +67,7 @@ pt-BR:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -94,6 +95,9 @@ pt-BR:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -111,6 +111,7 @@ pt-BR:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -98,7 +98,6 @@ pt-BR:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -110,8 +109,8 @@ pt-BR:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -92,10 +92,15 @@ zh-CN:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -57,6 +57,7 @@ zh-CN:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -84,6 +85,9 @@ zh-CN:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -65,6 +65,7 @@ zh-CN:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -101,6 +101,7 @@ zh-CN:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -88,7 +88,6 @@ zh-CN:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -100,8 +99,8 @@ zh-CN:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -92,10 +92,15 @@ zh-TW:
       success:
     update:
       success:
+      invalid_gem:
     edit:
       edit_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
+      invalid_key:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -57,6 +57,7 @@ zh-TW:
   api_keys:
     create:
       success:
+      invalid_gem:
     destroy:
       success:
     index:
@@ -84,6 +85,9 @@ zh-TW:
       new_api_key:
       multifactor_auth:
       enable_mfa:
+      rubygem_scope:
+      rubygem_scope_info:
+      all_gems:
     reset:
       success:
     update:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -65,6 +65,7 @@ zh-TW:
       name:
       scopes:
       age:
+      gem:
       last_access:
       action:
       delete:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -101,6 +101,7 @@ zh-TW:
       rubygem_scope_info:
       invalid_key:
     all_gems:
+    gem_ownership_removed:
   clearance_mailer:
     change_password:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -88,7 +88,6 @@ zh-TW:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
     reset:
       success:
     update:
@@ -100,8 +99,8 @@ zh-TW:
       enable_mfa:
       rubygem_scope:
       rubygem_scope_info:
-      all_gems:
       invalid_key:
+    all_gems:
   clearance_mailer:
     change_password:
       title:

--- a/db/migrate/20220329203703_create_api_key_rubygem_scope.rb
+++ b/db/migrate/20220329203703_create_api_key_rubygem_scope.rb
@@ -1,0 +1,9 @@
+class CreateApiKeyRubygemScope < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_key_rubygem_scopes do |t|
+      t.references :api_key, null: false
+      t.references :ownership, null: false, index: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220329203956_add_soft_deleted_at_to_api_keys.rb
+++ b/db/migrate/20220329203956_add_soft_deleted_at_to_api_keys.rb
@@ -1,0 +1,5 @@
+class AddSoftDeletedAtToApiKeys < ActiveRecord::Migration[7.0]
+  def change
+    add_column :api_keys, :soft_deleted_at, :datetime
+  end
+end

--- a/db/migrate/20220329203956_add_soft_deleted_at_to_api_keys.rb
+++ b/db/migrate/20220329203956_add_soft_deleted_at_to_api_keys.rb
@@ -1,5 +1,6 @@
 class AddSoftDeletedAtToApiKeys < ActiveRecord::Migration[7.0]
   def change
     add_column :api_keys, :soft_deleted_at, :datetime
+    add_column :api_keys, :soft_deleted_rubygem_name, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_050124) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
+
+  create_table "api_key_rubygem_scopes", force: :cascade do |t|
+    t.bigint "api_key_id", null: false
+    t.bigint "ownership_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_key_id"], name: "index_api_key_rubygem_scopes_on_api_key_id"
+  end
 
   create_table "api_keys", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -31,6 +39,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_050124) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "mfa", default: false, null: false
+    t.datetime "soft_deleted_at"
     t.index ["hashed_key"], name: "index_api_keys_on_hashed_key", unique: true
     t.index ["user_id"], name: "index_api_keys_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
     t.datetime "updated_at", null: false
     t.boolean "mfa", default: false, null: false
     t.datetime "soft_deleted_at"
+    t.string "soft_deleted_rubygem_name"
     t.index ["hashed_key"], name: "index_api_keys_on_hashed_key", unique: true
     t.index ["user_id"], name: "index_api_keys_on_user_id"
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -195,4 +195,9 @@ FactoryBot.define do
   factory :gem_typo_exception do
     name
   end
+
+  factory :api_key_rubygem_scope do
+    ownership
+    api_key { create(:api_key, key: SecureRandom.hex(24)) }
+  end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -573,6 +573,21 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
     end
   end
 
+  context "create with a soft deleted api key" do
+    setup do
+      create(:ownership, user: create(:user), rubygem: create(:rubygem, name: "test"))
+      create(:api_key, key: "12343", push_rubygem: true).soft_delete!
+      @request.env["HTTP_AUTHORIZATION"] = "12343"
+
+      post :create, body: gem_file("test-1.0.0.gem").read
+    end
+
+    should respond_with :forbidden
+    should "#render_soft_deleted_api_key and display an error" do
+      assert_equal "An invalid API key cannot be used. Please delete it and create a new one.", @response.body
+    end
+  end
+
   context "with incorrect api key" do
     context "on GET to index with JSON for a list of gems without api key" do
       setup do

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -132,7 +132,6 @@ class ApiKeysControllerTest < ActionController::TestCase
 
         should "have a gem scope with valid id" do
           post :create, params: { api_key: { name: "gem scope", add_owner: true, rubygem_id: @ownership.rubygem.id } }
-          Delayed::Worker.new.work_off
 
           created_key = @user.reload.api_keys.find_by(name: "gem scope")
           assert_equal @ownership.rubygem, created_key.rubygem
@@ -140,7 +139,6 @@ class ApiKeysControllerTest < ActionController::TestCase
 
         should "display error with invalid id" do
           post :create, params: { api_key: { name: "gem scope", add_owner: true, rubygem_id: -1 } }
-          Delayed::Worker.new.work_off
 
           assert_equal "Selected gem cannot be scoped to this key", flash[:error]
           assert_empty @user.reload.api_keys

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -143,6 +143,13 @@ class ApiKeysControllerTest < ActionController::TestCase
           assert_equal "Selected gem cannot be scoped to this key", flash[:error]
           assert_empty @user.reload.api_keys
         end
+
+        should "displays error with gem scope without applicable scope enabled" do
+          post :create, params: { api_key: { name: "gem scope", index_rubygems: true, rubygem_id: @ownership.rubygem.id } }
+
+          assert_equal "Rubygem scope can only be set for push/yank rubygem, and add/remove owner scopes", flash[:error]
+          assert_empty @user.reload.api_keys
+        end
       end
     end
 
@@ -200,7 +207,7 @@ class ApiKeysControllerTest < ActionController::TestCase
       context "gem scope" do
         setup do
           @ownership = create(:ownership, user: @user, rubygem: create(:rubygem))
-          @api_key.update(rubygem_id: @ownership.rubygem.id)
+          @api_key.update(rubygem_id: @ownership.rubygem.id, push_rubygem: true)
         end
 
         should "to all gems" do
@@ -221,6 +228,14 @@ class ApiKeysControllerTest < ActionController::TestCase
             patch :update, params: { api_key: { rubygem_id: -1 }, id: @api_key.id }
 
             assert_equal "Selected gem cannot be scoped to this key", flash[:error]
+          end
+        end
+
+        should "displays error with gem scope without applicable scope enabled" do
+          assert_no_changes @api_key do
+            patch :update, params: { api_key: { push_rubygem: false }, id: @api_key.id }
+
+            assert_equal "Rubygem scope can only be set for push/yank rubygem, and add/remove owner scopes", flash[:error]
           end
         end
       end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -140,7 +140,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         should "display error with invalid id" do
           post :create, params: { api_key: { name: "gem scope", add_owner: true, rubygem_id: -1 } }
 
-          assert_equal "Selected gem cannot be scoped to this key", flash[:error]
+          assert_equal "Rubygem that is selected cannot be scoped to this key", flash[:error]
           assert_empty @user.reload.api_keys
         end
 
@@ -227,7 +227,7 @@ class ApiKeysControllerTest < ActionController::TestCase
           assert_no_changes @api_key do
             patch :update, params: { api_key: { rubygem_id: -1 }, id: @api_key.id }
 
-            assert_equal "Selected gem cannot be scoped to this key", flash[:error]
+            assert_equal "Rubygem that is selected cannot be scoped to this key", flash[:error]
           end
         end
 

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -189,7 +189,7 @@ class ApiKeysTest < SystemTest
 
     visit_profile_api_keys_path
     assert page.has_css? ".owners__row__invalid"
-    assert api_key.reload.soft_deleted?
+    assert_predicate api_key.reload, :soft_deleted?
 
     refute page.has_button? "Edit"
     visit_edit_profile_api_key_path(api_key)

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -181,6 +181,17 @@ class ApiKeysTest < SystemTest
   end
 
   test "gem ownership removed displays api key as invalid" do
+    api_key = create(:api_key, user: @user, ownership: @ownership)
+    visit_profile_api_keys_path
+    refute page.has_css? ".owners__row__invalid"
+
+    @ownership.destroy!
+
+    visit_profile_api_keys_path
+    assert page.has_css? ".owners__row__invalid"
+    assert api_key.reload.soft_deleted?
+
+    refute page.has_button? "Edit"
     visit_edit_profile_api_key_path(api_key)
     assert page.has_content? "An invalid API key cannot be edited. Please delete it and create a new one."
     assert_equal profile_api_keys_path, page.current_path

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -252,7 +252,7 @@ class ApiKeysTest < SystemTest
     assert_predicate api_key.reload, :soft_deleted?
 
     refute page.has_button? "Edit"
-    assert_equal "[?]", page.find('.owners__cell[data-title="Gem"]').text
+    assert_equal "#{@ownership.rubygem.name} [?]", page.find('.owners__cell[data-title="Gem"]').text
     visit_edit_profile_api_key_path(api_key)
     assert page.has_content? "An invalid API key cannot be edited. Please delete it and create a new one."
     assert_equal profile_api_keys_path, page.current_path

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -75,7 +75,7 @@ class ApiKeysTest < SystemTest
     click_button "Create"
 
     assert page.has_css? ".flash"
-    assert page.has_content? "Selected gem cannot be scoped to this key"
+    assert page.has_content? "Rubygem that is selected cannot be scoped to this key"
     assert_empty @user.api_keys
   end
 
@@ -182,7 +182,7 @@ class ApiKeysTest < SystemTest
     click_button "Update"
 
     assert page.has_css? ".flash"
-    assert page.has_content? "Selected gem cannot be scoped to this key"
+    assert page.has_content? "Rubygem that is selected cannot be scoped to this key"
     assert_equal @ownership.rubygem, api_key.reload.rubygem
   end
 

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ApiKeysTest < SystemTest
   setup do
+    headless_chrome_driver
     @user = create(:user)
     @ownership = create(:ownership, user: @user, rubygem: create(:rubygem))
 
@@ -168,6 +169,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Delete"
 
+    page.accept_alert
     assert page.has_content? "New API key"
   end
 
@@ -177,6 +179,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Reset"
 
+    page.accept_alert
     assert page.has_content? "New API key"
   end
 
@@ -212,5 +215,10 @@ class ApiKeysTest < SystemTest
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Confirm"
+  end
+
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
   end
 end

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -252,7 +252,7 @@ class ApiKeysTest < SystemTest
     assert_predicate api_key.reload, :soft_deleted?
 
     refute page.has_button? "Edit"
-    assert_nil page.find('.owners__cell[data-title="Gem"]').text
+    assert_equal "[?]", page.find('.owners__cell[data-title="Gem"]').text
     visit_edit_profile_api_key_path(api_key)
     assert page.has_content? "An invalid API key cannot be edited. Please delete it and create a new one."
     assert_equal profile_api_keys_path, page.current_path

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -36,6 +36,7 @@ class ApiKeysTest < SystemTest
     click_button "Create"
 
     assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert_equal @ownership.rubygem.name, page.find('.owners__cell[data-title="Gem"]').text
     assert_equal @ownership.rubygem, @user.api_keys.last.rubygem
   end
 
@@ -130,6 +131,7 @@ class ApiKeysTest < SystemTest
     page.select "All Gems"
     click_button "Update"
 
+    assert_equal "All Gems", page.find('.owners__cell[data-title="Gem"]').text
     assert_nil api_key.reload.rubygem
   end
 
@@ -250,6 +252,7 @@ class ApiKeysTest < SystemTest
     assert_predicate api_key.reload, :soft_deleted?
 
     refute page.has_button? "Edit"
+    assert_nil page.find('.owners__cell[data-title="Gem"]').text
     visit_edit_profile_api_key_path(api_key)
     assert page.has_content? "An invalid API key cannot be edited. Please delete it and create a new one."
     assert_equal profile_api_keys_path, page.current_path

--- a/test/unit/api_key_rubygems_scope_test.rb
+++ b/test/unit/api_key_rubygems_scope_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ApiKeyRubygemScopeTest < ActiveSupport::TestCase
+  should belong_to :api_key
+  should belong_to :ownership
+  should validate_presence_of(:ownership)
+  should validate_presence_of(:api_key)
+  should validate_uniqueness_of(:ownership_id).scoped_to(:api_key_id)
+
+  setup do
+    @api_key = create(:api_key)
+    @rubygem = create(:rubygem)
+    @ownership = create(:ownership, rubygem: @rubygem)
+    @api_key_scope = create(:api_key_rubygem_scope, api_key: @api_key, ownership: @ownership)
+  end
+
+  should "be valid with factory" do
+    assert_predicate build(:api_key_rubygem_scope), :valid?
+  end
+
+  context "#soft_delete_api_key!" do
+    should "be called if destroyed by association" do
+      @ownership.destroy!
+
+      assert_nil @api_key.reload.api_key_rubygem_scope
+      assert_predicate @api_key, :soft_deleted?
+    end
+
+    should "call #soft_delete_api_key! if not destroyed by association" do
+      @api_key.update(ownership: nil)
+
+      assert_nil @api_key.reload.api_key_rubygem_scope
+      refute_predicate @api_key, :soft_deleted?
+    end
+  end
+end

--- a/test/unit/api_key_rubygems_scope_test.rb
+++ b/test/unit/api_key_rubygems_scope_test.rb
@@ -24,6 +24,8 @@ class ApiKeyRubygemScopeTest < ActiveSupport::TestCase
 
       assert_nil @api_key.reload.api_key_rubygem_scope
       assert_predicate @api_key, :soft_deleted?
+      assert_predicate @api_key, :soft_deleted_by_ownership?
+      assert_equal @rubygem.name, @api_key.reload.soft_deleted_rubygem_name
     end
 
     should "call #soft_delete_api_key! if not destroyed by association" do
@@ -31,6 +33,8 @@ class ApiKeyRubygemScopeTest < ActiveSupport::TestCase
 
       assert_nil @api_key.reload.api_key_rubygem_scope
       refute_predicate @api_key, :soft_deleted?
+      refute_predicate @api_key, :soft_deleted_by_ownership?
+      assert_nil @api_key.reload.soft_deleted_rubygem_name
     end
   end
 end

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -125,6 +125,22 @@ class ApiKeyTest < ActiveSupport::TestCase
     end
   end
 
+  context "#soft_deleted_by_ownership?" do
+    should "return true if key soft deleted" do
+      ownership = create(:ownership)
+      api_key = create(:api_key, push_rubygem: true, user: ownership.user, ownership: ownership)
+      api_key.soft_delete!
+
+      assert_predicate api_key, :soft_deleted_by_ownership?
+    end
+
+    should "return false if key not soft deleted" do
+      api_key = create(:api_key)
+
+      refute_predicate api_key, :soft_deleted_by_ownership?
+    end
+  end
+
   should "be invalid if soft deleted" do
     api_key = create(:api_key)
     api_key.soft_delete!

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -126,10 +126,10 @@ class ApiKeyTest < ActiveSupport::TestCase
   end
 
   context "#soft_deleted_by_ownership?" do
-    should "return true if key soft deleted" do
+    should "return true if soft deleted gem name is present" do
       ownership = create(:ownership)
       api_key = create(:api_key, push_rubygem: true, user: ownership.user, ownership: ownership)
-      api_key.soft_delete!
+      api_key.soft_delete!(ownership: ownership)
 
       assert_predicate api_key, :soft_deleted_by_ownership?
     end

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -94,10 +94,9 @@ class ApiKeyTest < ActiveSupport::TestCase
         assert_nil @api_key.rubygem_id
       end
 
-      should "raise error when id is not associated with the user" do
-        assert_raise ActiveRecord::RecordNotFound do
-          create(:api_key, key: SecureRandom.hex(24), push_rubygem: true, user: @ownership.user, rubygem_id: -1)
-        end
+      should "add error when id is not associated with the user" do
+        api_key = ApiKey.new(hashed_key: SecureRandom.hex(24), push_rubygem: true, user: @ownership.user, rubygem_id: -1)
+        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
       end
     end
   end

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class ApiKeysHelperTest < ActionView::TestCase
+  context "gem_scope" do
+    should "return gem name" do
+      @ownership = create(:ownership)
+      @api_key = create(:api_key, push_rubygem: true, user: @ownership.user, ownership: @ownership)
+
+      assert_equal @ownership.rubygem.name, gem_scope(@api_key)
+    end
+
+    should "return all gems if there is no scope specified" do
+      assert_equal "All Gems", gem_scope(create(:api_key))
+    end
+
+    should "return if key if gem ownership is removed" do
+      @ownership = create(:ownership)
+      @api_key = create(:api_key, push_rubygem: true, user: @ownership.user, ownership: @ownership)
+      @ownership.destroy!
+
+      assert_nil gem_scope(@api_key.reload)
+    end
+  end
+end

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -17,13 +17,14 @@ class ApiKeysHelperTest < ActionView::TestCase
       @ownership = create(:ownership)
       @api_key = create(:api_key, push_rubygem: true, user: @ownership.user, ownership: @ownership)
       @ownership.destroy!
+      rubygem_name = @ownership.rubygem.name
 
       expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
-        <span#{' '}
-          class="tooltip__text"#{' '}
+        <span
+          class="tooltip__text"
           style="font-size:1em"
-          data-tooltip="Ownership of the gem has been removed after being scoped to this key."\
-        >[?]</span>
+          data-tooltip="Ownership of #{rubygem_name} has been removed after being scoped to this key."\
+        >#{rubygem_name} [?]</span>
       HTML
 
       assert_equal expected_dom, gem_scope(@api_key.reload)

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -13,12 +13,20 @@ class ApiKeysHelperTest < ActionView::TestCase
       assert_equal "All Gems", gem_scope(create(:api_key))
     end
 
-    should "return if key if gem ownership is removed" do
+    should "return error tooltip if key if gem ownership is removed" do
       @ownership = create(:ownership)
       @api_key = create(:api_key, push_rubygem: true, user: @ownership.user, ownership: @ownership)
       @ownership.destroy!
 
-      assert_nil gem_scope(@api_key.reload)
+      expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
+        <span#{' '}
+          class="tooltip__text"#{' '}
+          style="font-size:1em"
+          data-tooltip="Ownership of the gem has been removed after being scoped to this key."\
+        >[?]</span>
+      HTML
+
+      assert_equal expected_dom, gem_scope(@api_key.reload)
     end
   end
 end

--- a/test/unit/ownership_test.rb
+++ b/test/unit/ownership_test.rb
@@ -11,6 +11,7 @@ class OwnershipTest < ActiveSupport::TestCase
   should have_db_index :user_id
   should belong_to :authorizer
   should have_db_index %i[user_id rubygem_id]
+  should have_many(:api_key_rubygem_scopes).dependent(:destroy)
 
   context "with ownership" do
     setup do


### PR DESCRIPTION
### Background
This PR allows users to select a gem scope an API key when creating and editing. Keys with this scope can only push, yank, add/remove owners with only the selected gem. All other behaviour would remain the same.

### Data model additions
New join table `ApiKeyRubygemScope` that belong to a gem ownership and an API key. An API key can up to one `ApiKeyRubygemScope`, ownerships can have many `ApiKeyRubygemScope`.

There's also a `soft_deleted` column on ApiKeys, which will be explained more in the `What happens when an ownership is deleted?` section.

### Creating/Editing a Key with a Gem scope
If user finds themselves submitting an invalid rubygem id, an error will be displayed "Selected gem cannot be scoped to this key"

https://user-images.githubusercontent.com/42748004/161677305-ccff2bb3-b211-4627-a1bd-7e238e3e2133.mov



### CLI

https://user-images.githubusercontent.com/42748004/161677288-50109468-828a-4127-a272-4d94924a8187.mov

### What happens when an ownership is deleted?
When an ownership is deleted, it dependently destroys all associated ApiKeyRubygemScopes. In turn, in a before_destroy callback, the ApiKeyRubygemScope updates the `soft_deleted_at` associated ApiKey. Soft deleted API keys cannot be edited or used. The user can only delete it. Thought about `invalid` being the name but that can be confusing will Rails' validations


<img width="819" alt="Screen Shot 2022-04-05 at 12 12 16 AM" src="https://user-images.githubusercontent.com/42748004/161677398-ce18d406-0cd2-47c2-b189-40c58eab899c.png">


https://user-images.githubusercontent.com/42748004/161677262-2e61ce73-b188-487b-8776-d5b3276d4f5b.mov

