### PR TITLE
Prevent finding user with first nil handle

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,14 +73,17 @@ class User < ApplicationRecord
   end
 
   def self.find_by_slug(slug)
+    return if slug.blank?
     find_by(id: slug) || find_by(handle: slug)
   end
 
   def self.find_by_name(name)
+    return if name.blank?
     find_by(email: name) || find_by(handle: name)
   end
 
   def self.find_by_blocked(slug)
+    return if slug.blank?
     find_by(blocked_email: slug) || find_by(handle: slug)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ApplicationRecord
   end
 
   def self.find_by_slug!(slug)
+    raise ActiveRecord::RecordNotFound if slug.blank?
     find_by(id: slug) || find_by!(handle: slug)
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -487,30 +487,31 @@ class UserTest < ActiveSupport::TestCase
   end
 
   context ".find_by_slug" do
+    setup do
+      @user = create(:user, handle: "findable")
+      @nohandle = create(:user, handle: nil)
+    end
+
     should "return nil if using a falsy value" do
       refute User.find_by_slug(nil)
+      refute User.find_by_slug("")
+      refute User.find_by_slug(" ")
     end
 
-    context "foundable" do
-      setup { @user = create(:user, handle: "findable") }
-
-      should "return an AR when founded by id" do
-        assert_equal User.find_by_slug(@user.id), @user
-      end
-
-      should "return an AR when founded by handle" do
-        assert_equal User.find_by_slug(@user.handle), @user
-      end
+    should "return an user when founded by id" do
+      assert_equal User.find_by_slug(@user.id), @user
     end
 
-    context "not founded" do
-      should "return nil when using id" do
-        refute User.find_by_slug(-9999)
-      end
+    should "return an user when founded by handle" do
+      assert_equal User.find_by_slug(@user.handle), @user
+    end
 
-      should "return nil when not founded by handle" do
-        refute User.find_by_slug("notfoundable")
-      end
+    should "return nil when using id" do
+      refute User.find_by_slug(-9999)
+    end
+
+    should "return nil when not founded by handle" do
+      refute User.find_by_slug("notfoundable")
     end
   end
 
@@ -545,6 +546,52 @@ class UserTest < ActiveSupport::TestCase
       assert_raises ActiveRecord::RecordNotFound do
         User.find_by_slug!("")
       end
+    end
+  end
+
+  context ".find_by_name" do
+    setup do
+      @dorian = create(:user, handle: "dorianmariefr")
+      @nohandle = create(:user, handle: nil)
+    end
+
+    should "return an user if the slug matches" do
+      assert_equal @dorian, User.find_by_name("dorianmariefr")
+    end
+
+    should "raise error if not found" do
+      assert_nil User.find_by_name(SecureRandom.hex)
+    end
+
+    should "not return an user with nil handle if searching for nil" do
+      assert_nil User.find_by_name(nil)
+    end
+
+    should "not return an user with nil handle if searching for blank" do
+      assert_nil User.find_by_name("")
+    end
+  end
+
+  context ".find_by_blocked" do
+    setup do
+      @dorian = create(:user, handle: "dorianmariefr")
+      @nohandle = create(:user, handle: nil)
+    end
+
+    should "return an user if the slug matches" do
+      assert_equal @dorian, User.find_by_blocked("dorianmariefr")
+    end
+
+    should "raise error if not found" do
+      assert_nil User.find_by_blocked(SecureRandom.hex)
+    end
+
+    should "not return an user with nil handle if searching for nil" do
+      assert_nil User.find_by_blocked(nil)
+    end
+
+    should "not return an user with nil handle if searching for blank" do
+      assert_nil User.find_by_blocked("")
     end
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -514,6 +514,40 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context ".find_by_slug!" do
+    setup do
+      @dorian = create(:user, handle: "dorianmariefr")
+      @nohandle = create(:user, handle: nil)
+    end
+
+    should "return an user if the slug matches" do
+      assert_equal @dorian, User.find_by_slug!("dorianmariefr")
+    end
+
+    should "raise error if not found" do
+      assert_raises ActiveRecord::RecordNotFound do
+        User.find_by_slug!(SecureRandom.hex)
+      end
+    end
+
+    should "be able to find by id" do
+      assert_equal @dorian, User.find_by_slug!(@dorian.id)
+      assert_equal @nohandle, User.find_by_slug!(@nohandle.id)
+    end
+
+    should "not return an user with nil handle if searching for nil" do
+      assert_raises ActiveRecord::RecordNotFound do
+        User.find_by_slug!(nil)
+      end
+    end
+
+    should "not return an user with nil handle if searching for blank" do
+      assert_raises ActiveRecord::RecordNotFound do
+        User.find_by_slug!("")
+      end
+    end
+  end
+
   context "block when handle has uppercase" do
     setup { @user = create(:user, handle: "MikeJudge") }
 


### PR DESCRIPTION
See the tests, but finding by `nil` and by blank shouldn't return the first user with a nil handle, they can only be found by id/name/email/etc.