### PR TITLE
page has_content? -> assert_text

### DIFF
--- a/test/functional/adoptions_controller_test.rb
+++ b/test/functional/adoptions_controller_test.rb
@@ -30,7 +30,7 @@ class AdoptionsControllerTest < ActionController::TestCase
           should respond_with :success
 
           should "have button for approve and close all ownership requests" do
-            assert page.has_content?("example request")
+            assert_text("example request")
             assert page.has_selector?("input[value='Close']")
             assert page.has_selector?("input[value='Close all']")
           end
@@ -43,7 +43,7 @@ class AdoptionsControllerTest < ActionController::TestCase
           should respond_with :success
 
           should "have button to close ownership call" do
-            assert page.has_content?("example call")
+            assert_text("example call")
             assert page.has_selector?("input[value='Close']")
           end
         end
@@ -67,7 +67,7 @@ class AdoptionsControllerTest < ActionController::TestCase
           end
           should respond_with :success
           should "not show any ownership request" do
-            assert page.has_content?("No ownership requests for #{@rubygem.name}")
+            assert_text("No ownership requests for #{@rubygem.name}")
           end
         end
       end
@@ -91,7 +91,7 @@ class AdoptionsControllerTest < ActionController::TestCase
           end
           should respond_with :success
           should "have button to close ownership request" do
-            assert page.has_content?("example request")
+            assert_text("example request")
             assert page.has_selector?("input[value='Close']")
           end
         end
@@ -113,7 +113,7 @@ class AdoptionsControllerTest < ActionController::TestCase
         end
         should respond_with :success
         should "not show any ownership request" do
-          assert page.has_content?("There are no ownership calls for #{@rubygem.name}")
+          assert_text("There are no ownership calls for #{@rubygem.name}")
         end
       end
     end
@@ -134,7 +134,7 @@ class AdoptionsControllerTest < ActionController::TestCase
           refute page.has_selector?("input[value='Create']")
         end
         should "show ownership call" do
-          assert page.has_content?("example call")
+          assert_text("example call")
         end
       end
     end

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -27,7 +27,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
 
       should respond_with :bad_request
       should "explain failed request" do
-        assert page.has_content?("Request is missing param 'query'")
+        assert_text("Request is missing param 'query'")
       end
     end
   end

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -4,7 +4,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
   def self.should_not_find_it
     should respond_with :not_found
     should "say gem is not found" do
-      assert page.has_content?("could not be found")
+      assert_text("could not be found")
     end
   end
 
@@ -84,7 +84,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         should respond_with :success
         should "say successfully deployed" do
           content = "Successfully deployed webhook for #{@gemcutter.name} to #{@url}"
-          assert page.has_content?(content)
+          assert_text(content)
           assert WebHook.count.zero?
         end
       end
@@ -98,7 +98,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         should respond_with :bad_request
         should "say there was a problem" do
           content = "There was a problem deploying webhook for #{@gemcutter.name} to #{@url}"
-          assert page.has_content?(content)
+          assert_text(content)
           assert WebHook.count.zero?
         end
       end
@@ -110,7 +110,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         should respond_with :bad_request
         should "say url was not provided" do
           content = "URL was not provided"
-          assert page.has_content?(content)
+          assert_text(content)
         end
       end
     end
@@ -129,7 +129,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         end
         should respond_with :success
         should "say successfully deployed" do
-          assert page.has_content?("Successfully deployed webhook for #{@rubygem.name} to #{@url}")
+          assert_text("Successfully deployed webhook for #{@rubygem.name} to #{@url}")
           assert WebHook.count.zero?
         end
       end
@@ -143,7 +143,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         should respond_with :bad_request
         should "say there was a problem" do
           content = "There was a problem deploying webhook for #{@rubygem.name} to #{@url}"
-          assert page.has_content?(content)
+          assert_text(content)
           assert WebHook.count.zero?
         end
       end
@@ -174,7 +174,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
           should respond_with :success
           should "say webhook was removed" do
             content = "Successfully removed webhook for #{@rubygem.name} to #{@rubygem_hook.url}"
-            assert page.has_content?(content)
+            assert_text(content)
           end
           should "have actually removed the webhook" do
             assert_raise ActiveRecord::RecordNotFound do
@@ -192,7 +192,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
           should respond_with :success
           should "say webhook was removed" do
             content = "Successfully removed webhook for all gems to #{@global_hook.url}"
-            assert page.has_content?(content)
+            assert_text(content)
           end
           should "have actually removed the webhook" do
             assert_raise ActiveRecord::RecordNotFound do
@@ -216,7 +216,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
           should respond_with :not_found
           should "say webhook was not found" do
-            assert page.has_content?("No such webhook exists under your account.")
+            assert_text("No such webhook exists under your account.")
           end
           should "not delete the webhook" do
             assert_not_nil WebHook.find(@rubygem_hook.id)
@@ -231,7 +231,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
           should respond_with :not_found
           should "say webhook was not found" do
-            assert page.has_content?("No such webhook exists under your account.")
+            assert_text("No such webhook exists under your account.")
           end
           should "not delete the webhook" do
             assert_not_nil WebHook.find(@rubygem_hook.id)
@@ -246,7 +246,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
         should respond_with :created
         should "say webhook was created" do
-          assert page.has_content?("Successfully created webhook for #{@rubygem.name} to #{@url}")
+          assert_text("Successfully created webhook for #{@rubygem.name} to #{@url}")
         end
         should "link webhook to current user and rubygem" do
           assert_equal @user, WebHook.last.user
@@ -263,7 +263,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
         should respond_with :conflict
         should "be only 1 web hook" do
           assert_equal 1, WebHook.count
-          assert page.has_content?("#{@url} has already been registered for #{@rubygem.name}")
+          assert_text("#{@url} has already been registered for #{@rubygem.name}")
         end
       end
 
@@ -278,7 +278,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
           assert_nil WebHook.last.rubygem
         end
         should "respond with message that global hook was made" do
-          assert page.has_content?("Successfully created webhook for all gems to #{@url}")
+          assert_text("Successfully created webhook for all gems to #{@url}")
         end
       end
     end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -74,7 +74,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         should respond_with :success
 
         should "render api key of user" do
-          assert page.has_content? @api_key.name
+          assert_text @api_key.name
         end
       end
     end
@@ -85,7 +85,7 @@ class ApiKeysControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "render new api key form" do
-        assert page.has_content? "New API key"
+        assert_text "New API key"
       end
     end
 
@@ -117,7 +117,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         setup { post :create, params: { api_key: { add_owner: true } } }
 
         should "show error to user" do
-          assert page.has_content? "Name can't be blank"
+          assert_text "Name can't be blank"
         end
 
         should "not create new key for user" do
@@ -135,7 +135,7 @@ class ApiKeysControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "render edit api key form" do
-        assert page.has_content? "Edit API key"
+        assert_text "Edit API key"
         assert_select "form > input.form__input", value: "ci-key"
       end
     end
@@ -161,7 +161,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         end
 
         should "show error to user" do
-          assert page.has_content? "Name can't be blank"
+          assert_text "Name can't be blank"
         end
 
         should "not update scope of test key" do

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -52,7 +52,7 @@ class DashboardsControllerTest < ActionController::TestCase
       should respond_with :success
       should "render links" do
         @gems.each do |g|
-          assert page.has_content?(g.name)
+          assert_text(g.name)
           selector = "a[href='#{rubygem_path(g)}'][title='#{g.versions.most_recent.info}']"
           assert page.has_selector?(selector)
         end

--- a/test/functional/dependencies_controller_test.rb
+++ b/test/functional/dependencies_controller_test.rb
@@ -34,14 +34,14 @@ class DependenciesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "render gem name" do
-      assert page.has_content?(@rubygem.name)
+      assert_text(@rubygem.name)
     end
     should "render the specified version" do
-      assert page.has_content?(@version.number)
+      assert_text(@version.number)
     end
     should "render dependencies of gem" do
       @version.dependencies.each do |dependency|
-        assert page.has_content?(dependency.rubygem.name)
+        assert_text(dependency.rubygem.name)
       end
     end
 
@@ -52,7 +52,7 @@ class DependenciesControllerTest < ActionController::TestCase
       end
       should respond_with :success
       should "render gem name" do
-        assert page.has_content?(@rubygem.name)
+        assert_text(@rubygem.name)
       end
       should "render dependencies of gem" do
         refute page.has_content?(@dependency.name)

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -50,7 +50,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display otp form" do
-        assert page.has_content?("Multifactor authentication")
+        assert_text("Multifactor authentication")
       end
     end
   end
@@ -97,7 +97,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "display resend instructions" do
-      assert page.has_content?("We will email you confirmation link to activate your account.")
+      assert_text("We will email you confirmation link to activate your account.")
     end
   end
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -10,7 +10,7 @@ class HomeControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "display counts" do
-      assert page.has_content?("11,000,000")
+      assert_text("11,000,000")
     end
   end
 

--- a/test/functional/internal/ping_controller_test.rb
+++ b/test/functional/internal/ping_controller_test.rb
@@ -10,7 +10,7 @@ class Internal::PingControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "PONG" do
-      assert page.has_content?("PONG")
+      assert_text("PONG")
     end
   end
 

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -134,7 +134,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           should respond_with :success
           should "show recovery codes" do
             @user.reload.mfa_recovery_codes.each do |code|
-              assert page.has_content?(code)
+              assert_text(code)
             end
           end
           should "enable mfa" do

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -23,7 +23,7 @@ class OwnersControllerTest < ActionController::TestCase
         should respond_with :success
         should "render gem owners including unconfirmed in owners table" do
           @rubygem.ownerships_including_unconfirmed.each do |o|
-            assert page.has_content?(o.owner_name)
+            assert_text(o.owner_name)
           end
         end
       end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -34,7 +34,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display edit form" do
-        assert page.has_content?("Reset password")
+        assert_text("Reset password")
       end
     end
 
@@ -58,7 +58,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display otp form" do
-        assert page.has_content?("Multifactor authentication")
+        assert_text("Multifactor authentication")
       end
     end
   end
@@ -79,7 +79,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
         should respond_with :success
         should "display edit form" do
-          assert page.has_content?("Reset password")
+          assert_text("Reset password")
         end
       end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -54,7 +54,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display all gems of user" do
-        11.times { |i| assert page.has_content? @rubygems[i].name }
+        11.times { |i| assert_text @rubygems[i].name }
       end
     end
 
@@ -65,7 +65,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "render user show page" do
-        assert page.has_content? @user.handle
+        assert_text @user.handle
       end
     end
 
@@ -74,7 +74,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "render user edit page" do
-        assert page.has_content? "Edit profile"
+        assert_text "Edit profile"
       end
     end
 
@@ -152,7 +152,7 @@ class ProfilesControllerTest < ActionController::TestCase
         end
 
         should "not set unconfirmed_email" do
-          assert page.has_content? "Email address has already been taken"
+          assert_text "Email address has already been taken"
           refute_equal "cannotchange@tothis.com", @user.unconfirmed_email
         end
       end

--- a/test/functional/reverse_dependencies_controller_test.rb
+++ b/test/functional/reverse_dependencies_controller_test.rb
@@ -31,7 +31,7 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
 
     should "show reverse dependencies" do
       get :index, params: { rubygem_id: @rubygem_one.to_param }
-      assert page.has_content?(@rubygem_two.name)
+      assert_text(@rubygem_two.name)
       refute page.has_content?(@rubygem_three.name)
     end
 
@@ -41,7 +41,7 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
           rubygem_id: @rubygem_two.to_param,
           rdeps_query: @rubygem_three.name
         }
-      assert page.has_content?(@rubygem_three.name)
+      assert_text(@rubygem_three.name)
       refute page.has_content?(@rubygem_four.name)
     end
 

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -80,7 +80,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :success
     should "render links" do
       @gems.each do |g|
-        assert page.has_content?(g.name)
+        assert_text(g.name)
         assert page.has_selector?("a[href='#{rubygem_path(g)}']")
       end
     end
@@ -127,7 +127,7 @@ class RubygemsControllerTest < ActionController::TestCase
     end
     should respond_with :success
     should "render links" do
-      assert page.has_content?(@zgem.name)
+      assert_text(@zgem.name)
       assert page.has_selector?("a[href='#{rubygem_path(@zgem)}']")
     end
   end
@@ -146,7 +146,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :success
     should "render links" do
       @gems.each do |g|
-        assert page.has_content?(g.name)
+        assert_text(g.name)
         assert page.has_selector?("a[href='#{rubygem_path(g)}']")
       end
     end
@@ -161,11 +161,11 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "render info about the gem" do
-      assert page.has_content?(@rubygem.name)
-      assert page.has_content?(@latest_version.number)
+      assert_text(@rubygem.name)
+      assert_text(@latest_version.number)
       css = "small:contains('#{@latest_version.created_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
-      assert page.has_content?("Links")
+      assert_text("Links")
     end
   end
 
@@ -177,17 +177,17 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render plural licenses header for other than one license" do
       @latest_version.update(licenses: nil)
       get :show, params: { id: @rubygem.to_param }
-      assert page.has_content?("Licenses")
+      assert_text("Licenses")
 
       @latest_version.update(licenses: %w[MIT GPL-2])
       get :show, params: { id: @rubygem.to_param }
-      assert page.has_content?("Licenses")
+      assert_text("Licenses")
     end
 
     should "render singular license header for one line license" do
       @latest_version.update(licenses: ["MIT"])
       get :show, params: { id: @rubygem.to_param }
-      assert page.has_content?("License")
+      assert_text("License")
       assert page.has_no_content?("Licenses")
     end
   end
@@ -205,13 +205,13 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "render info about the gem" do
-      assert page.has_content?(@rubygem.name)
-      assert page.has_content?(@versions[0].number)
+      assert_text(@rubygem.name)
+      assert_text(@versions[0].number)
       css = "small:contains('#{@versions[0].built_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
 
-      assert page.has_content?("Versions")
-      assert page.has_content?(@versions[2].number)
+      assert_text("Versions")
+      assert_text(@versions[2].number)
       css = "small:contains('#{@versions[2].built_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
     end
@@ -234,7 +234,7 @@ class RubygemsControllerTest < ActionController::TestCase
       setup { get :show, params: { id: @rubygem.to_param } }
       should respond_with :success
       should "render info about the gem" do
-        assert page.has_content?("This gem is not currently hosted on RubyGems.org")
+        assert_text("This gem is not currently hosted on RubyGems.org")
         assert page.has_no_content?("Versions")
       end
     end
@@ -259,7 +259,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "render info about the gem" do
-        assert page.has_content?("The RubyGems.org team has reserved this gem name for 1 more day.")
+        assert_text("The RubyGems.org team has reserved this gem name for 1 more day.")
         assert page.has_no_content?("Versions")
       end
       should "renders owner gems overview link" do
@@ -275,7 +275,7 @@ class RubygemsControllerTest < ActionController::TestCase
     end
     should respond_with :success
     should "render info about the gem" do
-      assert page.has_content?("This gem is not currently hosted on RubyGems.org.")
+      assert_text("This gem is not currently hosted on RubyGems.org.")
     end
   end
 
@@ -291,12 +291,12 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show runtime dependencies and development dependencies" do
-      assert page.has_content?(@runtime.rubygem.name)
-      assert page.has_content?(@development.rubygem.name)
+      assert_text(@runtime.rubygem.name)
+      assert_text(@development.rubygem.name)
     end
     should "show runtime and development dependencies count" do
-      assert page.has_content?(@version.dependencies.runtime.count)
-      assert page.has_content?(@version.dependencies.development.count)
+      assert_text(@version.dependencies.runtime.count)
+      assert_text(@version.dependencies.development.count)
     end
   end
 
@@ -311,7 +311,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show unresolved dependencies" do
-      assert page.has_content?(@unresolved.name)
+      assert_text(@unresolved.name)
     end
   end
 
@@ -333,7 +333,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show only dependencies that have rubygem" do
-      assert page.has_content?(@runtime.rubygem.name)
+      assert_text(@runtime.rubygem.name)
       assert page.has_no_content?("1.2.0")
     end
   end
@@ -348,7 +348,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show runtime dependencies and development dependencies" do
-      assert page.has_content?(@runtime.rubygem.name)
+      assert_text(@runtime.rubygem.name)
     end
   end
 
@@ -367,7 +367,7 @@ class RubygemsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "render blacklisted page" do
-      assert page.has_content? "This namespace is reserved by rubygems.org."
+      assert_text "This namespace is reserved by rubygems.org."
     end
   end
 

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -41,7 +41,7 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the results" do
-      assert page.has_content?(@sinatra.name)
+      assert_text(@sinatra.name)
       assert page.has_selector?("a[href='#{rubygem_path(@sinatra)}']")
     end
     should "not see brando on the page in the results" do
@@ -49,7 +49,7 @@ class SearchesControllerTest < ActionController::TestCase
       refute page.has_selector?("a[href='#{rubygem_path(@brando)}']")
     end
     should "display 'gems' in pagination summary" do
-      assert page.has_content?("all 2 gems")
+      assert_text("all 2 gems")
     end
   end
 
@@ -155,8 +155,8 @@ class SearchesControllerTest < ActionController::TestCase
       Toxiproxy[:elasticsearch].down do
         get :show, params: { query: "sinatra" }
         assert_response :success
-        assert page.has_content?("Advanced search is currently unavailable. Falling back to legacy search.")
-        assert page.has_content?("Displaying")
+        assert_text("Advanced search is currently unavailable. Falling back to legacy search.")
+        assert_text("Displaying")
       end
     end
   end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -17,7 +17,7 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :success
       should "save user name in session" do
         assert_equal @controller.session[:mfa_user], @user.handle
-        assert page.has_content? "Multifactor authentication"
+        assert_text "Multifactor authentication"
       end
     end
 
@@ -66,7 +66,7 @@ class SessionsControllerTest < ActionController::TestCase
         should respond_with :unauthorized
 
         should "render sign in page" do
-          assert page.has_content? "Sign in"
+          assert_text "Sign in"
         end
 
         should "not sign in the user" do
@@ -106,7 +106,7 @@ class SessionsControllerTest < ActionController::TestCase
       should set_flash.now[:notice]
 
       should "render sign in page" do
-        assert page.has_content? "Sign in"
+        assert_text "Sign in"
       end
 
       should "not sign in the user" do

--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -20,19 +20,19 @@ class StatsControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "display number of gems" do
-      assert page.has_content?("1,337")
+      assert_text("1,337")
     end
 
     should "display number of users" do
-      assert page.has_content?("101")
+      assert_text("101")
     end
 
     should "display number of downloads" do
-      assert page.has_content?("42")
+      assert_text("42")
     end
 
     should "display the top gem" do
-      assert page.has_content?("rails_cinco")
+      assert_text("rails_cinco")
     end
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -23,7 +23,7 @@ class UsersControllerTest < ActionController::TestCase
           post :create
         end
         assert_response :ok
-        assert page.has_content?("Email address is not a valid email")
+        assert_text("Email address is not a valid email")
       end
     end
 

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -15,7 +15,7 @@ class VersionsControllerTest < ActionController::TestCase
 
     should "show all related versions" do
       @versions.each do |version|
-        assert page.has_content?(version.number)
+        assert_text(version.number)
       end
     end
   end
@@ -56,7 +56,7 @@ class VersionsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show not hosted notice" do
-      assert page.has_content?("This gem is not currently hosted")
+      assert_text("This gem is not currently hosted")
     end
     should "not show checksum" do
       assert page.has_no_content?("Sha 256 checksum")
@@ -75,18 +75,18 @@ class VersionsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "render info about the gem" do
-      assert page.has_content?(@rubygem.name)
+      assert_text(@rubygem.name)
     end
     should "render the specified version" do
-      assert page.has_content?(@latest_version.number)
+      assert_text(@latest_version.number)
     end
     should "render other related versions" do
       @versions.each do |version|
-        assert page.has_content?(version.number)
+        assert_text(version.number)
       end
     end
     should "render the checksum version" do
-      assert page.has_content?(@latest_version.sha256_hex)
+      assert_text(@latest_version.sha256_hex)
     end
   end
 
@@ -100,11 +100,11 @@ class VersionsControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "show yanked notice" do
-      assert page.has_content?("This version has been yanked")
+      assert_text("This version has been yanked")
     end
     should "render other versions" do
-      assert page.has_content?("Versions")
-      assert page.has_content?(@version.number)
+      assert_text("Versions")
+      assert_text(@version.number)
       css = "small:contains('#{@version.created_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
     end

--- a/test/integration/about_page_test.rb
+++ b/test/integration/about_page_test.rb
@@ -5,7 +5,7 @@ class AboutPageTest < ActionDispatch::IntegrationTest
     get page_url("about"), params: { locale: local }
 
     assert_response :success
-    assert page.has_content? I18n.t("pages.about.title")
+    assert_text I18n.t("pages.about.title")
   end
 
   test "about page i18n for all supported languages" do

--- a/test/integration/api_keys_test.rb
+++ b/test/integration/api_keys_test.rb
@@ -18,7 +18,7 @@ class ApiKeysTest < SystemTest
     refute page.has_content? "Enable MFA"
     click_button "Create"
 
-    assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert_text "Note that we won't be able to show the key to you again. New API key:"
     assert @user.api_keys.last.can_index_rubygems?
     refute @user.api_keys.last.mfa_enabled?
   end
@@ -33,7 +33,7 @@ class ApiKeysTest < SystemTest
     check "mfa"
     click_button "Create"
 
-    assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert_text "Note that we won't be able to show the key to you again. New API key:"
     assert @user.api_keys.last.mfa_enabled?
   end
 
@@ -46,7 +46,7 @@ class ApiKeysTest < SystemTest
     check "api_key[index_rubygems]"
     click_button "Create"
 
-    assert page.has_content? "Note that we won't be able to show the key to you again. New API key:"
+    assert_text "Note that we won't be able to show the key to you again. New API key:"
     assert @user.api_keys.last.mfa_enabled?
   end
 
@@ -56,7 +56,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Edit"
 
-    assert page.has_content? "Edit API key"
+    assert_text "Edit API key"
     check "api_key[add_owner]"
     refute page.has_content? "Enable MFA"
     click_button "Update"
@@ -72,7 +72,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Edit"
 
-    assert page.has_content? "Edit API key"
+    assert_text "Edit API key"
     check "api_key[add_owner]"
     check "mfa"
     click_button "Update"
@@ -89,7 +89,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Edit"
 
-    assert page.has_content? "Edit API key"
+    assert_text "Edit API key"
     check "api_key[add_owner]"
     refute page.has_content? "Enable MFA"
     click_button "Update"
@@ -104,7 +104,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Delete"
 
-    assert page.has_content? "New API key"
+    assert_text "New API key"
   end
 
   test "deleting all api key" do
@@ -113,7 +113,7 @@ class ApiKeysTest < SystemTest
     visit_profile_api_keys_path
     click_button "Reset"
 
-    assert page.has_content? "New API key"
+    assert_text "New API key"
   end
 
   def visit_profile_api_keys_path

--- a/test/integration/autocompletes_test.rb
+++ b/test/integration/autocompletes_test.rb
@@ -31,8 +31,8 @@ class AutocompletesTest < SystemTest
   test "search field" do
     @fill_field.set "rubocop"
     click_on class: "home__search__icon"
-    assert page.has_content? "search"
-    assert page.has_content? "rubocop"
+    assert_text "search"
+    assert_text "rubocop"
   end
 
   test "selected field is only one with cursor selecting" do
@@ -85,7 +85,7 @@ class AutocompletesTest < SystemTest
   test "mouse click a suggestion item to submit" do
     find("li", text: "rubocop", match: :first).click
     assert_equal current_path, search_path || "/gems/"
-    assert page.has_content? "rubocop"
+    assert_text "rubocop"
   end
 
   teardown do

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -16,7 +16,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
     create(:subscription, rubygem: rubygem, user: @user)
 
     get "/dashboard.atom?api_key=1234", as: :json
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
 
     get "/dashboard.atom?api_key[]=1234&api_key[]=key1", as: :json
     refute page.has_content? "sandworm"
@@ -28,7 +28,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
 
     get dashboard_path
 
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
     refute page.has_content?("arrakis")
   end
 
@@ -38,7 +38,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
 
     get dashboard_path
 
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
     refute page.has_content?("arrakis")
   end
 
@@ -55,6 +55,6 @@ class DashboardTest < ActionDispatch::IntegrationTest
     get dashboard_path(format: :atom)
     assert_response :success
     assert_equal "application/atom+xml", response.media_type
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
   end
 end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -17,7 +17,7 @@ class EmailConfirmationTest < SystemTest
   test "requesting confirmation mail does not tell if a user exists" do
     request_confirmation_mail "someone@example.com"
 
-    assert page.has_content? "We will email you confirmation link to activate your account if one exists."
+    assert_text "We will email you confirmation link to activate your account if one exists."
   end
 
   test "requesting confirmation mail with email of existing user" do
@@ -27,7 +27,7 @@ class EmailConfirmationTest < SystemTest
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
   end
 
@@ -39,7 +39,7 @@ class EmailConfirmationTest < SystemTest
     click_link "Sign out"
 
     visit link
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
     assert page.has_selector? "#flash_alert", text: "Please double check the URL or try submitting it again."
   end
 
@@ -65,6 +65,6 @@ class EmailConfirmationTest < SystemTest
     fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     click_button "Authenticate"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -8,21 +8,21 @@ class GemsTest < ActionDispatch::IntegrationTest
 
   test "gem page with a non valid HTTP_ACCEPT header" do
     get rubygem_path(@rubygem), headers: { "HTTP_ACCEPT" => "application/mercurial-0.1" }
-    assert page.has_content? "1.0.0"
+    assert_text "1.0.0"
   end
 
   test "gems page with atom format" do
     get rubygems_path(format: :atom)
     assert_response :success
     assert_equal "application/atom+xml", response.media_type
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
   end
 
   test "versions with atom format" do
     create(:version, rubygem: @rubygem)
     get rubygem_versions_path(@rubygem, format: :atom)
     assert_equal "application/atom+xml", response.media_type
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
   end
 
   test "canonical url for gem points to most recent version" do
@@ -66,7 +66,7 @@ class GemsSystemTest < SystemTest
 
     click_link "Subscribe"
 
-    assert page.has_content? "Unsubscribe"
+    assert_text "Unsubscribe"
     assert_equal @user.subscribed_gems.first, @rubygem
   end
 
@@ -78,7 +78,7 @@ class GemsSystemTest < SystemTest
 
     click_link "Unsubscribe"
 
-    assert page.has_content? "Subscribe"
+    assert_text "Subscribe"
     assert_empty @user.subscribed_gems
   end
 
@@ -88,7 +88,7 @@ class GemsSystemTest < SystemTest
     visit rubygem_path(@rubygem, as: @user.id)
 
     assert page.has_selector?(".gem__users__mfa-disabled .gem__users a")
-    assert page.has_content? "Please consider enabling multifactor"
+    assert_text "Please consider enabling multifactor"
   end
 
   test "shows owners without mfa when logged in as owner" do
@@ -160,7 +160,7 @@ class GemsSystemTest < SystemTest
 
     visit rubygem_path(@rubygem)
 
-    assert page.has_content? "Since 1.1.1"
+    assert_text "Since 1.1.1"
   end
 
   test "does show correct version that introduced mfa requirement" do
@@ -171,6 +171,6 @@ class GemsSystemTest < SystemTest
 
     visit rubygem_path(@rubygem)
 
-    assert page.has_content? "Since 3.3.3"
+    assert_text "Since 3.3.3"
   end
 end

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -140,7 +140,7 @@ class OwnerTest < SystemTest
     confirmation_link = confirm_rubygem_owners_url(@rubygem, token: SecureRandom.hex(20).encode("UTF-8"))
     visit confirmation_link
 
-    assert page.has_content? "Page not found."
+    assert_text "Page not found."
 
     assert_no_emails
   end

--- a/test/integration/ownership_call_test.rb
+++ b/test/integration/ownership_call_test.rb
@@ -26,7 +26,7 @@ class OwnershipCallsTest < SystemTest
     user = create(:user)
     visit rubygem_adoptions_path(rubygem, as: user)
 
-    assert page.has_content? "There are no ownership calls for #{rubygem.name}"
+    assert_text "There are no ownership calls for #{rubygem.name}"
   end
 
   test "create ownership call as owner" do
@@ -63,7 +63,7 @@ class OwnershipCallsTest < SystemTest
       click_link "Adoption"
     end
 
-    assert page.has_content? "There are no ownership calls for #{rubygem.name}"
+    assert_text "There are no ownership calls for #{rubygem.name}"
     assert page.has_field? "Note"
     assert page.has_button? "Create ownership request"
   end

--- a/test/integration/page_params_test.rb
+++ b/test/integration/page_params_test.rb
@@ -6,29 +6,29 @@ class PageParamsTest < SystemTest
   test "stats with page param more than 10" do
     visit stats_path(page: "11")
     assert redirect_to(stats_path(page: "1"))
-    assert page.has_content? "Stats"
-    assert page.has_content? "Page number is out of range. Redirected to default page."
+    assert_text "Stats"
+    assert_text "Page number is out of range. Redirected to default page."
   end
 
   test "search with page more than 100" do
     visit search_path(page: "102")
     assert redirect_to(search_path(page: "1"))
-    assert page.has_content? "search"
-    assert page.has_content? "Page number is out of range. Redirected to default page."
+    assert_text "search"
+    assert_text "Page number is out of range. Redirected to default page."
   end
 
   test "news with page more than 10" do
     visit news_path(page: "12")
     assert redirect_to(news_path(page: "1"))
-    assert page.has_content? "New Releases — All Gems"
-    assert page.has_content? "Page number is out of range. Redirected to default page."
+    assert_text "New Releases — All Gems"
+    assert_text "Page number is out of range. Redirected to default page."
   end
 
   test "popular news with page more than 10" do
     visit popular_news_path(page: "12")
     assert redirect_to(popular_news_path(page: "1"))
-    assert page.has_content? "New Releases — Popular Gems"
-    assert page.has_content? "Page number is out of range. Redirected to default page."
+    assert_text "New Releases — Popular Gems"
+    assert_text "Page number is out of range. Redirected to default page."
   end
 
   test "api search with page smaller than 1" do

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -24,7 +24,7 @@ class PasswordResetTest < SystemTest
   test "reset password form does not tell if a user exists" do
     forgot_password_with "someone@example.com"
 
-    assert page.has_content? "instructions for changing your password"
+    assert_text "instructions for changing your password"
   end
 
   test "resetting password without handle" do
@@ -45,7 +45,7 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 
   test "resetting a password with a blank password" do
@@ -56,8 +56,8 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: ""
     click_button "Save this password"
 
-    assert page.has_content? "Password can't be blank."
-    assert page.has_content? "Sign in"
+    assert_text "Password can't be blank."
+    assert_text "Sign in"
   end
 
   test "resetting a password when signed in" do
@@ -94,6 +94,6 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
 
-    assert page.has_content?("Sign out")
+    assert_text("Sign out")
   end
 end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -16,14 +16,14 @@ class ProfileTest < SystemTest
     sign_in
 
     visit profile_path("nick1")
-    assert page.has_content? "nick1"
+    assert_text "nick1"
 
     click_link "Edit Profile"
     fill_in "Username", with: "nick2"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert page.has_content? "nick2"
+    assert_text "nick2"
   end
 
   test "changing to an existing handle" do
@@ -37,7 +37,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert page.has_content? "Username has already been taken"
+    assert_text "Username has already been taken"
   end
 
   test "changing to invalid handle does not affect rendering" do
@@ -49,7 +49,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert page.has_content? "Username is too long (maximum is 40 characters)"
+    assert_text "Username is too long (maximum is 40 characters)"
     assert page.has_link?("nick1", href: "/profiles/nick1")
   end
 
@@ -117,7 +117,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Confirm"
 
-    assert page.has_content? "Your account deletion request has been enqueued."\
+    assert_text "Your account deletion request has been enqueued."\
                              " We will send you a confirmation mail when your request has been processed."
   end
 
@@ -148,7 +148,7 @@ class ProfileTest < SystemTest
     click_link "Adoptions"
 
     assert page.has_link?(rubygem.name, href: "/gems/#{rubygem.name}")
-    assert page.has_content? "special note"
-    assert page.has_content? "request note"
+    assert_text "special note"
+    assert_text "request note"
   end
 end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -16,9 +16,9 @@ class PushTest < ActionDispatch::IntegrationTest
 
     get rubygem_path("sandworm")
     assert_response :success
-    assert page.has_content?("sandworm")
-    assert page.has_content?("1.0.0")
-    assert page.has_content?("Pushed by")
+    assert_text("sandworm")
+    assert_text("1.0.0")
+    assert_text("Pushed by")
 
     css = %(div.gem__users a[alt=#{@user.handle}])
     assert page.has_css?(css, count: 2)
@@ -35,8 +35,8 @@ class PushTest < ActionDispatch::IntegrationTest
 
     get rubygem_path("sandworm")
     assert_response :success
-    assert page.has_content?("sandworm")
-    assert page.has_content?("2.0.0")
+    assert_text("sandworm")
+    assert_text("2.0.0")
   end
 
   test "pushing a gem with a known dependency" do
@@ -50,8 +50,8 @@ class PushTest < ActionDispatch::IntegrationTest
 
     get rubygem_path("sandworm")
     assert_response :success
-    assert page.has_content?("crysknife")
-    assert page.has_content?("> 0")
+    assert_text("crysknife")
+    assert_text("> 0")
   end
 
   test "pushing a gem with an unknown dependency" do
@@ -63,8 +63,8 @@ class PushTest < ActionDispatch::IntegrationTest
 
     get rubygem_path("sandworm")
     assert_response :success
-    assert page.has_content?("mauddib")
-    assert page.has_content?("> 1")
+    assert_text("mauddib")
+    assert_text("> 1")
   end
 
   test "pushing a signed gem" do
@@ -73,14 +73,14 @@ class PushTest < ActionDispatch::IntegrationTest
     get rubygem_path("valid_signature")
     assert_response :success
 
-    assert page.has_content?("Signature validity period")
-    assert page.has_content?("August 31, 2021")
-    assert page.has_content?("August 07, 2121")
+    assert_text("Signature validity period")
+    assert_text("August 31, 2021")
+    assert_text("August 07, 2121")
     refute page.has_content?("(expired)")
 
     travel_to Time.zone.local(2121, 8, 8)
     get rubygem_path("valid_signature")
-    assert page.has_content?("(expired)")
+    assert_text("(expired)")
   end
 
   test "push errors bubble out" do

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -13,9 +13,9 @@ class SearchTest < SystemTest
     fill_in "query", with: "LDAP"
     click_button "search_submit"
 
-    assert page.has_content? "LDAP"
+    assert_text "LDAP"
 
-    assert page.has_content? "LDAP-PLUS"
+    assert_text "LDAP-PLUS"
   end
 
   test "searching for a yanked gem" do
@@ -28,11 +28,11 @@ class SearchTest < SystemTest
     fill_in "query", with: "LDAP"
     click_button "search_submit"
 
-    assert page.has_content? "No gems found"
-    assert page.has_content? "Yanked (1)"
+    assert_text "No gems found"
+    assert_text "Yanked (1)"
 
     click_link "Yanked (1)"
-    assert page.has_content? "LDAP"
+    assert_text "LDAP"
     assert page.has_selector? "a[href='#{rubygem_path('LDAP')}']"
   end
 
@@ -47,7 +47,7 @@ class SearchTest < SystemTest
     fill_in "query", with: "LDAP"
     click_button "search_submit"
 
-    assert page.has_content?("1.1.1")
+    assert_text("1.1.1")
     refute page.has_content?("2.2.2")
   end
 
@@ -64,7 +64,7 @@ class SearchTest < SystemTest
     import_and_refresh
 
     visit "/search?query=ruby&original_script_name=javascript:alert(1)//&script_name=javascript:alert(1)//"
-    assert page.has_content? "ruby-ruby"
+    assert_text "ruby-ruby"
     assert page.has_link?("Next", href: "/search?page=2&query=ruby")
     Kaminari.configure { |c| c.default_per_page = 30 }
   end
@@ -81,10 +81,10 @@ class SearchTest < SystemTest
       import_and_refresh
 
       visit "/search?query=ruby"
-      assert page.has_content? "Displaying gem 1 - 1 of 3 in total"
+      assert_text "Displaying gem 1 - 1 of 3 in total"
 
       click_link "Last"
-      assert page.has_content? "Displaying gem 2 - 2 of 3 in total"
+      assert_text "Displaying gem 2 - 2 of 3 in total"
 
       Gemcutter::SEARCH_MAX_PAGES = orignal_val
       Kaminari.configure { |c| c.default_per_page = 30 }

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -33,19 +33,19 @@ class SettingsTest < SystemTest
     visit edit_settings_path
     click_button "Register a new device"
 
-    assert page.has_content? "Enabling multifactor auth"
+    assert_text "Enabling multifactor auth"
 
     totp = ROTP::TOTP.new(mfa_key)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
-    assert page.has_content? "Recovery codes"
+    assert_text "Recovery codes"
 
     click_link "[ copy ]"
     check "ack"
     click_button "Continue"
 
-    assert page.has_content? "You have enabled multifactor authentication."
+    assert_text "You have enabled multifactor authentication."
     css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
     assert page.has_css?(css, visible: true)
   end
@@ -55,13 +55,13 @@ class SettingsTest < SystemTest
     visit edit_settings_path
     click_button "Register a new device"
 
-    assert page.has_content? "Enabling multifactor auth"
+    assert_text "Enabling multifactor auth"
 
     totp = ROTP::TOTP.new(ROTP::Base32.random_base32)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert_text "You have not yet enabled multifactor authentication."
   end
 
   test "disabling multifactor authentication with valid otp" do
@@ -72,7 +72,7 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert_text "You have not yet enabled multifactor authentication."
     css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
     assert page.has_css?(css)
   end
@@ -86,7 +86,7 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: ROTP::TOTP.new(key).now
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have enabled multifactor authentication."
+    assert_text "You have enabled multifactor authentication."
   end
 
   test "disabling multifactor authentication with recovery code" do
@@ -98,7 +98,7 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
-    assert page.has_content? "Recovery codes"
+    assert_text "Recovery codes"
 
     recoveries = page.find_by_id("recovery-code-list").text.split
 
@@ -108,7 +108,7 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: recoveries.sample
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert_text "You have not yet enabled multifactor authentication."
   end
 
   teardown do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -14,7 +14,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 
   test "signing in with uppercase email" do
@@ -23,7 +23,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 
   test "signing in with wrong password" do
@@ -32,8 +32,8 @@ class SignInTest < SystemTest
     fill_in "Password", with: "wordcrimes12345"
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
-    assert page.has_content? "Bad email or password"
+    assert_text "Sign in"
+    assert_text "Bad email or password"
   end
 
   test "signing in with wrong email" do
@@ -42,8 +42,8 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
-    assert page.has_content? "Bad email or password"
+    assert_text "Sign in"
+    assert_text "Bad email or password"
   end
 
   test "signing in with unconfirmed email" do
@@ -59,8 +59,8 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
-    assert page.has_content? "Please confirm your email address with the link sent to your email."
+    assert_text "Sign in"
+    assert_text "Please confirm your email address with the link sent to your email."
   end
 
   test "signing in with current valid otp when mfa enabled" do
@@ -69,12 +69,12 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert_text "Multifactor authentication"
 
     fill_in "OTP code", with: ROTP::TOTP.new("thisisonemfaseed").now
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 
   test "signing in with invalid otp when mfa enabled" do
@@ -83,12 +83,12 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert_text "Multifactor authentication"
 
     fill_in "OTP code", with: "11111"
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 
   test "signing in with valid recovery code when mfa enabled" do
@@ -97,12 +97,12 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert_text "Multifactor authentication"
 
     fill_in "OTP code", with: "0123456789ab"
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
   end
 
   test "signing in with invalid recovery code when mfa enabled" do
@@ -111,12 +111,12 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert_text "Multifactor authentication"
 
     fill_in "OTP code", with: "ab0123456789"
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 
   test "siging in when user does not have handle" do
@@ -127,13 +127,13 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert_text "Multifactor authentication"
 
     fill_in "OTP code", with: ROTP::TOTP.new("thisisonemfaseed").now
     click_button "Sign in"
 
-    assert page.has_content? "john@example.com"
-    assert page.has_content? "Sign out"
+    assert_text "john@example.com"
+    assert_text "Sign out"
   end
 
   test "signing out" do
@@ -144,7 +144,7 @@ class SignInTest < SystemTest
 
     click_link "Sign out"
 
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 
   test "session expires in two weeks" do
@@ -155,7 +155,7 @@ class SignInTest < SystemTest
 
     travel 15.days do
       visit edit_profile_path
-      assert page.has_content? "Sign in"
+      assert_text "Sign in"
     end
   end
 
@@ -167,7 +167,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign in"
-    assert page.has_content? "Your account was blocked by rubygems team. Please email support@rubygems.org to recover your account."
+    assert_text "Sign in"
+    assert_text "Your account was blocked by rubygems team. Please email support@rubygems.org to recover your account."
   end
 end

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -19,7 +19,7 @@ class SignUpTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
-    assert page.has_content? "errors prohibited"
+    assert_text "errors prohibited"
   end
 
   test "sign up with bad handle" do
@@ -30,7 +30,7 @@ class SignUpTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
-    assert page.has_content? "error prohibited"
+    assert_text "error prohibited"
   end
 
   test "sign up with someone else's handle" do
@@ -42,7 +42,7 @@ class SignUpTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign up"
 
-    assert page.has_content? "error prohibited"
+    assert_text "error prohibited"
   end
 
   test "sign up when sign up is disabled" do
@@ -74,7 +74,7 @@ class SignUpTest < SystemTest
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
+    assert_text "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
   end
 

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -10,7 +10,7 @@ class StatsTest < SystemTest
   test "downloads animation bar" do
     visit stats_path
     assert page.find(:css, ".stats__graph__gem__meter")
-    assert page.has_content?(@rubygem.downloads)
+    assert_text(@rubygem.downloads)
   end
 
   teardown { Capybara.use_default_driver }

--- a/test/integration/transitive_dependencies_test.rb
+++ b/test/integration/transitive_dependencies_test.rb
@@ -23,15 +23,15 @@ class TransitiveDependenciesTest < SystemTest
     end
 
     visit rubygem_version_dependencies_path(rubygem_id: rubygem_one.name, version_id: version_one.number)
-    assert page.has_content?(rubygem_one.name)
-    assert page.has_content?(version_one.number)
-    assert page.has_content?(rubygem_two.name)
-    assert page.has_content?(version_two[2].number)
+    assert_text(rubygem_one.name)
+    assert_text(version_one.number)
+    assert_text(rubygem_two.name)
+    assert_text(version_two[2].number)
     find("span.deps_expanded-link").click
-    assert page.has_content?(version_four.rubygem.name)
-    assert page.has_content?(version_three.number)
-    assert page.has_content?(version_four.rubygem.name)
-    assert page.has_content?(version_four.number)
+    assert_text(version_four.rubygem.name)
+    assert_text(version_three.number)
+    assert_text(version_four.rubygem.name)
+    assert_text(version_four.number)
   end
 
   test "loading transitive dependencies for jruby platform" do
@@ -45,11 +45,11 @@ class TransitiveDependenciesTest < SystemTest
 
     visit rubygem_path(version.rubygem)
     click_on "Show all transitive dependencies"
-    assert page.has_content?(dep_version.rubygem.name)
-    assert page.has_content?(dep_version.slug)
+    assert_text(dep_version.rubygem.name)
+    assert_text(dep_version.slug)
     find("span.deps_expanded-link").click
-    assert page.has_content?(dep_dep_version.rubygem.name)
-    assert page.has_content?(dep_dep_version.slug)
+    assert_text(dep_dep_version.rubygem.name)
+    assert_text(dep_dep_version.slug)
   end
 
   # Reset sessions and driver between tests

--- a/test/integration/yank_test.rb
+++ b/test/integration/yank_test.rb
@@ -24,20 +24,20 @@ class YankTest < SystemTest
     page.driver.delete yank_api_v1_rubygems_path(gem_name: @rubygem.name, version: "2.2.2")
 
     visit dashboard_path
-    assert page.has_content? "sandworm"
+    assert_text "sandworm"
 
     click_link "sandworm"
-    assert page.has_content?("1.1.1")
+    assert_text("1.1.1")
     refute page.has_content?("2.2.2")
 
     within ".versions" do
       click_link "Show all versions (2 total)"
     end
     click_link "2.2.2"
-    assert page.has_content? "This version has been yanked"
+    assert_text "This version has been yanked"
     assert page.has_css? 'meta[name="robots"][content="noindex"]', visible: false
 
-    assert page.has_content?("Yanked by")
+    assert_text("Yanked by")
 
     css = %(div.gem__users a[alt=#{@user.handle}])
     assert page.has_css?(css, count: 3)
@@ -47,15 +47,15 @@ class YankTest < SystemTest
     create(:version, rubygem: @rubygem, number: "0.0.0")
 
     visit rubygem_path(@rubygem)
-    assert page.has_content? "sandworm"
-    assert page.has_content? "0.0.0"
+    assert_text "sandworm"
+    assert_text "0.0.0"
 
     page.driver.browser.header("Authorization", @user_api_key)
     page.driver.delete yank_api_v1_rubygems_path(gem_name: @rubygem.name, version: "0.0.0")
 
     visit rubygem_path(@rubygem)
-    assert page.has_content? "sandworm"
-    assert page.has_content? "This gem is not currently hosted on RubyGems.org"
+    assert_text "sandworm"
+    assert_text "This gem is not currently hosted on RubyGems.org"
 
     other_user_key = "12323"
     other_api_key = create(:api_key, key: other_user_key, push_rubygem: true)
@@ -66,8 +66,8 @@ class YankTest < SystemTest
       "CONTENT_TYPE" => "application/octet-stream"
 
     visit rubygem_path(@rubygem)
-    assert page.has_content? "sandworm"
-    assert page.has_content? "1.0.0"
+    assert_text "sandworm"
+    assert_text "1.0.0"
     assert page.has_selector?("a[alt='#{other_api_key.user.handle}']")
     refute page.has_content?("0.0.0")
     refute page.has_selector?("a[alt='#{@user.handle}']")


### PR DESCRIPTION
shorter, included by default, and preserve meaning