### PR TITLE
fix rubocop warning by re-enabling ruby and excluding files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,11 +128,6 @@ Style/CustomSafeNavigationCop:
   Exclude:
     - app/models/links.rb
 
-Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
-  Exclude:
-    - lib/lograge/formatters/datadog.rb
-
 Style/Documentation:
   Enabled: false
 
@@ -286,4 +281,8 @@ Minitest/MultipleAssertions:
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  Enabled: false
+  EnforcedStyle: compact
+  Exclude:
+    - lib/lograge/formatters/datadog.rb
+    - lib/gemcutter/middleware/hostess.rb
+    - lib/gemcutter/middleware/redirector.rb


### PR DESCRIPTION
```
.rubocop.yml:131: `Style/ClassAndModuleChildren` is concealed by line 288
```