### PR TITLE
Disable mfa_required_since usage

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -329,6 +329,7 @@ class Rubygem < ApplicationRecord
     user.mfa_enabled? || !mfa_required?
   end
 
+  # TODO: broken. don't use until #2964 is resolved.
   def mfa_required_since_version
     return unless mfa_required?
     non_mfa_version = public_versions.find { |v| !v.rubygems_mfa_required? }

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -60,7 +60,7 @@
     <h2 class="gem__ruby-version__heading t-list__heading">
       <%= t('.requires_mfa') %>:
       <span class="gem__ruby-version">
-        <%= t('.since', version: @rubygem.mfa_required_since_version) %>
+        true
       </span>
     </h2>
   <% end %>

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -160,7 +160,7 @@ class GemsSystemTest < SystemTest
 
     visit rubygem_path(@rubygem)
 
-    assert page.has_content? "Since 1.1.1"
+    assert page.has_content? "true"
   end
 
   test "does show correct version that introduced mfa requirement" do
@@ -171,6 +171,6 @@ class GemsSystemTest < SystemTest
 
     visit rubygem_path(@rubygem)
 
-    assert page.has_content? "Since 3.3.3"
+    assert page.has_content? "true"
   end
 end


### PR DESCRIPTION
Fixes server error on https://rubygems.org/gems/fabrication
```
NoMethodError: undefined method `number' for nil:NilClass
[PROJECT_ROOT]/app/models/rubygem.rb:336 :in
`mfa_required_since_version`
    non_mfa_version = public_versions.find { |v|
!v.rubygems_mfa_required? }
    if non_mfa_version
      non_mfa_version.next.number
    else
      public_versions.last.number
[PROJECT_ROOT]/app/views/rubygems/_aside.html.erb:63 :in
`_app_views_rubygems__aside_html_erb`
[PROJECT_ROOT]/app/views/rubygems/show.html.erb:67 :in
`_app_views_rubygems_show_html_erb`
```
Related: #2964