### PR TITLE
Fix various deprecations in tests.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,6 +64,6 @@ module ApplicationHelper
   end
 
   def i18n_api_scopes(api_key)
-    api_key.enabled_scopes.sum { |scope| tag.ul(t(".#{scope}"), class: "scopes__list") }
+    api_key.enabled_scopes.sum("") { |scope| tag.ul(t(scope, scope: %i[api_keys index]), class: "scopes__list") }
   end
 end

--- a/app/helpers/dynamic_errors_helper.rb
+++ b/app/helpers/dynamic_errors_helper.rb
@@ -40,7 +40,7 @@ module DynamicErrorsHelper
 
         message = options.include?(:message) ? options[:message] : locale.t(:body)
 
-        error_messages = objects.sum do |object|
+        error_messages = objects.map do |object|
           object.errors.full_messages.map do |msg|
             content_tag(:li, msg)
           end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -21,7 +21,7 @@ module SearchesHelper
     count = aggregration["buckets"][buckets_pos]["doc_count"]
     return unless count > 0
 
-    time_ago = (Time.zone.today - duration).to_s(:db)
+    time_ago = (Time.zone.today - duration).to_formatted_s(:db)
     path = search_path(params: { query: "#{params[:query]} AND updated:[#{time_ago} TO *}" })
     update_info = (duration == 30.days ? t("searches.show.month_update", count: count) : t("searches.show.week_update", count: count))
     link_to update_info, path, class: "t-link--black"

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -32,7 +32,7 @@
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.
-# Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
+Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
 
 # Change the format of the cache entry.
 # Changing this default means that all new cache entries added to the cache

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -347,7 +347,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       should respond_with :conflict
       should "not register new version" do
         version = Rubygem.last.reload.versions.most_recent
-        assert_equal @date.to_s(:db), version.built_at.to_s(:db), "(date)"
+        assert_equal @date.to_formatted_s(:db), version.built_at.to_formatted_s(:db), "(date)"
         assert_equal "Freewill", version.summary, "(summary)"
         assert_equal "Geddy Lee", version.authors, "(authors)"
       end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -43,4 +43,14 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_in_delta(stats_graph_meter(@rubygem, most_downloaded_count), 12.5)
     end
   end
+
+  context "i18n_api_scopes" do
+    setup do
+      @api_key = create(:api_key, index_rubygems: true, push_rubygem: true)
+    end
+    should "return concat of ul tags for enabled scopes" do
+      assert_equal '<ul class="scopes__list">Index rubygems</ul><ul class="scopes__list">Push rubygem</ul>',
+        i18n_api_scopes(@api_key)
+    end
+  end
 end

--- a/test/unit/version_test.rb
+++ b/test/unit/version_test.rb
@@ -742,10 +742,10 @@ class VersionTest < ActiveSupport::TestCase
       # Even though gem two was build before gem one, it was pushed to gemcutter first
       # Thus, we should have from newest to oldest, gem one, then gem two
       expected = [@subscribed_one, @subscribed_two].map do |s|
-        s.created_at.to_s(:db)
+        s.created_at.to_formatted_s(:db)
       end
       actual = Version.subscribed_to_by(@user).map do |s|
-        s.created_at.to_s(:db)
+        s.created_at.to_formatted_s(:db)
       end
       assert_equal expected, actual
     end


### PR DESCRIPTION
## after

```
[retro@retro  rubygems.org (fix-deprecations)]❤ bin/rails test test/                                                                                                                          
Run options: --seed 18310                                                                                                                                                                     
                                                                                                                                                                                              
# Running:                
                                               
..............................................................................................................................................................................................
..........................................................S.......................................................................................S........S..................................
.....................................................S........................................................................................................................................
..............................................................................................................................................................................................
..............................................................................................................................................................................................
................S...............................................................................................S.............................................................................
..............................................................................................................................................................................................
..............................................................................................................................................................................................
..............................................................................................................................................................................................
...............................................................................................................
                                                                                               
Finished in 146.780687s, 12.4063 runs/s, 24.3493 assertions/s.
1821 runs, 3574 assertions, 0 failures, 0 errors, 6 skips
                                                                                               
You have skipped tests. Run with --verbose for details.                                  
Coverage report generated for Functional Tests, Unit Tests to /home/retro/code/work/oss/rubygems.org/coverage. 3013 / 3081 LOC (97.79%) covered.

```