### PR TITLE
Add mfa_recommended? to Rubygem and User model

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -33,7 +33,7 @@ class Rubygem < ApplicationRecord
   after_create :create_gem_download
   before_destroy :mark_unresolved
 
-  MFA_RECOMMENDED_THRESHOLD = 175_000_000
+  MFA_RECOMMENDED_THRESHOLD = 165_000_000
 
   def create_gem_download
     GemDownload.create!(count: 0, rubygem_id: id, version_id: 0)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -33,6 +33,8 @@ class Rubygem < ApplicationRecord
   after_create :create_gem_download
   before_destroy :mark_unresolved
 
+  MFA_RECOMMENDED_THRESHOLD = 175_000_000
+
   def create_gem_download
     GemDownload.create!(count: 0, rubygem_id: id, version_id: 0)
   end
@@ -323,6 +325,10 @@ class Rubygem < ApplicationRecord
 
   def mfa_required?
     latest_version&.rubygems_mfa_required?
+  end
+
+  def mfa_recommended?
+    downloads > MFA_RECOMMENDED_THRESHOLD
   end
 
   def mfa_requirement_satisfied_for?(user)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -35,6 +35,8 @@ class Rubygem < ApplicationRecord
 
   MFA_RECOMMENDED_THRESHOLD = 165_000_000
 
+  scope :mfa_recommended, -> { joins(:gem_download).where("gem_downloads.count > ?", MFA_RECOMMENDED_THRESHOLD) }
+
   def create_gem_download
     GemDownload.create!(count: 0, rubygem_id: id, version_id: 0)
   end
@@ -325,10 +327,6 @@ class Rubygem < ApplicationRecord
 
   def mfa_required?
     latest_version&.rubygems_mfa_required?
-  end
-
-  def mfa_recommended?
-    downloads > MFA_RECOMMENDED_THRESHOLD
   end
 
   def mfa_requirement_satisfied_for?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,8 +225,12 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
+  def strong_mfa_level?
+    mfa_ui_and_gem_signin? || mfa_ui_and_api?
+  end
+
   def mfa_gem_signin_authorized?(otp)
-    return true unless mfa_ui_and_gem_signin? || mfa_ui_and_api?
+    return true unless strong_mfa_level?
     otp_verified?(otp)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,7 +236,8 @@ class User < ApplicationRecord
 
   def mfa_recommended?
     return false if strong_mfa_level?
-    rubygems.any?(&:mfa_recommended?)
+
+    rubygems.mfa_recommended.any?
   end
 
   def otp_verified?(otp)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,11 @@ class User < ApplicationRecord
     otp_verified?(otp)
   end
 
+  def mfa_recommended?
+    return false if strong_mfa_level?
+    rubygems.any?(&:mfa_recommended?)
+  end
+
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -873,25 +873,25 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context "#mfa_recommended?" do
-    should "be false if gem has fewer downloads than the recommended threshold" do
+  context ".mfa_recommended" do
+    should "not return gems with fewer downloads than the recommended threshold" do
       rubygem = create(:rubygem)
       GemDownload.increment(
         Rubygem::MFA_RECOMMENDED_THRESHOLD,
         rubygem_id: rubygem.id
       )
 
-      refute rubygem.mfa_recommended?
+      assert_empty Rubygem.mfa_recommended
     end
 
-    should "be true if gem has more downloads than the recommended threshold" do
+    should "return gems with more downloads than the recommended threshold" do
       rubygem = create(:rubygem)
       GemDownload.increment(
         Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
         rubygem_id: rubygem.id
       )
 
-      assert rubygem.mfa_recommended?
+      refute_empty Rubygem.mfa_recommended
     end
   end
 

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -873,6 +873,28 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
+  context "#mfa_recommended?" do
+    should "be false if gem has fewer downloads than the recommended threshold" do
+      rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_RECOMMENDED_THRESHOLD,
+        rubygem_id: rubygem.id
+      )
+
+      refute rubygem.mfa_recommended?
+    end
+
+    should "be true if gem has more downloads than the recommended threshold" do
+      rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+        rubygem_id: rubygem.id
+      )
+
+      assert rubygem.mfa_recommended?
+    end
+  end
+
   context "#mfa_requirement_satisfied_for?" do
     setup do
       @rubygem = create(:rubygem)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -355,6 +355,32 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    context "strong_mfa_level?" do
+      should "be true if the users mfa level is ui_and_api" do
+        user = create(:user, mfa_level: "ui_and_api")
+
+        assert user.strong_mfa_level?
+      end
+
+      should "be true if the users mfa level is ui_and_gem_signin" do
+        user = create(:user, mfa_level: "ui_and_gem_signin")
+
+        assert user.strong_mfa_level?
+      end
+
+      should "be false if users mfa level is ui_only" do
+        user = create(:user, mfa_level: "ui_only")
+
+        refute user.strong_mfa_level?
+      end
+
+      should "be false if users has mfa disabled" do
+        user = create(:user, mfa_level: "disabled")
+
+        refute user.strong_mfa_level?
+      end
+    end
+
     context "mfa_recommended?" do
       should "be false when a user doesn't own a gem with more downloads than the recommended threshold" do
         user = create(:user)


### PR DESCRIPTION
This PR adds `Rubygem#mfa_recommended?` and `User#mfa_recommended?` methods and the associated tests. `User#mfa_recommended?` is not yet called anywhere, we're just adding it for now. 

This lays the groundwork to start implementing [Phase 2 of the MFA RFC](https://github.com/rubygems/rfcs/pull/36/files#diff-3d5cc3acc06fe7e9150fdbfc43399c5ad42572c122187774bfc3a4857df524f1R46). If a user is an owner of a gem with more than 165,000,000 downloads (meaning their gem is 90% of the way to the required threshold, which will be set to the downloads of the 100th most downloaded gem)
and they don't have MFA enabled, we mark them as `mfa_recommended` so that in the future we may start nudging them to turn it on. 

cc @simi @sonalkr132 