### PR TITLE
Add MFA recommended warnings to gem push/yank, add/remove owner and signin

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -43,10 +43,6 @@ class Api::BaseController < ApplicationController
     render plain: "Gem requires MFA enabled; You do not have MFA enabled yet.", status: :forbidden
   end
 
-  def response_with_warning(response)
-    response_with_mfa_warning(response)
-  end
-
   def response_with_mfa_warning(response)
     message = response
     if @api_key.user.mfa_recommended_not_yet_enabled?

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -43,7 +43,7 @@ class Api::BaseController < ApplicationController
     render plain: "Gem requires MFA enabled; You do not have MFA enabled yet.", status: :forbidden
   end
 
-  def response_with_warnings(response)
+  def response_with_warning(response)
     response_with_mfa_warning(response)
   end
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -12,10 +12,10 @@ class Api::V1::DeletionsController < Api::BaseController
     if @deletion.save
       StatsD.increment "yank.success"
       enqueue_web_hook_jobs(@version)
-      render plain: response_with_warnings("Successfully deleted gem: #{@version.to_title}")
+      render plain: response_with_warning("Successfully deleted gem: #{@version.to_title}")
     else
       StatsD.increment "yank.failure"
-      render plain: response_with_warnings(@deletion.errors.full_messages.to_sentence),
+      render plain: response_with_warning(@deletion.errors.full_messages.to_sentence),
              status: :unprocessable_entity
     end
   end
@@ -24,10 +24,10 @@ class Api::V1::DeletionsController < Api::BaseController
 
   def validate_gem_and_version
     if !@rubygem.hosted?
-      render plain: response_with_warnings(t(:this_rubygem_could_not_be_found)),
+      render plain: response_with_warning(t(:this_rubygem_could_not_be_found)),
              status: :not_found
     elsif !@rubygem.owned_by?(@api_key.user)
-      render plain: response_with_warnings("You do not have permission to delete this gem."),
+      render plain: response_with_warning("You do not have permission to delete this gem."),
              status: :forbidden
     else
       begin
@@ -35,7 +35,7 @@ class Api::V1::DeletionsController < Api::BaseController
         platform = params.permit(:platform).fetch(:platform, nil)
         @version = @rubygem.find_version!(number: version, platform: platform)
       rescue ActiveRecord::RecordNotFound
-        render plain: response_with_warnings("The version #{version}#{" (#{platform})" if platform.present?} does not exist."),
+        render plain: response_with_warning("The version #{version}#{" (#{platform})" if platform.present?} does not exist."),
                status: :not_found
       end
     end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -21,13 +21,13 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
         Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
-        render plain: response_with_warnings("#{owner.display_handle} was added as an unconfirmed owner. "\
-                                             "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
+        render plain: response_with_warning("#{owner.display_handle} was added as an unconfirmed owner. "\
+                                            "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
       else
-        render plain: response_with_warnings(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
+        render plain: response_with_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
       end
     else
-      render plain: response_with_warnings("Owner could not be found."), status: :not_found
+      render plain: response_with_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -39,12 +39,12 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
         OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
-        render plain: response_with_warnings("Owner removed successfully.")
+        render plain: response_with_warning("Owner removed successfully.")
       else
-        render plain: response_with_warnings("Unable to remove owner."), status: :forbidden
+        render plain: response_with_warning("Unable to remove owner."), status: :forbidden
       end
     else
-      render plain: response_with_warnings("Owner could not be found."), status: :not_found
+      render plain: response_with_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -65,6 +65,6 @@ class Api::V1::OwnersController < Api::BaseController
 
   def verify_gem_ownership
     return if @api_key.user.rubygems.find_by_name(params[:rubygem_id])
-    render plain: response_with_warnings("You do not have permission to manage this gem."), status: :unauthorized
+    render plain: response_with_warning("You do not have permission to manage this gem."), status: :unauthorized
   end
 end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -39,12 +39,12 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
         OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
-        render plain: "Owner removed successfully."
+        render plain: response_with_warnings("Owner removed successfully.")
       else
-        render plain: "Unable to remove owner.", status: :forbidden
+        render plain: response_with_warnings("Unable to remove owner."), status: :forbidden
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_warnings("Owner could not be found."), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -21,13 +21,13 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
         Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
-        render plain: "#{owner.display_handle} was added as an unconfirmed owner. "\
-                      "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email."
+        render plain: response_with_warnings("#{owner.display_handle} was added as an unconfirmed owner. "\
+                                             "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
       else
-        render plain: ownership.errors.full_messages.to_sentence, status: :unprocessable_entity
+        render plain: response_with_warnings(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_warnings("Owner could not be found."), status: :not_found
     end
   end
 
@@ -65,6 +65,6 @@ class Api::V1::OwnersController < Api::BaseController
 
   def verify_gem_ownership
     return if @api_key.user.rubygems.find_by_name(params[:rubygem_id])
-    render plain: "You do not have permission to manage this gem.", status: :unauthorized
+    render plain: response_with_warnings("You do not have permission to manage this gem."), status: :unauthorized
   end
 end

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -21,13 +21,14 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
         Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
-        render plain: response_with_warning("#{owner.display_handle} was added as an unconfirmed owner. "\
-                                            "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
+        render plain: response_with_mfa_warning("#{owner.display_handle} was added as an unconfirmed owner. "\
+                                                "Ownership access will be enabled after the user clicks on the "\
+                                                "confirmation mail sent to their email.")
       else
-        render plain: response_with_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
+        render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
       end
     else
-      render plain: response_with_warning("Owner could not be found."), status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -39,12 +40,12 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
         OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
-        render plain: response_with_warning("Owner removed successfully.")
+        render plain: response_with_mfa_warning("Owner removed successfully.")
       else
-        render plain: response_with_warning("Unable to remove owner."), status: :forbidden
+        render plain: response_with_mfa_warning("Unable to remove owner."), status: :forbidden
       end
     else
-      render plain: response_with_warning("Owner could not be found."), status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -65,6 +66,6 @@ class Api::V1::OwnersController < Api::BaseController
 
   def verify_gem_ownership
     return if @api_key.user.rubygems.find_by_name(params[:rubygem_id])
-    render plain: response_with_warning("You do not have permission to manage this gem."), status: :unauthorized
+    render plain: response_with_mfa_warning("You do not have permission to manage this gem."), status: :unauthorized
   end
 end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::RubygemsController < Api::BaseController
 
     gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip, @api_key.rubygem)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
-    render plain: gemcutter.message, status: gemcutter.code
+    render plain: response_with_warnings(gemcutter.message), status: gemcutter.code
   rescue StandardError => e
     Honeybadger.notify(e)
     render plain: "Server error. Please try again.", status: :internal_server_error

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::RubygemsController < Api::BaseController
 
     gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip, @api_key.rubygem)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
-    render plain: response_with_warning(gemcutter.message), status: gemcutter.code
+    render plain: response_with_mfa_warning(gemcutter.message), status: gemcutter.code
   rescue StandardError => e
     Honeybadger.notify(e)
     render plain: "Server error. Please try again.", status: :internal_server_error

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::RubygemsController < Api::BaseController
 
     gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip, @api_key.rubygem)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
-    render plain: response_with_warnings(gemcutter.message), status: gemcutter.code
+    render plain: response_with_warning(gemcutter.message), status: gemcutter.code
   rescue StandardError => e
     Honeybadger.notify(e)
     render plain: "Server error. Please try again.", status: :internal_server_error

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -3,6 +3,23 @@
 # being exposed to all users in their public profile
 class User::WithPrivateFields < User
   def payload
-    super.merge({ "mfa" => mfa_level })
+    super.merge({ "mfa" => mfa_level, "warnings" => warnings })
+  end
+
+  private
+
+  def warnings
+    warnings = [ mfa_warning ]
+  end
+
+  def mfa_warning
+    if mfa_recommended_not_yet_enabled?
+      "For protection of your account and gems, we encourage you to set up multifactor authentication \
+      at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+    elsif mfa_recommended_weak_level_enabled?
+      "For protection of your account and gems, we encourage you to change your multifactor authentication \
+      level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
+      Your account will be required to have MFA enabled on one of these levels in the future."
+    end
   end
 end

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -9,17 +9,17 @@ class User::WithPrivateFields < User
   private
 
   def warnings
-    warnings = [ mfa_warning ]
+    [mfa_warning]
   end
 
   def mfa_warning
     if mfa_recommended_not_yet_enabled?
-      "For protection of your account and gems, we encourage you to set up multifactor authentication \
-      at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+      "For protection of your account and gems, we encourage you to set up multifactor authentication"\
+        " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
     elsif mfa_recommended_weak_level_enabled?
-      "For protection of your account and gems, we encourage you to change your multifactor authentication \
-      level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
-      Your account will be required to have MFA enabled on one of these levels in the future."
+      "For protection of your account and gems, we encourage you to change your multifactor authentication"\
+        " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
+        " Your account will be required to have MFA enabled on one of these levels in the future."
     end
   end
 end

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -10,10 +10,10 @@ class User::WithPrivateFields < User
 
   def mfa_warning
     if mfa_recommended_not_yet_enabled?
-      "For protection of your account and gems, we encourage you to set up multifactor authentication"\
+      "[WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication"\
         " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
     elsif mfa_recommended_weak_level_enabled?
-      "For protection of your account and gems, we encourage you to change your multifactor authentication"\
+      "[WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication"\
         " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
         " Your account will be required to have MFA enabled on one of these levels in the future."
     end

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -3,14 +3,10 @@
 # being exposed to all users in their public profile
 class User::WithPrivateFields < User
   def payload
-    super.merge({ "mfa" => mfa_level, "warnings" => warnings })
+    super.merge({ "mfa" => mfa_level, "warning" => mfa_warning })
   end
 
   private
-
-  def warnings
-    [mfa_warning]
-  end
 
   def mfa_warning
     if mfa_recommended_not_yet_enabled?

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -592,6 +592,81 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           assert_equal "An invalid API key cannot be used. Please delete it and create a new one.", @response.body
         end
       end
+
+      context "when mfa is recommended" do
+        setup do
+          User.any_instance.stubs(:mfa_recommended?).returns true
+          @emails = [@second_user.email, "doesnot@exist.com", @user.email, "no@permission.com"]
+        end
+
+        context "by user with mfa disabled" do
+          should "include mfa setup warning" do
+            @emails.each do |email|
+              delete :destroy, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = <<~WARN.chomp
+
+
+                [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+                at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+              WARN
+
+              assert_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_only` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          end
+
+          should "include change mfa level warning" do
+            @emails.each do |email|
+              delete :destroy, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = <<~WARN.chomp
+
+
+                [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+                level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
+                Your account will be required to have MFA enabled on one of these levels in the future.
+              WARN
+
+              assert_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_and_gem_signin` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          end
+
+          should "not include mfa warnings" do
+            @emails.each do |email|
+              delete :destroy, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = "[WARNING] For protection of your account and gems"
+
+              refute_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_and_api` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+          end
+
+          should "not include mfa warnings" do
+            @emails.each do |email|
+              delete :destroy, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = "[WARNING] For protection of your account and gems"
+
+              refute_includes @response.body, mfa_warning
+            end
+          end
+        end
+      end
     end
 
     context "without remove owner api key scope" do

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -317,6 +317,81 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           assert_equal "An invalid API key cannot be used. Please delete it and create a new one.", @response.body
         end
       end
+
+      context "when mfa is recommended" do
+        setup do
+          User.any_instance.stubs(:mfa_recommended?).returns true
+          @emails = [@second_user.email, "doesnot@exist.com", @user.email]
+        end
+
+        context "by user with mfa disabled" do
+          should "include mfa setup warning" do
+            @emails.each do |email|
+              post :create, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = <<~WARN.chomp
+
+
+                [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+                at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+              WARN
+
+              assert_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_only` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          end
+
+          should "include change mfa level warning" do
+            @emails.each do |email|
+              post :create, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = <<~WARN.chomp
+
+
+                [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+                level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
+                Your account will be required to have MFA enabled on one of these levels in the future.
+              WARN
+
+              assert_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_and_gem_signin` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          end
+
+          should "not include MFA warnings" do
+            @emails.each do |email|
+              post :create, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = "[WARNING] For protection of your account and gems"
+
+              refute_includes @response.body, mfa_warning
+            end
+          end
+        end
+
+        context "by user on `ui_and_api` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+          end
+
+          should "not include mfa warnings" do
+            @emails.each do |email|
+              post :create, params: { rubygem_id: @rubygem.to_param, email: email }, format: :json
+              mfa_warning = "[WARNING] For protection of your account and gems"
+
+              refute_includes @response.body, mfa_warning
+            end
+          end
+        end
+      end
     end
 
     context "without add owner api key scope" do

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -28,12 +28,12 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
   end
 
   def assert_warning_included(expected_warning)
-    assert response_body.key?("warnings")
-    assert_match expected_warning, response_body["warnings"].to_s
+    assert response_body.key?("warning")
+    assert_match expected_warning, response_body["warning"].to_s
   end
 
   def refute_warning_included(expected_warning)
-    refute_match expected_warning, response_body["warnings"].to_s
+    refute_match expected_warning, response_body["warning"].to_s
   end
 
   def refute_mfa_info_included(mfa_level)
@@ -97,7 +97,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
           end
 
           context "when mfa is disabled" do
-            should "include warnings" do
+            should "include warning" do
               expected_warning =
                 "For protection of your account and gems, we encourage you to set up multifactor authentication"\
                 " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
@@ -113,7 +113,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
                 get :me, format: format
               end
 
-              should "include warnings" do
+              should "include warning" do
                 expected_warning =
                   "For protection of your account and gems, we encourage you to change your multifactor authentication"\
                   " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
@@ -129,7 +129,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
                 get :me, format: format
               end
 
-              should "not include warnings in user json" do
+              should "not include warning in user json" do
                 unexpected_warning =
                   "For protection of your account and gems"
 
@@ -143,7 +143,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
                 get :me, format: format
               end
 
-              should "not include warnings" do
+              should "not include warning" do
                 unexpected_warning =
                   "For protection of your account and gems"
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -576,7 +576,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         end
 
         should respond_with :success
-        should "not include mfa warnings" do
+        should "not include mfa warning" do
           mfa_warning = "[WARNING] For protection of your account and gems"
 
           refute_includes @response.body, mfa_warning
@@ -591,7 +591,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         end
 
         should respond_with :success
-        should "not include mfa warnings" do
+        should "not include mfa warning" do
           mfa_warning = "[WARNING] For protection of your account and gems"
 
           refute_includes @response.body, mfa_warning

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -526,6 +526,78 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "when mfa is recommended" do
+      setup do
+        User.any_instance.stubs(:mfa_recommended?).returns true
+      end
+
+      context "by user with mfa disabled" do
+        setup do
+          post :create, body: gem_file("test-1.0.0.gem").read
+        end
+
+        should "include mfa setup warning" do
+          mfa_warning = <<~WARN.chomp
+
+
+            [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+            at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+          WARN
+
+          assert_includes @response.body, mfa_warning
+        end
+      end
+
+      context "by user on `ui_only` mfa level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          post :create, body: gem_file("test-1.0.0.gem").read
+        end
+
+        should "include change mfa level warning" do
+          mfa_warning = <<~WARN.chomp
+
+
+            [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+            level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
+            Your account will be required to have MFA enabled on one of these levels in the future.
+          WARN
+
+          assert_includes @response.body, mfa_warning
+        end
+      end
+
+      context "by user on `ui_and_gem_signin` mfa level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+          post :create, body: gem_file("test-1.0.0.gem").read
+        end
+
+        should respond_with :success
+        should "not include mfa warnings" do
+          mfa_warning = "[WARNING] For protection of your account and gems"
+
+          refute_includes @response.body, mfa_warning
+        end
+      end
+
+      context "by user on `ui_and_api` mfa level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
+          post :create, body: gem_file("test-1.0.0.gem").read
+        end
+
+        should respond_with :success
+        should "not include mfa warnings" do
+          mfa_warning = "[WARNING] For protection of your account and gems"
+
+          refute_includes @response.body, mfa_warning
+        end
+      end
+    end
   end
 
   context "push with api key with gem scoped" do

--- a/test/unit/user/with_private_fields_test.rb
+++ b/test/unit/user/with_private_fields_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class User::WithPrivateFieldsTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#warnings" do
+  end
+
+  context "#mfa_warnings" do
+  end
+end

--- a/test/unit/user/with_private_fields_test.rb
+++ b/test/unit/user/with_private_fields_test.rb
@@ -5,9 +5,65 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
-  context "#warnings" do
-  end
-
   context "#mfa_warnings" do
+    context "when mfa is recommended" do
+      setup do
+        @user = User::WithPrivateFields.new(email_confirmed: true, handle: "test")
+        @user.stubs(:mfa_recommended?).returns true
+      end
+
+      context "when mfa is disabled" do
+        should "include warnings in user json" do
+          expected_notice =
+            "For protection of your account and gems, we encourage you to set up multifactor authentication"\
+            " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+
+          assert_match expected_notice, @user.to_json
+        end
+      end
+
+      context "when mfa is enabled" do
+        context "on `ui_only` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          end
+
+          should "include warnings in user json" do
+            expected_notice =
+              "For protection of your account and gems, we encourage you to change your multifactor authentication"\
+              " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
+              " Your account will be required to have MFA enabled on one of these levels in the future."
+
+            assert_match expected_notice, @user.to_json
+          end
+        end
+
+        context "on `ui_and_gem_signin` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          end
+
+          should "not include warnings in user json" do
+            unexpected_notice =
+              "For protection of your account and gems"
+
+            refute_match unexpected_notice, @user.to_json
+          end
+        end
+
+        context "on `ui_and_api` level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          end
+
+          should "not include warnings in user json" do
+            unexpected_notice =
+              "For protection of your account and gems"
+
+            refute_match unexpected_notice, @user.to_json
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/user/with_private_fields_test.rb
+++ b/test/unit/user/with_private_fields_test.rb
@@ -15,7 +15,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
       context "when mfa is disabled" do
         should "include warning in user json" do
           expected_notice =
-            "For protection of your account and gems, we encourage you to set up multifactor authentication"\
+            "[WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication"\
             " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
 
           assert_match expected_notice, @user.to_json
@@ -30,7 +30,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
           should "include warning in user json" do
             expected_notice =
-              "For protection of your account and gems, we encourage you to change your multifactor authentication"\
+              "[WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication"\
               " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
               " Your account will be required to have MFA enabled on one of these levels in the future."
 
@@ -45,7 +45,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
           should "not include warning in user json" do
             unexpected_notice =
-              "For protection of your account and gems"
+              "[WARNING] For protection of your account and gems"
 
             refute_match unexpected_notice, @user.to_json
           end
@@ -58,7 +58,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
           should "not include warning in user json" do
             unexpected_notice =
-              "For protection of your account and gems"
+              "[WARNING] For protection of your account and gems"
 
             refute_match unexpected_notice, @user.to_json
           end

--- a/test/unit/user/with_private_fields_test.rb
+++ b/test/unit/user/with_private_fields_test.rb
@@ -5,7 +5,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
-  context "#mfa_warnings" do
+  context "#mfa_warning" do
     context "when mfa is recommended" do
       setup do
         @user = User::WithPrivateFields.new(email_confirmed: true, handle: "test")
@@ -13,7 +13,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
       end
 
       context "when mfa is disabled" do
-        should "include warnings in user json" do
+        should "include warning in user json" do
           expected_notice =
             "For protection of your account and gems, we encourage you to set up multifactor authentication"\
             " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
@@ -28,7 +28,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
             @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
           end
 
-          should "include warnings in user json" do
+          should "include warning in user json" do
             expected_notice =
               "For protection of your account and gems, we encourage you to change your multifactor authentication"\
               " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
@@ -43,7 +43,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
             @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
-          should "not include warnings in user json" do
+          should "not include warning in user json" do
             unexpected_notice =
               "For protection of your account and gems"
 
@@ -56,7 +56,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
             @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
           end
 
-          should "not include warnings in user json" do
+          should "not include warning in user json" do
             unexpected_notice =
               "For protection of your account and gems"
 


### PR DESCRIPTION
Blocked and builds from https://github.com/rubygems/rubygems.org/pull/2994 (uses `mfa_recommended_not_yet_enabled?` and `mfa_recommended_weak_level_enabled?`)
Part of: https://github.com/rubygems/rubygems.org/issues/2996

This PR contributes to Phase 2 of the MFA RFC. More specifically, when running gem push/yank and add/remove owner on the CLI, the response includes a warning for users to setup or change their MFA setting if they are recommended to (based on a gem threshold). Users can disregard the warning at this stage.

This was implemented by passing through the plain text response to a method in the base controller which appends the warning. It would be nice to respond with json and add a warnings field by that would break parts of the CLI.

### 1. User is not under `mfa_recommended?`
no change, redirects to user dashboard.

### 2. User is under `mfa_recommended?` and has mfa enabled on the `ui_and_gem_signin` and `ui_and_api` level
no change, redirects to user dashboard.

### 3. User has mfa disabled and is under `mfa_recommended?`
Display this warning in response
```
[WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
```

<img width="1209" alt="Screen Shot 2022-03-22 at 10 03 58 AM" src="https://user-images.githubusercontent.com/42748004/159618653-61a767fc-c56c-4210-b899-50d4ce495715.png">


### 4. User has mfa enabled under `ui_only` and is under `mfa_recommended?`
Display this warning in response
```
[WARNING] For protection of your account and gems, we encourage you to change your MFA level to `UI and gem signin` or `UI and API` at https://rubygems.org/settings/edit. Your account will be required to have MFA enabled on one of these levels in the future.
```
