### PR TITLE
Fix enabled scopes of API keys on index

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,6 +64,6 @@ module ApplicationHelper
   end
 
   def i18n_api_scopes(api_key)
-    api_key.enabled_scopes.sum("") { |scope| tag.ul(t(scope, scope: %i[api_keys index]), class: "scopes__list") }
+    api_key.enabled_scopes.sum(ActiveSupport::SafeBuffer.new) { |scope| tag.ul(t(".#{scope}"), class: "scopes__list") }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,8 +62,4 @@ module ApplicationHelper
     return title unless title_url
     link_to title, title_url, class: "t-link--black"
   end
-
-  def i18n_api_scopes(api_key)
-    api_key.enabled_scopes.sum(ActiveSupport::SafeBuffer.new) { |scope| tag.ul(t(".#{scope}"), class: "scopes__list") }
-  end
 end

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -41,7 +41,9 @@
           <%= api_key.name %>
         </td>
         <td class="owners__cell" data-title="Scopes">
-          <%= i18n_api_scopes api_key %>
+          <% api_key.enabled_scopes.each do |scope| %>
+            <ul class="scopes__list"><%= t(".#{scope}") %></ul>
+          <% end %>
         </td>
         <td class="owners__cell" data-title="Age">
           <%= time_ago_in_words(api_key.created_at) %>

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -51,6 +51,7 @@ class ApplicationHelperTest < ActionView::TestCase
     should "return concat of ul tags for enabled scopes" do
       assert_equal '<ul class="scopes__list">Index rubygems</ul><ul class="scopes__list">Push rubygem</ul>',
         i18n_api_scopes(@api_key)
+      assert_instance_of ActiveSupport::SafeBuffer, i18n_api_scopes(@api_key)
     end
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -43,15 +43,4 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_in_delta(stats_graph_meter(@rubygem, most_downloaded_count), 12.5)
     end
   end
-
-  context "i18n_api_scopes" do
-    setup do
-      @api_key = create(:api_key, index_rubygems: true, push_rubygem: true)
-    end
-    should "return concat of ul tags for enabled scopes" do
-      assert_equal '<ul class="scopes__list">Index rubygems</ul><ul class="scopes__list">Push rubygem</ul>',
-        i18n_api_scopes(@api_key)
-      assert_instance_of ActiveSupport::SafeBuffer, i18n_api_scopes(@api_key)
-    end
-  end
 end


### PR DESCRIPTION
API key scopes looks to be "broken".
<img width="827" alt="Screen Shot 2022-03-29 at 9 43 00 PM" src="https://user-images.githubusercontent.com/42748004/160733980-4832d4b9-8a13-4464-b973-80b0af37ee6a.png">

From https://github.com/rubygems/rubygems.org/commit/2402afc10bf76b2702f20f9df166c3ed476be86b, we're adding to an escaped string when we should be adding to an html safe string (`ActiveSupport::SafeBuffer.new`).

I don't see a benefit of keeping this method (it's a bit confusing to read, and it's only used once), so I thought a better idea would be to 🔥 the method completely.