### PR TITLE
Gracefully fail on rack's query parser fail.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,10 @@ module Gemcutter
     config.i18n.available_locales = [:en, :nl, "zh-CN", "zh-TW", "pt-BR", :fr, :es, :de, :ja]
     config.i18n.fallbacks = [:en]
 
-    config.middleware.insert 0, Rack::UTF8Sanitizer
+    require_relative "../lib/gemcutter/middleware/deep_params_handler"
+    config.middleware.insert 0, Gemcutter::Middleware::DeepParamsHandler
+    config.middleware.insert 1, Rack::UTF8Sanitizer
+
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
 

--- a/lib/gemcutter/middleware/deep_params_handler.rb
+++ b/lib/gemcutter/middleware/deep_params_handler.rb
@@ -1,0 +1,19 @@
+# gracefully fail on malicious request breaking rack's query parser
+#
+# this is temporary solution for now
+# TODO: remove once https://github.com/rack/rack/pull/1837 is solved
+module Gemcutter::Middleware # rubocop:disable Style/ClassAndModuleChildren
+  class DeepParamsHandler
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      Rack::Request.new(env).params
+      status, headers, response = @app.call(env)
+      [status, headers, response]
+    rescue RangeError
+      [302, { "Location" => "/400.html" }, []]
+    end
+  end
+end

--- a/public/400.html
+++ b/public/400.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link href="/stylesheets/static.css" rel='stylesheet' type='text/css'>
+    <title>Bad request | RubyGems.org</title>
+  </head>
+  <body>
+    <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="500 error" src="/images/sea_level.svg">
+      </div>
+      <div class="content">
+        <h1>Bad request.</h1>
+        <p>Something went wrong during request processing.</p>
+        <a href="/">Back to RubyGems.org →</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/unit/gemcutter/middleware/deep_params_handler_test.rb
+++ b/test/unit/gemcutter/middleware/deep_params_handler_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+require_relative "../../../../lib/gemcutter/middleware/deep_params_handler"
+
+class Gemcutter::Middleware::DeepParamsHandlerTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Gemcutter::Middleware::DeepParamsHandler.new(-> { [200, {}, ""] })
+  end
+
+  context "malicious request breaking deep params rack limit" do
+    should "gracefully fail" do
+      limit = Rack::Utils.param_depth_limit + 1
+      malicious_url = "/?#{'[test]' * limit}=test"
+      get malicious_url
+
+      assert_equal 302, last_response.status
+    end
+  end
+end


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/40972/faults/84787696

This is the only solution I was able to find out for now. I have opened discussion with potential solution directly on Rails side at https://github.com/rack/rack/pull/1837.

The only problem I do see is it redirects to 400 page, but the status code is not 400. Anyway this is going to be faced only using malicious (wrong) request on purpose. Also the same applies for other error pages. If needed, this can be fixed on nginx side in `nginx-configmap.yaml.erb` config.