### PR TITLE
Validate before updatiing unconfirmed email

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -7,13 +7,13 @@ class EmailConfirmationsController < ApplicationController
       @form_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
       render template: "multifactor_auths/otp_prompt"
     else
-      confirm_email_success
+      confirm_email
     end
   end
 
   def mfa_update
     if @user.mfa_enabled? && @user.otp_verified?(params[:otp])
-      confirm_email_success
+      confirm_email
     else
       @form_url       = mfa_update_email_confirmations_url(token: @user.confirmation_token)
       flash.now.alert = t("multifactor_auths.incorrect_otp")
@@ -57,10 +57,13 @@ class EmailConfirmationsController < ApplicationController
     redirect_to root_path, alert: t("failure_when_forbidden") unless @user&.valid_confirmation_token?
   end
 
-  def confirm_email_success
-    @user.confirm_email!
-    sign_in @user
-    redirect_to root_path, notice: t("email_confirmations.update.confirmed_email")
+  def confirm_email
+    if @user.confirm_email!
+      sign_in @user
+      redirect_to root_path, notice: t("email_confirmations.update.confirmed_email")
+    else
+      redirect_to root_path, alert: @user.errors.full_messages.to_sentence
+    end
   end
 
   def email_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,7 +163,7 @@ class User < ApplicationRecord
   end
 
   def confirm_email!
-    update_email! if unconfirmed_email
+    return false if unconfirmed_email && !update_email
     update!(email_confirmed: true, confirmation_token: nil)
   end
 
@@ -279,9 +279,9 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
-  def update_email!
+  def update_email
     self.attributes = { email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0 }
-    save!(validate: false)
+    save
   end
 
   def unconfirmed_email_uniqueness

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -1,6 +1,6 @@
 class MailerPreview < ActionMailer::Preview
   def email_reset
-    Mailer.email_reset(User.last)
+    Mailer.email_reset(User.first)
   end
 
   def email_reset_update


### PR DESCRIPTION
Using validate false meant that email uniqueness was not being
enforced. Multiple users could end up with same email address provided
that they all set their unconfirmed email to the same email.

### TODO
- [x] add tests