### PR TITLE
Use strong parameters for email confirmation token

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -71,6 +71,6 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def token_params
-    params.permit(:token).fetch(:token, "")
+    params.permit(:token).require(:token)
   end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -53,7 +53,7 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def validate_confirmation_token
-    @user = User.find_by(confirmation_token: params[:token])
+    @user = User.find_by(confirmation_token: token_params)
     redirect_to root_path, alert: t("failure_when_forbidden") unless @user&.valid_confirmation_token?
   end
 
@@ -68,5 +68,9 @@ class EmailConfirmationsController < ApplicationController
 
   def email_params
     params.permit(email_confirmation: :email).require(:email_confirmation).require(:email)
+  end
+
+  def token_params
+    params.permit(:token).fetch(:token, "")
   end
 end

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -28,6 +28,19 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       end
     end
 
+    context "array of tokens" do
+      setup do
+        get :update, params: { token: [@user.confirmation_token, Clearance::Token.new, Clearance::Token.new] }
+      end
+
+      should "warn about invalid url" do
+        assert_equal "Please double check the URL or try submitting it again.", flash[:alert]
+      end
+      should "not sign in user" do
+        refute cookies[:remember_token]
+      end
+    end
+
     context "token has expired" do
       setup do
         @user.update_attribute("token_expires_at", 2.minutes.ago)

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -33,9 +33,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         get :update, params: { token: [@user.confirmation_token, Clearance::Token.new, Clearance::Token.new] }
       end
 
-      should "warn about invalid url" do
-        assert_equal "Please double check the URL or try submitting it again.", flash[:alert]
-      end
+      should respond_with :bad_request
       should "not sign in user" do
         refute cookies[:remember_token]
       end


### PR DESCRIPTION
Part of: https://github.com/rubygems/rubygems.org/issues/1774

Allow only scalar type to be accepted as a param type for `token` in email confirmations.
@sonalkr132 