### PR TITLE
Prevent remaining possible silent failures for ownership create

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -126,14 +126,18 @@ class Pusher
 
   def update
     Rubygem.transaction do
-      rubygem.disown if rubygem.versions.indexed.count.zero?
-      rubygem.update_attributes_from_gem_specification!(version, spec)
-      raise ActiveRecord::Rollback unless rubygem.create_ownership(user)
+      update_gem
       set_info_checksum
       true
     rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique
       false
     end
+  end
+
+  def update_gem
+    rubygem.disown if rubygem.versions.indexed.count.zero?
+    rubygem.update_attributes_from_gem_specification!(version, spec)
+    raise ActiveRecord::Rollback unless rubygem.create_ownership(user)
   end
 
   def set_info_checksum

--- a/test/unit/ownership_test.rb
+++ b/test/unit/ownership_test.rb
@@ -122,15 +122,29 @@ class OwnershipTest < ActiveSupport::TestCase
 
   context "#create_confirmed" do
     setup do
-      rubygem = create(:rubygem)
-      user = create(:user)
-      Ownership.create_confirmed(rubygem, user, user)
+      @rubygem = create(:rubygem)
+      @user = create(:user)
+    end
+
+    should "return true" do
+      assert Ownership.create_confirmed(@rubygem, @user, @user)
     end
 
     should "create confirmed ownership" do
+      Ownership.create_confirmed(@rubygem, @user, @user)
       ownership = Ownership.last
       assert_nil ownership.token
       assert_predicate ownership, :confirmed?
+    end
+
+    context "when ownership has errors" do
+      setup do
+        create(:ownership, rubygem: @rubygem, user: @user)
+      end
+
+      should "return false" do
+        refute Ownership.create_confirmed(@rubygem, @user, @user)
+      end
     end
   end
 

--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -512,6 +512,22 @@ class PusherTest < ActiveSupport::TestCase
     end
   end
 
+  context "pushing a new version fails" do
+    setup do
+      @rubygem = create(:rubygem)
+      @gem = gem_file("valid_signature-0.0.0.gem")
+      @cutter = Pusher.new(@user, @gem)
+      @rubygem.stubs(:create_ownership).returns false
+      @cutter.stubs(:rubygem).returns @rubygem
+      @cutter.process
+    end
+
+    should "not save version if creating ownership fails" do
+      assert_match(/There was a problem saving your gem/, @cutter.message)
+      assert_equal 403, @cutter.code
+    end
+  end
+
   context "pushing to s3 fails" do
     setup do
       @gem = gem_file("test-1.0.0.gem")


### PR DESCRIPTION
# Resolves #2234 
## Description

Ownerships are created in the following places

- The owners API controller (the original location of the reported issue) https://github.com/rubygems/rubygems.org/blob/fc7cc3a9879d69adb48e2d37282aea34d7f311b0/app/controllers/api/v1/owners_controller.rb#L18-L21
- The owners controller https://github.com/rubygems/rubygems.org/blob/fc7cc3a9879d69adb48e2d37282aea34d7f311b0/app/controllers/owners_controller.rb#L34-L36
- The ownership request model https://github.com/rubygems/rubygems.org/blob/fc7cc3a9879d69adb48e2d37282aea34d7f311b0/app/models/ownership_request.rb#L16-L21
- The pusher https://github.com/rubygems/rubygems.org/blob/fc7cc3a9879d69adb48e2d37282aea34d7f311b0/app/models/pusher.rb#L127-L136


The only place where a silent failure could occur is in the last example.

In the first two, the original `.create` has already been replaced by a `.save` which has its return value checked. And in the third, the method will return false if trying to confirm an invalid ownership.

In the last one, the user for the ownership is already persisted and an ownership will only fail validation if a duplicate ownership exists. This should be a rare occurrence. However, I went ahead and added some extra safety just in case.

## Changes
### Features / major changes
- Wrap the pusher update code in a transaction and rollback if creating the ownership fails 
- Added tests 


