### PR TITLE
1774/strong params in api controllers

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -3,8 +3,12 @@ class Api::BaseController < ApplicationController
 
   private
 
+  def name_params
+    params.permit(:gem_name, :rubygem_name)
+  end
+
   def gem_name
-    params[:gem_name] || params[:rubygem_name]
+    name_params[:gem_name] || name_params[:rubygem_name]
   end
 
   def find_rubygem_by_name

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::ApiKeysController < Api::BaseController
       user = User.authenticate(username, password)
 
       check_mfa(user) do
-        api_key = user.api_keys.find_by!(hashed_key: hashed_key(params[:api_key]))
+        api_key = user.api_keys.find_by!(hashed_key: hashed_key(key_param))
 
         if api_key.update(api_key_update_params)
           respond_with "Scopes for the API key #{api_key.name} updated"
@@ -79,6 +79,10 @@ class Api::V1::ApiKeysController < Api::BaseController
 
   def otp
     request.headers["HTTP_OTP"]
+  end
+
+  def key_param
+    params.permit(:api_key).require(:api_key)
   end
 
   def api_key_create_params

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::OwnersController < Api::BaseController
   def create
     return render_api_key_forbidden unless @api_key.can_add_owner?
 
-    owner = User.find_by_name(params[:email])
+    owner = User.find_by_name(email_param)
     if owner
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
@@ -35,7 +35,7 @@ class Api::V1::OwnersController < Api::BaseController
   def destroy
     return render_api_key_forbidden unless @api_key.can_remove_owner?
 
-    owner = @rubygem.owners_including_unconfirmed.find_by_name(params[:email])
+    owner = @rubygem.owners_including_unconfirmed.find_by_name(email_param)
     if owner
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
@@ -67,5 +67,9 @@ class Api::V1::OwnersController < Api::BaseController
   def verify_gem_ownership
     return if @api_key.user.rubygems.find_by_name(params[:rubygem_id])
     render plain: response_with_mfa_warning("You do not have permission to manage this gem."), status: :unauthorized
+  end
+
+  def email_param
+    params.permit(:email).require(:email)
   end
 end

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -4,7 +4,7 @@ class Api::V2::VersionsController < Api::BaseController
   def show
     return unless stale?(@rubygem)
 
-    version = @rubygem.public_version_payload(params[:number], params[:platform])
+    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform])
     if version
       respond_to do |format|
         format.json { render json: version }
@@ -13,5 +13,11 @@ class Api::V2::VersionsController < Api::BaseController
     else
       render plain: "This version could not be found.", status: :not_found
     end
+  end
+
+  protected
+
+  def version_params
+    params.permit(:platform, :number)
   end
 end


### PR DESCRIPTION
# Resolves #1774
## Description
Though it seems like strong params were already being used wherever mass assignments were occurring, there was a comment in the linked issue that called out that it would be nice to also use strong params when the param value is used in an ActiveRecord query.

>We recently [fixed a issue](https://github.com/rubygems/rubygems.org/commit/b6c2777219242ff317dea1aad0ec71aeb0fc8ac0) where one could have improved chances of guessing api key by sending api_key param as array.
We may have a few other places in api where we are unintentionally allowing WHERE table.column IN ($1, $2) [["val1", "val2"]. It would be nice to fix those.

That's where I focused these changes.

## Changes
### Features / major changes
- Added strong name params in base controller
- Added strong platform, number param in versions controller
- Added strong api_key param in api keys controller
- Added strong platform, version param in deletions controller
- Added strong email param in owners controller to enforce scalar type

## Open questions
- I added one test but felt like I was testing default Rails behavior. Let me know if you'd prefer similar tests added for the other 4 changes.
