### PR TITLE
Ignore `vendor/bundle`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ chef
 public/assets
 latest_dump
 coverage
+vendor/bundle


### PR DESCRIPTION
I've followed [Development Setup](https://github.com/rubygems/rubygems.org/blob/master/CONTRIBUTING.md#development-setup) and am seeing `vendor/bundle` tracked after `bundle install`. Isn't it more comfortable not to include them? Let me hear what you think 🙂 