### PR TITLE
Add "fields" parameter to API v2 /versions endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,18 @@ Follow the instructions below on how to install Bundler and setup the database.
 * Start memcached: `memcached`
 * Run the tests: `bundle exec rake`
 
+You can run all the tests in a particular file via `bin/rails test`, e.g.,
+
+```sh
+bin/rails test test/functional/api/v2/versions_controller_test.rb
+```
+
+To run an individual test, for example, specify the line number of the `should` block:
+
+```sh
+bin/rails test test/functional/api/v2/versions_controller_test.rb:49
+```
+
 #### Confirmation emails links
 
 * [Account confirmation email](http://localhost:3000/rails/mailers/mailer/email_confirmation)

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -4,7 +4,8 @@ class Api::V2::VersionsController < Api::BaseController
   def show
     return unless stale?(@rubygem)
 
-    version = @rubygem.public_version_payload(params[:number], params[:platform])
+    fields = (params[:fields] || "").split(",").map(&:strip).compact_blank
+    version = @rubygem.public_version_payload(params[:number], platform: params[:platform], fields: fields)
     if version
       respond_to do |format|
         format.json { render json: version }

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -4,7 +4,7 @@ class Api::V2::VersionsController < Api::BaseController
   def show
     return unless stale?(@rubygem)
 
-    fields = (params[:fields] || "").split(",").map(&:strip).compact_blank
+    fields = (params[:fields] || "").split(",").compact_blank
     version = @rubygem.public_version_payload(params[:number], platform: params[:platform], fields: fields)
     if version
       respond_to do |format|

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -123,14 +123,18 @@ class Rubygem < ApplicationRecord
     versions.uniq.sort_by(&:position)
   end
 
-  def public_version_payload(number, platform = nil)
+  def public_version_payload(number, platform: nil, fields: [])
     version =
       if platform
         public_versions.find_by(number: number, platform: platform)
       else
         public_versions.find_by(number: number)
       end
-    payload(version).merge!(version.as_json) if version
+    return unless version
+
+    result = payload(version).merge!(version.as_json)
+    result = result.slice(*fields) if fields.present?
+    result
   end
 
   def hosted?


### PR DESCRIPTION
This adds support for a new parameter in the /versions API v2 endpoint: `fields`. The parameter is an optional comma-separated list of field names to limit what data is returned in the response. The idea is that we could reduce how much data is being sent in a response to just the data that the caller knows they need, if they're willing to tell us. This shouldn't break anything for existing users who omit the `fields` parameter.

For the implementation, I opted to just modify the response payload after it was fully calculated because that required the least change to the interface. If it's preferred, I think methods like Rubygem#payload, Version#payload, and Version#as_json could be restructured to take an optional list of fields so that only those specified have their payload value calculated, to save on calculating time to build the response.

I didn't see where in this repo the documentation on https://guides.rubygems.org/rubygems-org-api-v2/ was kept, maybe that's a separate repo. If this PR gets accepted, I'd be happy to update the docs, if I can find them, to mention the new parameter.

I also added a couple examples to the contributing docs about how to run individual tests and all the tests in a single file.