### PR TITLE
Re-design dependencies list on rubygems#show

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -212,6 +212,8 @@
   .gem__version-wrap .gem__version__date {
     font-weight: 400; }
 
+.gem__requirement-wrap {
+    line-height: inherit; }
 .gem__requirement-wrap a.t-list__item {
     display: inline-block; }
 
@@ -249,4 +251,8 @@
 
 .gem__previous__version {
   float: left;
+}
+
+.gem__dependencies:not(:first-of-type) {
+  margin-top: 36px;
 }

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -1,23 +1,21 @@
 <% if dependencies.present? && @latest_version.indexed %>
-  <div class="t-list__items">
-    <div class="dependencies" id="<%= dependencies.first.scope %>_dependencies">
-      <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies.size %>):</h3>
-      <div class="t-list__items">
-        <% dependencies.each do |dependency| %>
-          <% if rubygem = dependency.rubygem %>
-            <li class="gem__requirement-wrap">
-              <%= link_to rubygem_path(rubygem), :class => 't-list__item push--top-s' do %>
-                <strong><%= rubygem.name %></strong>
-              <% end %>
-              <%= dependency.clean_requirements %>
-            </li>
-          <% elsif dependency&.name %>
-            <p class="t-list__item gem__unregistered" title="unregistered gem">
-              <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>
-            </p>
-          <% end %>
+  <div class="dependencies gem__dependencies" id="<%= dependencies.first.scope %>_dependencies">
+    <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies.size %>):</h3>
+    <div class="t-list__items">
+      <% dependencies.each do |dependency| %>
+        <% if rubygem = dependency.rubygem %>
+          <li class="gem__requirement-wrap">
+            <%= link_to rubygem_path(rubygem), :class => 't-list__item' do %>
+              <strong><%= rubygem.name %></strong>
+            <% end %>
+            <%= dependency.clean_requirements %>
+          </li>
+        <% elsif dependency&.name %>
+          <p class="t-list__item gem__unregistered" title="unregistered gem">
+            <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>
+          </p>
         <% end %>
-      </div>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
- Align headers `VERSIONS:` and `RUNTIME DEPENDENCIES (NN):` on top
- Items in runtime/development dependencies should be listed with the same margins with ones in versions

### Refs.
- Updates #2326 and #2325

| before | after |
|-|-|
| ![before](https://user-images.githubusercontent.com/10229505/167360234-78278fff-7861-413e-8ceb-6750d5f6aa49.png) | ![after](https://user-images.githubusercontent.com/10229505/167359682-22b8b34f-25f7-419d-b8df-97dbc088c01b.png) |

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>