### PR TITLE
Use UTC in update_version_file_test, rake task

### DIFF
--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -77,7 +77,7 @@ namespace :compact_index do
 
   desc "Generate/update the versions.list file"
   task update_versions_file: :environment do
-    ts            = Time.now.iso8601
+    ts            = Time.now.utc.iso8601
     file_path     = Rails.application.config.rubygems["versions_file_location"]
     versions_file = CompactIndex::VersionsFile.new file_path
     gems          = GemInfo.compact_index_public_versions ts

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -10,7 +10,7 @@ class UpdateVersionsFileTest < ActiveSupport::TestCase
 
   def update_versions_file
     freeze_time do
-      @created_at = Time.now.iso8601
+      @created_at = Time.now.utc.iso8601
       Rake::Task["compact_index:update_versions_file"].invoke
     end
   end


### PR DESCRIPTION
I noticed when setting up my development environment, some tests in the `update_versions_file_test.rb` are failing, specifically because [this time comparison](https://github.com/rubygems/rubygems.org/blob/0f06cfab070dd7c7fe73e92863734c02d073185a/app/models/gem_info.rb#L58) isn't working as expected. It turns out that `ts` (which is passed from the rake task to `compact_index_public_versions` as the `updated_at` value) is in my home timezone but everything else is UTC:

See below:

```ruby
From: /Users/ryanbrushett/src/github.com/RyanBrushett/rubygems.org/lib/tasks/compact_index.rake:83 :

    78:   desc "Generate/update the versions.list file"
    79:   task update_versions_file: :environment do
    80:     ts            = Time.now.iso8601
    81:     require 'pry'
    82:     binding.pry
 => 83:     file_path     = Rails.application.config.rubygems["versions_file_location"]
    84:     versions_file = CompactIndex::VersionsFile.new file_path
    85:     gems          = GemInfo.compact_index_public_versions ts
    86:
    87:     versions_file.create gems, ts
    88:

[1] pry(main)> Time.zone
=> #<ActiveSupport::TimeZone:0x0000000105679ac0 @name="UTC", @tzinfo=#<TZInfo::DataTimezone: Etc/UTC>, @utc_offset=nil>
[2] pry(main)> ts
=> "2022-05-10T16:02:36-04:00"
```

Explicitly setting UTC for both the rake task and also the `created_at` time in the test that calls the rake task meant the tests passed happily!

There's a great chance I'm missing something so please let me know if this isn't necessary but I figured it might be better to be explicit about the timezone anyway.