### PR TITLE
Fix access to undefined variable `version` in GemcutterTaskshelper

### DIFF
--- a/lib/tasks/helpers/gemcutter_tasks_helper.rb
+++ b/lib/tasks/helpers/gemcutter_tasks_helper.rb
@@ -35,7 +35,7 @@ module GemcutterTaskshelper
     spec = Marshal.load(Gem::Util.inflate(file))
     spec.send(attribute_name)
   rescue StandardError => e
-    Rails.logger.info("[gemcutter:required_ruby_version:backfill] could not get required_ruby_version for version: #{version.full_name}"\
+    Rails.logger.info("[gemcutter:required_ruby_version:backfill] could not get required_ruby_version for version: #{version_full_name}"\
                       " error: #{e.inspect}")
     nil
   end


### PR DESCRIPTION
The rescue clause of the `get_spec_attribute` method is referencing `version.full_name` to build the log info message but the variable `version` is not defined in this context.

I think the intended reference was to the parameter `version_full_name`.