### PR TITLE
#2964 Display MFA state for each version

### DIFF
--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -56,9 +56,18 @@
     </i>
   </h2>
 
-  <% if @latest_version.rubygems_mfa_required? %>
+  <% if @rubygem.mfa_required? %>
     <h2 class="gem__ruby-version__heading t-list__heading">
       <%= t('.requires_mfa') %>:
+      <span class="gem__ruby-version">
+        true
+      </span>
+    </h2>
+  <% end %>
+
+  <% if @latest_version.rubygems_mfa_required? %>
+    <h2 class="gem__ruby-version__heading t-list__heading">
+      <%= t('.released_with_mfa') %>:
       <span class="gem__ruby-version">
         true
       </span>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -56,7 +56,7 @@
     </i>
   </h2>
 
-  <% if @rubygem.mfa_required? %>
+  <% if @latest_version.rubygems_mfa_required? %>
     <h2 class="gem__ruby-version__heading t-list__heading">
       <%= t('.requires_mfa') %>:
       <span class="gem__ruby-version">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -437,7 +437,7 @@ de:
       required_ruby_version: Erforderliche Ruby-Version
       required_rubygems_version:
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: Abzeichen
         bugs: Bug Tracker

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -424,8 +424,8 @@ en:
       install: install
       required_ruby_version: Required Ruby Version
       required_rubygems_version: Required Rubygems Version
-      requires_mfa: Requires MFA accounts
-      since: "Since %{version}"
+      requires_mfa: New versions require MFA
+      released_with_mfa: Version published with MFA
       links:
         badge: Badge
         bugs: Bug Tracker

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -468,7 +468,7 @@ es:
       required_ruby_version: Versión de Ruby requerida
       required_rubygems_version: Versión de Rubygems requerida
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: Badge
         bugs: Seguimiento de Bugs

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -466,7 +466,7 @@ fr:
       required_ruby_version: Version de Ruby requise
       required_rubygems_version:
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: Badge
         bugs: Suivi de bugs

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -422,7 +422,7 @@ ja:
       required_ruby_version: 必要Rubyバージョン
       required_rubygems_version: 必要Gemバージョン
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: バッジ
         bugs: バグトラッカー

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -441,7 +441,7 @@ nl:
       required_ruby_version: Required Ruby Version
       required_rubygems_version: Required Rubygems Version
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: Badge
         bugs: Bug-tracker

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -452,7 +452,7 @@ pt-BR:
       required_ruby_version: Versão Requerida do Ruby
       required_rubygems_version: Versão Requerida do RubyGems
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: Badge
         bugs:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -423,7 +423,7 @@ zh-CN:
       required_ruby_version: 需要的 Ruby 版本
       required_rubygems_version: 需要的 RubyGems 版本
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: 徽章
         bugs: Bug 追踪

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -424,7 +424,7 @@ zh-TW:
       required_ruby_version: Ruby 版本需求
       required_rubygems_version: RubyGems 版本需求
       requires_mfa:
-      since: "%{version}"
+      released_with_mfa:
       links:
         badge: 徽章
         bugs: Bug 追蹤

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -155,30 +155,61 @@ class GemsSystemTest < SystemTest
     assert page.has_no_selector?(".github-btn")
   end
 
-  test "does show version that introduced mfa requirement" do
+  test "shows both blocks if latest AND viewed version require MFA" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
+    create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_path(@rubygem)
+    visit rubygem_version_path(@rubygem, "0.1.1")
 
-    assert page.has_content? "true"
+    assert page.has_content? "New versions require MFA"
+    assert page.has_content? "Version published with MFA"
   end
 
-  test "does show correct version that introduced mfa requirement" do
+  test "shows 'new' block only if latest requires MFA but viewed version doesn't" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
-    create(:version, rubygem: @rubygem, number: "2.2.2")
-    create(:version, :mfa_required, rubygem: @rubygem, number: "3.3.3")
-    create(:version, :mfa_required, rubygem: @rubygem, number: "4.4.4")
+    create(:version, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_path(@rubygem)
+    visit rubygem_version_path(@rubygem, "0.1.1")
 
-    assert page.has_content? "true"
+    assert page.has_content? "New versions require MFA"
+    refute page.has_content? "Version published with MFA"
   end
 
-  test "does not show mfa block if version is published without mfa requirement" do
+  test "shows 'version' block only if latest does not require MFA but viewed version does" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
+    create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
+    visit rubygem_version_path(@rubygem, "0.1.1")
+
+    refute page.has_content? "New versions require MFA"
+    assert page.has_content? "Version published with MFA"
+  end
+
+  test "does not show either block if neither latest or viewed version require MFA" do
+    @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
+    create(:version, rubygem: @rubygem, number: "0.1.1")
+
+    visit rubygem_version_path(@rubygem, "0.1.1")
+
+    refute page.has_content? "New versions require MFA"
+    refute page.has_content? "Version published with MFA"
+  end
+
+  test "shows both blocks if MFA enabled for latest version and viewing latest version" do
+    @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
+    
     visit rubygem_path(@rubygem)
+    
+    assert page.has_content? "New versions require MFA"
+    assert page.has_content? "Version published with MFA"
+  end
 
-    refute page.has_content? "true"
+  test "shows neither block if MFA disabled for latest version and viewing latest version" do
+    @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
+    
+    visit rubygem_path(@rubygem)
+    
+    refute page.has_content? "New versions require MFA"
+    refute page.has_content? "Version published with MFA"
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -197,18 +197,18 @@ class GemsSystemTest < SystemTest
 
   test "shows both mfa headers if MFA enabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
-    
+
     visit rubygem_path(@rubygem)
-    
+
     assert page.has_content? "New versions require MFA"
     assert page.has_content? "Version published with MFA"
   end
 
   test "shows neither mfa header if MFA disabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
-    
+
     visit rubygem_path(@rubygem)
-    
+
     refute page.has_content? "New versions require MFA"
     refute page.has_content? "Version published with MFA"
   end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -155,7 +155,7 @@ class GemsSystemTest < SystemTest
     assert page.has_no_selector?(".github-btn")
   end
 
-  test "shows both blocks if latest AND viewed version require MFA" do
+  test "shows both mfa headers if latest AND viewed version require MFA" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
     create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
@@ -165,7 +165,7 @@ class GemsSystemTest < SystemTest
     assert page.has_content? "Version published with MFA"
   end
 
-  test "shows 'new' block only if latest requires MFA but viewed version doesn't" do
+  test "shows 'new' mfa header only if latest requires MFA but viewed version doesn't" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
     create(:version, rubygem: @rubygem, number: "0.1.1")
 
@@ -175,7 +175,7 @@ class GemsSystemTest < SystemTest
     refute page.has_content? "Version published with MFA"
   end
 
-  test "shows 'version' block only if latest does not require MFA but viewed version does" do
+  test "shows 'version' mfa header only if latest does not require MFA but viewed version does" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
     create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
@@ -185,7 +185,7 @@ class GemsSystemTest < SystemTest
     assert page.has_content? "Version published with MFA"
   end
 
-  test "does not show either block if neither latest or viewed version require MFA" do
+  test "does not show either mfa header if neither latest or viewed version require MFA" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
     create(:version, rubygem: @rubygem, number: "0.1.1")
 
@@ -195,7 +195,7 @@ class GemsSystemTest < SystemTest
     refute page.has_content? "Version published with MFA"
   end
 
-  test "shows both blocks if MFA enabled for latest version and viewing latest version" do
+  test "shows both mfa headers if MFA enabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
     
     visit rubygem_path(@rubygem)
@@ -204,7 +204,7 @@ class GemsSystemTest < SystemTest
     assert page.has_content? "Version published with MFA"
   end
 
-  test "shows neither block if MFA disabled for latest version and viewing latest version" do
+  test "shows neither mfa header if MFA disabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
     
     visit rubygem_path(@rubygem)

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -174,11 +174,11 @@ class GemsSystemTest < SystemTest
     assert page.has_content? "true"
   end
 
-  test "does versions published without mfa requirement hide mfa block" do
+  test "does not show mfa block if version is published without mfa requirement" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
 
     visit rubygem_path(@rubygem)
 
-    assert !(page.has_content? "test")
+    refute page.has_content? "true"
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -173,4 +173,12 @@ class GemsSystemTest < SystemTest
 
     assert page.has_content? "true"
   end
+
+  test "does versions published without mfa requirement hide mfa block" do
+    @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
+
+    visit rubygem_path(@rubygem)
+
+    assert !(page.has_content? "test")
+  end
 end


### PR DESCRIPTION
Fixes issue #2964

This change displays both of the following pieces of information on a gem's/version's page rather than just 1:
1. whether or not you need MFA to release a version of the gem today (we show this now)
2. whether or not a gem version had mfa enabled when released (used to show this)


I also found `Requires MFA accounts` a bit unclear, because I find myself asking "to do what?", and my interpretation is that the main goal of enabling MFA for a gem is to prevent unauthorized releases, so I changed it to `New versions require MFA`. Personally, I still think true / show nothing is a weird paradigm, it feels like this should be a badge, or just the header.



