### PR TITLE
Remove mfa_warnings cookie

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -79,19 +79,15 @@ class SessionsController < Clearance::SessionsController
   end
 
   def url_after_create
-    if mfa_warnings_enabled? && current_user.mfa_recommended_not_yet_enabled?
+    if current_user.mfa_recommended_not_yet_enabled?
       flash[:notice] = t("multifactor_auths.setup_recommended")
       new_multifactor_auth_path
-    elsif mfa_warnings_enabled? && current_user.mfa_recommended_weak_level_enabled?
+    elsif current_user.mfa_recommended_weak_level_enabled?
       flash[:notice] = t("multifactor_auths.strong_mfa_level_recommended")
       edit_settings_path
     else
       dashboard_path
     end
-  end
-
-  def mfa_warnings_enabled?
-    cookies[:mfa_warnings] == "true"
   end
 
   def ensure_not_blocked

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -99,7 +99,6 @@ class SessionsControllerTest < ActionController::TestCase
         setup do
           @user = User.new(email_confirmed: true, handle: "test")
           @user.stubs(:mfa_recommended?).returns true
-          @request.cookies[:mfa_warnings] = "true"
         end
 
         context "when mfa is disabled" do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -6,7 +6,6 @@ class SignInTest < SystemTest
     @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
-    page.driver.browser.set_cookie("mfa_warnings=true")
   end
 
   test "signing in" do


### PR DESCRIPTION
⚠️ **DO NOT MERGE UNTIL MFA RECOMMENDED LAUNCH**⚠️

Part of: https://github.com/rubygems/rubygems.org/pull/2994

This removes the mfa_warnings cookie that was added in https://github.com/rubygems/rubygems.org/pull/2994 so that anyone who should see the warnings does seem them without needing to individually turn on the cookie. 

