### PR TITLE
Remove api key rubygems_id from form url query string

### DIFF
--- a/app/assets/javascripts/api_key_form.js
+++ b/app/assets/javascripts/api_key_form.js
@@ -27,7 +27,7 @@ $(function() {
       id: hiddenRubygemId,
       name: "api_key[rubygem_id]",
       value: ""
-    }).appendTo(".t-body form");
+    }).appendTo(".t-body form .api_key_rubygem_id_form");
   }
 
   function removeHiddenRubygemField() {

--- a/app/views/api_keys/edit.html.erb
+++ b/app/views/api_keys/edit.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     </div>
 
-    <div class="form__group">
+    <div class="form__group api_key_rubygem_id_form">
       <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
       <p><%= t(".rubygem_scope_info") %></p>
       <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t(".all_gems") }, selected: :rubygem_id, class: "form__input form__select" %>

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     </div>
 
-    <div class="form__group">
+    <div class="form__group api_key_rubygem_id_form">
       <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
       <p><%= t(".rubygem_scope_info") %></p>
       <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t(".all_gems") }, selected: :rubygem_id, class: "form__input form__select" %>


### PR DESCRIPTION
When testing https://github.com/rubygems/rubygems.org/pull/2944 on staging, @sonalkr132 found that `api_key[rubygem_id]` was added as a query param on new and edit pages.

It's coming from the [hidden ](https://github.com/Shopify/rubygems.org/blob/a8cabfc62fb67de0316d72c40a1d8d3cde76c426/app/assets/javascripts/api_key_form.js#L28)`rubygems_id` [ input](https://github.com/Shopify/rubygems.org/blob/a8cabfc62fb67de0316d72c40a1d8d3cde76c426/app/assets/javascripts/api_key_form.js#L28) js (used when the original rubygems selector is disabled).

### Solution
HTML forms with `method: POST` should not include query strings for each input. It seems like this hidden input wasn't included in this clause (thought it was for GET request?). When I added the hidden input to the `rubygem_id` form group div, the query string doesn't get included anymore.

I updated tests to make that this doesn't happen again, let me know if it's overkill.