### PR TITLE
Clarify disabling MFA message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,7 +292,7 @@ en:
     recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your MFA device.'
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
-    require_mfa_disabled: Your multi-factor authentication has been enabled. You have to disable it first.
+    require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -321,8 +321,7 @@ es:
     recovery_code_html:
     incorrect_otp: Tu código OTP no es correcto.
     otp_code: código OTP
-    require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Primero
-      tienes que desactivarla.
+    require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para reconfigurarla, primero tendrás que desactivarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
     setup_recommended:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -314,7 +314,7 @@ fr:
     recovery_code_html:
     incorrect_otp: Votre clé OTP est incorrecte.
     otp_code: clé OTP
-    require_mfa_disabled: Votre authentification multifacteur a été activée. Vous
+    require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous voulez la reconfigurer, vous
       devez d'abord la désactiver.
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -292,7 +292,7 @@ zh-CN:
     recovery_code_html:
     incorrect_otp: 你的 OTP 码 不正确。
     otp_code: OTP 码
-    require_mfa_disabled: 你的多重要素验证已启用，请先停用。
+    require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     setup_recommended:
     strong_mfa_level_recommended:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -293,7 +293,7 @@ zh-TW:
     recovery_code_html:
     incorrect_otp: 你的 OTP 碼 不正確。
     otp_code: OTP 碼
-    require_mfa_disabled: 你的多重要素驗證已啟用，請先停用。
+    require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     setup_recommended:
     strong_mfa_level_recommended:


### PR DESCRIPTION
I found the "Disable it first" MFA message to be a bit confusing, especially right after signing in with an OTP. I tried clarifying it (English + French)
<img width="544" alt="image (6)" src="https://user-images.githubusercontent.com/44324811/172667180-0717d493-f5f6-46bd-9579-f83dc9515405.png">
