### PR TITLE
Mailer: Email to announce MFA Phase 2 rollout and blog post on Launch Day

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -72,7 +72,7 @@ class Mailer < ApplicationMailer
     @user = User.find(user_id)
 
     mail to: @user.email,
-      subject: "Official Recommendation: Enable multi-factor authentication on your RubyGems account"
+      subject: "Please enable multi-factor authentication on your RubyGems account"
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -68,6 +68,13 @@ class Mailer < ApplicationMailer
       subject: "Please consider enabling multi-factor authentication for your account"
   end
 
+  def mfa_recommendation_announcement(user_id)
+    @user = User.find(user_id)
+
+    mail to: @user.email,
+      subject: "Official Recommendation: Enable multi-factor authentication on your RubyGems account"
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -65,9 +65,7 @@
         <br/>
         <br/>
        
-        <p align="center">❤️ 💪 💎 💪 ❤️</p>
-        <p align="center"> Thank you for making the RubyGems ecosystem more secure.</p>
-        <p align="center">❤️ 💪 💎 💪 ❤️</p>
+        <p align="center">Thank you for making the RubyGems ecosystem more secure.</p>
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -20,7 +20,7 @@
         <p>
           On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
           Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. 
-          This recommendation will be repeated by the gem client. 
+          This recommendation will also be shown by the gem client. 
         </p>
         <br/>
 

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -1,0 +1,128 @@
+<% @title = "Enable multi-factor authentication (MFA) on your RubyGems account" %>
+<% @sub_title = "👋 Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Today, we've announced our security-focused ambitions to the community. 
+          Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
+        </p>
+        <br/>
+
+        <p>
+          On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
+          Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. 
+          This recommendation will be repeated by the gem client. 
+        </p>
+        <br/>
+
+        <% if @user.mfa_disabled? %> 
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
+            <b>Please enable multi-factor authentication on your RubyGems account 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the 
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br />
+        <% elsif @user.mfa_ui_only? %>
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers.
+            Fortunately, you've already taken the first step! But, there's opportunity to improve.
+            <b>Please upgrade your RubyGems account to a stronger MFA level 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the 
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br />
+        <% else %>
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
+            Fortunately, you've already done that. Kudos to you 🥳 🙌!
+          </p>
+          <br/>
+        <% end %>
+
+        <p>
+          For more information, check out our <a href="#" target="_blank">announcement</a>.
+        </p>
+        <br/>
+        <br/>
+       
+        <p align="center">❤️ 💪 💎 💪 ❤️</p>
+        <p align="center"> Thank you for making the RubyGems ecosystem more secure.</p>
+        <p align="center">❤️ 💪 💎 💪 ❤️</p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <% if @user.mfa_disabled? || @user.mfa_ui_only? %> 
+
+        <!-- Button -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center">
+              <table width="210" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" bgcolor="#e9573f">
+                    <table border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15">
+                          <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">
+                            <tr>
+                              <td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td>
+                            </tr>
+                          </table>
+                        </td>
+                        <td bgcolor="#e9573f">
+                          <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                              <span class="link-white" style="color:#ffffff; text-decoration:none">
+                                <%= "ENABLE MFA" if @user.mfa_disabled? %>
+                                <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>
+                              </span>
+                            </a>
+                          </div>
+                        </td>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <!-- END Button -->
+      <% end %>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -60,7 +60,7 @@
         <% end %>
 
         <p>
-          For more information, check out our <a href="#" target="_blank">announcement</a>.
+          For more information, check out our <a href="https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html" target="_blank">announcement</a>.
         </p>
         <br/>
         <br/>

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -63,9 +63,8 @@
           For more information, check out our <a href="https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html" target="_blank">announcement</a>.
         </p>
         <br/>
-        <br/>
        
-        <p align="center">Thank you for making the RubyGems ecosystem more secure.</p>
+        <p>Thank you for making the RubyGems ecosystem more secure.</p>
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
@@ -109,6 +108,16 @@
         </table>
         <!-- END Button -->
       <% end %>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <!-- Adding a horizontal rule -->
+      <table width="100%">
+        <tr>
+          <td width="100%" bgcolor="#cccccc" height="1" style="font-size: 1px; line-height: 1px;">&nbsp;</td>
+        </tr>
+      </table>
+
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -26,8 +26,8 @@
 
         <% if @user.mfa_disabled? %> 
           <p>
-            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
-            <b>Please enable multi-factor authentication on your RubyGems account 🙏.</b>
+            We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
+            So, we'd like to ask you to <b>please enable multi-factor authentication on your RubyGems account 🙏.</b>
           </p>
           <br/>
 
@@ -39,7 +39,7 @@
           <br />
         <% elsif @user.mfa_ui_only? %>
           <p>
-            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers.
+            We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
             Fortunately, you've already taken the first step! But, there's opportunity to improve.
             <b>Please upgrade your RubyGems account to a stronger MFA level 🙏.</b>
           </p>
@@ -53,8 +53,8 @@
           <br />
         <% else %>
           <p>
-            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
-            Fortunately, you've already done that. Kudos to you 🥳 🙌!
+            We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
+            Fortunately, you've already enabled MFA. Kudos to you 🥳 🙌!
           </p>
           <br/>
         <% end %>

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -20,7 +20,7 @@
         <p>
           On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
           Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. 
-          This recommendation will also be shown by the gem client. 
+          This recommendation will also be shown by the gem CLI.
         </p>
         <br/>
 

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -12,7 +12,7 @@
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
         <p>
-          Today, we've announced our security-focused ambitions to the community. 
+          Recently, we've announced our security-focused ambitions to the community.
           Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
         </p>
         <br/>

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -19,7 +19,9 @@
 
         <p>
           On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
-          Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. 
+          If maintainers don't have MFA enabled by this date, a number of operations will be restricted.
+          These restrictions include <a href=”https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations” target=”_blank”>privileged operations</a> (ie. push, yank, add/remove owners).
+          Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA.
           This recommendation will also be shown by the gem CLI.
         </p>
         <br/>

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -2,7 +2,7 @@
 
 Today, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
 
-On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will be repeated by the gem client. 
+On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem client. 
 
 <% if @user.mfa_disabled? %> 
 While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -1,0 +1,24 @@
+👋 Hi <%= @user.handle %>,
+
+Today, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
+
+On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will be repeated by the gem client. 
+
+<% if @user.mfa_disabled? %> 
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
+Please enable multi-factor authentication on your RubyGems account 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+<% elsif @user.mfa_ui_only? %>
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. Fortunately, you've already taken the first step! But, there's opportunity to improve.
+Please upgrade your RubyGems account to a stronger MFA level 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+<% else %>
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
+Fortunately, you've already done that. Kudos to you 🥳 🙌!
+<% end %>
+
+For more information, check out our announcement (#link-to-blog-post-tbd).
+
+❤️ Thank you for making the RubyGems ecosystem more secure

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -19,6 +19,6 @@ While this policy impacts specific RubyGems users, everyone can do their part to
 Fortunately, you've already done that. Kudos to you 🥳 🙌!
 <% end %>
 
-For more information, check out our announcement (#link-to-blog-post-tbd).
+For more information, check out our announcement (https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html).
 
 ❤️ Thank you for making the RubyGems ecosystem more secure

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -2,7 +2,10 @@
 
 Recently, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
 
-On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem CLI.
+On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
+If maintainers don't have MFA enabled by this date, a number of operations will be restricted.
+These restrictions include privileged operations (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem CLI.
 
 <% if @user.mfa_disabled? %> 
 We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads. 

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -1,22 +1,23 @@
 👋 Hi <%= @user.handle %>,
 
-Today, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
+Recently, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
 
 On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem client. 
 
 <% if @user.mfa_disabled? %> 
-While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
-Please enable multi-factor authentication on your RubyGems account 🙏.
+We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads. 
+So, we'd like to ask you to please enable multi-factor authentication on your RubyGems account 🙏.
 
 We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
 <% elsif @user.mfa_ui_only? %>
-While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. Fortunately, you've already taken the first step! But, there's opportunity to improve.
+We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
+Fortunately, you've already taken the first step! But, there's opportunity to improve.
 Please upgrade your RubyGems account to a stronger MFA level 🙏.
 
 We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
 <% else %>
-While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
-Fortunately, you've already done that. Kudos to you 🥳 🙌!
+We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
+Fortunately, you've already enabled MFA. Kudos to you 🥳 🙌!
 <% end %>
 
 For more information, check out our announcement (https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html).

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -2,7 +2,7 @@
 
 Recently, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
 
-On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem client. 
+On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will also be shown by the gem CLI.
 
 <% if @user.mfa_disabled? %> 
 We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads. 

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -1,0 +1,32 @@
+require "resolv"
+
+def mx_exists?(email)
+  domain = email.split("@").last
+  mx_resolver = Resolv::DNS.new
+  mx_resolver.timeouts = 10
+
+  return false if mx_resolver.getresources(domain, Resolv::DNS::Resource::IN::MX).empty?
+  true
+rescue StandardError => e
+  puts "Error during processing: #{$ERROR_INFO}"
+  puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+  false
+end
+
+namespace :mfa_policy do
+  # To be sent on launch day (June 13, 2022)
+  # rake mfa_policy:announce_recommendation
+  desc "Send email notification to all users about MFA Phase 2 rollout (MFA Recommendation for popular gems)"
+  task announce_recommendation: :environment do
+    users = User.all
+    total_users = users.count
+    puts "Sending #{total_users} MFA announcement email"
+
+    i = 0
+    users.find_each do |user|
+      Mailer.delay.mfa_recommendation_announcement(user.id) if mx_exists?(user.email)
+      i += 1
+      print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
+    end
+  end
+end

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -20,12 +20,13 @@ namespace :mfa_policy do
   # rake mfa_policy:announce_recommendation
   desc "Send email notification to all users about MFA Phase 2 rollout (MFA Recommendation for popular gems)"
   task announce_recommendation: :environment do
-    users = User.all
+    # users who own at least one gem with a minimum of 165,000,000 downloads or more
+    users = User.joins(rubygems: :gem_download).where("gem_downloads.count >= 165000000").uniq
     total_users = users.count
     puts "Sending #{total_users} MFA announcement email"
 
     i = 0
-    users.find_each do |user|
+    users.each do |user|
       Mailer.delay.mfa_recommendation_announcement(user.id) if mx_exists?(user.email)
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -14,7 +14,9 @@ rescue StandardError => e
 end
 
 namespace :mfa_policy do
-  # To be sent on launch day (June 13, 2022)
+  # This task is meant to be run on MFA Phase 2 launch day - June 13, 2022
+  # For more information on the MFA Phase 2 rollout, refer to this RFC:
+  # https://github.com/rubygems/rfcs/pull/36/files#diff-3d5cc3acc06fe7e9150fdbfc43399c5ad42572c122187774bfc3a4857df524f1R46-R67
   # rake mfa_policy:announce_recommendation
   desc "Send email notification to all users about MFA Phase 2 rollout (MFA Recommendation for popular gems)"
   task announce_recommendation: :environment do

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -37,6 +37,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.mfa_notification(User.last.id)
   end
 
+  def mfa_recommendation_announcement
+    Mailer.mfa_recommendation_announcement(User.last.id)
+  end
+
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
     Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -1,9 +1,13 @@
 require "test_helper"
 
 class MailerTest < ActiveSupport::TestCase
+  MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
+
   context "sending mail for mfa recommendation announcement" do
     setup do
       @user = create(:user)
+      create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY)
+
       Gemcutter::Application.load_tasks
       Rake::Task["mfa_policy:announce_recommendation"].invoke
       Delayed::Worker.new.work_off

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class MailerTest < ActiveSupport::TestCase
+  context "sending mail for mfa recommendation announcement" do
+    setup do
+      @user = create(:user)
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:announce_recommendation"].invoke
+      Delayed::Worker.new.work_off
+    end
+
+    should "send mail to users" do
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [@user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "Official Recommendation: Enable multi-factor authentication on your RubyGems account", email.subject
+      assert_match "Today, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+    end
+  end
+
+  teardown do
+    Rake::Task["mfa_policy:announce_recommendation"].reenable
+  end
+end

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -19,7 +19,7 @@ class MailerTest < ActiveSupport::TestCase
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "Official Recommendation: Enable multi-factor authentication on your RubyGems account", email.subject
-      assert_match "Today, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -18,7 +18,7 @@ class MailerTest < ActiveSupport::TestCase
       email = ActionMailer::Base.deliveries.last
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
-      assert_equal "Official Recommendation: Enable multi-factor authentication on your RubyGems account", email.subject
+      assert_equal "Please enable multi-factor authentication on your RubyGems account", email.subject
       assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
     end
   end


### PR DESCRIPTION
## 🤷‍♀️ What problem are you solving?
Contributes to https://github.com/Shopify/ruby-conventions/issues/88
Closes https://github.com/rubygems/rubygems.org/issues/3088

On Launch Day (June 13, 2022), RubyGems will be announcing the rollout of an MFA policy. To raise awareness about this policy which will be announced in a [blog post](https://github.com/rubygems/rubygems.github.io/pull/110), we plan on emailing all RubyGems users.


## 📋 How will you solve this?
🔹 **Create a mailer** (0d935233c9891ec989a2d8c2acc739b5174119c3)
- Adds a mailer action `mfa_recommendation_announcement` and a mailer view in both `HTML` and `plain text` formats
- Note that there are minor copy variations dependent on a user's MFA status:
  - If the user does not have MFA enabled at all
  - If the user has MFA enabled (`ui_only`)
  - If the user has MFA enabled (`ui_and_api` or `ui_and_gem_signin`)

🔹 **Set up mailer preview** (c1940df0cd8d8cab3a2b8f5b9e574bea706d0156)
- So we can more easily tophat and preview the email in both HTML and plain text, I've set up a mailer preview

🔹 **Add rake task for delivering the email** (d5e42d3495a4e297a74fad3e725772b151bb5126)
- This will be the task that the RubyGems Team will run on Launch Day to send out the email
- I've followed similar logging that they've done in a previous mailer

## 🎩 Tophat instructions
Below are the instructions for trying this out yourself:

**📧 To preview the email:**
- Once you have the app running (`rails s`) ...
- You can navigate to (`http://localhost:3000/rails/mailers`) to review the list of all mailers available for preview
  - To view this mailer, click on the link titled: `mfa_recommendation_announcement`
- The mailer for this PR is located at `http://localhost:3000/rails/mailers/mailer/mfa_recommendation_announcement`

**👤 To change the user:**
- The user is configured on the mailer preview based on `MailerPreview#mfa_recommendation_announcement`. 
  - To change the user to verify various MFA states, you can either replace `User.last.id` with a different user (e.g. `User.first`)
  - Alternatively, you can adjust the MFA status on your last user

### 👀 Email versions

**🚫 Email for users with MFA disabled**
<details>
  <summary>Archived screenshot (out of date)</summary>
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514024-4f39ab20-30ac-46bb-b6fa-b905d3bc019e.png" alt="Email for users with MFA disabled - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514023-fd4a9025-8c87-438c-b7dc-b56e96d22346.png" alt="Email for users with MFA disabled - Plain text format" width=250 />
  </kbd>
</p>
</details>



**🤞 Email for users with MFA enabled (`ui_only`) -- weak MFA**
<details>
  <summary>Archived screenshot (out of date)</summary>
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514015-a6b6a196-4478-4e94-8de6-f28dc580f6a0.png" alt="Email for users with MFA enabled set to ui_only - Plain text format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514013-4c868f06-8f52-4609-91c6-314379f94888.png" alt="Email for users with MFA enabled set to ui_only - HTML format" width=250 />
  </kbd>
</p>
</details>


**✅ Email for users with MFA enabled (`ui_and_api` or `ui_and_gem_signin`**
<details>
  <summary>Archived screenshot (out of date)</summary>
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172513999-273feb64-cb6e-4581-bafe-0264074d7e26.png" alt="Email for users with MFA enabled - Plain text format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172513996-e61e36fa-0f87-4cb6-b79a-fbc6e084ced6.png" alt="Email for users with MFA enabled - HTML format" width=250 />
  </kbd>
</p>
</details>

