### PR TITLE
Add reduced font size tooltip style

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -250,7 +250,6 @@ span#github-btn {
 
 .tooltip__text {
   color: #e9573f;
-  font-size: 0.7em;
   vertical-align: text-bottom;
   cursor: pointer;
   position: relative;
@@ -266,4 +265,8 @@ span#github-btn {
   color: white;
   padding: .25em .5em;
   font-size: .8em;
+}
+
+.tooltip__text--reduced-font-size {
+  font-size: 0.7em;
 }

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -12,7 +12,6 @@ module ApiKeysHelper
       :span,
       "#{name} [?]",
       class: "tooltip__text",
-      style: "font-size:1em",
       data: { tooltip: t("api_keys.gem_ownership_removed", rubygem_name: name) }
     )
   end

--- a/app/views/adoptions/index.html.erb
+++ b/app/views/adoptions/index.html.erb
@@ -11,7 +11,7 @@
 
 <div class="t-body">
   <h2 class="adoption__heading adoption__heading--no-padding"><%= t(".ownership_calls") %>
-    <span class="tooltip__text" data-tooltip="Looking for maintainers">[?]</span>
+    <span class="tooltip__text tooltip__text--reduced-font-size" data-tooltip="Looking for maintainers">[?]</span>
   </h2>
 </div>
 

--- a/app/views/ownership_requests/_list.html.erb
+++ b/app/views/ownership_requests/_list.html.erb
@@ -1,6 +1,6 @@
 <div class="t-body">
   <h2 class="adoption__heading"><%= t("ownership_requests.ownership_requests") %>
-    <span class="tooltip__text" data-tooltip="Intrested in becoming maintainer">[?]</span>
+    <span class="tooltip__text tooltip__text--reduced-font-size" data-tooltip="Interested in becoming maintainer">[?]</span>
   </h2>
 </div>
 

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -22,7 +22,6 @@ class ApiKeysHelperTest < ActionView::TestCase
       expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
         <span
           class="tooltip__text"
-          style="font-size:1em"
           data-tooltip="Ownership of #{rubygem_name} has been removed after being scoped to this key."\
         >#{rubygem_name} [?]</span>
       HTML


### PR DESCRIPTION
When testing https://github.com/rubygems/rubygems.org/pull/2944 on staging, the content security policy blocks inline styling (which is good!). Unfortunately, I did add an inline style patch for the tool tip style to make it default size.

This PR 
1. adds a  `tooltip__text--reduced-font-size` style class with `font-size: 0.7em`
2. removes `font-size: 0.7em` from `tooltip__text`
3. updates places using tool tip styles with the appropriate classes