### PR TITLE
Removed orphaned owners

### DIFF
--- a/db/migrate/20220609221942_remove_orphaned_owners.rb
+++ b/db/migrate/20220609221942_remove_orphaned_owners.rb
@@ -1,0 +1,9 @@
+class RemoveOrphanedOwners < ActiveRecord::Migration[7.0]
+  def up
+    Ownership.where.missing(:user).destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_06_09_221942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"


### PR DESCRIPTION
Trying to address [https://app.honeybadger.io/projects/40972/faults/68202479](https://app.honeybadger.io/projects/40972/faults/68202479), e.g. https://rubygems.org/gems/rmagick4j/owners not showing anything because the user got deleted.

This PR is a migration to delete ownership instances with nil users, and to make user deletion delete related ownerships in the future. My first time writing a migration, so I'm unsure if this is correct.