### PR TITLE
Fix "multifactor authentication" spelling throughout

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -49,14 +49,14 @@ class Api::BaseController < ApplicationController
       message += <<~WARN.chomp
 
 
-        [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+        [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
         at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
       WARN
     elsif @api_key.user.mfa_recommended_weak_level_enabled?
       message += <<~WARN.chomp
 
 
-        [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+        [WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication \
         level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
         Your account will be required to have MFA enabled on one of these levels in the future.
       WARN

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -65,7 +65,7 @@ class Mailer < ApplicationMailer
     @user = User.find(user_id)
 
     mail to: @user.email,
-      subject: "Please consider enabling multifactor authentication for your account"
+      subject: "Please consider enabling multi-factor authentication for your account"
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -10,10 +10,10 @@ class User::WithPrivateFields < User
 
   def mfa_warning
     if mfa_recommended_not_yet_enabled?
-      "[WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication"\
+      "[WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication"\
         " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
     elsif mfa_recommended_weak_level_enabled?
-      "[WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication"\
+      "[WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication"\
         " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
         " Your account will be required to have MFA enabled on one of these levels in the future."
     end

--- a/app/views/mailer/_compromised_instructions.html.erb
+++ b/app/views/mailer/_compromised_instructions.html.erb
@@ -3,7 +3,7 @@
     <ul>
       <li><%= link_to("Change your password", new_password_url) %></li>
       <li><%= link_to("Reset your API key", profile_api_keys_url) %></li>
-      <li><%= link_to("Enable multifactor authentication", edit_settings_url) %></li>
+      <li><%= link_to("Enable multi-factor authentication", edit_settings_url) %></li>
     </ul>
   </li>
   <%= yield %>

--- a/app/views/mailer/honeycomb_reset_api_key.erb
+++ b/app/views/mailer/honeycomb_reset_api_key.erb
@@ -16,7 +16,7 @@
           We do not have any record of your key being abused. However, we have reset your key
           as a precautionary step. To be completely sure, please double-check any gems published
           by your RubyGems.org account between 6 November 2018 and 19 July 2019.
-          Note that if you had enabled multifactor authentication (MFA) for <%= link_to("UI and API", "https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels") %>
+          Note that if you had enabled multi-factor authentication (MFA) for <%= link_to("UI and API", "https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels") %>
           gem push, yank, owner (-a/r) operations were not compromised.
           For complete information about the issue, please  <%= link_to("read our blog post", "https://blog.rubygems.org") %>.
         </p>

--- a/app/views/mailer/mfa_notification.html.erb
+++ b/app/views/mailer/mfa_notification.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Please enable multifactor authentication (MFA)" %>
+<% @title = "Please enable multi-factor authentication (MFA)" %>
 <% @sub_title = "Hi #{@user.handle}" %>
 
 <!-- Body -->
@@ -11,12 +11,12 @@
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
-        We care about keeping your RubyGems.org account secure and recommend enabling multifactor authentication for <b>both UI and API</b>.
-        Setting up multifactor authentication (MFA) only takes a few minutes and goes a long way towards protecting your account and the Ruby ecosystem.
+        We care about keeping your RubyGems.org account secure and recommend enabling multi-factor authentication for <b>both UI and API</b>.
+        Setting up multi-factor authentication (MFA) only takes a few minutes and goes a long way towards protecting your account and the Ruby ecosystem.
         <br/>
         Once enabled, we will ask you for an OTP for actions like <b>sign in</b> and <b>gem push</b>.
         <br/>
-        Please click on the Enable Multifactor Authentication (MFA) button below to register a new device. You may be asked to first log in to your account. You can also find the same link on your <%= link_to("Edit Profile", "https://rubygems.org/profile/edit") %> page.
+        Please click on the Enable Multi-factor Authentication (MFA) button below to register a new device. You may be asked to first log in to your account. You can also find the same link on your <%= link_to("Edit Profile", "https://rubygems.org/profile/edit") %> page.
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
@@ -34,7 +34,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTIFACTOR AUTHENTICATION (MFA)</span></a>
+                          <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTI-FACTOR AUTHENTICATION (MFA)</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
@@ -50,7 +50,7 @@
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
-        Check our guides for more details on <%= link_to("setting up multifactor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multifactor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,11 +23,11 @@ en:
   please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
   please_sign_in: Please sign in to continue.
   otp_incorrect: Your OTP code is incorrect. Please check it and retry.
-  otp_missing: You have enabled multifactor authentication but no OTP code provided. Please fill it and retry.
+  otp_missing: You have enabled multi-factor authentication but no OTP code provided. Please fill it and retry.
   sign_in: Sign in
   sign_up: Sign up
   dependency_list: Show all transitive dependencies
-  multifactor_authentication: Multifactor authentication
+  multifactor_authentication: Multi-factor authentication
   subtitle: your community gem host
   this_rubygem_could_not_be_found: This rubygem could not be found.
   time_ago: "%{duration} ago"
@@ -90,7 +90,7 @@ en:
       mfa: MFA
     new:
       new_api_key: New API key
-      multifactor_auth: Multifactor authentication
+      multifactor_auth: Multi-factor authentication
       enable_mfa: Enable MFA
       rubygem_scope: Gem Scope
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
@@ -101,7 +101,7 @@ en:
       invalid_gem: Selected gem cannot be scoped to this key
     edit:
       edit_api_key: "Edit API key"
-      multifactor_auth: Multifactor authentication
+      multifactor_auth: Multi-factor authentication
       enable_mfa: Enable MFA
       rubygem_scope: Gem Scope
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
@@ -292,12 +292,12 @@ en:
     recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your MFA device.'
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
-    require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.
-    require_mfa_enabled: Your multifactor authentication has not been enabled. You have to enable it first.
-    setup_recommended: For protection of your account and your gems, we encourage you to set up multifactor authentication. Your account will be required to have MFA enabled in the future.
+    require_mfa_disabled: Your multi-factor authentication has been enabled. You have to disable it first.
+    require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
+    setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
     new:
-      title: Enabling multifactor auth
+      title: Enabling multi-factor auth
       scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.
       otp_prompt: Type digit code from auth app to continue.
       confirm: I have kept my recovery codes safe.
@@ -307,7 +307,7 @@ en:
       time_based: "Time based: Yes"
     create:
       qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
-      success: You have successfully enabled multifactor authentication.
+      success: You have successfully enabled multi-factor authentication.
     recovery:
       continue: Continue
       title: Recovery codes
@@ -315,9 +315,9 @@ en:
       saved: I acknowledge that I have saved my recovery codes.
       note_html: "Please <strong class='recovery__bold'>copy and save</strong> these recovery codes. You can use these codes to login and reset your MFA if your lose your authentication device. Each of the code can be used once."
     destroy:
-      success: You have successfully disabled multifactor authentication.
+      success: You have successfully disabled multi-factor authentication.
     update:
-      success: You have successfully updated your multifactor authentication level.
+      success: You have successfully updated your multi-factor authentication level.
   notifiers:
     update:
       success: You have successfully updated your email notification settings.
@@ -371,10 +371,10 @@ en:
       reset_password:
         title: Reset password
       mfa:
-        multifactor_auth: Multifactor authentication
-        disabled_html: You have not yet enabled multifactor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
+        multifactor_auth: Multi-factor authentication
+        disabled_html: You have not yet enabled multi-factor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         go_settings: Register a new device
-        enabled_html: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
+        enabled_html: You have enabled multi-factor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
           Refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         update: Update
         level:
@@ -451,12 +451,12 @@ en:
       header: "%{title} Dependencies"
     gem_members:
       authors_header: Authors
-      self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling multifactor authentication (MFA)</a> to keep your account secure.
-      not_using_mfa_warning_show: "* Some owners are not using multifactor authentication (MFA). Click for the complete list."
-      not_using_mfa_warning_hide: "* The following owners are not using multifactor authentication (MFA). Click to hide."
+      self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling multi-factor authentication (MFA)</a> to keep your account secure.
+      not_using_mfa_warning_show: "* Some owners are not using multi-factor authentication (MFA). Click for the complete list."
+      not_using_mfa_warning_hide: "* The following owners are not using multi-factor authentication (MFA). Click to hide."
       owners_header: Owners
       pushed_by: Pushed by
-      using_mfa_info: "* All owners are using multifactor authentication (MFA)."
+      using_mfa_info: "* All owners are using multi-factor authentication (MFA)."
       yanked_by: Yanked by
       sha_256_checksum: SHA 256 checksum
       signature_period: Signature validity period

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -196,7 +196,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
                 at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
               WARN
 
@@ -218,7 +218,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication \
                 level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
                 Your account will be required to have MFA enabled on one of these levels in the future.
               WARN

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -331,7 +331,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
                 at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
               WARN
 
@@ -351,7 +351,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication \
                 level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
                 Your account will be required to have MFA enabled on one of these levels in the future.
               WARN
@@ -606,7 +606,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
                 at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
               WARN
 
@@ -626,7 +626,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               mfa_warning = <<~WARN.chomp
 
 
-                [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+                [WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication \
                 level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
                 Your account will be required to have MFA enabled on one of these levels in the future.
               WARN

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -99,7 +99,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
           context "when mfa is disabled" do
             should "include warning" do
               expected_warning =
-                "For protection of your account and gems, we encourage you to set up multifactor authentication"\
+                "For protection of your account and gems, we encourage you to set up multi-factor authentication"\
                 " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
 
               assert_warning_included(expected_warning)
@@ -115,7 +115,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
 
               should "include warning" do
                 expected_warning =
-                  "For protection of your account and gems, we encourage you to change your multifactor authentication"\
+                  "For protection of your account and gems, we encourage you to change your multi-factor authentication"\
                   " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
                   " Your account will be required to have MFA enabled on one of these levels in the future."
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -541,7 +541,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           mfa_warning = <<~WARN.chomp
 
 
-            [WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication \
+            [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
             at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
           WARN
 
@@ -559,7 +559,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           mfa_warning = <<~WARN.chomp
 
 
-            [WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication \
+            [WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication \
             level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. \
             Your account will be required to have MFA enabled on one of these levels in the future.
           WARN

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -91,7 +91,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display otp form" do
-        assert page.has_content?("Multifactor authentication")
+        assert page.has_content?("Multi-factor authentication")
       end
     end
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -58,7 +58,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should respond_with :success
       should "display otp form" do
-        assert page.has_content?("Multifactor authentication")
+        assert page.has_content?("Multi-factor authentication")
       end
     end
   end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -16,7 +16,7 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :success
       should "save user name in session" do
         assert_equal @controller.session[:mfa_user], @user.id
-        assert page.has_content? "Multifactor authentication"
+        assert page.has_content? "Multi-factor authentication"
       end
     end
 
@@ -112,7 +112,7 @@ class SessionsControllerTest < ActionController::TestCase
           should redirect_to("the mfa setup page") { new_multifactor_auth_path }
 
           should "set notice flash" do
-            expected_notice = "For protection of your account and your gems, we encourage you to set up multifactor authentication. " \
+            expected_notice = "For protection of your account and your gems, we encourage you to set up multi-factor authentication. " \
                               "Your account will be required to have MFA enabled in the future."
             assert_equal expected_notice, flash[:notice]
           end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -88,7 +88,7 @@ class GemsSystemTest < SystemTest
     visit rubygem_path(@rubygem, as: @user.id)
 
     assert page.has_selector?(".gem__users__mfa-disabled .gem__users a")
-    assert page.has_content? "Please consider enabling multifactor"
+    assert page.has_content? "Please consider enabling multi-factor"
   end
 
   test "shows owners without mfa when logged in as owner" do

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -28,12 +28,12 @@ class SettingsTest < SystemTest
     page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
   end
 
-  test "enabling multifactor authentication with valid otp" do
+  test "enabling multi-factor authentication with valid otp" do
     sign_in
     visit edit_settings_path
     click_button "Register a new device"
 
-    assert page.has_content? "Enabling multifactor auth"
+    assert page.has_content? "Enabling multi-factor auth"
 
     totp = ROTP::TOTP.new(mfa_key)
     page.fill_in "otp", with: totp.now
@@ -45,26 +45,26 @@ class SettingsTest < SystemTest
     check "ack"
     click_button "Continue"
 
-    assert page.has_content? "You have enabled multifactor authentication."
+    assert page.has_content? "You have enabled multi-factor authentication."
     css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
     assert page.has_css?(css, visible: true)
   end
 
-  test "enabling multifactor authentication with invalid otp" do
+  test "enabling multi-factor authentication with invalid otp" do
     sign_in
     visit edit_settings_path
     click_button "Register a new device"
 
-    assert page.has_content? "Enabling multifactor auth"
+    assert page.has_content? "Enabling multi-factor auth"
 
     totp = ROTP::TOTP.new(ROTP::Base32.random_base32)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert page.has_content? "You have not yet enabled multi-factor authentication."
   end
 
-  test "disabling multifactor authentication with valid otp" do
+  test "disabling multi-factor authentication with valid otp" do
     sign_in
     enable_mfa
     visit edit_settings_path
@@ -72,12 +72,12 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert page.has_content? "You have not yet enabled multi-factor authentication."
     css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
     assert page.has_css?(css)
   end
 
-  test "disabling multifactor authentication with invalid otp" do
+  test "disabling multi-factor authentication with invalid otp" do
     sign_in
     enable_mfa
     visit edit_settings_path
@@ -86,10 +86,10 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: ROTP::TOTP.new(key).now
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have enabled multifactor authentication."
+    assert page.has_content? "You have enabled multi-factor authentication."
   end
 
-  test "disabling multifactor authentication with recovery code" do
+  test "disabling multi-factor authentication with recovery code" do
     sign_in
     visit edit_settings_path
     click_button "Register a new device"
@@ -108,7 +108,7 @@ class SettingsTest < SystemTest
     page.fill_in "otp", with: recoveries.sample
     change_auth_level "Disabled"
 
-    assert page.has_content? "You have not yet enabled multifactor authentication."
+    assert page.has_content? "You have not yet enabled multi-factor authentication."
   end
 
   teardown do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -70,7 +70,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: ROTP::TOTP.new("thisisonemfaseed").now
     click_button "Sign in"
@@ -84,7 +84,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "11111"
     click_button "Sign in"
@@ -98,7 +98,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "0123456789ab"
     click_button "Sign in"
@@ -112,7 +112,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "ab0123456789"
     click_button "Sign in"
@@ -133,7 +133,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    expected_notice = "For protection of your account and your gems, we encourage you to set up multifactor authentication. " \
+    expected_notice = "For protection of your account and your gems, we encourage you to set up multi-factor authentication. " \
                       "Your account will be required to have MFA enabled in the future."
     assert page.has_selector? "#flash_notice", text: expected_notice
     assert_current_path(new_multifactor_auth_path)
@@ -153,7 +153,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "0123456789ab"
     click_button "Sign in"
@@ -180,7 +180,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "0123456789ab"
     click_button "Sign in"
@@ -204,7 +204,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: "0123456789ab"
     click_button "Sign in"
@@ -222,7 +222,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Multifactor authentication"
+    assert page.has_content? "Multi-factor authentication"
 
     fill_in "OTP code", with: ROTP::TOTP.new("thisisonemfaseed").now
     click_button "Sign in"

--- a/test/unit/user/with_private_fields_test.rb
+++ b/test/unit/user/with_private_fields_test.rb
@@ -15,7 +15,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
       context "when mfa is disabled" do
         should "include warning in user json" do
           expected_notice =
-            "[WARNING] For protection of your account and gems, we encourage you to set up multifactor authentication"\
+            "[WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication"\
             " at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
 
           assert_match expected_notice, @user.to_json
@@ -30,7 +30,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
           should "include warning in user json" do
             expected_notice =
-              "[WARNING] For protection of your account and gems, we encourage you to change your multifactor authentication"\
+              "[WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication"\
               " level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit."\
               " Your account will be required to have MFA enabled on one of these levels in the future."
 


### PR DESCRIPTION
Closes https://github.com/rubygems/rubygems.org/issues/3092
Closes https://github.com/Shopify/ruby-conventions/issues/119

## 🤷‍♀️ What problem are you solving?
The term `multi-factor authentication` is spelled inconsistently throughout `rubygems`. For the majority of cases, it was spelled as `multifactor authentication`, without the hyphen. However, that's not the proper spelling. The improper spelling observation was previously noted in [another PR](https://github.com/rubygems/rubygems.org/pull/2685) as well.

This PR replace all instances of `multifactor` with `multi-factor`.


## 📋 How will you solve this?
- Updated all `multifactor` references in the [`locales/en.yml` file](https://github.com/rubygems/rubygems.org/blob/master/config/locales/en.yml)
- Completed a global search in the repo for any other `multifactor` reference and replaced with `multi-factor`
- Any code-related references (e.g. variables, path names, etc.) have not been changed as it's not necessary for them to be revised.