### PR TITLE
Revert to 'multifactor' wording in API response.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
   please_sign_in: Please sign in to continue.
   otp_incorrect: Your OTP code is incorrect. Please check it and retry.
-  otp_missing: You have enabled multi-factor authentication but no OTP code provided. Please fill it and retry.
+  otp_missing: You have enabled multifactor authentication but no OTP code provided. Please fill it and retry.
   sign_in: Sign in
   sign_up: Sign up
   dependency_list: Show all transitive dependencies


### PR DESCRIPTION
- it is hardcoded in rubygems client

fixes https://github.com/rubygems/rubygems.org/issues/3096