### PR TITLE
Add foreign key to ownership model

### DIFF
--- a/db/migrate/20220614221414_ownership_foreign_key.rb
+++ b/db/migrate/20220614221414_ownership_foreign_key.rb
@@ -3,7 +3,7 @@ class OwnershipForeignKey < ActiveRecord::Migration[7.0]
     add_foreign_key :ownerships, :users, on_delete: :cascade
   end
 
-  def gem_downloads
+  def down
     remove_foreign_key :ownerships, :users
   end
 end

--- a/db/migrate/20220614221414_ownership_foreign_key.rb
+++ b/db/migrate/20220614221414_ownership_foreign_key.rb
@@ -1,0 +1,9 @@
+class OwnershipForeignKey < ActiveRecord::Migration[7.0]
+  def up
+    add_foreign_key :ownerships, :users, on_delete: :cascade
+  end
+
+  def gem_downloads
+    remove_foreign_key :ownerships, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,8 +126,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_14_221414) do
     t.bigint "user_id"
     t.text "note"
     t.boolean "status", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["rubygem_id"], name: "index_ownership_calls_on_rubygem_id"
     t.index ["user_id"], name: "index_ownership_calls_on_user_id"
   end
@@ -139,8 +139,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_14_221414) do
     t.text "note"
     t.integer "status", limit: 2, default: 0, null: false
     t.integer "approver_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["ownership_call_id"], name: "index_ownership_requests_on_ownership_call_id"
     t.index ["rubygem_id"], name: "index_ownership_requests_on_rubygem_id"
     t.index ["user_id"], name: "index_ownership_requests_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_06_14_221414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "plpgsql"
@@ -127,8 +126,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
     t.bigint "user_id"
     t.text "note"
     t.boolean "status", default: true, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["rubygem_id"], name: "index_ownership_calls_on_rubygem_id"
     t.index ["user_id"], name: "index_ownership_calls_on_user_id"
   end
@@ -140,8 +139,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
     t.text "note"
     t.integer "status", limit: 2, default: 0, null: false
     t.integer "approver_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["ownership_call_id"], name: "index_ownership_requests_on_ownership_call_id"
     t.index ["rubygem_id"], name: "index_ownership_requests_on_rubygem_id"
     t.index ["user_id"], name: "index_ownership_requests_on_user_id"
@@ -282,4 +281,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_29_203956) do
   end
 
   add_foreign_key "api_keys", "users"
+  add_foreign_key "ownerships", "users", on_delete: :cascade
 end


### PR DESCRIPTION
Follow-up to https://github.com/rubygems/rubygems.org/pull/3091, addressing https://app.honeybadger.io/projects/40972/faults/68202479

Adds foreign key to ownership db object, so that when a user is deleted, all their related ownerships get deleted too