### PR TITLE
Add tests to prevent missing OTP and API key forbidden response modifications

### DIFF
--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -48,6 +48,10 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       assert_response 401
       assert_match I18n.t("otp_missing"), @response.body
     end
+
+    should "return body that starts with MFA enabled message" do
+      assert @response.body.start_with?("You have enabled multifactor authentication")
+    end
   end
 
   def self.should_return_api_key_successfully

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -46,6 +46,9 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
             delete :create, params: { gem_name: @rubygem.to_param, version: @v1.number }
           end
           should respond_with :unauthorized
+          should "return body that starts with MFA enabled message" do
+            assert @response.body.start_with?("You have enabled multifactor authentication")
+          end
         end
 
         context "ON DELETE to create for existing gem version with incorrect OTP" do

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -426,5 +426,8 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
     end
 
     should respond_with :forbidden
+    should "return body that starts with denied access message" do
+      assert @response.body.start_with?("The API key doesn't have access")
+    end
   end
 end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -403,10 +403,13 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         rubygem = create(:rubygem, owners: [api_key.user])
 
         @request.env["HTTP_AUTHORIZATION"] = "12323"
-        post :create, params: { rubygem_id: rubygem.to_param, email: "some@email.com" }, format: :json
+        post :create, params: { rubygem_id: rubygem.to_param, email: "some@email.com" }
       end
 
       should respond_with :forbidden
+      should "return body that starts with denied access message" do
+        assert @response.body.start_with?("The API key doesn't have access")
+      end
     end
   end
 
@@ -681,10 +684,13 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         rubygem = create(:rubygem, owners: [api_key.user])
 
         @request.env["HTTP_AUTHORIZATION"] = "12342"
-        delete :destroy, params: { rubygem_id: rubygem.to_param, email: "some@owner.com" }, format: :json
+        delete :destroy, params: { rubygem_id: rubygem.to_param, email: "some@owner.com" }
       end
 
       should respond_with :forbidden
+      should "return body that starts with denied access message" do
+        assert @response.body.start_with?("The API key doesn't have access")
+      end
     end
   end
 

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -120,6 +120,9 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           should "fail to add new owner" do
             refute_includes @rubygem.owners_including_unconfirmed, @second_user
           end
+          should "return body that starts with MFA enabled message" do
+            assert @response.body.start_with?("You have enabled multifactor authentication")
+          end
         end
 
         context "adding other user as gem owner with incorrect OTP" do
@@ -441,6 +444,9 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           should respond_with :unauthorized
           should "fail to remove gem owner" do
             assert_includes @rubygem.owners, @second_user
+          end
+          should "return body that starts with MFA enabled message" do
+            assert @response.body.start_with?("You have enabled multifactor authentication")
           end
         end
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -693,6 +693,9 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         post :create, body: gem_file("test-1.0.0.gem").read
       end
       should respond_with :forbidden
+      should "return body that starts with denied access message" do
+        assert @response.body.start_with?("The API key doesn't have access")
+      end
     end
   end
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -212,6 +212,9 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           post :create, body: gem_file.read
         end
         should respond_with :unauthorized
+        should "return body that starts with MFA enabled message" do
+          assert @response.body.start_with?("You have enabled multifactor authentication")
+        end
       end
 
       context "On post to create for new gem with incorrect OTP" do


### PR DESCRIPTION
Fixes: https://github.com/rubygems/rubygems.org/issues/3100

Adds tests to make sure that `otp_missing` returns a body that starts with `You have enabled multifactor authentication`, and `api_key_forbidden` returns a body that starts with `The API key doesn't have access`.

This is so the CLI can recognize whether the user needs to enter an OTP code (for `otp_missing`) or if a scope should be added (for `api_key_forbidden`).

Am I missing other cases?