### PR TITLE
Separate MFA methods from User to its own concern

### DIFF
--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -1,0 +1,82 @@
+module UserMultifactorMethods
+  extend ActiveSupport::Concern
+
+  included do
+    enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2, ui_and_gem_signin: 3 }, _prefix: :mfa
+
+    def mfa_enabled?
+      !mfa_disabled?
+    end
+
+    def disable_mfa!
+      mfa_disabled!
+      self.mfa_seed = ""
+      self.mfa_recovery_codes = []
+      save!(validate: false)
+    end
+
+    def verify_and_enable_mfa!(seed, level, otp, expiry)
+      if expiry < Time.now.utc
+        errors.add(:base, I18n.t("multifactor_auths.create.qrcode_expired"))
+      elsif verify_digit_otp(seed, otp)
+        enable_mfa!(seed, level)
+      else
+        errors.add(:base, I18n.t("multifactor_auths.incorrect_otp"))
+      end
+    end
+
+    def enable_mfa!(seed, level)
+      self.mfa_level = level
+      self.mfa_seed = seed
+      self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
+      save!(validate: false)
+    end
+
+    def mfa_gem_signin_authorized?(otp)
+      return true unless strong_mfa_level?
+      otp_verified?(otp)
+    end
+
+    def mfa_recommended_not_yet_enabled?
+      mfa_recommended? && mfa_disabled?
+    end
+
+    def mfa_recommended_weak_level_enabled?
+      mfa_recommended? && mfa_ui_only?
+    end
+
+    def otp_verified?(otp)
+      otp = otp.to_s
+      return true if verify_digit_otp(mfa_seed, otp)
+
+      return false unless mfa_recovery_codes.include? otp
+      mfa_recovery_codes.delete(otp)
+      save!(validate: false)
+    end
+
+    private
+
+    def strong_mfa_level?
+      mfa_ui_and_gem_signin? || mfa_ui_and_api?
+    end
+
+    def mfa_recommended?
+      return false if strong_mfa_level?
+
+      rubygems.mfa_recommended.any?
+    end
+
+    def verify_digit_otp(seed, otp)
+      totp = ROTP::TOTP.new(seed)
+      return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30)
+
+      save!(validate: false)
+    end
+  end
+
+  class_methods do
+    def without_mfa
+      where(mfa_level: "disabled")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include UserMultifactorMethods
   include Clearance::User
   include Gravtastic
   is_gravtastic default: "retro"
@@ -58,8 +59,6 @@ class User < ApplicationRecord
   validate :unconfirmed_email_uniqueness
   validate :toxic_email_domain, on: :create
 
-  enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2, ui_and_gem_signin: 3 }, _prefix: :mfa
-
   def self.authenticate(who, password)
     user = find_by(email: who.downcase) || find_by(handle: who)
     user if user&.authenticated?(password)
@@ -97,10 +96,6 @@ class User < ApplicationRecord
 
   def self.ownership_request_notifiable_owners
     where(ownerships: { ownership_request_notifier: true })
-  end
-
-  def self.without_mfa
-    where(mfa_level: "disabled")
   end
 
   def name
@@ -201,66 +196,6 @@ class User < ApplicationRecord
     remember_token_expires_at && remember_token_expires_at > Time.zone.now
   end
 
-  def mfa_enabled?
-    !mfa_disabled?
-  end
-
-  def disable_mfa!
-    mfa_disabled!
-    self.mfa_seed = ""
-    self.mfa_recovery_codes = []
-    save!(validate: false)
-  end
-
-  def verify_and_enable_mfa!(seed, level, otp, expiry)
-    if expiry < Time.now.utc
-      errors.add(:base, I18n.t("multifactor_auths.create.qrcode_expired"))
-    elsif verify_digit_otp(seed, otp)
-      enable_mfa!(seed, level)
-    else
-      errors.add(:base, I18n.t("multifactor_auths.incorrect_otp"))
-    end
-  end
-
-  def enable_mfa!(seed, level)
-    self.mfa_level = level
-    self.mfa_seed = seed
-    self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-    save!(validate: false)
-  end
-
-  def strong_mfa_level?
-    mfa_ui_and_gem_signin? || mfa_ui_and_api?
-  end
-
-  def mfa_gem_signin_authorized?(otp)
-    return true unless strong_mfa_level?
-    otp_verified?(otp)
-  end
-
-  def mfa_recommended?
-    return false if strong_mfa_level?
-
-    rubygems.mfa_recommended.any?
-  end
-
-  def mfa_recommended_not_yet_enabled?
-    mfa_recommended? && mfa_disabled?
-  end
-
-  def mfa_recommended_weak_level_enabled?
-    mfa_recommended? && mfa_ui_only?
-  end
-
-  def otp_verified?(otp)
-    otp = otp.to_s
-    return true if verify_digit_otp(mfa_seed, otp)
-
-    return false unless mfa_recovery_codes.include? otp
-    mfa_recovery_codes.delete(otp)
-    save!(validate: false)
-  end
-
   def block!
     original_email = email
     transaction do
@@ -283,13 +218,6 @@ class User < ApplicationRecord
   end
 
   private
-
-  def verify_digit_otp(seed, otp)
-    totp = ROTP::TOTP.new(seed)
-    return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30)
-
-    save!(validate: false)
-  end
 
   def update_email
     self.attributes = { email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0 }

--- a/test/unit/user_multifactor_methods_test.rb
+++ b/test/unit/user_multifactor_methods_test.rb
@@ -1,0 +1,222 @@
+require "test_helper"
+
+class UserMultifactorMethodsTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#mfa_enabled" do
+    should "return true if multifactor auth is not disabled" do
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      assert_predicate @user, :mfa_enabled?
+    end
+
+    should "return true if multifactor auth is disabled" do
+      @user.disable_mfa!
+      refute_predicate @user, :mfa_enabled?
+    end
+  end
+
+  context "#disable_mfa!" do
+    setup do
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.disable_mfa!
+    end
+
+    should "disable mfa" do
+      assert_predicate @user, :mfa_disabled?
+      assert_empty @user.mfa_seed
+      assert_empty @user.mfa_recovery_codes
+    end
+  end
+
+  context "#verify_and_enable_mfa!" do
+    setup do
+      @seed = ROTP::Base32.random_base32
+      @expiry = 30.minutes.from_now
+    end
+
+    should "enable mfa" do
+      @user.verify_and_enable_mfa!(
+        @seed,
+        :ui_and_api,
+        ROTP::TOTP.new(@seed).now,
+        @expiry
+      )
+
+      assert_predicate @user, :mfa_enabled?
+    end
+
+    should "add error if qr code expired" do
+      @user.verify_and_enable_mfa!(
+        @seed,
+        :ui_and_api,
+        ROTP::TOTP.new(@seed).now,
+        5.minutes.ago
+      )
+
+      refute_predicate @user, :mfa_enabled?
+      expected_error = "The QR-code and key is expired. Please try registering a new device again."
+      assert_contains @user.errors[:base], expected_error
+    end
+
+    should "add error if otp code is incorrect" do
+      @user.verify_and_enable_mfa!(
+        @seed,
+        :ui_and_api,
+        ROTP::TOTP.new(ROTP::Base32.random_base32).now,
+        @expiry
+      )
+
+      refute_predicate @user, :mfa_enabled?
+      assert_contains @user.errors[:base], "Your OTP code is incorrect."
+    end
+  end
+
+  context "#enable_mfa!" do
+    setup do
+      @seed = ROTP::Base32.random_base32
+      @level = :ui_and_api
+      @user.enable_mfa!(@seed, @level)
+    end
+
+    should "enable mfa" do
+      assert_equal @seed, @user.mfa_seed
+      assert_predicate @user, :mfa_ui_and_api?
+      assert_equal 10, @user.mfa_recovery_codes.length
+    end
+  end
+
+  context "#mfa_gem_signin_authorized?" do
+    setup do
+      @seed = ROTP::Base32.random_base32
+    end
+
+    should "return true if mfa is ui_and_api and otp is correct" do
+      @user.enable_mfa!(@seed, :ui_and_api)
+      assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
+    end
+
+    should "return true if mfa is ui_and_gem_signin and otp is correct" do
+      @user.enable_mfa!(@seed, :ui_and_gem_signin)
+      assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
+    end
+
+    should "return true if mfa is disabled" do
+      assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
+    end
+
+    should "return true if mfa is ui_only" do
+      @user.enable_mfa!(@seed, :ui_only)
+      assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
+    end
+
+    should "return false if otp is incorrect" do
+      @user.enable_mfa!(@seed, :ui_and_gem_signin)
+      refute @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+    end
+  end
+
+  context "#mfa_recommended_not_yet_enabled?" do
+    setup do
+      @popular_rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+        rubygem_id: @popular_rubygem.id
+      )
+    end
+
+    should "return true if instance owns a gem that exceeds recommended threshold and has mfa disabled" do
+      create(:ownership, user: @user, rubygem: @popular_rubygem)
+
+      assert_predicate @user, :mfa_recommended_not_yet_enabled?
+    end
+
+    should "return false if instance owns a gem that exceeds recommended threshold and has mfa enabled" do
+      create(:ownership, user: @user, rubygem: @popular_rubygem)
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+
+      refute_predicate @user, :mfa_recommended_not_yet_enabled?
+    end
+
+    should "return false if instance does not own a gem that exceeds recommended threshold and has mfa disabled" do
+      create(:ownership, user: @user, rubygem: create(:rubygem))
+
+      refute_predicate @user, :mfa_recommended_not_yet_enabled?
+    end
+  end
+
+  context "#mfa_recommended_weak_level_enabled?" do
+    setup do
+      @popular_rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+        rubygem_id: @popular_rubygem.id
+      )
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    end
+
+    should "return true if instance owns a gem that exceeds recommended threshold and has mfa ui_only" do
+      create(:ownership, user: @user, rubygem: @popular_rubygem)
+
+      assert_predicate @user, :mfa_recommended_weak_level_enabled?
+    end
+
+    should "return false if instance owns a gem that exceeds recommended threshold and has mfa disabled" do
+      create(:ownership, user: @user, rubygem: @popular_rubygem)
+      @user.disable_mfa!
+
+      refute_predicate @user, :mfa_recommended_weak_level_enabled?
+    end
+
+    should "return false if instance does not own a gem that exceeds recommended threshold and has mfa disabled" do
+      create(:ownership, user: @user, rubygem: create(:rubygem))
+
+      refute_predicate @user, :mfa_recommended_weak_level_enabled?
+    end
+  end
+
+  context "#otp_verified?" do
+    setup do
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    end
+
+    should "return true if otp is correct" do
+      assert @user.otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+    end
+
+    should "return true for otp in last interval" do
+      last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
+      assert @user.otp_verified?(last_otp)
+    end
+
+    should "return true for otp in next interval" do
+      next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
+      assert @user.otp_verified?(next_otp)
+    end
+
+    should "return false if otp is incorrect" do
+      refute @user.otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+    end
+
+    should "return true if recovery code is correct" do
+      recovery_code = @user.mfa_recovery_codes.first
+
+      assert @user.otp_verified?(recovery_code)
+      refute_includes @user.mfa_recovery_codes, recovery_code
+    end
+  end
+
+  context ".without_mfa" do
+    setup do
+      create(:user, mfa_level: :ui_and_api)
+    end
+
+    should "return instances without mfa" do
+      user_without_mfa = User.without_mfa
+
+      assert_equal 1, user_without_mfa.size
+      assert_equal @user, user_without_mfa.first
+    end
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -370,32 +370,6 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context "strong_mfa_level?" do
-      should "be true if the users mfa level is ui_and_api" do
-        user = create(:user, mfa_level: "ui_and_api")
-
-        assert_predicate user, :strong_mfa_level?
-      end
-
-      should "be true if the users mfa level is ui_and_gem_signin" do
-        user = create(:user, mfa_level: "ui_and_gem_signin")
-
-        assert_predicate user, :strong_mfa_level?
-      end
-
-      should "be false if users mfa level is ui_only" do
-        user = create(:user, mfa_level: "ui_only")
-
-        refute_predicate user, :strong_mfa_level?
-      end
-
-      should "be false if users has mfa disabled" do
-        user = create(:user, mfa_level: "disabled")
-
-        refute_predicate user, :strong_mfa_level?
-      end
-    end
-
     context "recommend mfa" do
       setup do
         @rubygem = create(:rubygem)
@@ -409,10 +383,6 @@ class UserTest < ActiveSupport::TestCase
             Rubygem::MFA_RECOMMENDED_THRESHOLD,
             rubygem_id: @rubygem.id
           )
-        end
-
-        should "return false for mfa_recommended?" do
-          refute_predicate @user, :mfa_recommended?
         end
 
         should "return false for mfa_recommended_not_yet_enabled?" do
@@ -430,10 +400,6 @@ class UserTest < ActiveSupport::TestCase
             Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
             rubygem_id: @rubygem.id
           )
-        end
-
-        should "return true for mfa_recommended?" do
-          assert_predicate @user, :mfa_recommended?
         end
 
         should "return true for mfa_recommended_not_yet_enabled?" do
@@ -455,10 +421,6 @@ class UserTest < ActiveSupport::TestCase
           )
         end
 
-        should "return true for mfa_recommended?" do
-          assert_predicate @user, :mfa_recommended?
-        end
-
         should "return false for mfa_recommended_not_yet_enabled?" do
           refute_predicate @user, :mfa_recommended_not_yet_enabled?
         end
@@ -476,10 +438,6 @@ class UserTest < ActiveSupport::TestCase
             Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
             rubygem_id: @rubygem.id
           )
-        end
-
-        should "return false for mfa_recommended?" do
-          refute_predicate @user, :mfa_recommended?
         end
 
         should "return false for mfa_recommended_not_yet_enabled?" do


### PR DESCRIPTION
Solves: https://github.com/rubygems/rubygems.org/issues/3012

Currently, there is a code climate violation suggesting that there were too many methods in `User.rb` when working on the MFA work (https://github.com/rubygems/rubygems.org/pull/2994#issuecomment-1095346404). Before we move on with implementing requiring MFA, this issue should be addressed.

This PR moves any mfa related methods from user into its own concern called `MultifactorAuthable` and includes it in the User model.

### Reviewers should focus on
- Does `MultifactorAuthable` make sense? Better suggestions for names?
- Created a dummy class to test the concern. Is it overkill since the User class would probably only use it? Most of the functionality is tested again in the User.
- Any methods I missed that should be in this concern?

