### PR TITLE
Expose Version#built_at on the versions index page

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -1,6 +1,10 @@
+:root {
+  --gem-version-color: #a6aab2;
+}
+
 .gem__version {
   position: relative;
-  color: #a6aab2; }
+  color: var(--gem-version-color); }
   @media (max-width: 929px) {
     .gem__version {
       top: 5px;
@@ -197,7 +201,10 @@
   margin-bottom: 12px; }
 
 .gem__version__date {
-  color: #a6aab2; }
+  color: var(--gem-version-color); }
+
+.gem__version__date.tooltip__text {
+  color: var(--gem-version-color); }
 
 .gem__versions-wrap {
   overflow: auto; }
@@ -218,7 +225,7 @@
     display: inline-block; }
 
 .gem__unregistered {
-  color: #a6aab2;
+  color: var(--gem-version-color);
   cursor: help;
 }
 

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -9,7 +9,7 @@ module PagesHelper
 
   def subtitle
     subtitle = "v#{version_number}"
-    subtitle += " - #{nice_date_for(version.created_at)}"
+    subtitle += " - #{nice_date_for(version.authored_at)}"
     subtitle
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -1,0 +1,18 @@
+module VersionsHelper
+  def version_date_tag(version)
+    data = {}
+    klass = ["gem__version__date"]
+    text = version_authored_date(version)
+    if version.rely_on_built_at?
+      klass << "tooltip__text"
+      data.merge!(tooltip: t("versions.index.imported_gem_version_notice", import_date: nice_date_for(Version::RUBYGEMS_IMPORT_DATE)))
+      text << " [?]"
+    end
+
+    content_tag(:small, text, class: klass, data: data)
+  end
+
+  def version_authored_date(version)
+    "- #{nice_date_for(version.authored_at)}"
+  end
+end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,6 +1,8 @@
 require "digest/sha2"
 
 class Version < ApplicationRecord
+  RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
+
   belongs_to :rubygem, touch: true
   has_many :dependencies, -> { order("rubygems.name ASC").includes(:rubygem) }, dependent: :destroy, inverse_of: "version"
   has_one :gem_download, inverse_of: :version, dependent: :destroy
@@ -175,6 +177,18 @@ class Version < ApplicationRecord
   end
 
   delegate :reorder_versions, to: :rubygem
+
+  def authored_at
+    return built_at if rely_on_built_at?
+
+    created_at
+  end
+
+  def rely_on_built_at?
+    return false if created_at.to_date != RUBYGEMS_IMPORT_DATE
+
+    built_at && built_at <= RUBYGEMS_IMPORT_DATE
+  end
 
   def refresh_rubygem_indexed
     rubygem.refresh_indexed!

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -21,7 +21,7 @@
               <a href="<%= rubygem_path(version.rubygem) %>" class="dashboard__gem">
                 <div class="dashboard__gem__info">
                   <strong class="dashboard__gem__name"><%= version.to_title %></strong>
-                  <i class="dashboard__gem__version"><%= t 'time_ago', :duration => time_ago_in_words(version.created_at) %></i>
+                  <i class="dashboard__gem__version"><%= t 'time_ago', :duration => time_ago_in_words(version.authored_at) %></i>
                 </div>
                 <p class="dashboard__gem__desc"><%= short_info(version) %></p>
               </a>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -1,6 +1,6 @@
 <li class="gem__version-wrap">
   <%= link_to version.number, rubygem_version_path(version.rubygem, version.slug), :class => 't-list__item' %>
-  <small class="gem__version__date">- <%= nice_date_for(version.created_at) %></small>
+  <%= version_date_tag(version) %>
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -4,7 +4,7 @@
     <p><%= t('.not_hosted_notice') %></p>
   </div>
 <% else %>
-  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@versions.map(&:created_at).min)) %>:</h3>
+  <h3 class="t-list__heading"><%= t('.versions_since', :count => @versions.size, :since => nice_date_for(@versions.map(&:authored_at).min)) %>:</h3>
   <div class="versions">
     <ul class="t-list__items">
       <%= render @versions %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -538,6 +538,7 @@ de:
       not_hosted_notice: Dieses Gem wird nicht gerade von RubyGems.org gehostet.
       title: Alle Versionen von %{name}
       versions_since: "%{count} Versionen seit %{since}"
+      imported_gem_version_notice:
     version:
       yanked:
   will_paginate:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -526,6 +526,7 @@ en:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
       title: All versions of %{name}
       versions_since: "%{count} versions since %{since}"
+      imported_gem_version_notice: "This gem version was imported to RubyGems.org on %{import_date}. The date displayed was specified by the author in the gemspec."
     version:
       yanked: yanked
   will_paginate:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -583,6 +583,7 @@ es:
       not_hosted_notice: Esta gema no está alojada actualmente en RubyGems.org.
       title: Todas las versiones de %{name}
       versions_since: "%{count} versiones desde %{since}"
+      imported_gem_version_notice:
     version:
       yanked: borrada
   will_paginate:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -580,6 +580,7 @@ fr:
       not_hosted_notice: Gem non hébergé sur Rubygems.
       title: Toutes les versions de %{name}
       versions_since: "%{count} versions depuis %{since}"
+      imported_gem_version_notice:
     version:
       yanked: retiré
   will_paginate:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -527,6 +527,7 @@ ja:
       not_hosted_notice: このGemはRubyGems.org上ではホストされていません。
       title: "%{name}の全バージョン履歴"
       versions_since: "%{since}からの%{count}項目"
+      imported_gem_version_notice:
     version:
       yanked: yanked
   will_paginate:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -542,6 +542,7 @@ nl:
       not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org
       title: Alle versies van %{name}
       versions_since: "%{count} versies sinds %{since}"
+      imported_gem_version_notice:
     version:
       yanked: verwijderd
   will_paginate:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -565,6 +565,7 @@ pt-BR:
       not_hosted_notice: Esta gem não está hospdada no Gemcutter.
       title: Todas as versões para %{name}
       versions_since: "%{count} versões desde %{since}"
+      imported_gem_version_notice:
     version:
       yanked: removida
   will_paginate:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -524,6 +524,7 @@ zh-CN:
       not_hosted_notice: 此 Gem 目前没有托管在 Gemcutter。
       title: "%{name} 的所有版本"
       versions_since: 自 %{since} 以来有 %{count} 个版本
+      imported_gem_version_notice:
     version:
       yanked: 已废弃
   will_paginate:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -525,6 +525,7 @@ zh-TW:
       not_hosted_notice: 這個 Gem 目前沒有在 Gemcutter 上
       title: "%{name} 的所有版本"
       versions_since: 自從 %{since} 以來，有 %{count} 個版本
+      imported_gem_version_notice:
     version:
       yanked: 已被移除
   will_paginate:

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -163,7 +163,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render info about the gem" do
       assert page.has_content?(@rubygem.name)
       assert page.has_content?(@latest_version.number)
-      css = "small:contains('#{@latest_version.created_at.to_date.to_formatted_s(:long)}')"
+      css = "small:contains('#{@latest_version.authored_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
       assert page.has_content?("Links")
     end

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -63,6 +63,29 @@ class VersionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to index with imported versions" do
+    setup do
+      @built_at = Date.parse("2000-01-01")
+      rubygem = create(:rubygem)
+      create(:version, rubygem: rubygem, created_at: Version::RUBYGEMS_IMPORT_DATE, built_at: @built_at)
+      get :index, params: { rubygem_id: rubygem.name }
+    end
+
+    should respond_with :success
+
+    should "show imported versions authored_at dates with an asterisk" do
+      tooltip_text = <<~NOTICE.squish
+        This gem version was imported to RubyGems.org on July 25, 2009.
+        The date displayed was specified by the author in the gemspec.
+      NOTICE
+
+      assert_select ".gem__version__date", text: "- January 01, 2000 [?]", count: 1 do |elements|
+        version = elements.first
+        assert_equal(tooltip_text, version["data-tooltip"])
+      end
+    end
+  end
+
   context "On GET to show" do
     setup do
       @latest_version = create(:version, built_at: 1.week.ago, created_at: 1.day.ago)
@@ -105,7 +128,7 @@ class VersionsControllerTest < ActionController::TestCase
     should "render other versions" do
       assert page.has_content?("Versions")
       assert page.has_content?(@version.number)
-      css = "small:contains('#{@version.created_at.to_date.to_formatted_s(:long)}')"
+      css = "small:contains('#{@version.authored_at.to_date.to_formatted_s(:long)}')"
       assert page.has_css?(css)
     end
     should "renders owner gems overview link" do


### PR DESCRIPTION
Hey folks! Me and @Schwad would like to propose a change to the `Version` index page
We would like to use a bit more accurate date especially for gems that were imported into rubygems on `July 25, 2009`
Currently all gems use `version.created_at` (interestingly it was switched from `version.built_at`) - https://github.com/rubygems/rubygems.org/pull/1504
but for older versions of gems like `nokogiri` `created_at` has not a lot of meaning, for example:
https://rubygems.org/gems/nokogiri/versions
<details>
  <summary>Currently on production for nokogiri</summary>
  <img width="409" alt="image" src="https://user-images.githubusercontent.com/5512772/175616492-349ee498-4208-40bc-88cc-bdba3b461482.png">
</details>

So we went with a little verbose but backwards-compatible approach that falls back to `built_at` attribute for gems that we consider "imported", or, literally created on `July 25th, 2009`
Naming was hard so feel free to suggest your options, but we added a new method `authored_at` that performs this fallback by checking whether the version was `seeded?` which just compares `created_at` date to be equal `July 25th, 2009` (time part is stripped)

Which results in a nicer and more insightful history of older `nokogiri` versions:
<details>
  <summary>After using built_at for pre-rubygems gems</summary>
<img width="418" alt="image" src="https://user-images.githubusercontent.com/5512772/175618781-0386c80d-dccd-4d25-aab9-38a940f1669c.png">

</details>

Side-to-side comparison 

<img width="909" alt="image" src="https://user-images.githubusercontent.com/5512772/175627207-f6f21976-f370-4e68-88ad-5a2ddd5a4606.png">


