### PR TITLE
Use position in CSS correctly on gem page

### DIFF
--- a/app/assets/stylesheets/modules/shared.css
+++ b/app/assets/stylesheets/modules/shared.css
@@ -177,7 +177,7 @@ a.page__heading {
   margin-top: 15px; }
 
 /* style used to be applied on iframe of github_buttons */
-span#github-btn {
+span.github-btn {
   display: block;
   margin-bottom: 15px;
   margin-top: 5px;

--- a/app/views/rubygems/_github_button.html.erb
+++ b/app/views/rubygems/_github_button.html.erb
@@ -1,7 +1,7 @@
-<span class="github-btn" id="github-btn" data-params=<%= github_data_params %> %>
-  <a class="gh-btn" id="gh-btn" href="#" target="_blank" aria-label="">
+<span class="github-btn" data-params=<%= github_data_params %> %>
+  <a class="gh-btn" href="#" rel="noopener noreferrer" target="_blank">
     <span class="gh-ico" aria-hidden="true"></span>
-    <span class="gh-text" id="gh-text"></span>
+    <span class="gh-text"></span>
   </a>
-  <a class="gh-count" id="gh-count" href="#" target="_blank" aria-label=""></a>
+  <a class="gh-count" href="#" rel="noopener noreferrer" target="_blank" aria-hidden="true"></a>
 </span>

--- a/vendor/assets/javascripts/github_buttons.js
+++ b/vendor/assets/javascripts/github_buttons.js
@@ -11,39 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Soure repo: https://github.com/mdo/github-buttons
+ * Source: https://github.com/mdo/github-buttons/blob/7c1da76484288ce76fa061362fc1c1f0db1f6553/src/js.js
  * Modification: Changed params to read attributes from data-params
- *               Changed jsonp to invoke callback after GET url (JSON-P callback endpoint was used originally to avoid cross domain issues)
- *               Execute only when #github-btn exists
+ *               Execute only when .github-btn exists
  */
 
-// Read a page's GET URL variables and return them as an associative array.
-// Source: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
-if ($("#github-btn").length) {
-  var params = (function () {
-    var vars = [],
-        hash;
+if ($(".github-btn").length) {
+  (function() {
+    'use strict';
+
+  // Read a page's GET URL variables and return them as an associative array.
+  // Source: https://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
+  function getUrlParameters() {
+    var vars = [];
+    var hash;
     var hashes = $('.github-btn').attr('data-params').split('&');
+
     for (var i = 0; i < hashes.length; i++) {
       hash = hashes[i].split('=');
       vars.push(hash[0]);
       vars[hash[0]] = hash[1];
     }
-    return vars;
-  }());
 
-  var user = params.user,
-      repo = params.repo,
-      type = params.type,
-      count = params.count,
-      size = params.size,
-      v = params.v,
-      head = document.getElementsByTagName('head')[0],
-      button = document.getElementById('gh-btn'),
-      mainButton = document.getElementById('github-btn'),
-      text = document.getElementById('gh-text'),
-      counter = document.getElementById('gh-count'),
-      labelSuffix = ' on GitHub';
+    return vars;
+  }
 
   // Add commas to numbers
   function addCommas(n) {
@@ -51,96 +42,139 @@ if ($("#github-btn").length) {
   }
 
   function jsonp(path) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', path, true);
-    xhr.responseType = 'json';
-    xhr.onload = function() {
-      var status = xhr.status;
-      if (status === 200) {
-        var res = { data: { stargazers_count: xhr.response.stargazers_count } };
-        callback(res);
-      } else {
-        console.log("Request to github failed with status:", status)
-      }
-    };
-    xhr.send();
+    var head = document.head;
+    var script = document.createElement('script');
+
+    script.src = path + '?callback=callback';
+    head.insertBefore(script, head.firstChild);
   }
 
-  function callback(obj) {
+  var parameters = getUrlParameters();
+
+  // Parameters
+  var user = parameters.user;
+  var repo = parameters.repo;
+  var type = parameters.type;
+  var count = parameters.count;
+  var size = parameters.size;
+  var v = parameters.v;
+
+  // Elements
+  var button = document.querySelector('.gh-btn');
+  var mainButton = document.querySelector('.github-btn');
+  var text = document.querySelector('.gh-text');
+  var counter = document.querySelector('.gh-count');
+
+  // Constants
+  var LABEL_SUFFIX = ' on GitHub';
+  var GITHUB_URL = 'https://github.com/';
+  var API_URL = 'https://api.github.com/';
+  var REPO_URL = GITHUB_URL + user + '/' + repo;
+  var USER_REPO = user + '/' + repo;
+
+  window.callback = function(obj) {
+    if (obj.data.message === 'Not Found') {
+      return;
+    }
+
     switch (type) {
       case 'watch':
         if (v === '2') {
-          counter.innerHTML = addCommas(obj.data.subscribers_count);
-          counter.setAttribute('aria-label', counter.innerHTML + ' watchers' + labelSuffix);
+          counter.textContent = obj.data.subscribers_count && addCommas(obj.data.subscribers_count);
+          counter.setAttribute('aria-label', counter.textContent + ' watchers' + LABEL_SUFFIX);
         } else {
-          counter.innerHTML = addCommas(obj.data.stargazers_count);
-          counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+          counter.textContent = obj.data.stargazers_count && addCommas(obj.data.stargazers_count);
+          counter.setAttribute('aria-label', counter.textContent + ' stargazers' + LABEL_SUFFIX);
         }
+
         break;
       case 'star':
-        counter.innerHTML = addCommas(obj.data.stargazers_count);
-        counter.setAttribute('aria-label', counter.innerHTML + ' stargazers' + labelSuffix);
+        counter.textContent = obj.data.stargazers_count && addCommas(obj.data.stargazers_count);
+        counter.setAttribute('aria-label', counter.textContent + ' stargazers' + LABEL_SUFFIX);
         break;
       case 'fork':
-        counter.innerHTML = addCommas(obj.data.network_count);
-        counter.setAttribute('aria-label', counter.innerHTML + ' forks' + labelSuffix);
+        counter.textContent = obj.data.network_count && addCommas(obj.data.network_count);
+        counter.setAttribute('aria-label', counter.textContent + ' forks' + LABEL_SUFFIX);
         break;
       case 'follow':
-        counter.innerHTML = addCommas(obj.data.followers);
-        counter.setAttribute('aria-label', counter.innerHTML + ' followers' + labelSuffix);
+        counter.textContent = obj.data.followers && addCommas(obj.data.followers);
+        counter.setAttribute('aria-label', counter.textContent + ' followers' + LABEL_SUFFIX);
         break;
     }
 
-    // Show the count if asked
-    if (count === 'true' && counter.innerHTML !== 'undefined') {
+    // Show the count if asked and if it's not empty
+    if (count === 'true' && counter.textContent !== '') {
       counter.style.display = 'block';
+      counter.removeAttribute('aria-hidden');
     }
-  }
+  };
 
   // Set href to be URL for repo
-  button.href = 'https://github.com/' + user + '/' + repo + '/';
+  button.href = REPO_URL;
+
+  var title;
 
   // Add the class, change the text label, set count link href
   switch (type) {
     case 'watch':
       if (v === '2') {
         mainButton.className += ' github-watchers';
-        text.innerHTML = 'Watch';
-        counter.href = 'https://github.com/' + user + '/' + repo + '/watchers';
+        text.textContent = 'Watch';
+        counter.href = REPO_URL + '/watchers';
       } else {
         mainButton.className += ' github-stargazers';
-        text.innerHTML = 'Star';
-        counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+        text.textContent = 'Star';
+        counter.href = REPO_URL + '/stargazers';
       }
+
+      title = text.textContent + ' ' + USER_REPO;
       break;
     case 'star':
       mainButton.className += ' github-stargazers';
-      text.innerHTML = 'Star';
-      counter.href = 'https://github.com/' + user + '/' + repo + '/stargazers';
+      text.textContent = 'Star';
+      counter.href = REPO_URL + '/stargazers';
+      title = text.textContent + ' ' + USER_REPO;
       break;
     case 'fork':
       mainButton.className += ' github-forks';
-      text.innerHTML = 'Fork';
-      button.href = 'https://github.com/' + user + '/' + repo + '/fork';
-      counter.href = 'https://github.com/' + user + '/' + repo + '/network';
+      text.textContent = 'Fork';
+      button.href = REPO_URL + '/fork';
+      counter.href = REPO_URL + '/network';
+      title = text.textContent + ' ' + USER_REPO;
       break;
     case 'follow':
       mainButton.className += ' github-me';
-      text.innerHTML = 'Follow @' + user;
-      button.href = 'https://github.com/' + user;
-      counter.href = 'https://github.com/' + user + '/followers';
+      text.textContent = 'Follow @' + user;
+      button.href = GITHUB_URL + user;
+      counter.href = GITHUB_URL + user + '?tab=followers';
+      title = text.textContent;
+      break;
+    case 'sponsor':
+      mainButton.className += ' github-me';
+      text.textContent = 'Sponsor @' + user;
+      button.href = GITHUB_URL + 'sponsors/' + user;
+      title = text.textContent;
       break;
   }
-  button.setAttribute('aria-label', text.innerHTML + labelSuffix);
 
-  // Change the size
+  button.setAttribute('aria-label', title + LABEL_SUFFIX);
+  document.title = title + LABEL_SUFFIX;
+
+  // Change the size if requested
   if (size === 'large') {
     mainButton.className += ' github-btn-large';
   }
 
-  if (type === 'follow') {
-    jsonp('https://api.github.com/users/' + user);
-  } else {
-    jsonp('https://api.github.com/repos/' + user + '/' + repo);
+  // If count is not requested or type is sponsor,
+  // there's no need to make an API call
+  if (count !== 'true' || type === 'sponsor') {
+    return;
   }
+
+  if (type === 'follow') {
+    jsonp(API_URL + 'users/' + user);
+  } else {
+    jsonp(API_URL + 'repos/' + user + '/' + repo);
+  }
+})();
 }

--- a/vendor/assets/stylesheets/github_buttons.css.scss
+++ b/vendor/assets/stylesheets/github_buttons.css.scss
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Source repo: https://github.com/mdo/github-buttons
- * Modification - Removed style on body tag
- *              - increase z-index of gh-count:before and :after
- *              - change data:image/.. to url with file
+ * Source: https://github.com/mdo/github-buttons/blob/7c1da76484288ce76fa061362fc1c1f0db1f6553/src/styles.css
+ * Modification - Remove style on body tag
+ *              - Add font from body to .github-btn
+ *              - Remove `position: relative` from .gh-count (see https://github.com/rubygems/rubygems.org/issues/3117)
  */
 
 .github-btn {
-  font: bold 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font: 700 11px/14px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   height: 20px;
   overflow: hidden;
 }
@@ -38,13 +38,9 @@
 }
 .gh-btn {
   background-color: #eee;
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #fcfcfc), color-stop(100%, #eee));
-  background-image: -webkit-linear-gradient(top, #fcfcfc 0, #eee 100%);
-  background-image: -moz-linear-gradient(top, #fcfcfc 0, #eee 100%);
-  background-image: -ms-linear-gradient(top, #fcfcfc 0, #eee 100%);
-  background-image: -o-linear-gradient(top, #fcfcfc 0, #eee 100%);
+  /* stylelint-disable-next-line function-no-unknown */
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #fcfcfc), to(#eee));
   background-image: linear-gradient(to bottom, #fcfcfc 0, #eee 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#eeeeee', GradientType=0);
   background-repeat: no-repeat;
   border: 1px solid #d5d5d5;
 }
@@ -52,31 +48,24 @@
 .gh-btn:focus {
   text-decoration: none;
   background-color: #ddd;
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #eee), color-stop(100%, #ddd));
-  background-image: -webkit-linear-gradient(top, #eee 0, #ddd 100%);
-  background-image: -moz-linear-gradient(top, #eee 0, #ddd 100%);
-  background-image: -ms-linear-gradient(top, #eee 0, #ddd 100%);
-  background-image: -o-linear-gradient(top, #eee 0, #ddd 100%);
+  /* stylelint-disable-next-line function-no-unknown */
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #eee), to(#ddd));
   background-image: linear-gradient(to bottom, #eee 0, #ddd 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#eeeeee', endColorstr='#dddddd', GradientType=0);
   border-color: #ccc;
 }
 .gh-btn:active {
-  background-image: none;
   background-color: #dcdcdc;
+  background-image: none;
   border-color: #b5b5b5;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, .15);
 }
 .gh-ico {
   width: 14px;
   height: 14px;
   margin-right: 4px;
-  background-image: image-url('github_icon.png');
-  background-size: 100% 100%;
-  background-repeat: no-repeat;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='12 12 40 40'%3e%3cpath fill='%23333' d='M32 13.4c-10.5 0-19 8.5-19 19 0 8.4 5.5 15.5 13 18 1 .2 1.3-.4 1.3-.9v-3.2c-5.3 1.1-6.4-2.6-6.4-2.6-.9-2.1-2.1-2.7-2.1-2.7-1.7-1.2.1-1.1.1-1.1 1.9.1 2.9 2 2.9 2 1.7 2.9 4.5 2.1 5.5 1.6.2-1.2.7-2.1 1.2-2.6-4.2-.5-8.7-2.1-8.7-9.4 0-2.1.7-3.7 2-5.1-.2-.5-.8-2.4.2-5 0 0 1.6-.5 5.2 2 1.5-.4 3.1-.7 4.8-.7 1.6 0 3.3.2 4.7.7 3.6-2.4 5.2-2 5.2-2 1 2.6.4 4.6.2 5 1.2 1.3 2 3 2 5.1 0 7.3-4.5 8.9-8.7 9.4.7.6 1.3 1.7 1.3 3.5v5.2c0 .5.4 1.1 1.3.9 7.5-2.6 13-9.7 13-18.1 0-10.5-8.5-19-19-19z'/%3e%3c/svg%3e") 0 0 / 100% 100% no-repeat;
 }
 .gh-count {
-  position: relative;
   display: none; /* hidden to start */
   margin-left: 4px;
   background-color: #fafafa;
@@ -84,30 +73,29 @@
 }
 .gh-count:hover,
 .gh-count:focus {
-  color: #4183C4;
+  color: #0366d6;
 }
-.gh-count:before,
-.gh-count:after {
-  content: '';
+.gh-count::before,
+.gh-count::after {
   position: absolute;
   display: inline-block;
   width: 0;
   height: 0;
+  content: "";
   border-color: transparent;
   border-style: solid;
 }
-.gh-count:before {
+.gh-count::before {
   top: 50%;
   left: -3px;
-  z-index: 1;
   margin-top: -4px;
   border-width: 4px 4px 4px 0;
   border-right-color: #fafafa;
 }
-.gh-count:after {
+.gh-count::after {
   top: 50%;
   left: -4px;
-  z-index: 0;
+  z-index: -1;
   margin-top: -5px;
   border-width: 5px 5px 5px 0;
   border-right-color: #d4d4d4;
@@ -129,12 +117,12 @@
 .github-btn-large .gh-count {
   margin-left: 6px;
 }
-.github-btn-large .gh-count:before {
+.github-btn-large .gh-count::before {
   left: -5px;
   margin-top: -6px;
   border-width: 6px 6px 6px 0;
 }
-.github-btn-large .gh-count:after {
+.github-btn-large .gh-count::after {
   left: -6px;
   margin-top: -7px;
   border-width: 7px 7px 7px 0;


### PR DESCRIPTION
Update CSS and JS from mdo/github-buttons with the latest version mdo/github-buttons@7c1da76484288ce76fa061362fc1c1f0db1f6553 and then remove extra `postion: relative` to fix z-index disorder on gem page.

### Other improvements
- Replace PNG icon with SVG icon as per the upstream
   - `github_icon.png` will be still used from `app/views/layouts/mailer.html.erb` and so we cannot delete it at the moment
- Remove unnecessary `id`s from `app/views/rubygems/_github_button.html.erb`
- Make modification notice from the upstream more clear

Closes #3117

Updates #1827

Fixes #1840

### Screenshots

#### before
The popup is behind the GitHub counter badge:
![](https://user-images.githubusercontent.com/10229505/175772796-467afa68-0528-43d3-852e-48e1c2e080f2.png)

#### after
The popup is NOT behind the GitHub counter badge, but is shown completely on top:
![](https://user-images.githubusercontent.com/10229505/175775536-1c602093-2606-4fd0-b8bd-411a9a78c871.png)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)