### PR TITLE
Add case insensitive uniqueness validation to user handle

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
   validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 
-  validates :handle, uniqueness: true, allow_nil: true
+  validates :handle, uniqueness: { case_sensitive: false }, allow_nil: true, if: :handle_changed?
   validates :handle, format: {
     with: /\A[A-Za-z][A-Za-z_\-0-9]*\z/,
     message: "must start with a letter and can only contain letters, numbers, underscores, and dashes"

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -35,6 +35,21 @@ class UserTest < ActiveSupport::TestCase
         refute_predicate user, :valid?
       end
 
+      should "be invalid with duplicate handle on create" do
+        create(:user, handle: "test")
+        user = build(:user, handle: "Test")
+        refute_predicate user, :valid?
+      end
+
+      should "be invalid with duplicate handle on update" do
+        create(:user, handle: "test")
+        user = create(:user, handle: "test2")
+        user.update(handle: "Test")
+
+        assert_contains user.errors[:handle], "has already been taken"
+        refute_predicate user, :valid?
+      end
+
       should "be valid when nil and other users have a nil handle" do
         assert_predicate build(:user, handle: nil), :valid?
         assert_predicate build(:user, handle: nil), :valid?


### PR DESCRIPTION
We don't want to allow users to have duplicate handles. This only
affects users on sign up or if existing user try to update handle.

related: #3119