### PR TITLE
Add per user rate limit to gem push

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -121,7 +121,7 @@ class Pusher
     Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
     rubygem.delay.index_document
     GemCachePurger.call(rubygem.name)
-    RackAttackReset.gem_push_backoff(@remote_ip) if @remote_ip.present?
+    RackAttackReset.gem_push_backoff(@remote_ip, @user.display_id) if @remote_ip.present?
     StatsD.increment "push.success"
   end
 

--- a/lib/rack_attack_reset.rb
+++ b/lib/rack_attack_reset.rb
@@ -1,14 +1,14 @@
 module RackAttackReset
   class << self
-    def gem_push_backoff(remote_ip)
+    def gem_push_backoff(remote_ip, user_display_id)
       Rack::Attack::EXP_BACKOFF_LEVELS.each do |level|
-        keys(level, remote_ip).each { |key| Rack::Attack.cache.store.delete(key) }
+        keys(level, remote_ip, user_display_id).each { |key| Rack::Attack.cache.store.delete(key) }
       end
     end
 
     private
 
-    def keys(level, remote_ip)
+    def keys(level, remote_ip, user_display_id)
       period            = Rack::Attack::EXP_BASE_LIMIT_PERIOD**level
       time_counter      = (Time.now.to_i / period).to_i
       # counter may have incremented by 1 since the key was set, best to reset prev counter as well.
@@ -18,7 +18,9 @@ module RackAttackReset
       prefix            = Rack::Attack.cache.prefix
 
       ["#{prefix}:#{time_counter}:#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}",
-       "#{prefix}:#{prev_time_counter}:#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}"]
+       "#{prefix}:#{prev_time_counter}:#{Rack::Attack::PUSH_EXP_THROTTLE_KEY}/#{level}:#{remote_ip}",
+       "#{prefix}:#{time_counter}:#{Rack::Attack::PUSH_THROTTLE_PER_USER_KEY}/#{level}:#{user_display_id}",
+       "#{prefix}:#{prev_time_counter}:#{Rack::Attack::PUSH_THROTTLE_PER_USER_KEY}/#{level}:#{user_display_id}"]
     end
   end
 end

--- a/test/helpers/rate_limit_helpers.rb
+++ b/test/helpers/rate_limit_helpers.rb
@@ -93,10 +93,10 @@ module RateLimitHelpers
     expo_exceeding_limit.times { Rack::Attack.cache.count("#{scope}:#{id}", expo_limit_period) }
   end
 
-  def exceed_exponential_api_key_limit_for(scope, api_key, level)
+  def exceed_exponential_api_key_limit_for(scope, user_display_id, level)
     expo_exceeding_limit = exceeding_exp_base_limit * level
     expo_limit_period = exp_base_limit_period**level
-    expo_exceeding_limit.times { Rack::Attack.cache.count("#{scope}:#{api_key}", expo_limit_period) }
+    expo_exceeding_limit.times { Rack::Attack.cache.count("#{scope}:#{user_display_id}", expo_limit_period) }
   end
 
   def encode(username, password)

--- a/test/integration/api/v1/rubygems_test.rb
+++ b/test/integration/api/v1/rubygems_test.rb
@@ -3,12 +3,13 @@ require "test_helper"
 class Api::V1::RubygemsTest < ActionDispatch::IntegrationTest
   setup do
     @key = "12345"
-    create(:api_key, key: @key, index_rubygems: true, push_rubygem: true)
+    @user = create(:user)
+    create(:api_key, user: @user, key: @key, index_rubygems: true, push_rubygem: true)
   end
 
   test "request has remote addr present" do
     ip_address = "1.2.3.4"
-    RackAttackReset.expects(:gem_push_backoff).with(ip_address).once
+    RackAttackReset.expects(:gem_push_backoff).with(ip_address, @user.display_id).once
 
     post "/api/v1/gems",
           params: gem_file("test-1.0.0.gem").read,


### PR DESCRIPTION
gem push mfa rate limit is sensitive to brute force. we also want to add rate limit per user. Limits are same as per IP limit.
Related: 
https://github.com/rubygems/rubygems.org/security/advisories/GHSA-8m6q-8hm4-fvh2

Also updates key used for rate limit to use display handle instead of plain text api key.