### PR TITLE
Use Capybara find to wait for page to load

### DIFF
--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -128,7 +128,7 @@ class SettingsTest < SystemTest
     page.accept_confirm do
       click_button "Continue"
     end
-    page.find('h1', text: 'Edit settings')
+    page.find("h1", text: "Edit settings")
     assert_equal page.current_path, edit_settings_path
   end
 

--- a/test/integration/settings_test.rb
+++ b/test/integration/settings_test.rb
@@ -128,6 +128,7 @@ class SettingsTest < SystemTest
     page.accept_confirm do
       click_button "Continue"
     end
+    page.find('h1', text: 'Edit settings')
     assert_equal page.current_path, edit_settings_path
   end
 


### PR DESCRIPTION
This test was flaky: https://github.com/rubygems/rubygems.org/pull/3082#discussion_r901001440

I added a Capybara find method call which should wait a short amount of time until it finds the settings page: https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Finders:find

I'm unsure how to recreate a test failure on my local machine to ensure my fix actually works