### PR TITLE
Reorganize locales by running bin/fill-locales

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -64,8 +64,8 @@ de:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -309,7 +309,7 @@ de:
     require_mfa_enabled:
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -75,8 +75,8 @@ es:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -321,12 +321,13 @@ es:
     recovery_code_html:
     incorrect_otp: Tu código OTP no es correcto.
     otp_code: código OTP
-    require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para reconfigurarla, primero tendrás que desactivarla.
+    require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para
+      reconfigurarla, primero tendrás que desactivarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title: Activando autenticación de múltiples factores
       scan_prompt: Por favor escanea el código QR con tu aplicación de Autenticación.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -66,8 +66,8 @@ fr:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -314,13 +314,13 @@ fr:
     recovery_code_html:
     incorrect_otp: Votre clé OTP est incorrecte.
     otp_code: clé OTP
-    require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous voulez la reconfigurer, vous
-      devez d'abord la désactiver.
+    require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous
+      voulez la reconfigurer, vous devez d'abord la désactiver.
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title: Activer l'authentification multifacteur
       scan_prompt: Veuillez scanner le QR code avec votre app d'authentification.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -68,8 +68,8 @@ ja:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -296,7 +296,7 @@ ja:
     require_mfa_enabled:
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -67,8 +67,8 @@ nl:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -313,7 +313,7 @@ nl:
     require_mfa_enabled:
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -74,8 +74,8 @@ pt-BR:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -324,7 +324,7 @@ pt-BR:
     require_mfa_enabled:
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -64,8 +64,8 @@ zh-CN:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -296,7 +296,7 @@ zh-CN:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title: 启用多重要素验证
       scan_prompt: 请用你的验证装置扫描 QR-code。如果你没办法扫描，手动输入下面的资料。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -64,8 +64,8 @@ zh-TW:
       api_keys:
       name:
       scopes:
-      age:
       gem:
+      age:
       last_access:
       action:
       delete:
@@ -297,7 +297,7 @@ zh-TW:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     setup_recommended:
     strong_mfa_level_recommended:
-    ui_only_warning: 
+    ui_only_warning:
     new:
       title: 啟用多重要素驗證
       scan_prompt: 請用你的驗證裝置掃描 QR-code。如果你沒辦法掃描，手動輸入下面的資料。


### PR DESCRIPTION
Contribution guide suggests using `bin/fill-locales` script to automatically populate newly added translation key to all locales.
https://github.com/rubygems/rubygems.org/blob/667c51fdf590022ffd6795a13c5d01eb572ac76a/CONTRIBUTING.md?plain=1#L196

However it seems like currently translation keys are not organized in accordance with the expectation of the script which makes new contributions a bit noisy as it performs both additions of the new keys and sorting of the existing ones.

This PR is a result of running the tool against current main branch. Having these changes should allow new contributors to use the tool without producing unnecessary changes to the locale files