### PR TITLE
Add User.mfa_required?

### DIFF
--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -45,6 +45,14 @@ module UserMultifactorMethods
       mfa_recommended? && mfa_ui_only?
     end
 
+    def mfa_required_not_yet_enabled?
+      mfa_required? && mfa_disabled?
+    end
+
+    def mfa_required_weak_level_enabled?
+      mfa_required? && mfa_ui_only?
+    end
+
     def otp_verified?(otp)
       otp = otp.to_s
       return true if verify_digit_otp(mfa_seed, otp)
@@ -61,9 +69,15 @@ module UserMultifactorMethods
     end
 
     def mfa_recommended?
-      return false if strong_mfa_level?
+      return false if strong_mfa_level? || mfa_required?
 
       rubygems.mfa_recommended.any?
+    end
+
+    def mfa_required?
+      return false if strong_mfa_level?
+
+      rubygems.mfa_required.any?
     end
 
     def verify_digit_otp(seed, otp)

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -27,7 +27,7 @@ class Pusher
   end
 
   def verify_mfa_requirement
-    user.mfa_enabled? || !(version_mfa_required? || rubygem.mfa_required?) ||
+    user.mfa_enabled? || !(version_mfa_required? || rubygem.metadata_mfa_required?) ||
       notify("Rubygem requires owners to enable MFA. You must enable MFA before pushing new version.", 403)
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -348,7 +348,7 @@ class Version < ApplicationRecord
     Links::LINKS.any? { |_, long| metadata.key? long }
   end
 
-  def rubygems_mfa_required?
+  def rubygems_metadata_mfa_required?
     ActiveRecord::Type::Boolean.new.cast(metadata["rubygems_mfa_required"])
   end
 

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -56,7 +56,7 @@
     </i>
   </h2>
 
-  <% if @rubygem.mfa_required? %>
+  <% if @rubygem.metadata_mfa_required? %>
     <h2 class="gem__ruby-version__heading t-list__heading">
       <%= t('.requires_mfa') %>:
       <span class="gem__ruby-version">
@@ -65,7 +65,7 @@
     </h2>
   <% end %>
 
-  <% if @latest_version.rubygems_mfa_required? %>
+  <% if @latest_version.rubygems_metadata_mfa_required? %>
     <h2 class="gem__ruby-version__heading t-list__heading">
       <%= t('.released_with_mfa') %>:
       <span class="gem__ruby-version">

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -522,7 +522,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           assert_equal 2, Rubygem.last.versions.count
         end
         should "disable mfa requirement" do
-          refute_predicate @rubygem, :mfa_required?
+          refute_predicate @rubygem, :metadata_mfa_required?
         end
       end
     end

--- a/test/unit/rubygem_test.rb
+++ b/test/unit/rubygem_test.rb
@@ -873,7 +873,7 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context ".mfa_recommended" do
+  context ".mfa_recommended scope" do
     should "not return gems with fewer downloads than the recommended threshold" do
       rubygem = create(:rubygem)
       GemDownload.increment(
@@ -892,6 +892,28 @@ class RubygemTest < ActiveSupport::TestCase
       )
 
       refute_empty Rubygem.mfa_recommended
+    end
+  end
+
+  context ".mfa_required scope" do
+    should "not return gems with fewer downloads than the required threshold" do
+      rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_REQUIRED_THRESHOLD,
+        rubygem_id: rubygem.id
+      )
+
+      assert_empty Rubygem.mfa_required
+    end
+
+    should "return gems with more downloads than the required threshold" do
+      rubygem = create(:rubygem)
+      GemDownload.increment(
+        Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+        rubygem_id: rubygem.id
+      )
+
+      assert_includes Rubygem.mfa_required, rubygem
     end
   end
 


### PR DESCRIPTION
Adds a function to check if a User requires mfa due to the number of downloads on one of their gems in preparation for future MFA requirement work.

Edit, more info:

The mfa_required function will check if a user needs to enable mfa because one of the packages they own passed the MFA-required downloads threshold. Eventually, this will block them from taking some actions that require authentication.


Doesn't use the function/block the user's access to anything.