### PR TITLE
Add rubygem scope to API key create API endpoint

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -42,6 +42,12 @@ class ApiKey < ApplicationRecord
     errors.add :rubygem, "that is selected cannot be scoped to this key"
   end
 
+  def rubygem_name=(name)
+    self.rubygem_id = name.blank? ? nil : Rubygem.find_by_name!(name).id
+  rescue ActiveRecord::RecordNotFound
+    errors.add :rubygem, "that is selected cannot be scoped to this key"
+  end
+
   def soft_delete!(ownership: nil)
     update_attribute(:soft_deleted_at, Time.now.utc)
     update_attribute(:soft_deleted_rubygem_name, ownership.rubygem.name) if ownership

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -45,7 +45,7 @@ class ApiKey < ApplicationRecord
   def rubygem_name=(name)
     self.rubygem_id = name.blank? ? nil : Rubygem.find_by_name!(name).id
   rescue ActiveRecord::RecordNotFound
-    errors.add :rubygem, "that is selected cannot be scoped to this key"
+    errors.add :rubygem, "could not be found"
   end
 
   def soft_delete!(ownership: nil)

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -39,7 +39,7 @@ class ApiKey < ApplicationRecord
   def rubygem_id=(id)
     self.ownership = id.blank? ? nil : user.ownerships.find_by!(rubygem_id: id)
   rescue ActiveRecord::RecordNotFound
-    errors.add :rubygem, "that is selected cannot be scoped to this key"
+    errors.add :rubygem, "must be a gem that you are an owner of"
   end
 
   def rubygem_name=(name)

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -277,7 +277,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
-      context "oh successful save" do
+      context "on successful save" do
         setup do
           perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
             post :create, params: { name: "test-key", index_rubygems: "true" }, format: "text"
@@ -318,6 +318,8 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
           post :create, params: { name: "mfa", index_rubygems: "true", mfa: "true" }, format: "text"
         end
 
+        should_return_api_key_successfully
+
         should "have MFA" do
           created_key = @user.api_keys.find_by(name: "mfa")
 
@@ -338,13 +340,12 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
                 format: "text"
             end
 
-            should respond_with :success
+            should_return_api_key_successfully
 
             should "have a rubygem associated" do
               created_key = @user.api_keys.find_by(name: "gem-scoped-key")
 
               assert_equal @ownership.rubygem, created_key.rubygem
-              assert_equal created_key.hashed_key, Digest::SHA256.hexdigest(response.body)
             end
           end
 

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -374,7 +374,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
           should respond_with :unprocessable_entity
 
           should "respond with an error" do
-            assert_equal "Rubygem that is selected cannot be scoped to this key", response.body
+            assert_equal "Rubygem could not be found", response.body
           end
         end
       end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -147,7 +147,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         should "display error with invalid id" do
           post :create, params: { api_key: { name: "gem scope", add_owner: true, rubygem_id: -1 } }
 
-          assert_equal "Rubygem that is selected cannot be scoped to this key", flash[:error]
+          assert_equal "Rubygem must be a gem that you are an owner of", flash[:error]
           assert_empty @user.reload.api_keys
         end
 
@@ -235,7 +235,7 @@ class ApiKeysControllerTest < ActionController::TestCase
           assert_no_changes @api_key do
             patch :update, params: { api_key: { rubygem_id: -1 }, id: @api_key.id }
 
-            assert_equal "Rubygem that is selected cannot be scoped to this key", flash[:error]
+            assert_equal "Rubygem must be a gem that you are an owner of", flash[:error]
           end
         end
 

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -103,7 +103,7 @@ class ApiKeyTest < ActiveSupport::TestCase
       should "add error when id is not associated with the user" do
         api_key = ApiKey.new(hashed_key: SecureRandom.hex(24), push_rubygem: true, user: @ownership.user, rubygem_id: -1)
 
-        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
+        assert_contains api_key.errors[:rubygem], "must be a gem that you are an owner of"
       end
     end
 
@@ -135,7 +135,7 @@ class ApiKeyTest < ActiveSupport::TestCase
           rubygem_name: rubygem.name
         )
 
-        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
+        assert_contains api_key.errors[:rubygem], "must be a gem that you are an owner of"
       end
 
       should "add error when name is not a valid gem name" do

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -106,6 +106,49 @@ class ApiKeyTest < ActiveSupport::TestCase
         assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
       end
     end
+
+    context "#rubygem_name=" do
+      should "set ownership to a gem" do
+        api_key = create(
+          :api_key,
+          key: SecureRandom.hex(24),
+          push_rubygem: true,
+          user: @ownership.user,
+          rubygem_name: @ownership.rubygem.name
+        )
+
+        assert_equal @ownership.rubygem, api_key.rubygem
+      end
+
+      should "set ownership to nil when name is blank" do
+        @api_key.rubygem_name = nil
+
+        assert_nil @api_key.ownership
+      end
+
+      should "add error when gem is not associated with the user" do
+        rubygem = create(:rubygem, name: "another-gem")
+        api_key = ApiKey.new(
+          hashed_key: SecureRandom.hex(24),
+          push_rubygem: true,
+          user: @ownership.user,
+          rubygem_name: rubygem.name
+        )
+
+        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
+      end
+
+      should "add error when name is not a valid gem name" do
+        api_key = ApiKey.new(
+          hashed_key: SecureRandom.hex(24),
+          push_rubygem: true,
+          user: @ownership.user,
+          rubygem_name: "invalid-gem-name"
+        )
+
+        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
+      end
+    end
   end
 
   context "#soft_deleted?" do

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -146,7 +146,7 @@ class ApiKeyTest < ActiveSupport::TestCase
           rubygem_name: "invalid-gem-name"
         )
 
-        assert_contains api_key.errors[:rubygem], "that is selected cannot be scoped to this key"
+        assert_contains api_key.errors[:rubygem], "could not be found"
       end
     end
   end

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -100,7 +100,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     click_button "Create"
 
     assert page.has_css? ".flash"
-    assert page.has_content? "Rubygem that is selected cannot be scoped to this key"
+    assert page.has_content? "Rubygem must be a gem that you are an owner of"
     assert_empty @user.api_keys
   end
 
@@ -211,7 +211,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     click_button "Update"
 
     assert page.has_css? ".flash"
-    assert page.has_content? "Rubygem that is selected cannot be scoped to this key"
+    assert page.has_content? "Rubygem must be a gem that you are an owner of"
     assert_equal @ownership.rubygem, api_key.reload.rubygem
   end
 


### PR DESCRIPTION
Adds onto: https://github.com/rubygems/rubygems.org/pull/2944

Adds support to scope an API key to a gem when creating an API key through the API. This will be used when the user runs `gem signin`.

### How is this implemented?
Added a `rubygem_name` param to API key create. During `gem signin`, the client asks for the name of the gem.

```
...
Enter the name of the gem you want to scope this key to (strongly recommended).
Gem Scope [All gems]: rails
...
```

CLI PR: https://github.com/rubygems/rubygems/pull/5710

### Alternatives
I thought about having the user select from a list of their gems but it's difficult to display correctly if the user has many gems. Furthermore, the only endpoint that returns the gems someone owns requires an API key with the `index_rubygems` scope which can't work because the command is creating an API key. So if we were going to go down this path, we would need to allow for basic auth to the endpoint instead.

### Other Notes
I omitted adding the `rubygem_name` param to update for now as `assign_attributes` autosaves associations and "half saves" the api key if validations fail. I have a [branch](https://github.com/rubygems/rubygems.org/compare/master...Shopify:rubygems.org:gem-scope-api-key-update?expand=1) with a monkey patch for it but I want to spend more time figuring out if there's a better way. Nonetheless, the update endpoint won't be used for `gem signin`.

### Testing
1. Create or have a user on hand
2. Have the user own a gem (`Rubygem.create(name: "a-gem")`, `Ownership.create_confirmed(Rubygem.find_by_name("a-gem", User.first, User.first`)
3. Run `RUBYGEMS_HOST=http://localhost:3000 ruby -Ilib bin/gem signin` in the rubygems directory
4. Enable one or more of the applicable scopes (add/yank rubygems, add/remove owner) and you will see a gem scope prompt. Enter the name of the gem that the owner owns and the created API key should have the scope
5. Do step 4 again (should gem signout) and type something else, an error will return as the owner doesn't own a gem named that and an API key would not be created.
6. Do step 4 again and enable one of the other scopes (eg. index_rubygems) and you will not see a gem scope prompt. 