### PR TITLE
Keep original page title when GH button is rendered.

### DIFF
--- a/vendor/assets/javascripts/github_buttons.js
+++ b/vendor/assets/javascripts/github_buttons.js
@@ -14,6 +14,7 @@
  * Source: https://github.com/mdo/github-buttons/blob/7c1da76484288ce76fa061362fc1c1f0db1f6553/src/js.js
  * Modification: Changed params to read attributes from data-params
  *               Execute only when .github-btn exists
+ *               Remove title update (mdo/github-buttons@cbf5395b)
  */
 
 if ($(".github-btn").length) {
@@ -166,7 +167,6 @@ if ($(".github-btn").length) {
   }
 
   button.setAttribute('aria-label', title + LABEL_SUFFIX);
-  document.title = title + LABEL_SUFFIX;
 
   // Change the size if requested
   if (size === 'large') {


### PR DESCRIPTION
fix for https://github.com/rubygems/rubygems.org/pull/3118/files/e360b5b735a196fa0753472ea0a91fab505af086#diff-acf734494695689a08a046f2de07f50d018ebcc460081e28562f9bd4d8604824

/cc @tnir @jhawthorn