### PR TITLE
skip sending emails when user has no email address

### DIFF
--- a/app/jobs/email_reset_mailer.rb
+++ b/app/jobs/email_reset_mailer.rb
@@ -2,11 +2,15 @@ EmailResetMailer = Struct.new(:user_id) do
   def perform
     user = User.find(user_id)
 
-    if user.confirmation_token
-      Mailer.email_reset_update(user).deliver
-      Mailer.email_reset(user).deliver
-    else
-      Rails.logger.info("[jobs:email_reset_mailer] confirmation token not found. skipping sending mail for #{user.handle}")
+    if user.confirmation_token.blank?
+      return Rails.logger.info("[jobs:email_reset_mailer] confirmation token not found. skipping sending mail for #{user.handle}")
     end
+
+    if user.unconfirmed_email.blank?
+      return Rails.logger.info("[jobs:email_reset_mailer] unconfirmed email not found. skipping sending mail for #{user.handle}")
+    end
+
+    Mailer.email_reset_update(user).deliver
+    Mailer.email_reset(user).deliver
   end
 end


### PR DESCRIPTION
based on this backtrace, we seem to be trying to email an empty address. this change should stop us from doing that.

```
SMTP To address may not be blank: []
/usr/local/bundle/gems/mail-2.7.1/lib/mail/check_delivery_params.rb:21:in `check_to'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/check_delivery_params.rb:7:in `check'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp_connection.rb:52:in `deliver!'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp.rb:101:in `block in deliver!'
/usr/local/lib/ruby/gems/3.1.0/gems/net-smtp-0.3.1/lib/net/smtp.rb:605:in `start'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/message.rb:2159:in `do_delivery'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/message.rb:260:in `block in deliver'
/usr/local/bundle/gems/actionmailer-7.0.2.4/lib/action_mailer/base.rb:565:in `block in deliver_mail'
/usr/local/bundle/gems/activesupport-7.0.2.4/lib/active_support/notifications.rb:206:in `block in instrument'
/usr/local/bundle/gems/activesupport-7.0.2.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/usr/local/bundle/gems/activesupport-7.0.2.4/lib/active_support/notifications.rb:206:in `instrument'
/usr/local/bundle/gems/actionmailer-7.0.2.4/lib/action_mailer/base.rb:563:in `deliver_mail'
/usr/local/bundle/gems/mail-2.7.1/lib/mail/message.rb:260:in `deliver'
/usr/local/bundle/gems/roadie-rails-3.0.0/lib/roadie/rails/inline_on_delivery.rb:13:in `deliver'
/usr/local/lib/ruby/3.1.0/delegate.rb:87:in `method_missing'
/app/app/jobs/email_reset_mailer.rb:7:in `perform'
```