### PR TITLE
Fix webhooks for users with multiple API keys

### DIFF
--- a/app/jobs/notifier.rb
+++ b/app/jobs/notifier.rb
@@ -8,7 +8,7 @@ Notifier = Struct.new(:url, :protocol, :host_with_port, :rubygem, :version, :api
   end
 
   def authorization
-    Digest::SHA2.hexdigest(rubygem.name + version.number + api_key)
+    Digest::SHA2.hexdigest([rubygem.name, version.number, api_key].compact.join)
   end
 
   def perform

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -17,12 +17,17 @@ class WebHook < ApplicationRecord
   end
 
   def fire(protocol, host_with_port, deploy_gem, version, delayed: true)
-    job = Notifier.new(url, protocol, host_with_port, deploy_gem, version, user.api_key)
+    job = Notifier.new(url, protocol, host_with_port, deploy_gem, version, api_key)
+
     if delayed
       Delayed::Job.enqueue job, priority: PRIORITIES[:web_hook]
     else
       job.perform
     end
+  end
+
+  def api_key
+    user.api_key || user.api_keys.first&.hashed_key
   end
 
   def global?


### PR DESCRIPTION
The vast majority of the 34,000 failed delayed jobs stored in the database are all exceptions caused by `user.api_key` being `nil`. That is in fact the expected and desired state now that users `has_many :api_keys`, so this PR adds tests to make sure there won't be exceptions and then uses the first API key it can find to generate an auth header for the webhook. We should probably use a dedicated webhook secret at some point, but for now this will at least stop the ongoing exceptions.

The backtrace that led me here was:

```
no implicit conversion of nil into String                                                                                                                                        
/app/app/jobs/notifier.rb:11:in `+'                                                                                                                                              
/app/app/jobs/notifier.rb:11:in `authorization'                                                                                                                                  
/app/app/jobs/notifier.rb:21:in `block in perform'                                                                                                                               
/usr/local/bundle/gems/timeout-0.3.0/lib/timeout.rb:179:in `block in timeout'                                                                                                    
/usr/local/bundle/gems/timeout-0.3.0/lib/timeout.rb:36:in `block in catch'                                                                                                       
/usr/local/bundle/gems/timeout-0.3.0/lib/timeout.rb:36:in `catch'                                                                                                                
/usr/local/bundle/gems/timeout-0.3.0/lib/timeout.rb:36:in `catch'                                                                                                                
/usr/local/bundle/gems/timeout-0.3.0/lib/timeout.rb:188:in `timeout'                                                                                                             
/app/app/jobs/notifier.rb:33:in `timeout'                                                                                                                                        
/app/app/jobs/notifier.rb:15:in `perform' 
```