### PR TITLE
Redirect MFA-required users away from authenticated endpoints (UI)

### DIFF
--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -14,6 +14,11 @@
   font-style: italic;
   color: #141c22; }
 
+.flash a {
+  color: #141c22;
+  text-decoration: underline;
+  font-weight: bold;
+}
 /* Announcement Styles */
 
 #announcement {

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,6 +1,8 @@
 class ApiKeysController < ApplicationController
   include ApiKeyable
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
   before_action :redirect_to_verify, unless: :password_session_active?
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Clearance::Authentication
   include Clearance::Authorization
+  include ApplicationMultifactorMethods
 
   helper ActiveSupport::NumberHelper
 
@@ -10,6 +11,8 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :reject_null_char_param
   before_action :reject_null_char_cookie
+
+  add_flash_types :notice_html
 
   def set_locale
     I18n.locale = user_locale

--- a/app/controllers/concerns/application_multifactor_methods.rb
+++ b/app/controllers/concerns/application_multifactor_methods.rb
@@ -1,0 +1,29 @@
+module ApplicationMultifactorMethods
+  extend ActiveSupport::Concern
+
+  included do
+    def mfa_required_cookie?
+      cookies[:mfa_required] == "true"
+    end
+
+    def redirect_to_new_mfa
+      message = t("multifactor_auths.setup_required_html")
+      redirect_to new_multifactor_auth_path, notice_html: message
+    end
+
+    def mfa_required_not_yet_enabled?
+      return false if current_user.nil?
+      current_user.mfa_required_not_yet_enabled? && mfa_required_cookie?
+    end
+
+    def redirect_to_settings_strong_mfa_required
+      message = t("multifactor_auths.strong_mfa_level_required_html")
+      redirect_to edit_settings_path, notice_html: message
+    end
+
+    def mfa_required_weak_level_enabled?
+      return false if current_user.nil?
+      current_user.mfa_required_weak_level_enabled? && mfa_required_cookie?
+    end
+  end
+end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,8 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_with_api_key, unless: :signed_in?
   before_action :redirect_to_signin, unless: -> { signed_in? || @api_key&.can_show_dashboard? }
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
 
   def show
     respond_to do |format|

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,5 +1,7 @@
 class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: :unconfirmed
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: :unconfirmed
   before_action :validate_confirmation_token, only: %i[update mfa_update]
 
   def update

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -1,5 +1,7 @@
 class NotifiersController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
 
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name

--- a/app/controllers/ownership_calls_controller.rb
+++ b/app/controllers/ownership_calls_controller.rb
@@ -1,6 +1,8 @@
 class OwnershipCallsController < ApplicationController
   before_action :find_rubygem, except: :index
   before_action :redirect_to_signin, unless: :signed_in?, except: :index
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, except: :index
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, except: :index
   before_action :render_forbidden, unless: :owner?, only: %i[create close]
 
   def index

--- a/app/controllers/ownership_requests_controller.rb
+++ b/app/controllers/ownership_requests_controller.rb
@@ -2,6 +2,8 @@ class OwnershipRequestsController < ApplicationController
   before_action :find_rubygem
   before_action :find_ownership_request, only: :update
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
 
   def create
     render_forbidden && return unless current_user.can_request_ownership?(@rubygem)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, except: :show
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, except: :show
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, except: :show
   before_action :verify_password, only: %i[update destroy]
   before_action :set_cache_headers, only: :edit
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,7 @@
 class SessionsController < Clearance::SessionsController
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify authenticate]
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: %i[verify authenticate]
+  before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: %i[verify authenticate]
   before_action :ensure_not_blocked, only: :create
 
   def create

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :set_cache_headers
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,4 +62,9 @@ module ApplicationHelper
     return title unless title_url
     link_to title, title_url, class: "t-link--black"
   end
+
+  def flash_message(name, msg)
+    return sanitize(msg) if name.end_with? "html"
+    msg
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,7 +90,7 @@
     <% flash.each do |name, msg| %>
       <div id="flash-border" class="flash">
         <div class="flash-wrap">
-          <div id="flash_<%= name %>" class="l-wrap--b"><span><b><%= msg %></b></span></div>
+          <div id="flash_<%= name %>" class="l-wrap--b"><span><b><%= flash_message(name, msg) %></b></span></div>
         </div>
       </div>
     <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -307,7 +307,9 @@ de:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,9 @@ en:
     otp_code: OTP code
     require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
+    setup_required_html: For protection of your account and your gems, you are required to set up multi-factor authentication. Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
+    strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
     ui_only_warning: Updating multi-factor authentication to "UI Only" is no longer supported. Please use "UI and gem signin" or "UI and API".
     new:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -325,7 +325,9 @@ es:
       reconfigurarla, primero tendrás que desactivarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -323,7 +323,9 @@ fr:
       voulez la reconfigurer, vous devez d'abord la désactiver.
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -294,7 +294,9 @@ ja:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -311,7 +311,9 @@ nl:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -322,7 +322,9 @@ pt-BR:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -294,7 +294,9 @@ zh-CN:
     otp_code: OTP 码
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -295,7 +295,9 @@ zh-TW:
     otp_code: OTP 碼
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
+    setup_required_html:
     setup_recommended:
+    strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     ui_only_warning:
     new:

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -107,6 +107,44 @@ class DashboardsControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
+      setup do
+        @rubygem = create(:rubygem)
+        create(:ownership, rubygem: @rubygem, user: @user)
+        GemDownload.increment(
+          Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+          rubygem_id: @rubygem.id
+        )
+        @request.cookies[:mfa_required] = "true"
+      end
+
+      context "user has mfa disabled" do
+        setup { get :show }
+        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+      end
+
+      context "user has mfa set to weak level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          get :show
+        end
+
+        should redirect_to("the settings page") { edit_settings_path }
+      end
+
+      context "user has MFA set to strong level, expect normal behaviour" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          get :show
+        end
+
+        should "stay on dashboard page without redirecting" do
+          assert_response :success
+          assert page.has_content? "Dashboard"
+        end
+      end
+    end
   end
 
   context "On GET to show without being signed in" do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -221,6 +221,158 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         expected_notice = "You will receive an email within the next few minutes. It contains instructions for confirming your new email address."
         assert_equal expected_notice, flash[:notice]
       end
+
+      context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
+        setup do
+          @rubygem = create(:rubygem)
+          create(:ownership, rubygem: @rubygem, user: @user)
+          GemDownload.increment(
+            Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+            rubygem_id: @rubygem.id
+          )
+          @request.cookies[:mfa_required] = "true"
+        end
+
+        context "user has mfa disabled" do
+          context "on GET to update" do
+            setup do
+              get :update, params: { token: @user.confirmation_token }
+            end
+
+            should "should confirm user account" do
+              assert @user.email_confirmed
+            end
+          end
+
+          context "on POST to mfa_update" do
+            setup do
+              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+            end
+
+            should respond_with :unauthorized
+          end
+
+          context "on PATCH to unconfirmed" do
+            setup { patch :unconfirmed }
+            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          end
+
+          context "on GET to new" do
+            setup { get :new }
+            should "not redirect to mfa" do
+              assert_response :success
+              assert page.has_content? "Resend confirmation email"
+            end
+          end
+
+          context "on POST to create" do
+            setup do
+              create(:user, email: "foo@bar.com")
+              post :create, params: { email_confirmation: { email: "foo@bar.com" } }
+              Delayed::Worker.new.work_off
+            end
+
+            should respond_with :redirect
+            should redirect_to("the homepage") { root_url }
+          end
+        end
+
+        context "user has mfa set to weak level" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          end
+
+          context "on GET to update" do
+            setup do
+              get :update, params: { token: @user.confirmation_token }
+            end
+
+            should "should confirm user account" do
+              assert @user.email_confirmed
+            end
+          end
+
+          context "on POST to mfa_update" do
+            setup do
+              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+            end
+
+            should respond_with :unauthorized
+          end
+
+          context "on PATCH to unconfirmed" do
+            setup { patch :unconfirmed }
+            should redirect_to("the edit settings page") { edit_settings_path }
+          end
+
+          context "on GET to new" do
+            setup { get :new }
+            should "not redirect to mfa" do
+              assert_response :success
+              assert page.has_content? "Resend confirmation email"
+            end
+          end
+
+          context "on POST to create" do
+            setup do
+              create(:user, email: "foo@bar.com")
+              post :create, params: { email_confirmation: { email: "foo@bar.com" } }
+              Delayed::Worker.new.work_off
+            end
+
+            should respond_with :redirect
+            should redirect_to("the homepage") { root_url }
+          end
+        end
+
+        context "user has MFA set to strong level, expect normal behaviour" do
+          setup do
+            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          end
+
+          context "on GET to update" do
+            setup do
+              get :update, params: { token: @user.confirmation_token }
+            end
+
+            should "should confirm user account" do
+              assert @user.email_confirmed
+            end
+          end
+
+          context "on POST to mfa_update" do
+            setup do
+              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+            end
+
+            should respond_with :unauthorized
+          end
+
+          context "on PATCH to unconfirmed" do
+            setup { patch :unconfirmed }
+            should redirect_to("edit profile page") { edit_profile_path }
+          end
+
+          context "on GET to new" do
+            setup { get :new }
+            should "not redirect to mfa" do
+              assert_response :success
+              assert page.has_content? "Resend confirmation email"
+            end
+          end
+
+          context "on POST to create" do
+            setup do
+              create(:user, email: "foo@bar.com")
+              post :create, params: { email_confirmation: { email: "foo@bar.com" } }
+              Delayed::Worker.new.work_off
+            end
+
+            should respond_with :redirect
+            should redirect_to("the homepage") { root_url }
+          end
+        end
+      end
     end
   end
 end

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class NotifiersControllerTest < ActionController::TestCase
+  context "when not logged in" do
+    setup do
+      @user = create(:user)
+      get :show
+    end
+    should redirect_to("the sign in page") { sign_in_path }
+  end
+
+  context "when logged in" do
+    setup do
+      @user = create(:user)
+      sign_in_as(@user)
+    end
+
+    context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
+      setup do
+        @rubygem = create(:rubygem)
+        @ownership = create(:ownership, rubygem: @rubygem, user: @user)
+        GemDownload.increment(
+          Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+          rubygem_id: @rubygem.id
+        )
+        @request.cookies[:mfa_required] = "true"
+      end
+
+      redirect_scenarios = {
+        "GET to show" => [:show, { method: "GET" }],
+        "PATCH to update" => [:update, { method: "PATCH", params: { ownerships: { 1 => { push: "off" } } } }],
+        "PUT to update" => [:update, { method: "PUT", params: { ownerships: { 1 => { push: "off" } } } }]
+      }
+
+      context "user has mfa disabled" do
+        redirect_scenarios.each do |label, request_params|
+          context "on #{label}" do
+            setup { process(request_params.first, **request_params.last) }
+
+            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          end
+        end
+      end
+
+      context "user has mfa set to weak level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+        end
+
+        redirect_scenarios.each do |label, request_params|
+          context "on #{label}" do
+            setup { process(request_params.first, **request_params.last) }
+
+            should redirect_to("the settings page") { edit_settings_path }
+          end
+        end
+      end
+
+      context "user has MFA set to strong level, expect normal behaviour" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        end
+
+        context "on GET to show" do
+          setup do
+            get :show
+          end
+
+          should "stay on notifiers page without redirecting" do
+            assert_response :success
+            assert page.has_content? "Email notifications"
+          end
+        end
+
+        context "on PATCH to update" do
+          setup do
+            patch :update, params: { ownerships: { @ownership.id => { push: "off" } } }
+          end
+
+          should redirect_to("the notifier page") { notifier_path }
+        end
+
+        context "on PUT to update" do
+          setup do
+            put :update, params: { ownerships: { @ownership.id => { push: "off" } } }
+          end
+
+          should redirect_to("the notifier page") { notifier_path }
+        end
+      end
+    end
+  end
+end

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class SettingsControllerTest < ActionController::TestCase
+  context "when not logged in" do
+    setup do
+      @user = create(:user)
+      get :edit
+    end
+    should redirect_to("the sign in page") { sign_in_path }
+  end
+
+  context "when logged in" do
+    setup do
+      @user = create(:user)
+      sign_in_as(@user)
+    end
+
+    context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
+      setup do
+        @rubygem = create(:rubygem)
+        create(:ownership, rubygem: @rubygem, user: @user)
+        GemDownload.increment(
+          Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+          rubygem_id: @rubygem.id
+        )
+        @request.cookies[:mfa_required] = "true"
+      end
+
+      context "user has mfa disabled" do
+        setup { get :edit }
+        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+      end
+
+      context "user has mfa set to weak level" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          get :edit
+        end
+
+        should "stay on edit settings page without redirecting" do
+          assert_response :success
+          assert page.has_content? "Edit settings"
+        end
+      end
+
+      context "user has MFA set to strong level, expect normal behaviour" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          get :edit
+        end
+
+        should "stay on edit settings page without redirecting" do
+          assert_response :success
+          assert page.has_content? "Edit settings"
+        end
+      end
+    end
+  end
+end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -43,4 +43,18 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_in_delta(stats_graph_meter(@rubygem, most_downloaded_count), 12.5)
     end
   end
+
+  context "flash_message string with html" do
+    setup do
+      @message = "This is a <strong>test</strong>"
+    end
+
+    should "sanitize with :notice_html" do
+      assert_instance_of ActiveSupport::SafeBuffer, flash_message(:notice_html, @message)
+    end
+
+    should "not sanitize with :notice" do
+      assert_instance_of String, flash_message(:notice, @message)
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Uses functions added in https://github.com/rubygems/rubygems.org/pull/3135

In the future, gem owners with more than 180 million downloads on any of their gems will be required to have MFA enabled. 
This requirement should mean that they cannot access sensitive information in the UI unless they have MFA enabled, and they should be redirected to setup MFA. Alternatively, if they are at the `UI only` MFA level, they should be sent to the settings page to upgrade their MFA level.

I've implemented the above with a cookie feature flag, so on release day the cookie can be removed. 

# Which pages are blocked?
I've blocked every page that had a before_action signin requirement, i.e. any page that requires you to be signed in. I'm unsure if that covers everything that we need, but it should be a good starting point. This means: 
API Keys, Dashboard, Email Confirmations, Notifiers, Ownership Calls, Ownership Requests, Profiles, Settings. Note that visiting settings with UI Only will not redirect to settings because that would create a loop.

Tests: every route for the affected controllers, for mfa disabled, weak level (ui only), and strong level. 
- For disabled, a redirect to the new mfa setup page is expected.
- For weak mfa enabled, a redirect to the edit settings page is expected.
- For strong mfa enabled, the page loading normally or redirecting normally is expected
There are a few exceptions routes, found in except: clauses at the top of controllers, e.g. the public profile :show page.

<s>Tests
-The tests are numerous and all very similar, so to help with the mental model:
- The tests are all after the user logs in, and they are all functional tests.~~
- Settings and Notifiers didn't have existing functional tests so I made new files for them to maintain the pattern.~~
- There are 3 test for each controller, one for mfa disabled, weak mfa enabled, and strong mfa enabled.~~
- For disabled, a redirect to the new mfa setup page is expected.
- For weak mfa enabled, a redirect to the edit settings page is expected.
- For strong mfa enabled, the page loading normally or redirecting normally is expected, so I looked for text most of the time
A table summary of what the attributes for each controller were:

| Controller | Intended destination | Disabled redirects to | Weak redirects to | What to expect when Strong
| --- | --- | --- | --- | --- |
| api_keys | get new | mfa/new | settings/edit | "New API key" |
| dashboard | get show | '' | '' | "Dashboard" |
| email_confirmations | get new | '' | '' | "Resend confirmation email" | 
| notifiers | get show | '' | '' | "Email notifications" |
| ownership_calls | post create | '' | '' | redirect to adoptions| 
| ownership_requests | post create | '' | '' | redirects to adoptions |
| profiles | get edit | '' | '' | "Edit profile" |
| settings | get edit | '' | does not redirect | "Edit Settings" |</s>

