### PR TITLE
Fix more translations in ja

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,18 +1,18 @@
 ---
 ja:
   edit: 編集
-  failure_when_forbidden: URLを確認するか、再試行して下さい。
+  failure_when_forbidden: URLを確認するか、再試行してください。
   feed_latest: RubyGems.org | 最新のGemの一覧
   feed_subscribed: RubyGems.org | 購読したGemの一覧
-  footer_about_html: RubyGems.orgはRubyコミュニティのGemのホスティングサービスです。 すぐに<a href="%{publish_docs}">あなたが実装したGemを公開したり</a><a
-    href="%{install_docs}">インストールしたり</a>することができます。 <a href="%{api_docs}">API</a>を使用して<a
-    href="%{gem_list}">利用可能なGem</a>についてさらに探すことができます。 <a href="%{contributing_docs}">コントリビューターとなって</a>あなたのサイトをよりよくしてください。
+  footer_about_html: RubyGems.orgはRubyコミュニティのGemのホスティングサービスです。 すぐに<a href="%{publish_docs}">Gemを公開</a>し<a
+    href="%{install_docs}">インストール</a>できます。 <a href="%{api_docs}">API</a>を使用して<a
+    href="%{gem_list}">利用可能なGem</a>を発見できます。 あなた自身が<a href="%{contributing_docs}">コントリビューターとなって</a>サイトをよりよくしてください。
   footer_sponsors_html: RubyGems.orgは大きなRubyコミュニティとのパートナーシップを通じて作られました。 <a href="https://www.fastly.com/">Fastly</a>が帯域を提供してくださり、CDNサポートをしてくださっています。
-    <a href="http://www.rubycentral.org/">Ruby Central</a>がインフラの費用を賄ってくださり、 <a href="https://rubytogether.org/?source=rubygems">Ruby
+    <a href="https://www.rubycentral.org/">Ruby Central</a>がインフラの費用を賄ってくださり、 <a href="https://rubytogether.org/?source=rubygems">Ruby
     Together</a>が開発や運用の費用を出資してくださっています。 <a href="%{sponsors_page}">スポンサーや一緒に働く方法について詳細を確認する</a>。
   footer_join_rt_html: RubyGems.orgをすべての人がスムーズに使えるよう続けていくために、開発者の時間を賄うためのあなたの援助が必要です。
     <a href="https://rubytogether.org/join?source=rubygems">Ruby Togetherに参加する</a>。
-  form_disable_with: お待ち下さい...
+  form_disable_with: お待ちください...
   invalid_page:
   locale_name: 日本語
   none: なし
@@ -46,7 +46,7 @@ ja:
         funding:
       session:
         password: パスワード
-        who: Email又はユーザー名
+        who: Emailまたはユーザー名
       user:
         avatar: アバター
         email: Emailアドレス
@@ -119,7 +119,7 @@ ja:
       migrating_link_text: 統合
       mine: あなたのGem
       my_subscriptions: 購読
-      no_owned_html: あなたはまだGemを公開していません。よろしければGemの%{creating_link}又はRubyForgeからの%{migrating_link}ガイドをご覧ください。
+      no_owned_html: あなたはまだGemを公開していません。よろしければGemの%{creating_link}またはRubyForgeからの%{migrating_link}ガイドをご覧ください。
       no_subscriptions_html: あなたはまだGemを購読していません。%{gem_link}から購読を行なってみてください。
       title:
   dependencies:
@@ -198,7 +198,7 @@ ja:
       title:
       subtitle:
       subject: あなたのアカウントはrubygems.orgから削除されませんでした
-      body_html: あなたのrubygems.orgにおけるアカウント削除申請は処理されませんでした。申し訳ありませんが、現在アカウントを削除することができません。しばらく待ってから再度お試し頂くか、問題が継続するようならば%{contact}をお願いいたします。
+      body_html: あなたのrubygems.orgにおけるアカウント削除申請は処理されませんでした。申し訳ありませんが、現在アカウントを削除することができません。しばらく待ってから再度お試しいただくか、問題が継続するようならば%{contact}をお願いいたします。
     notifiers_changed:
       subject:
       title:
@@ -287,7 +287,7 @@ ja:
     new:
       submit: パスワードをリセットする
       title: パスワードを変更する
-      will_email_notice: パスワード変更のためのメールが送信されます。\
+      will_email_notice: パスワード変更のためのメールが送信されます。
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:


### PR DESCRIPTION
Follows up #2430 since #2111 was created before #2430 but merged after it.

Copyedits more strings.

### Modernize Japanse verbs/adverbs
- 下さい => ください
- 又は => または
- 頂く => いただく

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>