### PR TITLE
Mailer: Email to remind maintainers of gems with 180M+ downloads to enable MFA

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -77,9 +77,17 @@ class Mailer < ApplicationMailer
 
   def mfa_required_soon_announcement(user_id)
     @user = User.find(user_id)
+    case @user.mfa_level
+    when "disabled"
+      subject = "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
+      @heading = "Enable multi-factor authentication on your RubyGems account"
+    when "ui_only"
+      subject = "[Action Required] Upgrade the multi-factor authentication level on your RubyGems account by August 15"
+      @heading = "Upgrade the multi-factor authentication level on your RubyGems account"
+    end
 
     mail to: @user.email,
-      subject: "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
+      subject: subject
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -75,6 +75,13 @@ class Mailer < ApplicationMailer
       subject: "Please enable multi-factor authentication on your RubyGems account"
   end
 
+  def mfa_required_soon_announcement(user_id)
+    @user = User.find(user_id)
+
+    mail to: @user.email,
+      subject: "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/views/mailer/mfa_required_soon_announcement.html.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.html.erb
@@ -23,7 +23,7 @@
 
         <p>
           If you don't have MFA enabled by this date, a number of operations will be restricted.
-          These restrictions include accessing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
+          These restrictions include editing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
         </p>
         <br/>
 

--- a/app/views/mailer/mfa_required_soon_announcement.html.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Enable multi-factor authentication (MFA) on your RubyGems account" %>
+<% @title = @heading %>
 <% @sub_title = "👋 Hi #{@user.handle}" %>
 
 <!-- Body -->

--- a/app/views/mailer/mfa_required_soon_announcement.html.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.html.erb
@@ -1,0 +1,119 @@
+<% @title = "Enable multi-factor authentication (MFA) on your RubyGems account" %>
+<% @sub_title = "👋 Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Recently, we've <a href="https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html" target="_blank">announced</a> our security-focused ambitions to the community.
+        </p>
+        <br/>
+
+        <p>
+          Next week, on August 15, 2022, we will begin requiring maintainers like yourself, who are owners of packages with more than 180 million downloads, to have multi-factor authentication (MFA) enabled.
+        </p>
+        <br/>
+
+        <p>
+          If you don't have MFA enabled by this date, a number of operations will be restricted.
+          These restrictions include accessing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
+        </p>
+        <br/>
+
+        <% if @user.mfa_disabled? %>
+          <p> 
+            To avoid any disruptions with your RubyGems account, <b>please enable multi-factor authentication 🙏.</b>
+          </p>
+          <br/>
+        <% elsif @user.mfa_ui_only? %>
+          <p>
+            We're notifying you of this policy because you have MFA enabled only for the UI.
+            <b>Please upgrade your RubyGems account to a stronger MFA level 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br />
+        <% end %>
+        <br/>
+
+        <p>Thank you for making the RubyGems ecosystem more secure.</p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <% if @user.mfa_disabled? || @user.mfa_ui_only? %>
+
+        <!-- Button -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center">
+              <table width="210" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" bgcolor="#e9573f">
+                    <table border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15">
+                          <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">
+                            <tr>
+                              <td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td>
+                            </tr>
+                          </table>
+                        </td>
+                        <td bgcolor="#e9573f">
+                          <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                              <span class="link-white" style="color:#ffffff; text-decoration:none">
+                                <%= "ENABLE MFA" if @user.mfa_disabled? %>
+                                <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>
+                              </span>
+                            </a>
+                          </div>
+                        </td>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <!-- END Button -->
+      <% end %>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <!-- Adding a horizontal rule -->
+      <table width="100%">
+        <tr>
+          <td width="100%" bgcolor="#cccccc" height="1" style="font-size: 1px; line-height: 1px;">&nbsp;</td>
+        </tr>
+      </table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/mfa_required_soon_announcement.text.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.text.erb
@@ -1,0 +1,19 @@
+👋 Hi <%= @user.handle %>,
+
+Recently, we've announced our security-focused ambitions to the community (https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html).
+
+Next week, on August 15, 2022, we will begin requiring maintainers like yourself, who are owners of packages with more than 180 million downloads, to have multi-factor authentication (MFA) enabled.
+
+If you don't have MFA enabled by this date, a number of operations will be restricted.
+These restrictions include accessing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+
+<% if @user.mfa_disabled? %> 
+To avoid any disruptions with your RubyGems account, please enable multi-factor authentication 🙏.
+<% elsif @user.mfa_ui_only? %>
+We're notifying you of this policy because you have MFA enabled only for the UI.
+Please upgrade your RubyGems account to a stronger MFA level 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+<% end %>
+
+❤️ Thank you for making the RubyGems ecosystem more secure

--- a/app/views/mailer/mfa_required_soon_announcement.text.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.text.erb
@@ -5,7 +5,7 @@ Recently, we've announced our security-focused ambitions to the community (https
 Next week, on August 15, 2022, we will begin requiring maintainers like yourself, who are owners of packages with more than 180 million downloads, to have multi-factor authentication (MFA) enabled.
 
 If you don't have MFA enabled by this date, a number of operations will be restricted.
-These restrictions include accessing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+These restrictions include editing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
 
 <% if @user.mfa_disabled? %> 
 To avoid any disruptions with your RubyGems account, please enable multi-factor authentication 🙏.

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -32,4 +32,23 @@ namespace :mfa_policy do
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
     end
   end
+
+  # This task is meant to be run one week prior to MFA Phase 3 launch day - send out on Aug 8, 2022
+  # For more information on the MFA Phase 3 rollout, refer to this RFC:
+  # https://github.com/rubygems/rfcs/pull/36/files#diff-3d5cc3acc06fe7e9150fdbfc43399c5ad42572c122187774bfc3a4857df524f1R69-R85
+  # rake mfa_policy:reminder_enable_mfa
+  desc "Send email reminder to users who will have MFA enforced about impending MFA Phase 3 rollout"
+  task reminder_enable_mfa: :environment do
+    # users who own at least one gem with 180,000,000 downloads or more with weak or no MFA
+    users = User.joins(rubygems: :gem_download).where("gem_downloads.count >= 180000000").where(mfa_level: %w[disabled ui_only])
+    total_users = users.count
+    puts "Sending #{total_users} MFA reminder email"
+
+    i = 0
+    users.each do |user|
+      Mailer.delay.mfa_required_soon_announcement(user.id) if mx_exists?(user.email)
+      i += 1
+      print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
+    end
+  end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -41,6 +41,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.mfa_recommendation_announcement(User.last.id)
   end
 
+  def mfa_required_soon_announcement
+    Mailer.mfa_required_soon_announcement(User.last.id)
+  end
+
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
     Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,6 +72,8 @@ Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
 Capybara.always_include_port = true
 Capybara.server = :webrick
 
+Gemcutter::Application.load_tasks
+
 class SystemTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -30,7 +30,6 @@ class MailerTest < ActionMailer::TestCase
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
       @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
-
       Delayed::Worker.new.work_off
 
       refute_empty ActionMailer::Base.deliveries
@@ -40,6 +39,44 @@ class MailerTest < ActionMailer::TestCase
       assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
       assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
       assert_match "Sending 1 MFA reminder email", @io_output
+    end
+
+    should "send mail to users with with more than 180M+ downloads and have weak MFA" do
+      user = create(:user, mfa_level: "ui_only")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      Delayed::Worker.new.work_off
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
+      assert_match "Recently, we've announced our security-focused ambitions to the community", email.text_part.body.to_s
+      assert_match "Sending 1 MFA reminder email", @io_output
+    end
+
+    should "not send mail to users with with more than 180M+ downloads and have strong MFA" do
+      user = create(:user, mfa_level: "ui_and_api")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      Delayed::Worker.new.work_off
+
+      assert_empty ActionMailer::Base.deliveries
+      assert_match "Sending 0 MFA reminder email", @io_output
+    end
+
+    should "not send mail to users with with less than 180M downloads" do
+      user = create(:user)
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY - 1)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      Delayed::Worker.new.work_off
+
+      assert_empty ActionMailer::Base.deliveries
+      assert_match "Sending 0 MFA reminder email", @io_output
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -52,7 +52,7 @@ class MailerTest < ActionMailer::TestCase
       email = ActionMailer::Base.deliveries.last
       assert_equal [user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
-      assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
+      assert_equal "[Action Required] Upgrade the multi-factor authentication level on your RubyGems account by August 15", email.subject
       assert_match "Recently, we've announced our security-focused ambitions to the community", email.text_part.body.to_s
       assert_match "Sending 1 MFA reminder email", @io_output
     end

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class MailerTest < ActiveSupport::TestCase
   MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
+  MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY = 180_000_000
 
   context "sending mail for mfa recommendation announcement" do
     setup do
@@ -19,7 +20,25 @@ class MailerTest < ActiveSupport::TestCase
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "Please enable multi-factor authentication on your RubyGems account", email.subject
-      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+    end
+  end
+
+  context "sending mail for mfa required soon announcement" do
+    should "send mail to users with with more than 180M+ downloads and have MFA disabled" do
+      user = create(:user, mfa_level: "disabled")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      Delayed::Worker.new.work_off
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
+      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -9,7 +9,7 @@ class MailerTest < ActionMailer::TestCase
       @user = create(:user)
       create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY)
 
-      Rake::Task["mfa_policy:announce_recommendation"].invoke
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_recommendation"].execute }
       Delayed::Worker.new.work_off
     end
 
@@ -20,6 +20,7 @@ class MailerTest < ActionMailer::TestCase
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "Please enable multi-factor authentication on your RubyGems account", email.subject
       assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+      assert_match "Sending 1 MFA announcement email", @io_output
     end
   end
 
@@ -28,7 +29,8 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "disabled")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+
       Delayed::Worker.new.work_off
 
       refute_empty ActionMailer::Base.deliveries
@@ -37,6 +39,7 @@ class MailerTest < ActionMailer::TestCase
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
       assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+      assert_match "Sending 1 MFA reminder email", @io_output
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class MailerTest < ActiveSupport::TestCase
+class MailerTest < ActionMailer::TestCase
   MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
   MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY = 180_000_000
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -9,7 +9,6 @@ class MailerTest < ActionMailer::TestCase
       @user = create(:user)
       create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY)
 
-      Gemcutter::Application.load_tasks
       Rake::Task["mfa_policy:announce_recommendation"].invoke
       Delayed::Worker.new.work_off
     end
@@ -29,7 +28,6 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "disabled")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      Gemcutter::Application.load_tasks
       Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
       Delayed::Worker.new.work_off
 


### PR DESCRIPTION
## 🤷‍♀️ What problem are you solving?
Contributes to https://github.com/Shopify/ruby-conventions/issues/134
Closes https://github.com/rubygems/rubygems.org/issues/3164

We need to send out a reminder email on August 8, 2022 to remind maintainers of gems with 180M+ downloads to enable MFA. This mailer is crafted with a targeted approach. It's only being sent to those impacted maintainers who have yet to enable MFA (`disabled`), or have weak MFA enabled (`ui_only`).


## 📋 How will you solve this?
🔹 **Create a mailer**
- Adds a mailer action `mfa_required_soon_announcement` and a mailer view in both `HTML` and `plain text` formats
- Note that there are minor copy variations dependent on a user's MFA status:
  - If the user does not have MFA enabled at all (`disabled`)
  - If the user has MFA enabled (`ui_only`)

🔹 **Add rake task for delivering the email** 
- This will be the task that the RubyGems Team will run on August 8 to send out the email reminder
- I've followed similar logging that they've done in a previous mailer
- Task to be run: `rake mfa_policy:reminder_enable_mfa`

🔹 **Set up mailer preview**
- So we can more easily tophat and preview the email in both HTML and plain text, I've set up a mailer preview


## 🎩 Tophat instructions
Below are the instructions for trying this out yourself:

**📧 To preview the email:**
- Once you have the app running (`rails s`) ...
- You can navigate to (`http://localhost:3000/rails/mailers`) to review the list of all mailers available for preview
  - To view this mailer, click on the link titled: `mfa_required_soon_announcement`
- The mailer for this PR is located at `http://localhost:3000/rails/mailers/mailer/mfa_required_soon_announcement`

**👤 To change the user:**
- The user is configured on the mailer preview based on `MailerPreview#mfa_required_soon_announcement`. 
  - To change the user to verify various MFA states, you can either replace `User.last.id` with a different user (e.g. `User.first`)
  - Alternatively, you can adjust the MFA status on your last user

### 👀 Email versions

**🚫 Email for users with MFA disabled**
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/183558242-60fc8299-3924-4712-a299-8d5b1e28da1a.png" alt="Email for users with MFA disabled - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/183558329-1ff67486-ecb1-4b1c-9864-18364d126c28.png" alt="Email for users with MFA disabled - Plain text format" width=250 />
  </kbd>
</p>

**🤞 Email for users with MFA enabled (`ui_only`) -- weak MFA**
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/183558126-001d412a-3702-48cb-98d9-bd67e535c47d.png" alt="Email for users with MFA enabled set to ui_only - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/183558056-06da65f3-e5d2-436c-ab0e-63bc472fc802.png" alt="Email for users with MFA enabled set to ui_only - Plain text format" width=250 />
  </kbd>
</p>

