### PR TITLE
To Investigate: Debug flaky MFA announcement mailer tests

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -75,6 +75,13 @@ class Mailer < ApplicationMailer
       subject: "Please enable multi-factor authentication on your RubyGems account"
   end
 
+  def mfa_required_soon_announcement(user_id)
+    @user = User.find(user_id)
+
+    mail to: @user.email,
+      subject: "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/views/mailer/mfa_required_soon_announcement.html.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.html.erb
@@ -1,0 +1,118 @@
+<% @title = "Enable multi-factor authentication (MFA) on your RubyGems account" %>
+<% @sub_title = "👋 Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Recently, we've <a href="https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html" target="_blank">announced</a> our security-focused ambitions to the community.
+        </p>
+        <br/>
+
+        <p>
+          Next week, on August 15, 2022, we will begin requiring maintainers like yourself, who are owners of packages with more than 180 million downloads, to have multi-factor authentication (MFA) enabled.
+        </p>
+        <br/>
+
+        <p>
+          If you don't have MFA enabled by this date, a number of operations will be restricted.
+          These restrictions include accessing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
+        </p>
+        <br/>
+
+        <% if @user.mfa_disabled? %>
+          <p> 
+            To avoid any disruptions with your RubyGems account, <b>please enable multi-factor authentication 🙏.</b>
+          </p>
+          <br/>
+        <% elsif @user.mfa_ui_only? %>
+          <p>
+            We're notifying you of this policy because you have MFA enabled only for the UI.
+            <b>Please upgrade your RubyGems account to a stronger MFA level 🙏.</b>
+          </p>
+          <br/>
+        <% else %>
+          <p>
+            We're notifying you of this policy because you maintain at least one gem that has more than 165 million downloads.
+            Fortunately, you've already enabled MFA. Kudos to you 🥳 🙌!
+          </p>
+          <br/>
+        <% end %>
+        <br/>
+
+        <p>Thank you for making the RubyGems ecosystem more secure.</p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <% if @user.mfa_disabled? || @user.mfa_ui_only? %>
+
+        <!-- Button -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center">
+              <table width="210" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" bgcolor="#e9573f">
+                    <table border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15">
+                          <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">
+                            <tr>
+                              <td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td>
+                            </tr>
+                          </table>
+                        </td>
+                        <td bgcolor="#e9573f">
+                          <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                              <span class="link-white" style="color:#ffffff; text-decoration:none">
+                                <%= "ENABLE MFA" if @user.mfa_disabled? %>
+                                <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>
+                              </span>
+                            </a>
+                          </div>
+                        </td>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <!-- END Button -->
+      <% end %>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <!-- Adding a horizontal rule -->
+      <table width="100%">
+        <tr>
+          <td width="100%" bgcolor="#cccccc" height="1" style="font-size: 1px; line-height: 1px;">&nbsp;</td>
+        </tr>
+      </table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/mfa_required_soon_announcement.text.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.text.erb
@@ -1,0 +1,17 @@
+👋 Hi <%= @user.handle %>,
+
+Recently, we've announced our security-focused ambitions to the community (https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html).
+
+Next week, on August 15, 2022, we will begin requiring maintainers like yourself, who are owners of packages with more than 180 million downloads, to have multi-factor authentication (MFA) enabled.
+
+If you don't have MFA enabled by this date, a number of operations will be restricted.
+These restrictions include accessing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+
+<% if @user.mfa_disabled? %> 
+To avoid any disruptions with your RubyGems account, please enable multi-factor authentication 🙏.
+<% elsif @user.mfa_ui_only? %>
+We're notifying you of this policy because you have MFA enabled only for the UI.
+Please upgrade your RubyGems account to a stronger MFA level 🙏.
+<% end %>
+
+❤️ Thank you for making the RubyGems ecosystem more secure

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -32,4 +32,23 @@ namespace :mfa_policy do
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
     end
   end
+
+  # This task is meant to be run one week prior to MFA Phase 3 launch day - send out on Aug 8, 2022
+  # For more information on the MFA Phase 3 rollout, refer to this RFC:
+  # https://github.com/rubygems/rfcs/pull/36/files#diff-3d5cc3acc06fe7e9150fdbfc43399c5ad42572c122187774bfc3a4857df524f1R69-R85
+  # rake mfa_policy:reminder_enable_mfa
+  desc "Send email reminder to users who will have MFA enforced about impending MFA Phase 3 rollout"
+  task reminder_enable_mfa: :environment do
+    # users who own at least one gem with 180,000,000 downloads or more with weak or no MFA
+    users = User.joins(rubygems: :gem_download).where("gem_downloads.count >= 180000000").where(mfa_level: %w[disabled ui_only])
+    total_users = users.count
+    puts "Sending #{total_users} MFA announcement email"
+
+    i = 0
+    users.each do |user|
+      Mailer.delay.mfa_required_soon_announcement(user.id) if mx_exists?(user.email)
+      i += 1
+      print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
+    end
+  end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -41,6 +41,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.mfa_recommendation_announcement(User.last.id)
   end
 
+  def mfa_required_soon_announcement
+    Mailer.mfa_required_soon_announcement(User.last.id)
+  end
+
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
     Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class MailerTest < ActiveSupport::TestCase
   MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
+  MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY = 180_000_000
 
   context "sending mail for mfa recommendation announcement" do
     setup do
@@ -19,7 +20,25 @@ class MailerTest < ActiveSupport::TestCase
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "Please enable multi-factor authentication on your RubyGems account", email.subject
-      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+    end
+  end
+
+  context "sending mail for mfa required soon announcement" do
+    should "send mail to users with with more than 180M+ downloads and have MFA disabled" do
+      @user = create(:user, mfa_level: "disabled")
+      create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      Delayed::Worker.new.work_off
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [@user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
+      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
     end
   end
 

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -20,12 +20,14 @@ class MailerTest < ActiveSupport::TestCase
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "Please enable multi-factor authentication on your RubyGems account", email.subject
-      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
     end
   end
 
   context "sending mail for mfa required soon announcement" do
     should "send mail to users with with more than 180M+ downloads and have MFA disabled" do
+      ActionMailer::Base.deliveries.clear
+      
       @user = create(:user, mfa_level: "disabled")
       create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
@@ -33,12 +35,63 @@ class MailerTest < ActiveSupport::TestCase
       Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
       Delayed::Worker.new.work_off
 
+      sleep 4
+
       refute_empty ActionMailer::Base.deliveries
       email = ActionMailer::Base.deliveries.last
       assert_equal [@user.email], email.to
       assert_equal ["no-reply@mailer.rubygems.org"], email.from
       assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
-      assert_match "Thank you for making the RubyGems ecosystem more secure", email.text_part.body.to_s
+      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+    end
+
+    should "send mail to users with with more than 180M+ downloads and have weak MFA" do
+      ActionMailer::Base.deliveries.clear
+     
+      user = create(:user, mfa_level: "ui_only")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      Delayed::Worker.new.work_off
+
+      sleep 4
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15", email.subject
+      assert_match "Recently, we've announced our security-focused ambitions to the community.", email.text_part.body.to_s
+    end
+
+    should "not send mail to users with with more than 180M+ downloads and have strong MFA" do
+      ActionMailer::Base.deliveries.clear
+
+      user = create(:user, mfa_level: "ui_and_api")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      Delayed::Worker.new.work_off
+
+      sleep 4
+
+      assert_empty ActionMailer::Base.deliveries
+    end
+
+    should "not send mail to users with with less than 180M downloads" do
+      ActionMailer::Base.deliveries.clear
+      user = create(:user)
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY - 1)
+
+      Gemcutter::Application.load_tasks
+      Rake::Task["mfa_policy:reminder_enable_mfa"].invoke
+      Delayed::Worker.new.work_off
+
+      sleep 4
+
+      assert_empty ActionMailer::Base.deliveries
     end
   end
 


### PR DESCRIPTION
### 🤷‍♀️ What problem are you trying to solve?
This PR is to follow up on the [MFA reminder mailer PR](https://github.com/rubygems/rubygems.org/pull/3166). @jchestershopify and I have been debugging this set of tests. When each one is run in isolation, they pass. However, when the whole suite of tests are run together, the tests start failing.

### 🔍 What we've observed so far:
It appears that the collection in `ActionMailer::Base.deliveries` is not always emptied correctly. We've attempted to clear the collection through calling `ActionMailer::Base.deliveries.clear`. Regardless of whether we clear the collection during `setup`, `teardown`, or inline within each test, it appears to not have made any difference. Some tests continue to fail.

We're opening this as a separate PR from the MFA reminder mailer since there's a time constraint to completing the mailer. If we end up shipping the mailer PR with only the one test which tests the expected path, we still want to backfill the other remaining tests.
