### PR TITLE
Fix api keys controller test typos

### DIFF
--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -33,12 +33,12 @@ class ApiKeysControllerTest < ActionController::TestCase
     end
 
     context "on DELETE to destroy" do
-      setup { post :create, params: { id: 1 } }
+      setup { delete :destroy, params: { id: 1 } }
 
       should redirect_to("the sign in page") { sign_in_path }
     end
 
-    context "on DELETE to destroy" do
+    context "on DELETE to reset" do
       setup { delete :reset }
 
       should redirect_to("the sign in page") { sign_in_path }


### PR DESCRIPTION
The api keys controller tests have some typos (/test/functional/api_keys_controller_test.rb) with the api requests, I've corrected them.