### PR TITLE
MFA required (Phase 3) remove feature flag cookie

### DIFF
--- a/app/controllers/concerns/application_multifactor_methods.rb
+++ b/app/controllers/concerns/application_multifactor_methods.rb
@@ -2,10 +2,6 @@ module ApplicationMultifactorMethods
   extend ActiveSupport::Concern
 
   included do
-    def mfa_required_cookie?
-      cookies[:mfa_required] == "true"
-    end
-
     def redirect_to_new_mfa
       message = t("multifactor_auths.setup_required_html")
       redirect_to new_multifactor_auth_path, notice_html: message
@@ -13,7 +9,7 @@ module ApplicationMultifactorMethods
 
     def mfa_required_not_yet_enabled?
       return false if current_user.nil?
-      current_user.mfa_required_not_yet_enabled? && mfa_required_cookie?
+      current_user.mfa_required_not_yet_enabled?
     end
 
     def redirect_to_settings_strong_mfa_required
@@ -23,7 +19,7 @@ module ApplicationMultifactorMethods
 
     def mfa_required_weak_level_enabled?
       return false if current_user.nil?
-      current_user.mfa_required_weak_level_enabled? && mfa_required_cookie?
+      current_user.mfa_required_weak_level_enabled?
     end
   end
 end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -304,7 +304,6 @@ class ApiKeysControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       redirect_scenarios = {

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -116,7 +116,6 @@ class DashboardsControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       context "user has mfa disabled" do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -230,7 +230,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
             Rubygem::MFA_REQUIRED_THRESHOLD + 1,
             rubygem_id: @rubygem.id
           )
-          @request.cookies[:mfa_required] = "true"
         end
 
         context "user has mfa disabled" do

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -23,7 +23,6 @@ class NotifiersControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       redirect_scenarios = {

--- a/test/functional/ownership_calls_controller_test.rb
+++ b/test/functional/ownership_calls_controller_test.rb
@@ -129,7 +129,6 @@ class OwnershipCallsControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       context "user has mfa disabled" do

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -253,7 +253,6 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @mfa_rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
         @rubygem = create(:rubygem)
         create(:ownership_call, rubygem: @rubygem)
         @ownership_request = create(:ownership_request)

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -246,7 +246,6 @@ class ProfilesControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       redirect_scenarios = {

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -295,7 +295,6 @@ class SessionsControllerTest < ActionController::TestCase
         Rubygem::MFA_REQUIRED_THRESHOLD + 1,
         rubygem_id: @rubygem.id
       )
-      @request.cookies[:mfa_required] = "true"
     end
 
     context "user has mfa disabled" do

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -23,7 +23,6 @@ class SettingsControllerTest < ActionController::TestCase
           Rubygem::MFA_REQUIRED_THRESHOLD + 1,
           rubygem_id: @rubygem.id
         )
-        @request.cookies[:mfa_required] = "true"
       end
 
       context "user has mfa disabled" do


### PR DESCRIPTION
A cookie feature flag was added in https://github.com/rubygems/rubygems.org/pull/3153, the PR that enables MFA requirement/redirection for the RubyGems.org UI for owners of popular gems. On launch day, this PR should be merged to remove that cookie is removed and such owners are properly blocked from actions on the UI if they don't have MFA enabled.