### PR TITLE
Mailer: Email to announce MFA is required for maintainers of gems with 180M+ downloads

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,37 @@
+module MailerHelper
+  def mfa_required_soon_subject(mfa_level)
+    case mfa_level
+    when "disabled"
+      "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
+    when "ui_only"
+      "[Action Required] Upgrade the multi-factor authentication level on your RubyGems account by August 15"
+    end
+  end
+
+  def mfa_required_soon_heading(mfa_level)
+    case mfa_level
+    when "disabled"
+      "Enable multi-factor authentication on your RubyGems account"
+    when "ui_only"
+      "Upgrade the multi-factor authentication level on your RubyGems account"
+    end
+  end
+
+  def mfa_required_popular_gems_subject(mfa_level)
+    case mfa_level
+    when "disabled"
+      "[Action Required] Enabling multi-factor authentication is required on your RubyGems account"
+    when "ui_only"
+      "[Action Required] Upgrading the multi-factor authentication level is required on your RubyGems account"
+    end
+  end
+
+  def mfa_required_popular_gems_heading(mfa_level)
+    case mfa_level
+    when "disabled"
+      "Enable multi-factor authentication on your RubyGems account"
+    when "ui_only"
+      "Upgrade the multi-factor authentication level on your RubyGems account"
+    end
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -92,17 +92,12 @@ class Mailer < ApplicationMailer
 
   def mfa_required_popular_gems_announcement(user_id)
     @user = User.find(user_id)
-    case @user.mfa_level
-    when "disabled"
-      subject = "[Action Required] Enabling multi-factor authentication is required on your RubyGems account"
-      @heading = "Enable multi-factor authentication on your RubyGems account"
-    when "ui_only"
-      subject = "[Action Required] Upgrading the multi-factor authentication level is required on your RubyGems account"
-      @heading = "Upgrade the multi-factor authentication level on your RubyGems account"
-    end
+    heading_cta = @user.mfa_ui_only? ? "Upgrade the" : "Enable"
+    subject_cta = @user.mfa_ui_only? ? "Upgrading the" : "Enabling"
+    @heading = "#{heading_cta} multi-factor authentication#{' level' if @user.mfa_ui_only?} on your RubyGems account"
 
     mail to: @user.email,
-      subject: subject
+      subject: "[Action Required] #{subject_cta} multi-factor authentication#{' level' if @user.mfa_ui_only?} is required on your RubyGems account"
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,5 +1,6 @@
 class Mailer < ApplicationMailer
   include Roadie::Rails::Automatic
+  include MailerHelper
 
   default from: Clearance.configuration.mailer_sender
 
@@ -77,27 +78,18 @@ class Mailer < ApplicationMailer
 
   def mfa_required_soon_announcement(user_id)
     @user = User.find(user_id)
-    case @user.mfa_level
-    when "disabled"
-      subject = "[Action Required] Enable multi-factor authentication on your RubyGems account by August 15"
-      @heading = "Enable multi-factor authentication on your RubyGems account"
-    when "ui_only"
-      subject = "[Action Required] Upgrade the multi-factor authentication level on your RubyGems account by August 15"
-      @heading = "Upgrade the multi-factor authentication level on your RubyGems account"
-    end
+    @heading = mfa_required_soon_heading(@user.mfa_level)
 
     mail to: @user.email,
-      subject: subject
+      subject: mfa_required_soon_subject(@user.mfa_level)
   end
 
   def mfa_required_popular_gems_announcement(user_id)
     @user = User.find(user_id)
-    heading_cta = @user.mfa_ui_only? ? "Upgrade the" : "Enable"
-    subject_cta = @user.mfa_ui_only? ? "Upgrading the" : "Enabling"
-    @heading = "#{heading_cta} multi-factor authentication#{' level' if @user.mfa_ui_only?} on your RubyGems account"
+    @heading = mfa_required_popular_gems_heading(@user.mfa_level)
 
     mail to: @user.email,
-      subject: "[Action Required] #{subject_cta} multi-factor authentication#{' level' if @user.mfa_ui_only?} is required on your RubyGems account"
+      subject: mfa_required_popular_gems_subject(@user.mfa_level)
   end
 
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -90,6 +90,21 @@ class Mailer < ApplicationMailer
       subject: subject
   end
 
+  def mfa_required_popular_gems_announcement(user_id)
+    @user = User.find(user_id)
+    case @user.mfa_level
+    when "disabled"
+      subject = "[Action Required] Enabling multi-factor authentication is required on your RubyGems account"
+      @heading = "Enable multi-factor authentication on your RubyGems account"
+    when "ui_only"
+      subject = "[Action Required] Upgrading the multi-factor authentication level is required on your RubyGems account"
+      @heading = "Upgrade the multi-factor authentication level on your RubyGems account"
+    end
+
+    mail to: @user.email,
+      subject: subject
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
+++ b/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
@@ -1,0 +1,124 @@
+<% @title = @heading %>
+<% @sub_title = "👋 Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Effective today, multi-factor authentication (MFA) is required on your RubyGems account.
+        </p>
+        <br/>
+
+        <% if @user.mfa_disabled? %>
+          <p>
+            A number of operations are now restricted until you enable MFA.
+            These restrictions include editing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
+          </p>
+          <br/>
+
+          <p> 
+            To avoid further disruptions on your account, <b>please enable multi-factor authentication 🙏.</b>
+          </p>
+          <br/>
+        <% elsif @user.mfa_ui_only? %>
+          <p>
+            Your current MFA level is no longer recommended. In fact, it's deprecated.
+            <b>You need to upgrade your RubyGems account to a stronger MFA level 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br/>
+
+          <p>
+            A number of operations are restricted until you upgrade your MFA setting.
+            These restrictions include editing profile pages on the web, signing in on the command line, and performing <a href="https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations" target="_blank">privileged actions</a> (ie. push, yank, add/remove owners).
+          </p>
+          <br/>
+        <% end %>
+
+        <p>
+          For more information, check out our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html" target="_blank">announcement</a>.
+        </p>
+        <br/>
+
+        <p>Thank you for making the RubyGems ecosystem more secure.</p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <% if @user.mfa_disabled? || @user.mfa_ui_only? %>
+
+        <!-- Button -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center">
+              <table width="210" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" bgcolor="#e9573f">
+                    <table border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15">
+                          <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">
+                            <tr>
+                              <td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td>
+                            </tr>
+                          </table>
+                        </td>
+                        <td bgcolor="#e9573f">
+                          <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                              <span class="link-white" style="color:#ffffff; text-decoration:none">
+                                <%= "ENABLE MFA" if @user.mfa_disabled? %>
+                                <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>
+                              </span>
+                            </a>
+                          </div>
+                        </td>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <!-- END Button -->
+      <% end %>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <!-- Adding a horizontal rule -->
+      <table width="100%">
+        <tr>
+          <td width="100%" bgcolor="#cccccc" height="1" style="font-size: 1px; line-height: 1px;">&nbsp;</td>
+        </tr>
+      </table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
+++ b/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
@@ -24,7 +24,7 @@
           <br/>
 
           <p> 
-            To avoid further disruptions on your account, <b>please enable multi-factor authentication 🙏.</b>
+            To re-enable these operations for your account, <b>please enable multi-factor authentication 🙏.</b>
           </p>
           <br/>
         <% elsif @user.mfa_ui_only? %>

--- a/app/views/mailer/mfa_required_popular_gems_announcement.text.erb
+++ b/app/views/mailer/mfa_required_popular_gems_announcement.text.erb
@@ -1,0 +1,24 @@
+👋 Hi <%= @user.handle %>,
+
+Effective today, multi-factor authentication (MFA) is required on your RubyGems account.
+
+<% if @user.mfa_disabled? %> 
+A number of operations are now restricted until you enable MFA.
+
+These restrictions include editing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+
+To avoid further disruptions on your account, please enable multi-factor authentication 🙏.
+<% elsif @user.mfa_ui_only? %>
+Your current MFA level is no longer recommended. In fact, it's deprecated.
+You need to upgrade your RubyGems account to a stronger MFA level 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+
+A number of operations are restricted until you upgrade your MFA setting.
+
+These restrictions include editing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
+<% end %>
+
+For more information, check out our announcement (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
+
+❤️ Thank you for making the RubyGems ecosystem more secure

--- a/app/views/mailer/mfa_required_popular_gems_announcement.text.erb
+++ b/app/views/mailer/mfa_required_popular_gems_announcement.text.erb
@@ -7,7 +7,7 @@ A number of operations are now restricted until you enable MFA.
 
 These restrictions include editing profile pages on the web, signing in on the command line, and performing privileged actions (ie. push, yank, add/remove owners) (https://guides.rubygems.org/mfa-requirement-opt-in/#privileged-operations).
 
-To avoid further disruptions on your account, please enable multi-factor authentication 🙏.
+To re-enable these operations for your account, please enable multi-factor authentication 🙏.
 <% elsif @user.mfa_ui_only? %>
 Your current MFA level is no longer recommended. In fact, it's deprecated.
 You need to upgrade your RubyGems account to a stronger MFA level 🙏.

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -45,6 +45,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.mfa_required_soon_announcement(User.last.id)
   end
 
+  def mfa_required_popular_gems_announcement
+    Mailer.mfa_required_popular_gems_announcement(User.last.id)
+  end
+
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
     Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -80,6 +80,62 @@ class MailerTest < ActionMailer::TestCase
     end
   end
 
+  context "sending mail for mfa required on popular gems announcement" do
+    should "send mail to users with with more than 180M+ downloads and have MFA disabled" do
+      user = create(:user, mfa_level: "disabled")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      Delayed::Worker.new.work_off
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Enabling multi-factor authentication is required on your RubyGems account", email.subject
+      assert_match "Effective today, multi-factor authentication (MFA) is required on your RubyGems account.", email.text_part.body.to_s
+      assert_match "Sending 1 MFA required for popular gems email", @io_output
+    end
+
+    should "send mail to users with more than 180M+ downloads and have weak MFA enabled" do
+      user = create(:user, mfa_level: "ui_only")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      Delayed::Worker.new.work_off
+
+      refute_empty ActionMailer::Base.deliveries
+      email = ActionMailer::Base.deliveries.last
+      assert_equal [user.email], email.to
+      assert_equal ["no-reply@mailer.rubygems.org"], email.from
+      assert_equal "[Action Required] Upgrading the multi-factor authentication level is required on your RubyGems account", email.subject
+      assert_match "Effective today, multi-factor authentication (MFA) is required on your RubyGems account.", email.text_part.body.to_s
+      assert_match "Sending 1 MFA required for popular gems email", @io_output
+    end
+
+    should "not send mail to users with more than 180M+ downloads and have strong MFA enabled" do
+      user = create(:user, mfa_level: "ui_and_api")
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      Delayed::Worker.new.work_off
+
+      assert_empty ActionMailer::Base.deliveries
+      assert_match "Sending 0 MFA required for popular gems email", @io_output
+    end
+
+    should "not send mail to users with less than 180M downloads" do
+      user = create(:user)
+      create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY - 1)
+
+      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      Delayed::Worker.new.work_off
+
+      assert_empty ActionMailer::Base.deliveries
+      assert_match "Sending 0 MFA required for popular gems email", @io_output
+    end
+  end
+
   teardown do
     Rake::Task["mfa_policy:announce_recommendation"].reenable
   end


### PR DESCRIPTION
## 🤷‍♀️ What problem are you solving?
Contributes to https://github.com/Shopify/ruby-conventions/issues/137
Closes https://github.com/rubygems/rubygems.org/issues/3165

We need to send out an email on August 15, 2022 to notify maintainers of gems with 180M+ downloads that MFA enforcement is now in effect. Similar to the [reminder email](https://github.com/rubygems/rubygems.org/pull/3166), this mailer continues with a targeted approach. It's only being sent to impacted users who have not yet enabled MFA (`disabled`), or have weak MFA enabled (`ui_only`).


## 📋 How will you solve this?
🔹 **Create a mailer**
- Adds a mailer action `mfa_required_popular_gems_announcement` and a mailer view in both `HTML` and `plain text` formats
- Note that there are minor copy variations dependent on a user's MFA status:
  - If the user does not have MFA enabled at all (`disabled`)
  - If the user has MFA enabled (`ui_only`)

🔹 **Add rake task for delivering the email** 
- This will be the task that the RubyGems Team will run on `August 15, 2022` to send out this announcement
- Task to be run: `rake mfa_policy:announce_enforcement_for_popular_gems`

🔹 **Set up mailer preview**
- So we can more easily tophat and preview the email in both HTML and plain text, I've set up a mailer preview


## 🎩 Tophat instructions
Below are the instructions for trying this out yourself:

**📧 To preview the email:**
- Once you have the app running (`rails s`) ...
- You can navigate to (`http://localhost:3000/rails/mailers`) to review the list of all mailers available for preview
  - To view this mailer, click on the link titled: `mfa_required_popular_gems_announcement`
- The mailer for this PR is located at `http://localhost:3000/rails/mailers/mailer/mfa_required_soon_announcement`

**👤 To change the user:**
- The user is configured on the mailer preview based on `MailerPreview#mfa_required_popular_gems_announcement`. 
  - To change the user to verify various MFA states, you can either replace `User.last.id` with a different user (e.g. `User.first`)
  - Alternatively, you can adjust the MFA status on your last user

### 👀 Email versions

**🚫 Email for users with MFA disabled**
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/184063897-879fc81f-27d1-4ad9-8412-e859ea27f0ab.png" alt="Email for users with MFA disabled - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/184063904-b9e3bac5-4f7d-4417-8aa9-e984be6ff374.png" alt="Email for users with MFA disabled - Plain text format" width=250 />
  </kbd>
</p>

**🤞 Email for users with MFA enabled (`ui_only`) -- weak MFA**
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/184063825-9967dda8-0d5a-4d0f-bdc5-bc3a85de53a5.png" alt="Email for users with MFA enabled set to ui_only - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/184063838-d103610e-1273-4f4c-8243-9213a3e25848.png" alt="Email for users with MFA enabled set to ui_only - Plain text format" width=250 />
  </kbd>
</p>


