### PR TITLE
Added [ERROR] to CLI error message

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -72,7 +72,7 @@ class Api::BaseController < ApplicationController
 
   def render_mfa_setup_required_error
     error = <<~ERROR.chomp
-      For protection of your account and your gems, you are required to set up multi-factor authentication \
+      [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
       at https://rubygems.org/multifactor_auth/new.
 
       Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -82,7 +82,7 @@ class Api::BaseController < ApplicationController
 
   def render_mfa_strong_level_required_error
     error = <<~ERROR.chomp
-      For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+      [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
       at https://rubygems.org/settings/edit.
 
       Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -321,7 +321,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         should "deny access" do
           assert_response 403
           mfa_error = <<~ERROR.chomp
-            For protection of your account and your gems, you are required to set up multi-factor authentication \
+            [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
             at https://rubygems.org/multifactor_auth/new.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -340,7 +340,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         should "deny access" do
           assert_response 403
           mfa_error = <<~ERROR.chomp
-            For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+            [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
             at https://rubygems.org/settings/edit.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -183,7 +183,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
           should "show error message" do
             mfa_error = <<~ERROR.chomp
-              For protection of your account and your gems, you are required to set up multi-factor authentication \
+              [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
               at https://rubygems.org/multifactor_auth/new.
 
               Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -203,7 +203,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
           should "show error message" do
             mfa_error = <<~ERROR.chomp
-              For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+              [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
               at https://rubygems.org/settings/edit.
 
               Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -331,7 +331,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
               assert_equal 403, @response.status
               mfa_error = <<~ERROR.chomp
-                For protection of your account and your gems, you are required to set up multi-factor authentication \
+                [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
                 at https://rubygems.org/multifactor_auth/new.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -352,7 +352,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
               assert_equal 403, @response.status
               mfa_error = <<~ERROR.chomp
-                For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+                [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
                 at https://rubygems.org/settings/edit.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -680,7 +680,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
               assert_equal 403, response.status
               mfa_error = <<~ERROR.chomp
-                For protection of your account and your gems, you are required to set up multi-factor authentication \
+                [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
                 at https://rubygems.org/multifactor_auth/new.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -701,7 +701,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
               assert_equal 403, @response.status
               mfa_error = <<~ERROR.chomp
-                For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+                [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
                 at https://rubygems.org/settings/edit.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -541,7 +541,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
         should "show error message" do
           mfa_error = <<~ERROR.chomp
-            For protection of your account and your gems, you are required to set up multi-factor authentication \
+            [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
             at https://rubygems.org/multifactor_auth/new.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
@@ -561,7 +561,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
         should "show error message" do
           mfa_error = <<~ERROR.chomp
-            For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
+            [ERROR] For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' \
             at https://rubygems.org/settings/edit.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).


### PR DESCRIPTION
When a user who is the owner of a popular gem  (>180 million downloads) who has MFA disabled or set to UI Only
tries to push, yank, add owner,  remove owner, or signin, all using the CLI, they receive all the normal CLI printouts followed by our error message:

```
For protection of your account and your gems, you are required to change your MFA level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit.

Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
```

This makes it unclear that their action failed, so we should add [ERROR] to the start of this message to make it clearer that the action failed.