### PR TITLE
Tighten word spacing for monospace text

### DIFF
--- a/app/assets/stylesheets/type.css
+++ b/app/assets/stylesheets/type.css
@@ -158,7 +158,8 @@ a.t-list__item {
     word-break: normal; }
 .t-body code {
   font-weight: bold;
-  font-family: "courier", monospace; }
+  font-family: "courier", monospace;
+  word-spacing: -0.2em; }
 .t-body ul, .t-body ol {
   margin-top: 18px; }
   .t-body ul li, .t-body ol li {

--- a/app/assets/stylesheets/type.css
+++ b/app/assets/stylesheets/type.css
@@ -159,7 +159,7 @@ a.t-list__item {
 .t-body code {
   font-weight: bold;
   font-family: "courier", monospace;
-  word-spacing: -0.2em; }
+  word-spacing: -0.3em; }
 .t-body ul, .t-body ol {
   margin-top: 18px; }
   .t-body ul li, .t-body ol li {


### PR DESCRIPTION
@kevinlinxc noticed in the [recent MFA announcement](https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html) that monospace text is very &nbsp; &nbsp;  widely &nbsp;&nbsp; spaced &nbsp; &nbsp; apart. This change narrows the space between words in monospaced text.