### PR TITLE
Add redirect uri to MFA setup and upgrade

### DIFF
--- a/app/controllers/concerns/application_multifactor_methods.rb
+++ b/app/controllers/concerns/application_multifactor_methods.rb
@@ -4,6 +4,7 @@ module ApplicationMultifactorMethods
   included do
     def redirect_to_new_mfa
       message = t("multifactor_auths.setup_required_html")
+      session["mfa_redirect_uri"] = request.path_info
       redirect_to new_multifactor_auth_path, notice_html: message
     end
 
@@ -14,6 +15,7 @@ module ApplicationMultifactorMethods
 
     def redirect_to_settings_strong_mfa_required
       message = t("multifactor_auths.strong_mfa_level_required_html")
+      session["mfa_redirect_uri"] = request.path_info
       redirect_to edit_settings_path, notice_html: message
     end
 

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -20,6 +20,8 @@ class MultifactorAuthsController < ApplicationController
       redirect_to edit_settings_url
     else
       flash[:success] = t(".success")
+      @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
+      session.delete("mfa_redirect_uri")
       render :recovery
     end
   end
@@ -27,10 +29,12 @@ class MultifactorAuthsController < ApplicationController
   def update
     if current_user.otp_verified?(otp_param)
       handle_new_level_param
+      redirect_to session.fetch("mfa_redirect_uri", edit_settings_path)
+      session.delete("mfa_redirect_uri")
     else
       flash[:error] = t("multifactor_auths.incorrect_otp")
+      redirect_to edit_settings_path
     end
-    redirect_to edit_settings_url
   end
 
   private

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -14,5 +14,5 @@
     <%= check_box_tag "ack", "ack", false, class: "form__checkbox__input" %>
     <%= label_tag "checked", t(".saved"), class: "form__checkbox__label" %>
   </div>
-  <%= button_to t(".continue"), edit_settings_path, method: "get", class: "form__submit form__submit--no-hover", disabled: true %>
+  <%= button_to t(".continue"), @continue_path, method: "get", class: "form__submit form__submit--no-hover", disabled: true %>
 </div>

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -121,6 +121,9 @@ class DashboardsControllerTest < ActionController::TestCase
       context "user has mfa disabled" do
         setup { get :show }
         should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should "set mfa_redirect_uri" do
+          assert_equal dashboard_path, session[:mfa_redirect_uri]
+        end
       end
 
       context "user has mfa set to weak level" do
@@ -130,6 +133,9 @@ class DashboardsControllerTest < ActionController::TestCase
         end
 
         should redirect_to("the settings page") { edit_settings_path }
+        should "set mfa_redirect_uri" do
+          assert_equal dashboard_path, session[:mfa_redirect_uri]
+        end
       end
 
       context "user has MFA set to strong level, expect normal behaviour" do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -254,6 +254,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
           context "on PATCH to unconfirmed" do
             setup { patch :unconfirmed }
             should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should "set mfa_redirect_uri" do
+              assert_equal unconfirmed_email_confirmations_path, session[:mfa_redirect_uri]
+            end
           end
 
           context "on GET to new" do
@@ -302,6 +305,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
           context "on PATCH to unconfirmed" do
             setup { patch :unconfirmed }
             should redirect_to("the edit settings page") { edit_settings_path }
+            should "set mfa_redirect_uri" do
+              assert_equal unconfirmed_email_confirmations_path, session[:mfa_redirect_uri]
+            end
           end
 
           context "on GET to new" do

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -26,17 +26,20 @@ class NotifiersControllerTest < ActionController::TestCase
       end
 
       redirect_scenarios = {
-        "GET to show" => [:show, { method: "GET" }],
-        "PATCH to update" => [:update, { method: "PATCH", params: { ownerships: { 1 => { push: "off" } } } }],
-        "PUT to update" => [:update, { method: "PUT", params: { ownerships: { 1 => { push: "off" } } } }]
+        "GET to show" => { action: :show, request: { method: "GET" }, path: "/notifier" },
+        "PATCH to update" => { action: :update, request: { method: "PATCH", params: { ownerships: { 1 => { push: "off" } } } }, path: "/notifier" },
+        "PUT to update" => { action: :update, request: { method: "PUT", params: { ownerships: { 1 => { push: "off" } } } }, path: "/notifier" }
       }
 
       context "user has mfa disabled" do
         redirect_scenarios.each do |label, request_params|
           context "on #{label}" do
-            setup { process(request_params.first, **request_params.last) }
+            setup { process(request_params[:action], **request_params[:request]) }
 
             should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should "set mfa_redirect_uri" do
+              assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]
+            end
           end
         end
       end
@@ -48,9 +51,12 @@ class NotifiersControllerTest < ActionController::TestCase
 
         redirect_scenarios.each do |label, request_params|
           context "on #{label}" do
-            setup { process(request_params.first, **request_params.last) }
+            setup { process(request_params[:action], **request_params[:request]) }
 
             should redirect_to("the settings page") { edit_settings_path }
+            should "set mfa_redirect_uri" do
+              assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]
+            end
           end
         end
       end

--- a/test/functional/ownership_calls_controller_test.rb
+++ b/test/functional/ownership_calls_controller_test.rb
@@ -147,6 +147,9 @@ class OwnershipCallsControllerTest < ActionController::TestCase
             patch :close, params: { rubygem_id: @rubygem.name }
           end
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal close_rubygem_ownership_calls_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "on POST to create" do
@@ -154,6 +157,9 @@ class OwnershipCallsControllerTest < ActionController::TestCase
             post :create, params: { rubygem_id: @rubygem.name, note: "short note" }
           end
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_calls_path, session[:mfa_redirect_uri]
+          end
         end
       end
 
@@ -177,6 +183,9 @@ class OwnershipCallsControllerTest < ActionController::TestCase
             patch :close, params: { rubygem_id: @rubygem.name }
           end
           should redirect_to("edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal close_rubygem_ownership_calls_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "on POST to create" do
@@ -184,6 +193,9 @@ class OwnershipCallsControllerTest < ActionController::TestCase
             post :create, params: { rubygem_id: @rubygem.name, note: "short note" }
           end
           should redirect_to("edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_calls_path, session[:mfa_redirect_uri]
+          end
         end
       end
 

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -263,24 +263,36 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           setup { post :create, params: { rubygem_id: @rubygem.name, note: "small note" } }
 
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_requests_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PATCH to close_all" do
           setup { patch :close_all, params: { rubygem_id: @rubygem.name } }
 
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal close_all_rubygem_ownership_requests_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PATCH to update" do
           setup { patch :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PUT to update" do
           setup { put :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
           should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]
+          end
         end
       end
 
@@ -293,6 +305,9 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           setup { post :create, params: { rubygem_id: @rubygem.name, note: "small note" } }
 
           should redirect_to("the edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_requests_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PATCH to close_all" do
@@ -301,18 +316,27 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           end
 
           should redirect_to("the edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal close_all_rubygem_ownership_requests_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PATCH to update" do
           setup { patch :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
           should redirect_to("the edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]
+          end
         end
 
         context "PUT to update" do
           setup { put :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
           should redirect_to("the edit settings page") { edit_settings_path }
+          should "set mfa_redirect_uri" do
+            assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]
+          end
         end
       end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -249,12 +249,12 @@ class ProfilesControllerTest < ActionController::TestCase
       end
 
       redirect_scenarios = {
-        "GET to adoptions" => [:adoptions, { method: "GET", params: { id: 1 } }],
-        "GET to delete" => [:delete, { method: "GET", params: { id: 1 } }],
-        "DELETE to destroy" => [:destroy, { method: "DELETE", params: { id: 1 } }],
-        "GET to edit" => [:edit, { method: "GET", params: { id: 1 } }],
-        "PATCH to update" => [:update, { method: "PATCH", params: { id: 1 } }],
-        "PUT to update" => [:update, { method: "PUT", params: { id: 1 } }]
+        "GET to adoptions" => { action: :adoptions, request: { method: "GET", params: { id: 1 } }, path: "/profile/adoptions" },
+        "GET to delete" => { action: :delete, request: { method: "GET", params: { id: 1 } }, path: "/profile/delete" },
+        "DELETE to destroy" => { action: :destroy, request: { method: "DELETE", params: { id: 1 } }, path: "/profile" },
+        "GET to edit" => { action: :edit, request: { method: "GET", params: { id: 1 } }, path: "/profile/edit" },
+        "PATCH to update" => { action: :update, request: { method: "PATCH", params: { id: 1 } }, path: "/profile" },
+        "PUT to update" => { action: :update, request: { method: "PUT", params: { id: 1 } }, path: "/profile" }
       }
 
       context "user has mfa disabled" do
@@ -269,9 +269,12 @@ class ProfilesControllerTest < ActionController::TestCase
 
         redirect_scenarios.each do |label, request_params|
           context "on #{label}" do
-            setup { process(request_params.first, **request_params.last) }
+            setup { process(request_params[:action], **request_params[:request]) }
 
             should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should "set mfa_redirect_uri" do
+              assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]
+            end
           end
         end
       end
@@ -292,9 +295,12 @@ class ProfilesControllerTest < ActionController::TestCase
 
         redirect_scenarios.each do |label, request_params|
           context "on #{label}" do
-            setup { process(request_params.first, **request_params.last) }
+            setup { process(request_params[:action], **request_params[:request]) }
 
             should redirect_to("the settings page") { edit_settings_path }
+            should "set mfa_redirect_uri" do
+              assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]
+            end
           end
         end
       end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -302,12 +302,18 @@ class SessionsControllerTest < ActionController::TestCase
         setup { get :verify, params: { user_id: @user.id } }
 
         should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should "set mfa_redirect_uri" do
+          assert_equal verify_session_path, session[:mfa_redirect_uri]
+        end
       end
 
       context "on POST to authenticate" do
         setup { post :authenticate, params: { user_id: @user.id, verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD } } }
 
         should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should "set mfa_redirect_uri" do
+          assert_equal authenticate_session_path, session[:mfa_redirect_uri]
+        end
       end
     end
 
@@ -320,12 +326,18 @@ class SessionsControllerTest < ActionController::TestCase
         setup { get :verify, params: { user_id: @user.id } }
 
         should redirect_to("the settings page") { edit_settings_path }
+        should "set mfa_redirect_uri" do
+          assert_equal verify_session_path, session[:mfa_redirect_uri]
+        end
       end
 
       context "on POST to authenticate" do
         setup { post :authenticate, params: { user_id: @user.id, verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD } } }
 
         should redirect_to("the settings page") { edit_settings_path }
+        should "set mfa_redirect_uri" do
+          assert_equal authenticate_session_path, session[:mfa_redirect_uri]
+        end
       end
     end
 

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -28,6 +28,9 @@ class SettingsControllerTest < ActionController::TestCase
       context "user has mfa disabled" do
         setup { get :edit }
         should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should "set mfa_redirect_uri" do
+          assert_equal edit_settings_path, session[:mfa_redirect_uri]
+        end
       end
 
       context "user has mfa set to weak level" do

--- a/test/integration/multifactor_auths_test.rb
+++ b/test/integration/multifactor_auths_test.rb
@@ -1,0 +1,142 @@
+require "test_helper"
+
+class MultifactorAuthsTest < SystemTest
+  setup do
+    headless_chrome_driver
+    @user = create(:user, email: "testuser@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "testuser")
+    @rubygem = create(:rubygem)
+    create(:ownership, rubygem: @rubygem, user: @user)
+    GemDownload.increment(
+      Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+      rubygem_id: @rubygem.id
+    )
+    @seed = ROTP::Base32.random_base32
+    @totp = ROTP::TOTP.new(@seed)
+  end
+
+  test "user with mfa disabled gets redirected back to adoptions after setting up mfa" do
+    redirect_test_mfa_disabled(adoptions_profile_path)
+  end
+
+  test "user with mfa disabled gets redirected back to dashboard pages after setting up mfa" do
+    redirect_test_mfa_disabled(dashboard_path)
+  end
+
+  test "user with mfa disabled gets redirected back to delete profile pages after setting up mfa" do
+    redirect_test_mfa_disabled(delete_profile_path)
+  end
+
+  test "user with mfa disabled gets redirected back to edit profile pages after setting up mfa" do
+    redirect_test_mfa_disabled(edit_profile_path)
+  end
+
+  test "user with mfa disabled gets redirected back to new api keys pages after setting up mfa" do
+    redirect_test_mfa_disabled(new_profile_api_key_path) { verify_password }
+  end
+
+  test "user with mfa disabled gets redirected back to notifier pages after setting up mfa" do
+    redirect_test_mfa_disabled(notifier_path)
+  end
+
+  test "user with mfa disabled gets redirected back to profile api keys pages after setting up mfa" do
+    create(:api_key, push_rubygem: true, user: @user, ownership: @ownership)
+    redirect_test_mfa_disabled(profile_api_keys_path) { verify_password }
+  end
+
+  test "user with mfa disabled gets redirected back to verify session pages after setting up mfa" do
+    redirect_test_mfa_disabled(verify_session_path)
+  end
+
+  test "user with weak level mfa gets redirected back to adoptions after setting up mfa" do
+    redirect_test_mfa_weak_level(adoptions_profile_path)
+  end
+
+  test "user with weak level mfa gets redirected back to dashboard pages after setting up mfa" do
+    redirect_test_mfa_weak_level(dashboard_path)
+  end
+
+  test "user with weak level mfa gets redirected back to delete profile pages after setting up mfa" do
+    redirect_test_mfa_weak_level(delete_profile_path)
+  end
+
+  test "user with weak level mfa gets redirected back to edit profile pages after setting up mfa" do
+    redirect_test_mfa_weak_level(edit_profile_path)
+  end
+
+  test "user with weak level mfa gets redirected back to new api keys pages after setting up mfa" do
+    redirect_test_mfa_weak_level(new_profile_api_key_path) { verify_password }
+  end
+
+  test "user with weak level mfa gets redirected back to notifier pages after setting up mfa" do
+    redirect_test_mfa_weak_level(notifier_path)
+  end
+
+  test "user with weak level mfa gets redirected back to profile api keys pages after setting up mfa" do
+    create(:api_key, push_rubygem: true, user: @user, ownership: @ownership)
+    redirect_test_mfa_weak_level(profile_api_keys_path) { verify_password }
+  end
+
+  test "user with weak level mfa gets redirected back to verify session pages after setting up mfa" do
+    redirect_test_mfa_weak_level(verify_session_path)
+  end
+
+  def redirect_test_mfa_disabled(path)
+    sign_in
+    visit path
+    assert(page.has_content?("Enabling multi-factor auth"), "#{path} was not redirected to mfa setup page")
+
+    totp = ROTP::TOTP.new(mfa_key)
+    fill_in "otp", with: totp.now
+    click_button "Enable"
+
+    assert page.has_content? "Recovery codes"
+    click_link "[ copy ]"
+    check "ack"
+    click_button "Continue"
+    yield if block_given?
+    assert_equal path, current_path, "was not redirected back to original destination: #{path}"
+  end
+
+  def redirect_test_mfa_weak_level(path)
+    sign_in
+    @user.enable_mfa!(@seed, :ui_only)
+    visit path
+    assert page.has_content? "Edit settings"
+
+    fill_in "otp", with: @totp.now
+    change_auth_level "UI and gem signin"
+
+    yield if block_given?
+    assert_equal path, current_path, "was not redirected back to original destination: #{path}"
+  end
+
+  def sign_in
+    visit sign_in_path
+    fill_in "Email or Username", with: @user.reload.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+  end
+
+  def mfa_key
+    key_regex = /( (\w{4})){8}/
+    page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
+  end
+
+  def verify_password
+    return unless page.has_css? "#verify_password_password"
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Confirm"
+  end
+
+  def change_auth_level(type)
+    page.select type
+    click_button "Update"
+  end
+
+  teardown do
+    @user.disable_mfa!
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+end


### PR DESCRIPTION
Currently, if a user gets redirected to {set up/upgrade} MFA because they own a popular gem and have mfa {disabled/at a weak level}, after they {set up/upgrade} MFA, they get sent to the edit settings page. 

It would be convenient if the site sent them back to where they were trying to go originally, and that's what this PR attempts to do.