### PR TITLE
Set autocomplete value for OTP text field

### DIFF
--- a/app/views/multifactor_auths/new.html.erb
+++ b/app/views/multifactor_auths/new.html.erb
@@ -18,7 +18,7 @@
   <div class="text_field">
     <%= label_tag :otp, 'OTP code', class: 'form__label' %>
     <p class='form__field__instructions'><%= t '.otp_prompt' %></p>
-    <%= text_field_tag :otp, '', class: 'form__input', autocomplete: :off %>
+    <%= text_field_tag :otp, '', class: 'form__input', autocomplete: 'one-time-code' %>
   </div>
   <%= submit_tag t('.enable'), class: 'form__submit' %>
 <% end %>


### PR DESCRIPTION
Autocomplete of the OTP did not work for me on my iPhone. I believe the reason behind is, that the password manager does not recognize the OTP field.

This is why I am proposing to set the autocomplete field to provide a hint for the `one-time-code`.

Ref. https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete