### PR TITLE
Update CI to Ubuntu 20.04.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build:
     name: Docker build (and optional push)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       RUBYGEMS_VERSION: 3.3.11
       RUBY_VERSION: 3.1.2

--- a/.github/workflows/erd.yml
+++ b/.github/workflows/erd.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   erd:
     name: Verify ERD up-to-date
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Install and start database service

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -20,7 +20,7 @@ jobs:
       run: bundle exec rubocop
   brakeman:
     name: Brakeman
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         rubygems_version: ['3.3.11', 'latest']
         ruby_version: ['3.1.2']
     name: Rails tests (Ruby ${{ matrix.ruby_version }}, RubyGems ${{ matrix.rubygems_version }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       RUBYGEMS_VERSION: ${{ matrix.rubygems_version }}
       # If we don't supply a CC_TEST_REPORTER_ID simplecov won't output coverage in a way that


### PR DESCRIPTION
- currently used 18.04 is deprecated (https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

Btw. we can upgrade to 22.04 as well (https://github.com/rubygems/rubygems.org/pull/3188), but there is big change with upgrade to OpenSSL 3 and since our Docker base image is based on Alpine still using OpenSSL 1 I'll prefer to wait for new Alpine release (cca 4 months) and upgrade both at the same time.