### PR TITLE
Use superscript star for a rubygem version date with a tooltip

### DIFF
--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -2,14 +2,16 @@ module VersionsHelper
   def version_date_tag(version)
     data = {}
     klass = ["gem__version__date"]
-    text = version_authored_date(version)
+    date = version_authored_date(version)
     if version.rely_on_built_at?
       klass << "tooltip__text"
       data.merge!(tooltip: t("versions.index.imported_gem_version_notice", import_date: nice_date_for(Version::RUBYGEMS_IMPORT_DATE)))
-      text << " [?]"
     end
 
-    content_tag(:small, text, class: klass, data: data)
+    content_tag(:small, class: klass, data: data) do
+      concat date
+      concat content_tag(:sup, "*") if version.rely_on_built_at?
+    end
   end
 
   def version_authored_date(version)

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -67,22 +67,24 @@ class VersionsControllerTest < ActionController::TestCase
     setup do
       @built_at = Date.parse("2000-01-01")
       rubygem = create(:rubygem)
-      create(:version, rubygem: rubygem, created_at: Version::RUBYGEMS_IMPORT_DATE, built_at: @built_at)
+      create(:version, number: "1.1.2", rubygem: rubygem, created_at: Version::RUBYGEMS_IMPORT_DATE, built_at: @built_at)
       get :index, params: { rubygem_id: rubygem.name }
     end
 
     should respond_with :success
 
-    should "show imported versions authored_at dates with an asterisk" do
+    should "show imported version number with an superscript asterisk and a tooltip" do
       tooltip_text = <<~NOTICE.squish
         This gem version was imported to RubyGems.org on July 25, 2009.
         The date displayed was specified by the author in the gemspec.
       NOTICE
 
-      assert_select ".gem__version__date", text: "- January 01, 2000 [?]", count: 1 do |elements|
+      assert_select ".gem__version__date", text: "- January 01, 2000*", count: 1 do |elements|
         version = elements.first
         assert_equal(tooltip_text, version["data-tooltip"])
       end
+
+      assert_select ".gem__version__date sup", text: "*", count: 1
     end
   end
 


### PR DESCRIPTION
Addresses https://github.com/rubygems/rubygems.org/pull/3115#issuecomment-1204285320

Use a superscript start next to an imported version instead of the `[?]` symbol to indicate presence of a tooltip

New look:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/5512772/186491056-ba3c9c59-1336-4620-bc27-d5b9d881fd2a.png">


~One thing is that maybe we should put the superscript star next to the release date instead of the version number as the date is the piece that has special meaning for these versions~ ✅ Done

cc: @sonalkr132 