### PR TITLE
Simplify API v1 GH scanning endpoint tests.

### DIFF
--- a/test/integration/api/v1/github_secret_scanning_test.rb
+++ b/test/integration/api/v1/github_secret_scanning_test.rb
@@ -14,11 +14,9 @@ class Api::V1::GithubSecretScanningTest < ActionDispatch::IntegrationTest
 
   context "on POST to revoke" do
     setup do
-      key = OpenSSL::PKey::EC.new("secp256k1").generate_key
+      key = OpenSSL::PKey::EC.generate("secp256k1")
       @private_key_pem = key.to_pem
-      pkey = OpenSSL::PKey::EC.new(key.public_key.group)
-      pkey.public_key = key.public_key
-      @public_key_pem = pkey.to_pem
+      @public_key_pem = key.public_to_pem
 
       h = KEYS_RESPONSE_BODY.dup
       h["public_keys"][0]["key"] = @public_key_pem


### PR DESCRIPTION
- makes it OpenSSL 3 compatible at the same time

:information_source: recommended at https://github.com/ruby/openssl/pull/480#issuecomment-1221505331
:information_source: cherry-picked from https://github.com/rubygems/rubygems.org/pull/3188/commits/23d3cabc513de9208784bc989b7e278090cc2120