### PR TITLE
Use recommended to_utf8 method when comparing cert subject.

### DIFF
--- a/test/unit/pusher_test.rb
+++ b/test/unit/pusher_test.rb
@@ -582,7 +582,7 @@ class PusherTest < ActiveSupport::TestCase
       assert_not_nil @cutter.version
       assert_not_nil @cutter.version.cert_chain
       assert_equal 1, @cutter.version.cert_chain.size
-      assert_equal "/CN=snakeoil/DC=example/DC=invalid", @cutter.version.cert_chain.first.subject.to_s
+      assert_equal "CN=snakeoil/DC=example/DC=invalid", @cutter.version.cert_chain.first.subject.to_utf8
     end
 
     teardown { RubygemFs.mock! }


### PR DESCRIPTION
- see https://github.com/ruby/openssl/blob/74041a35d49ac64baf268e0e2e87a6a4311b4f63/ext/openssl/ossl_x509name.c#L280-L302 for more info, this method can be unstable in between OpenSSL versions

:information_source: cherry-picked from https://github.com/rubygems/rubygems.org/pull/3188/files#diff-b21822a11515613ebb78cadf8e145857ba7121fe48d6f77df4da2f5a4c5cbfbc
:information_source: makes it compatible with OpenSSL 3