### PR TITLE
Use Rubocop plugin for CodeClimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,17 +1,4 @@
-version: "2"
-exclude_patterns:
-- "config/"
-- "db/"
-- "dist/"
-- "features/"
-- "**/node_modules/"
-- "script/"
-- "**/spec/"
-- "**/test/"
-- "**/tests/"
-- "**/vendor/"
-- "**/*.d.ts"
-- "app/models/user.rb"
-method-count:
-    config:
-      threshold: 25
+plugins:
+  rubocop:
+    enabled: true
+    channel: "rubocop-1-23-0"


### PR DESCRIPTION
CodeClimate has custom configuration. Currently we lint using Rubocop and code coverage is done using CI CodeCov action. We can give up on CodeClimate at all or try to follow rubocop rules (I'm tryin this in this PR).