### PR TITLE
Fix MFA status label on owners index page

### DIFF
--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -34,7 +34,7 @@
       <td class="owners__cell" data-title="MFA">
         <span class="owners__icon">
           <%= mfa_status(ownership.user) %>
-          <%= t("profiles.edit.mfa.level." + ownership.user.mfa_level) %>
+          <%= t("settings.edit.mfa.level." + ownership.user.mfa_level) %>
         </span>
       </td>
       <td class="owners__cell" data-title="Added By">


### PR DESCRIPTION
The MFA status on the owners list is missing a translation:
 
![image](https://user-images.githubusercontent.com/233676/189224792-2bf724fb-eee4-4eb0-820a-0afbda315709.png)

That's because the status levels are defined under [`settings`](https://github.com/rubygems/rubygems.org/blob/master/config/locales/en.yml#L377-L389) rather than `profiles`.