### PR TITLE
Bump rubocop-rails from 2.15.2 to 2.16.0 and fix issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development, :test do
 
   gem "brakeman", require: false
   gem "rubocop", "~> 1.23", require: false
-  gem "rubocop-rails", "~> 2.12", require: false
+  gem "rubocop-rails", "~> 2.16", require: false
   gem "rubocop-performance", "~> 1.12", require: false
   gem "rubocop-minitest", "~> 0.16", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,10 +380,10 @@ GEM
     rubocop-performance (1.14.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.15.2)
+    rubocop-rails (2.16.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.7.0, < 2.0)
+      rubocop (>= 1.33.0, < 2.0)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
@@ -521,7 +521,7 @@ DEPENDENCIES
   rubocop (~> 1.23)
   rubocop-minitest (~> 0.16)
   rubocop-performance (~> 1.12)
-  rubocop-rails (~> 2.12)
+  rubocop-rails (~> 2.16)
   sassc-rails
   selenium-webdriver
   shoryuken (~> 4.0)

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -21,7 +21,7 @@ class ApiKeysController < ApplicationController
     @api_key = ApiKey.new(build_params)
 
     if @api_key.errors.present?
-      flash[:error] = @api_key.errors.full_messages.to_sentence
+      flash.now[:error] = @api_key.errors.full_messages.to_sentence
       @api_key = current_user.api_keys.build(api_key_params.merge(rubygem_id: nil))
       return render :new
     end
@@ -32,7 +32,7 @@ class ApiKeysController < ApplicationController
       session[:api_key] = key
       redirect_to profile_api_keys_path, flash: { notice: t(".success") }
     else
-      flash[:error] = @api_key.errors.full_messages.to_sentence
+      flash.now[:error] = @api_key.errors.full_messages.to_sentence
       render :new
     end
   end
@@ -50,14 +50,14 @@ class ApiKeysController < ApplicationController
     @api_key.assign_attributes(api_key_params)
 
     if @api_key.errors.present?
-      flash[:error] = @api_key.errors.full_messages.to_sentence
+      flash.now[:error] = @api_key.errors.full_messages.to_sentence
       return render :edit
     end
 
     if @api_key.save
       redirect_to profile_api_keys_path, flash: { notice: t(".success") }
     else
-      flash[:error] = @api_key.errors.full_messages.to_sentence
+      flash.now[:error] = @api_key.errors.full_messages.to_sentence
       render :edit
     end
   end

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -19,7 +19,7 @@ class MultifactorAuthsController < ApplicationController
       flash[:error] = current_user.errors[:base].join
       redirect_to edit_settings_url
     else
-      flash[:success] = t(".success")
+      flash.now[:success] = t(".success")
       @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
       session.delete("mfa_redirect_uri")
       render :recovery

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -77,7 +77,7 @@ class OwnersController < ApplicationController
 
   def index_with_error(msg, status)
     @ownerships = @rubygem.ownerships_including_unconfirmed.includes(:user, :authorizer)
-    flash[:alert] = msg
+    flash.now[:alert] = msg
     render :index, status: status
   end
 


### PR DESCRIPTION
This new version of `rubocop-rails` contains a new cop (`Rails/ActionControllerFlashBeforeRender`) that will detect and fix a well-known bug as [this example](https://github.com/rubygems/rubygems.org/issues/3149)

This PR bumps the `rubocop-rails` version and fixes the other occurrences of that bug.

