### PR TITLE
Refactor rubygems/_dependencies partial template

### DIFF
--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -3,17 +3,11 @@
     <h3 class="t-list__heading"><%= t '.header', :title => dependencies.first.scope.titleize %> (<%= dependencies.size %>):</h3>
     <div class="t-list__items">
       <% dependencies.each do |dependency| %>
-        <% if rubygem = dependency.rubygem %>
-          <li class="gem__requirement-wrap">
-            <%= link_to rubygem_path(rubygem), :class => 't-list__item' do %>
-              <strong><%= rubygem.name %></strong>
-            <% end %>
+        <% dependency.rubygem.tap do |rubygem| %>
+          <div class="<%= class_names("gem__requirement-wrap", "gem__unregistered": !rubygem) %>">
+            <%= link_to_if rubygem, tag.strong(rubygem&.name || dependency.name), {}, class: "t-list__item" %>
             <%= dependency.clean_requirements %>
-          </li>
-        <% elsif dependency&.name %>
-          <p class="t-list__item gem__unregistered" title="unregistered gem">
-            <strong><%= dependency.name %></strong> <%= dependency.clean_requirements %>
-          </p>
+          </div>
         <% end %>
       <% end %>
     </div>

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -332,9 +332,9 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should respond_with :success
-    should "show only dependencies that have rubygem" do
+    should "show dependencies that have rubygem with version" do
       assert page.has_content?(@runtime.rubygem.name)
-      assert page.has_no_content?("1.2.0")
+      assert page.has_content?("1.2.0")
     end
   end
 


### PR DESCRIPTION
Closes #3211

- Removes the conditional blocks
- Removes extra margins around the gems not available on `rubygems.org`.

### Screenshots

| Before | After |
|-|-|
| ![rubygems org_gems_carrierwave_securefile](https://user-images.githubusercontent.com/10229505/189544060-bfd5bf06-655e-4438-8335-9d17c6460d72.png) | ![argon2](https://user-images.githubusercontent.com/10229505/189546750-9551eea6-46e9-4f1e-b56e-52230e09bfc2.png) |

Follows up #3062

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)