### PR TITLE
Re-enable some cops in RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,10 +18,6 @@ AllCops:
 Rails:
   Enabled: true
 
-# TODO: Enable on rubocop 0.67.3
-Rails/ActiveRecordOverride:
-  Enabled: false
-
 Rails/SkipsModelValidations:
   Enabled: false
 
@@ -86,11 +82,6 @@ Metrics/ModuleLength:
 
 Metrics/PerceivedComplexity:
   Max: 10 # TODO: Lower to 7
-
-# TODO: Enable on rubocop 0.67.3
-Naming/RescuedExceptionsVariableName:
-  Exclude:
-    - app/jobs/notifier.rb
 
 Performance/RedundantMerge:
   Enabled: false


### PR DESCRIPTION
Re-enables some cops in RuboCop, which were temporarily disabled in #1961, to decrease `.rubocop.yml` size.

- Follows up #1961

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>