### PR TITLE
Add rake task to migrate mfa `ui_only` users to `ui_and_gem_signin`

### DIFF
--- a/lib/tasks/multifactor_auth.rake
+++ b/lib/tasks/multifactor_auth.rake
@@ -1,0 +1,22 @@
+namespace :multifactor_auth do
+  desc "Migrate user mfa level from ui_only to ui_and_gem_signin"
+  task migrate_ui_only: :environment do
+    users = User.where(mfa_level: :ui_only)
+
+    total = users.count
+    puts "Total: #{total}"
+
+    completed_migrations = 0
+    users.find_each do |user|
+      begin
+        user.update!(mfa_level: :ui_and_gem_signin)
+      rescue StandardError => e
+        puts "Cannot update mfa level for: #{user.handle}"
+        puts "Caught exception: #{e}"
+      end
+
+      completed_migrations += 1
+      print format("\r%.2f%% (%d/%d) complete", completed_migrations.to_f / total * 100.0, completed_migrations, total)
+    end
+  end
+end


### PR DESCRIPTION
Part of https://github.com/rubygems/rubygems.org/issues/2968

Adds a rake task to migrate mfa levels from `ui_only` to `ui_and_gem_signin` for September 22nd.
To run `rake multifactor_auth:migrate_ui_only`.

To test, I added this task to create users of various mfa levels
```
task import_users: :environment do
  (1..500).each do |i|
    user = User.create!(handle: "username#{i}", email: "email#{i}@example.com", password: "passworddslkfslkfnl")
    if i % 4 == 0
      user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
    elsif i % 4 == 1
      user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
    elsif i % 4 == 2
      user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
    end
    puts i
  rescue StandardError => e
    puts e
  end
end
```