### PR TITLE
Use DelayedJob as active job adapter.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,8 @@ module Gemcutter
 
     config.eager_load_paths << Rails.root.join("lib")
     config.toxic_domains_filepath = Rails.root.join("vendor", "toxic_domains_whole.txt")
+
+    config.active_job.queue_adapter = :delayed_job
   end
 
   def self.config


### PR DESCRIPTION
It is not used directly, but we can benefit from this already for some jobs included in gems (like `searchkick`). I'll migrate `delayed` calls to active job classes in next step (if welcomed).