### PR TITLE
Protect the package placeholder name

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -24,6 +24,7 @@ module Patterns
     thread
     unicode_normalize
     ubygems
+    update_with_your_gem_name_prior_to_release_to_rubygems_org
 
     jruby
     mri


### PR DESCRIPTION
In reference to this PR (https://github.com/rubygems/rubygems/pull/6093) we need to protect the placeholder name from being brand jacked:

`update_with_your_gem_name_prior_to_release_to_rubygems_org`