### PR TITLE
Fix Mocha deprecation warnings in tests.

### DIFF
--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -7,6 +7,8 @@ class Net::HTTP::Purge < Net::HTTPRequest
 end
 
 class Fastly
+  # These are not kwargs because delayed_job doesn't correctly support kwargs in Fastly.delay.purge
+  # See: https://github.com/collectiveidea/delayed_job/issues/1134
   def self.purge(options = {})
     return unless ENV["FASTLY_DOMAINS"]
     ENV["FASTLY_DOMAINS"].split(",").each do |domain|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,9 @@ require "helpers/webauthn_helpers"
 
 RubygemFs.mock!
 Aws.config[:stub_responses] = true
+Mocha.configure do |c|
+  c.strict_keyword_argument_matching = true
+end
 
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods

--- a/test/unit/deletion_test.rb
+++ b/test/unit/deletion_test.rb
@@ -120,8 +120,8 @@ class DeletionTest < ActiveSupport::TestCase
       end
 
       should "purge fastly" do
-        Fastly.expects(:purge).with(path: "gems/#{@version.full_name}.gem").times(2)
-        Fastly.expects(:purge).with(path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz").times(2)
+        Fastly.expects(:purge).with({ path: "gems/#{@version.full_name}.gem" }).times(2)
+        Fastly.expects(:purge).with({ path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz" }).times(2)
 
         Delayed::Worker.new.work_off
       end

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -28,7 +28,7 @@ class FastlyTest < ActiveSupport::TestCase
         timeout: 10,
         headers: { "Fastly-Key" => "api-key" }
       }
-      RestClient::Request.expects(:execute).with(params).returns("{}")
+      RestClient::Request.expects(:execute).with(**params).returns("{}")
       Fastly.purge_key("some-key")
     end
   end

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -15,10 +15,13 @@ class GemCachePurgerTest < ActiveSupport::TestCase
     end
 
     should "purge cdn cache" do
-      Fastly.expects(:purge).with(path: "info/#{@gem_name}", soft: true)
-      Fastly.expects(:purge).with(path: "gem/#{@gem_name}", soft: true)
-      Fastly.expects(:purge).with(path: "names", soft: true)
-      Fastly.expects(:purge).with(path: "versions", soft: true)
+      # Purposely uses a hash because delayed_job lacks correct support for kwargs.
+      # Mocha handles kwargs correctly and complains if we expect kwargs when delay sends a hash.
+      # See: https://github.com/collectiveidea/delayed_job/issues/1134
+      Fastly.expects(:purge).with({ path: "info/#{@gem_name}", soft: true })
+      Fastly.expects(:purge).with({ path: "gem/#{@gem_name}", soft: true })
+      Fastly.expects(:purge).with({ path: "names", soft: true })
+      Fastly.expects(:purge).with({ path: "versions", soft: true })
 
       GemCachePurger.call(@gem_name)
       Delayed::Worker.new.work_off


### PR DESCRIPTION
Switches to strict kwarg expectations in mocha.
Conforms to kwarg vs hash arguments where needed.
This also ran into the situation where delayed_job passes kwargs as a hash. I made a comment to explain why we couldn't switch to kwargs in Fastly.purge since it was confusing for me at first and sent me down a small rabbit hole regarding delayed_job ruby 3.0 failures.