### PR TITLE
Create ES index in search_test before relying on it

### DIFF
--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -3,6 +3,10 @@ require "test_helper"
 class SearchTest < SystemTest
   include ESHelper
 
+  setup do
+    Rubygem.__elasticsearch__.create_index! force: true
+  end
+
   test "searching for a gem" do
     create(:rubygem, name: "LDAP", number: "1.0.0")
     create(:rubygem, name: "LDAP-PLUS", number: "1.0.0")


### PR DESCRIPTION
There was an order dependent failure caused by test/integration/search_test.rb using the index without creating it.

We now create the index in that test. Any future tests that need the index should make sure to create it.