### PR TITLE
Add WebAuthn verification URL endpoint

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,11 +27,11 @@ Lint/UselessMethodDefinition:
   Exclude:
     - 'config/initializers/gem_version_monkeypatch.rb'
 
-# Offense count: 15
+# Offense count: 16
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 186
+  Max: 187
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -5,12 +5,12 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
 
       if user
         if user.webauthn_credentials.present?
-          token = user.refresh_webauthn_verification.path_token
-          webauthn_path = "example.com/webauthn/#{token}"
+          verification = user.refresh_webauthn_verification
+          webauthn_path = "example.com/webauthn/#{verification.path_token}"
           respond_to do |format|
             format.any(:all) { render plain: webauthn_path }
-            format.yaml { render yaml: { path: webauthn_path } }
-            format.json { render json: { path: webauthn_path } }
+            format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
+            format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
           end
         else
           render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -6,8 +6,12 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
       if user
         if user.webauthn_credentials.present?
           token = user.refresh_webauthn_verification.path_token
-
-          render yaml: { path: "example.com/webauthn/#{token}" }
+          webauthn_path = "example.com/webauthn/#{token}"
+          respond_to do |format|
+            format.yaml { render yaml: { path: webauthn_path } }
+            format.json { render json: { path: webauthn_path } }
+            format.any(:all) { render plain: webauthn_path }
+          end
         else
           render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -8,9 +8,9 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
           token = user.refresh_webauthn_verification.path_token
           webauthn_path = "example.com/webauthn/#{token}"
           respond_to do |format|
+            format.any(:all) { render plain: webauthn_path }
             format.yaml { render yaml: { path: webauthn_path } }
             format.json { render json: { path: webauthn_path } }
-            format.any(:all) { render plain: webauthn_path }
           end
         else
           render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::WebauthnVerificationsController < Api::BaseController
+  def create
+    authenticate_or_request_with_http_basic do |username, password|
+      user = User.authenticate(username.strip, password)
+
+      if user
+        if user.webauthn_credentials.present?
+          token = user.refresh_webauthn_verification.path_token
+
+          render yaml: { path: "example.com/webauthn/#{token}" }
+        else
+          render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
+        end
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -31,7 +31,7 @@ module UserWebauthnMethods
   def refresh_webauthn_verification
     self.webauthn_verification = WebauthnVerification.create(
       path_token: SecureRandom.base58(16),
-      path_token_expires_at: 5.minutes.from_now,
+      path_token_expires_at: 2.minutes.from_now,
       user_id: id
     )
   end

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -27,4 +27,12 @@ module UserWebauthnMethods
       user_verification: "discouraged"
     )
   end
+
+  def refresh_webauthn_verification
+    self.webauthn_verification = WebauthnVerification.create(
+      path_token: SecureRandom.base58(16),
+      path_token_expires_at: 5.minutes.from_now,
+      user_id: id
+    )
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
         end
       end
       resource :multifactor_auth, only: :show
+      resource :webauthn_verification, only: :create
       resources :profiles, only: :show
       get "profile/me", to: "profiles#me"
       resources :downloads, only: :index do

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -26,11 +26,11 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
 
         token = @user.webauthn_verification.path_token
 
-        if [:json, :yaml].include?(format) # API request from 3rd party client
+        if format == :plain # API request from 3rd party client
+          assert_equal @response.body, "example.com/webauthn/#{token}"
+        else # plain text request, as from gem CLI
           response = YAML.load(@response.body)
           assert_equal response["path"], "example.com/webauthn/#{token}"
-        else # plain text request, as from gem CLI
-          assert_equal @response.body, "example.com/webauthn/#{token}"
         end
       end
     end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -26,9 +26,9 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
 
         token = @user.webauthn_verification.path_token
 
-        if format == :plain # API request from 3rd party client
+        if format == :plain
           assert_equal @response.body, "example.com/webauthn/#{token}"
-        else # plain text request, as from gem CLI
+        else
           response = YAML.load(@response.body)
           assert_equal response["path"], "example.com/webauthn/#{token}"
         end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -11,7 +11,7 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
   end
 
   def self.should_respond_to_format(format)
-    context "when the request asks for format '#{format.to_s}'" do
+    context "when the request asks for format '#{format}'" do
       setup do
         @user = create(:user)
         create(:webauthn_credential, user: @user)

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
+  should "route new paths to new controller" do
+    route = { controller: "api/v1/webauthn_verifications", action: "create" }
+    assert_recognizes(route, { path: "/api/v1/webauthn_verification", method: :post })
+  end
+
+  def authorize_with(str)
+    @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64.encode64(str)}"
+  end
+
+  context "on POST to create" do
+    context "with no credentials" do
+      setup { post :create }
+      should_deny_access
+    end
+
+    context "with invalid credentials" do
+      setup do
+        @user = create(:user)
+        create(:webauthn_credential, user: @user)
+        authorize_with("bad\0:creds")
+        post :create
+      end
+
+      should "deny access" do
+        assert_response 401
+        assert_match "HTTP Basic: Access denied.", @response.body
+      end
+    end
+
+    context "user has enabled webauthn" do
+      setup do
+        @user = create(:user)
+        create(:webauthn_credential, user: @user)
+        authorize_with("#{@user.email}:#{@user.password}")
+        post :create, format: :yaml
+      end
+
+      should respond_with :success
+
+      should "return Webauthn verification URL with path token" do
+        response = YAML.load(@response.body)
+        assert_not_nil response
+
+        token = @user.webauthn_verification.path_token
+
+        assert_equal response["path"], "example.com/webauthn/#{token}"
+      end
+
+      should "not sign in user" do
+        refute_predicate @controller.request.env[:clearance], :signed_in?
+      end
+    end
+
+    context "user has not enabled webauthn" do
+      setup do
+        @user = create(:user)
+        authorize_with("#{@user.email}:#{@user.password}")
+        post :create
+      end
+
+      should respond_with :unprocessable_entity
+      should "tell the user they don't have a WebAuthn hardware token" do
+        assert_match "You don't have any security devices", response.body
+      end
+    end
+  end
+end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -29,7 +29,7 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
         if format == :plain
           assert_equal @response.body, "example.com/webauthn/#{token}"
         else
-          response = YAML.load(@response.body)
+          response = YAML.safe_load(@response.body)
           assert_equal response["path"], "example.com/webauthn/#{token}"
         end
       end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -17,20 +17,24 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
         create(:webauthn_credential, user: @user)
         authorize_with("#{@user.email}:#{@user.password}")
         post :create, format: format
+
+        @token = @user.webauthn_verification.path_token
       end
 
       should respond_with :success
 
-      should "return Webauthn verification URL with path token" do
+      should "have a body" do
         assert_not_nil @response.body
+      end
 
-        token = @user.webauthn_verification.path_token
-
-        if format == :plain
-          assert_equal @response.body, "example.com/webauthn/#{token}"
-        else
+      if format == :plain
+        should "return only the Webauthn verification URL with path token" do
+          assert_equal @response.body, "example.com/webauthn/#{@token}"
+        end
+      else
+        should "return a YAML or JSON document with path token" do
           response = YAML.safe_load(@response.body)
-          assert_equal response["path"], "example.com/webauthn/#{token}"
+          assert_equal response["path"], "example.com/webauthn/#{@token}"
         end
       end
     end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -16,7 +16,10 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
         @user = create(:user)
         create(:webauthn_credential, user: @user)
         authorize_with("#{@user.email}:#{@user.password}")
-        post :create, format: format
+
+        travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
+          post :create, format: format
+        end
 
         @token = @user.webauthn_verification.path_token
       end
@@ -35,6 +38,11 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
         should "return a YAML or JSON document with path token" do
           response = YAML.safe_load(@response.body)
           assert_equal response["path"], "example.com/webauthn/#{@token}"
+        end
+
+        should "return a YAML or JSON document with path expiry" do
+          response = YAML.safe_load(@response.body)
+          assert_equal "2023-01-01T00:02:00.000Z", response["expiry"]
         end
       end
     end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -13,7 +13,10 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "with no credentials" do
       setup { post :create }
-      should_deny_access
+      should "deny access" do
+        assert_response 401
+        assert_match "HTTP Basic: Access denied.", @response.body
+      end
     end
 
     context "with invalid credentials" do

--- a/test/unit/user_webauthn_methods_test.rb
+++ b/test/unit/user_webauthn_methods_test.rb
@@ -53,7 +53,7 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
     end
 
     should "set a 5 minute expiry" do
-      assert_equal Time.utc(2023, 1, 1, 0, 5, 0), @webauthn_verification.path_token_expires_at
+      assert_equal Time.utc(2023, 1, 1, 0, 2, 0), @webauthn_verification.path_token_expires_at
     end
 
     should "store a path token in the database" do

--- a/test/unit/user_webauthn_methods_test.rb
+++ b/test/unit/user_webauthn_methods_test.rb
@@ -43,11 +43,17 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
 
   context "#refresh_webauthn_verification" do
     setup do
-      @webauthn_verification = @user.refresh_webauthn_verification
+      travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
+        @webauthn_verification = @user.refresh_webauthn_verification
+      end
     end
 
     should "create a token that is 16 characters long" do
       assert_equal 16, @webauthn_verification.path_token.length
+    end
+
+    should "set a 5 minute expiry" do
+      assert_equal Time.utc(2023, 1, 1, 0, 5, 0), @webauthn_verification.path_token_expires_at
     end
 
     should "store a path token in the database" do

--- a/test/unit/user_webauthn_methods_test.rb
+++ b/test/unit/user_webauthn_methods_test.rb
@@ -40,4 +40,25 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
       assert_equal [@webauthn_credential.external_id], get_options.allow
     end
   end
+
+  context "#refresh_webauthn_verification" do
+    setup do
+      @webauthn_verification = @user.refresh_webauthn_verification
+    end
+
+    should "create a token that is 16 characters long" do
+      assert_equal 16, @webauthn_verification.path_token.length
+    end
+
+    should "store a path token in the database" do
+      assert_equal @user.webauthn_verification.path_token, @webauthn_verification.path_token
+    end
+
+    should "reset the token each time the method is called" do
+      token_before = @webauthn_verification.path_token
+      @user.refresh_webauthn_verification
+
+      refute_equal token_before, @user.webauthn_verification.path_token
+    end
+  end
 end


### PR DESCRIPTION
## What problem are you solving?

This PR primarily intendeds to add an endpoint to be consumed by the CLI during the WebAuthn verification flow.

Part of https://github.com/rubygems/rubygems.org/pull/3298, which adds WebAuthn verification support to the CLI. It builds on the `WebauthnVerification` model introduced in https://github.com/Shopify/rubygems.org/pull/76.

Added in this PR:
- `/api/v1/webauthn_verification`
- `WebauthnVerificationController`
- `WebauthnUserMethods#refresh_webauthn_verification`

Note: The hostname in generated URLs is hardcoded to example.com, pending followup to use Rails config.

## What approach did you choose and why?

The approach here is a standard Rails controller, with a singular route. This is because only one verification per `User` will be valid at a time. Each time a verification path is requested, the relevant `path_token` is reset.

Logic for creating the `WebauthnVerification` is located in the `UserWebauthnMethods` module. While the underlying data for a verification is properly separated from the User (not all users will have a current verification), the User acts as a natural point at which to request that a new `WebauthnVerification` be created.

## What should reviewers focus on?

The tests were inspired by the tests in [`ApiKeysControllerTest`](https://github.com/rubygems/rubygems.org/blob/master/test/functional/api/v1/api_keys_controller_test.rb), with scenarios removed that didn't make sense (for example, requiring an OTP code doesn't make sense during the Webauthn verification process). I am keen to get feedback on whether the tests have overlooked key scenarios.