### PR TITLE
Fail fast on services down during tests

### DIFF
--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -54,6 +54,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   end
 
   test "/names output" do
+    requires_cache
     get names_path
 
     assert_response :success
@@ -122,6 +123,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   end
 
   test "/info with existing gem" do
+    requires_cache
     expected = <<~VERSIONS_FILE
       ---
       1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,12 @@ class ActiveSupport::TestCase
     Capybara::Node::Simple.new(@response.body)
   end
 
+  def requires_cache
+    Rails.cache.write("test", "test")
+    return if Rails.cache.read("test") == "test"
+    raise "Rails.cache is not working, but was required for this test. Is Memcached running?"
+  end
+
   def requires_toxiproxy
     return if Toxiproxy.running?
     raise "Toxiproxy not running, but REQUIRE_TOXIPROXY was set." if ENV["REQUIRE_TOXIPROXY"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,13 @@ Mocha.configure do |c|
   c.strict_keyword_argument_matching = true
 end
 
+begin
+  Elasticsearch::Model.client.cluster.health
+rescue Faraday::ConnectionFailed => e
+  puts "ElasticSearch is not reachable: #{e}"
+  exit 1
+end
+
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
   include GemHelpers


### PR DESCRIPTION
Sometimes when running the tests I forget to make sure the services are running.

This fails immediately when elasticsearch is not running.

This also fails the 2 tests that directly rely on memcahed to be working.
Since there are only 2 tests, I didn't fail the entire suite at the start. I took a similar approach to `requires_toxiproxy`.