### PR TITLE
Cache usage in GemInfo is already well tested in gem_info_test.rb

### DIFF
--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -60,7 +60,6 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     expected_body = "---\ngemA\ngemA1\ngemA2\ngemB\n"
     assert_equal expected_body, @response.body
     assert_equal etag(expected_body), @response.headers["ETag"]
-    assert_equal %w[gemA gemA1 gemA2 gemB], Rails.cache.read("names")
   end
 
   test "/names partial response" do
@@ -135,7 +134,6 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers["ETag"]
-    assert_equal expected, CompactIndex.info(Rails.cache.read("info/gemA"))
   end
 
   test "/info has surrogate key header" do


### PR DESCRIPTION
Removing these two checks allows the test run to succeed when memcached is not running, simplifying test runs.

The existing tests of GemInfo, which mock Rails.cache, more thoroughly test the caching behavior. I don't think the integration test of the compact index endpoints need to be concerned with the low level behavior.

Fixes one of my concerns in #3307.