### PR TITLE
Reduce 'Cognitive Complexity' of WebauthnVerificationController#create

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -2,21 +2,18 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
   def create
     authenticate_or_request_with_http_basic do |username, password|
       user = User.authenticate(username.strip, password)
+      next false if user.nil?
 
-      if user
-        if user.webauthn_credentials.present?
-          verification = user.refresh_webauthn_verification
-          webauthn_path = "example.com/webauthn/#{verification.path_token}"
-          respond_to do |format|
-            format.any(:all) { render plain: webauthn_path }
-            format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
-            format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
-          end
-        else
-          render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
+      if user.webauthn_credentials.present?
+        verification = user.refresh_webauthn_verification
+        webauthn_path = "example.com/webauthn/#{verification.path_token}"
+        respond_to do |format|
+          format.any(:all) { render plain: webauthn_path }
+          format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
+          format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
         end
       else
-        false
+        render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -2,9 +2,8 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
   def create
     authenticate_or_request_with_http_basic do |username, password|
       user = User.authenticate(username.strip, password)
-      next false if user.nil?
 
-      if user.webauthn_credentials.present?
+      if user&.webauthn_credentials.present?
         verification = user.refresh_webauthn_verification
         webauthn_path = "example.com/webauthn/#{verification.path_token}"
         respond_to do |format|
@@ -12,8 +11,10 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
           format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
           format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
         end
-      else
+      elsif user # the user exists but hasn't configured any credentials
         render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
+      else # invalid user
+        false
       end
     end
   end


### PR DESCRIPTION
## What problem are you solving?

Code Climate didn't run on https://github.com/rubygems/rubygems.org/pull/3305. When running on the subsequent `webauthn-cli` [draft PR](https://github.com/rubygems/rubygems.org/pull/3298) Code Climate [complained that `WebauthnVerificationController#create` was too complex](https://codeclimate.com/github/rubygems/rubygems.org/pull/3298).

## What approach did you choose and why?

In the original `#create` code, we check for the presence of a `user` before proceeding to the main logic. If the user is not present, we provide `false` as the final value of the `authenticate_or_request_with_http_basic` block, which in turn causes Rails to return a `401`.

This means that we have nested if statements, which we believe are the root of Code Climate's objection.

In this PR we extract that user nil check into a standalone guard clause.

Note: because `false` needs to be the value of the block passed to `authenticate_or_request_with_http_basic`, using the `return` keyword doesn't work correctly. The `next` keyword behaves like `return` in a block context, setting the value of the block to `false` when control returns to `authenticate_or_request_with_http_basic`.

## What should reviewers focus on?

Does this code still read clearly to you?