### PR TITLE
Add webauthn verification page

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Lint/UselessMethodDefinition:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 187
+  Max: 188
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
 
       if user&.webauthn_credentials.present?
         verification = user.refresh_webauthn_verification
-        webauthn_path = "example.com/webauthn/#{verification.path_token}"
+        webauthn_path = webauthn_verification_url(verification.path_token)
         respond_to do |format|
           format.any(:all) { render plain: webauthn_path }
           format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -8,11 +8,11 @@ class WebauthnVerificationsController < ApplicationController
   private
 
   def set_user
-    token = WebauthnVerification.find_by(path_token: webauthn_token_param)
-    if !token || token.path_token_expires_at < Time.now.utc
+    verification = WebauthnVerification.find_by(path_token: webauthn_token_param)
+    if !verification || verification.path_token_expires_at < Time.now.utc
       render_not_found
     else
-      @user = token.user
+      @user = verification.user
     end
   end
 

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -1,0 +1,22 @@
+class WebauthnVerificationsController < ApplicationController
+  before_action :set_user, only: :verify
+
+  def verify
+    # TODO: Verify webauthn
+  end
+
+  private
+
+  def set_user
+    token = WebauthnVerification.find_by(path_token: webauthn_token_param)
+    if !token || token.path_token_expires_at < Time.now.utc
+      render_not_found
+    else
+      @user = token.user
+    end
+  end
+
+  def webauthn_token_param
+    params.permit(:webauthn_token).require(:webauthn_token)
+  end
+end

--- a/app/views/webauthn_verifications/verify.html.erb
+++ b/app/views/webauthn_verifications/verify.html.erb
@@ -1,0 +1,16 @@
+<% @title = t("webauthn_verification.title")%>
+
+<% if @user.webauthn_credentials.any? %>
+  <div class="t-body">
+    <h2><%= t("webauthn_verification.authenticating_as") %> <%= @user.name %></h2>
+    <p><%= t("settings.edit.webauthn_credential_note") %></p>
+  </div>
+
+  <%= form_tag webauthn_verification_path, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
+    <div class="form_bottom">
+      <p hidden class="l-text-red-600 js-webauthn-session--error"></p>
+
+      <%= submit_tag t("webauthn_verification.authenticate"), class: 'js-webauthn-session--submit form__submit form__submit--no-hover' %>
+    </div>
+  <% end %>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -348,6 +348,10 @@ de:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,10 @@ en:
       owner_heading: Ownership Notifications
       owner_request_heading: Ownership Request Notifications
       push_heading: Push Notifications
+  webauthn_verification:
+    title: Authenticate with Security Device
+    authenticating_as: Authenticating as
+    authenticate: Authenticate
   owners:
     confirm:
       confirmed_email: You were added as an owner to %{gem} gem

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -370,6 +370,10 @@ es:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -373,6 +373,10 @@ fr:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -335,6 +335,10 @@ ja:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -352,6 +352,10 @@ nl:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -363,6 +363,10 @@ pt-BR:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -335,6 +335,10 @@ zh-CN:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -336,6 +336,10 @@ zh-TW:
       owner_heading:
       owner_request_heading:
       push_heading:
+  webauthn_verification:
+    title:
+    authenticating_as:
+    authenticate:
   owners:
     confirm:
       confirmed_email:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Rails.application.routes.draw do
 
     resources :ownership_calls, only: :index
     resources :webauthn_credentials, only: :destroy
+    get 'webauthn_verification/:webauthn_token', to: 'webauthn_verifications#verify', as: 'webauthn_verification'
 
     ################################################################################
     # Clearance Overrides and Additions

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -32,12 +32,12 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
 
       if format == :plain
         should "return only the Webauthn verification URL with path token" do
-          assert_equal @response.body, "example.com/webauthn/#{@token}"
+          assert_equal @response.body, "http://test.host/webauthn_verification/#{@token}"
         end
       else
         should "return a YAML or JSON document with path token" do
           response = YAML.safe_load(@response.body)
-          assert_equal response["path"], "example.com/webauthn/#{@token}"
+          assert_equal response["path"], "http://test.host/webauthn_verification/#{@token}"
         end
 
         should "return a YAML or JSON document with path expiry" do

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class WebauthnVerificationsControllerTest < ActionController::TestCase
+  context "#verify" do
+    context "when given an expired webauthn token" do
+      setup do
+        @user = create(:user)
+        token = create(:webauthn_verification, user: @user, path_token_expires_at: 1.minute.ago).path_token
+        get :verify, params: { webauthn_token: token }
+      end
+
+      should "return a 404" do
+        assert_response :not_found
+      end
+    end
+
+    context "when given an invalid webauthn token" do
+      setup do
+        @user = create(:user)
+        get :verify, params: { webauthn_token: "not_valid1234" }
+      end
+
+      should "return a 404" do
+        assert_response :not_found
+      end
+    end
+
+    context "when given a valid webauthn token param" do
+      setup do
+        @user = create(:user)
+        create(:webauthn_credential, user: @user)
+        token = create(:webauthn_verification, user: @user).path_token
+        get :verify, params: { webauthn_token: token }
+      end
+
+      should respond_with :success
+      should "render the verification page" do
+        assert page.has_content?("Authenticate with Security Device")
+      end
+
+      should "set the user" do
+        assert page.has_content?(@user.name)
+      end
+
+      should "provide the verification button" do
+        assert page.has_button?("Authenticate")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298, which adds WebAuthn verification support to the CLI.

This follows up on https://github.com/rubygems/rubygems.org/pull/3305, which added the ability to generate a path token and send the verification URL containing that token in the API. Now, we replace the stubbed out `example.com` host for the token by creating the actual verification page that that URL leads to.  We leave the work of actually doing the authentication dance to a future PR. 

## What approach did you choose and why?

The verification url is only valid when given a valid, non-expired token, and it sets the user that you're authenticating as as the user for whom the token is for.

Valid Token: 
<img width="673" alt="image" src="https://user-images.githubusercontent.com/8496209/209398312-b6b46fe7-d8e6-46c4-8363-23ab9c2f0aaa.png">

Invalid Token:
<img width="772" alt="image" src="https://user-images.githubusercontent.com/8496209/209395669-bf73e1d0-ac62-4b7f-afc1-a9f3242d203c.png">


## What should reviewers focus on?

The 404 for invalid tokens is the same approach NPM takes, though they do add an error message to their 404 page that says "Invalid or expired token. Please try again." I considered adding that error here, however our 404 pages are completely static right now and don't take any dynamic content or flash messages. I ultimately decided that a 404 was clear enough without the message and the most idiomatic status. (After all, when you go to `rubygems.org/gems/invalid_gem_name` we don't give you an error explaining that the gem couldn't be found because the gem name is invalid. Its implied in the 404. Why would this be any different?) But I'm open to different opinions. 