### PR TITLE
Upgrade elasticsearch for Ruby 3 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,11 +151,11 @@ GEM
     elasticsearch-api (7.10.1)
       multi_json
     elasticsearch-dsl (0.1.10)
-    elasticsearch-model (7.1.1)
+    elasticsearch-model (7.2.1)
       activesupport (> 3)
-      elasticsearch (> 1)
+      elasticsearch (~> 7)
       hashie
-    elasticsearch-rails (7.1.1)
+    elasticsearch-rails (7.2.1)
     elasticsearch-transport (7.10.1)
       faraday (~> 1)
       multi_json
@@ -168,7 +168,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.0)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -184,8 +184,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -201,7 +201,7 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     gravtastic (3.2.6)
-    hashie (4.1.0)
+    hashie (5.0.0)
     high_voltage (3.1.2)
     honeybadger (5.0.2)
     http-accept (1.7.0)
@@ -264,7 +264,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     msgpack (1.6.0)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     net-imap (0.2.3)
       digest
       net-protocol

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -29,5 +29,5 @@ end
 if Rails.env.development?
   tracer = ActiveSupport::Logger.new('log/elasticsearch.log')
   tracer.level = Logger::DEBUG
-  Elasticsearch::Model.client.transport.tracer = tracer
+  Elasticsearch::Model.client.transport.transport.tracer = tracer
 end


### PR DESCRIPTION
I was getting the following error when running the following command from CONTRIBUTING.md docs:

```
$ bundle exec rake environment elasticsearch:import:all DIR=app/models FORCE=y --trace                                         
** Invoke environment (first_time)
** Execute environment
** Invoke elasticsearch:import:all (first_time)
** Execute elasticsearch:import:all
[IMPORT] Loading models from: app/models
[IMPORT] Processing model: Rubygem...
** Invoke elasticsearch:import:model (first_time)
** Execute elasticsearch:import:model
rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 0)
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/activerecord-7.0.4/lib/active_record/relation/batches.rb:128:in `find_in_batches'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/activerecord-7.0.4/lib/active_record/querying.rb:22:in `find_in_batches'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-model-7.1.1/lib/elasticsearch/model/proxy.rb:121:in `method_missing'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-model-7.1.1/lib/elasticsearch/model/adapters/active_record.rb:105:in `__find_in_batches'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-model-7.1.1/lib/elasticsearch/model/importing.rb:161:in `import'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-rails-7.2.1/lib/elasticsearch/rails/tasks/import.rb:80:in `block (3 levels) in <main>'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-rails-7.2.1/lib/elasticsearch/rails/tasks/import.rb:121:in `block (4 levels) in <main>'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-rails-7.2.1/lib/elasticsearch/rails/tasks/import.rb:104:in `each'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/elasticsearch-rails-7.2.1/lib/elasticsearch/rails/tasks/import.rb:104:in `block (3 levels) in <main>'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:24:in `block (2 levels) in perform'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/command.rb:51:in `invoke'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => elasticsearch:import:model
```

Turns out this is fixed upstream by this PR by @indirect: https://github.com/elastic/elasticsearch-rails/pull/992.

This PR is just a less ambitious version of #3299, just to get past this error.