### PR TITLE
Remove ES test helper in search test.

### DIFF
--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -3,10 +3,6 @@ require "test_helper"
 class SearchTest < SystemTest
   include SearchKickHelper
 
-  setup do
-    Rubygem.__elasticsearch__.create_index! force: true
-  end
-
   test "searching for a gem" do
     create(:rubygem, name: "LDAP", number: "1.0.0")
     create(:rubygem, name: "LDAP-PLUS", number: "1.0.0")


### PR DESCRIPTION
- it was replaced by import_and_refresh

:information_source: @martinemde SearchKick was merged, this is not needed anymore.