### PR TITLE
Introduce timeout on OTP page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,6 +11,8 @@ class SessionsController < Clearance::SessionsController
       setup_webauthn_authentication
       setup_mfa_authentication
 
+      session[:mfa_expires_at] = 15.minutes.from_now
+
       render "sessions/prompt"
     else
       do_login
@@ -23,6 +25,9 @@ class SessionsController < Clearance::SessionsController
 
     if params[:credentials].blank?
       login_failure("Credentials required")
+      return
+    elsif !session_active?
+      login_failure(t("multifactor_auths.session_expired"))
       return
     end
 
@@ -45,17 +50,22 @@ class SessionsController < Clearance::SessionsController
     login_failure(e.message)
   ensure
     session.delete(:webauthn_authentication)
+    session.delete(:mfa_expires_at)
   end
 
   def mfa_create
     @user = User.find(session[:mfa_user])
     session.delete(:mfa_user)
 
-    if @user&.mfa_enabled? && @user&.otp_verified?(params[:otp])
+    if login_conditions_met?
       do_login
+    elsif !session_active?
+      login_failure(t("multifactor_auths.session_expired"))
     else
       login_failure(t("multifactor_auths.incorrect_otp"))
     end
+  ensure
+    session.delete(:mfa_expires_at)
   end
 
   def verify
@@ -95,6 +105,7 @@ class SessionsController < Clearance::SessionsController
 
   def login_failure(message)
     StatsD.increment "login.failure"
+
     respond_to do |format|
       format.json do
         render json: { message: message }, status: :unauthorized
@@ -154,5 +165,13 @@ class SessionsController < Clearance::SessionsController
   def setup_mfa_authentication
     return if @user.mfa_disabled?
     session[:mfa_user] = @user.id
+  end
+
+  def session_active?
+    session[:mfa_expires_at] > Time.current
+  end
+
+  def login_conditions_met?
+    @user&.mfa_enabled? && @user&.otp_verified?(params[:otp]) && session_active?
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -304,6 +304,7 @@ de:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
+    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,6 +291,7 @@ en:
   multifactor_auths:
     recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your multi-factor authentication device or to your security device.'
     incorrect_otp: Your OTP code is incorrect.
+    session_expired: Your login page session has expired.
     otp_code: OTP code
     require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -320,6 +320,7 @@ es:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: Tu código OTP no es correcto.
+    session_expired:
     otp_code: código OTP
     require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para
       reconfigurarla, primero tendrás que desactivarla.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -323,6 +323,7 @@ fr:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: Votre clé OTP est incorrecte.
+    session_expired:
     otp_code: clé OTP
     require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous
       voulez la reconfigurer, vous devez d'abord la désactiver.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -291,6 +291,7 @@ ja:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
+    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -308,6 +308,7 @@ nl:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
+    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -319,6 +319,7 @@ pt-BR:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
+    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -291,6 +291,7 @@ zh-CN:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: 你的 OTP 码 不正确。
+    session_expired:
     otp_code: OTP 码
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -292,6 +292,7 @@ zh-TW:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: 你的 OTP 碼 不正確。
+    session_expired:
     otp_code: OTP 碼
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
@@ -527,7 +528,6 @@ zh-TW:
       otp_or_recovery:
       security_device:
       verify_code:
-
   stats:
     index:
       title:

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -79,6 +79,26 @@ class SignInTest < SystemTest
     assert page.has_content? "Sign out"
   end
 
+  test "signing in with current valid otp when mfa enabled but 30 minutes has passed" do
+    visit sign_in_path
+    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Multi-factor authentication"
+
+    travel 30.minutes do
+      within(".mfa-form") do
+        fill_in "OTP or recovery code", with: ROTP::TOTP.new("thisisonemfaseed").now
+        click_button "Verify code"
+      end
+
+      assert page.has_content? "Sign in"
+      expected_notice = "Your login page session has expired."
+      assert page.has_selector? "#flash_notice", text: expected_notice
+    end
+  end
+
   test "signing in with invalid otp when mfa enabled" do
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
@@ -264,6 +284,31 @@ class SignInTest < SystemTest
 
     # Cleanup test data
     @authenticator.remove!
+  end
+
+  test "sign in with webauthn but it expired" do
+    create_webauthn_credential
+
+    visit sign_in_path
+
+    fill_in "Email or Username", with: @user.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+
+    WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true
+
+    travel 30.minutes do
+      click_on "Authenticate with security device"
+
+      assert page.has_content? "Your login page session has expired."
+      assert page.has_content? "Multi-factor authentication"
+
+      # Cleanup test data
+      @authenticator.remove!
+    end
   end
 
   test "signing out" do


### PR DESCRIPTION
Rubygems.org suffered a vulnerability where the OTP page didn't timeout, allowing an OTP code to be used for login even after password was changed. This PR introduces a timeout to the page by allowing the user to only have 15 minutes from the time OTP was request to when they can submit.

Closes #3279 

If more than 15 minutes is taken by the user to enter an OTP, the user will not be logged in, and will be directed back to the login page with an error informing them the session expired. 

<img width="1155" alt="Screenshot 2023-01-06 at 2 59 47 PM" src="https://user-images.githubusercontent.com/71022385/211091850-84d7f2e3-ee43-44bd-928e-1051130c3ede.png">
