### PR TITLE
Webauthn tokens expire after use

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -1,3 +1,5 @@
+# This controller generates a single-use link as part of the Webauthn CLI flow. It does not challenge
+# the user with a Webauthn login. That is done in controllers/webauthn_verifications_controller.
 class Api::V1::WebauthnVerificationsController < Api::BaseController
   def create
     authenticate_or_request_with_http_basic do |username, password|

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -2,7 +2,6 @@
 # by the APIv1 WebauthnVerificationsController (controllers/api/v1/webauthn_verifications_controller).
 class WebauthnVerificationsController < ApplicationController
   before_action :set_verification, :set_user
-  after_action :expire_webauthn_verification, only: :authenticate
 
   def prompt
     redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?
@@ -24,6 +23,8 @@ class WebauthnVerificationsController < ApplicationController
 
     user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
     # TODO: generate webauthn verification otp
+
+    expire_webauthn_verification
 
     # TODO: render html with webauthn verification otp instead of json
     render json: { message: "success" }

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -2,12 +2,13 @@ class WebauthnVerificationsController < ApplicationController
   before_action :set_user
 
   def prompt
-    redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?
+    redirect_to root_path, alert: t("webauthn_verifications.prompt.no_webauthn_devices") if @user.webauthn_credentials.blank?
 
     @webauthn_options = @user.webauthn_options_for_get
 
     session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge
+      "challenge" => @webauthn_options.challenge,
+      "user" => @user.id
     }
   end
 

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -1,3 +1,5 @@
+# This controller is for the user interface Webauthn challenge after a user follows a link generated
+# by the APIv1 WebauthnVerificationsController (controllers/api/v1/webauthn_verifications_controller).
 class WebauthnVerificationsController < ApplicationController
   before_action :set_user
 

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -24,7 +24,7 @@ class WebauthnVerificationsController < ApplicationController
     user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
     # TODO: generate webauthn verification otp
 
-    expire_webauthn_verification
+    @verification.expire_path_token
 
     # TODO: render html with webauthn verification otp instead of json
     render json: { message: "success" }
@@ -47,11 +47,6 @@ class WebauthnVerificationsController < ApplicationController
 
   def set_user
     @user = @verification.user
-  end
-
-  def expire_webauthn_verification
-    @verification.path_token_expires_at = 1.second.ago
-    @verification.save!
   end
 
   def webauthn_credential

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -42,7 +42,7 @@ class WebauthnVerificationsController < ApplicationController
     @verification = WebauthnVerification.find_by(path_token: webauthn_token_param)
 
     render_not_found and return unless @verification
-    redirect_to root_path, alert: t(".expired_or_already_used") if @verification.path_token_expires_at < Time.now.utc
+    redirect_to root_path, alert: t(".expired_or_already_used") if @verification.path_token_expired?
   end
 
   def set_user

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -4,4 +4,9 @@ class WebauthnVerification < ApplicationRecord
   validates :user_id, uniqueness: true
   validates :path_token, presence: true, uniqueness: true
   validates :path_token_expires_at, presence: true
+
+  def expire_path_token
+    self.path_token_expires_at = 1.second.ago
+    self.save!
+  end
 end

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -7,10 +7,10 @@ class WebauthnVerification < ApplicationRecord
 
   def expire_path_token
     self.path_token_expires_at = 1.second.ago
-    self.save!
+    save!
   end
 
   def path_token_expired?
-    self.path_token_expires_at < Time.now.utc
+    path_token_expires_at < Time.now.utc
   end
 end

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -9,4 +9,8 @@ class WebauthnVerification < ApplicationRecord
     self.path_token_expires_at = 1.second.ago
     self.save!
   end
+
+  def path_token_expired?
+    self.path_token_expires_at < Time.now.utc
+  end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -355,6 +355,8 @@ de:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,8 @@ en:
       authenticating_as: Authenticating as
       authenticate: Authenticate
       no_webauthn_devices: You don't have any security devices enabled
+    authenticate:
+      expired_or_already_used: The token in the link you used has either expired or been used already.
   owners:
     confirm:
       confirmed_email: You were added as an owner to %{gem} gem

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -377,6 +377,8 @@ es:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -380,6 +380,8 @@ fr:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -342,6 +342,8 @@ ja:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -359,6 +359,8 @@ nl:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -370,6 +370,8 @@ pt-BR:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -342,6 +342,8 @@ zh-CN:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -343,6 +343,8 @@ zh-TW:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    authenticate:
+      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -218,9 +218,9 @@ FactoryBot.define do
   factory :webauthn_verification do
     user
     path_token { SecureRandom.base58(20) }
-    path_token_expires_at { Time.now.utc + 1.minute }
+    path_token_expires_at { Time.now.utc + 2.minute }
     otp { SecureRandom.base58(20) }
-    otp_expires_at { Time.now.utc + 1.minute }
+    otp_expires_at { Time.now.utc + 2.minute }
   end
 
   factory :api_key_rubygem_scope do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -218,9 +218,9 @@ FactoryBot.define do
   factory :webauthn_verification do
     user
     path_token { SecureRandom.base58(20) }
-    path_token_expires_at { Time.now.utc + 2.minute }
+    path_token_expires_at { Time.now.utc + 2.minutes }
     otp { SecureRandom.base58(20) }
-    otp_expires_at { Time.now.utc + 2.minute }
+    otp_expires_at { Time.now.utc + 2.minutes }
   end
 
   factory :api_key_rubygem_scope do

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
 
+# Not to be confused with WebauthnVerificationsControllerTest. This is for the API.
+
 class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
   should "route new paths to new controller" do
     route = { controller: "api/v1/webauthn_verifications", action: "create" }

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -39,6 +39,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
 
         should respond_with :success
         should "set webauthn authentication" do
+          assert_equal @user.id, session[:webauthn_authentication]["user"]
           assert_not_nil session[:webauthn_authentication]["challenge"]
         end
 

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
 
+# Not to be confused with Api::V1::WebauthnVerificationsControllerTest. This is for the UI.
+
 class WebauthnVerificationsControllerTest < ActionController::TestCase
   context "#prompt" do
     context "when given an expired webauthn token" do

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -123,6 +123,11 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should "return error message" do
         assert_equal "Credentials required", JSON.parse(response.body)["message"]
       end
+
+      should "not expire the path token" do
+        verification = WebauthnVerification.find_by!(path_token: @token)
+        assert_equal Time.utc(2023, 1, 1, 0, 2, 0), verification.path_token_expires_at
+      end
     end
 
     context "when providing wrong credentials" do

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -4,18 +4,6 @@ require "test_helper"
 
 class WebauthnVerificationsControllerTest < ActionController::TestCase
   context "#prompt" do
-    context "when given an expired webauthn token" do
-      setup do
-        @user = create(:user)
-        token = create(:webauthn_verification, user: @user, path_token_expires_at: 1.minute.ago).path_token
-        get :prompt, params: { webauthn_token: token }
-      end
-
-      should "return a 404" do
-        assert_response :not_found
-      end
-    end
-
     context "when given an invalid webauthn token" do
       setup do
         @user = create(:user)
@@ -41,7 +29,6 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
 
         should respond_with :success
         should "set webauthn authentication" do
-          assert_equal @user.id, session[:webauthn_authentication]["user"]
           assert_not_nil session[:webauthn_authentication]["challenge"]
         end
 
@@ -76,8 +63,10 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
     setup do
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
-      @token = create(:webauthn_verification, user: @user).path_token
-      get :prompt, params: { webauthn_token: @token }
+      travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
+        @token = create(:webauthn_verification, user: @user).path_token
+        get :prompt, params: { webauthn_token: @token }
+      end
     end
 
     context "when verifying the challenge" do
@@ -90,35 +79,44 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
           webauthn_credential: @webauthn_credential,
           client: @client
         )
-        post(
-          :authenticate,
-          params: {
-            credentials:
-              WebauthnHelpers.get_result(
-                client: @client,
-                challenge: @challenge
-              ),
-            webauthn_token: @token
-          },
-          format: :json
-        )
+        travel_to Time.utc(2023, 1, 1, 0, 0, 3) do
+          post(
+            :authenticate,
+            params: {
+              credentials:
+                WebauthnHelpers.get_result(
+                  client: @client,
+                  challenge: @challenge
+                ),
+              webauthn_token: @token
+            },
+            format: :json
+          )
+        end
       end
 
       should respond_with :success
       should "return success message" do
         assert_equal "success", JSON.parse(response.body)["message"]
       end
+
+      should "expire the path token by setting its expiry to 1 second prior" do
+        verification = WebauthnVerification.find_by!(path_token: @token)
+        assert_equal Time.utc(2023, 1, 1, 0, 0, 2), verification.path_token_expires_at
+      end
     end
 
     context "when not providing credentials" do
       setup do
-        post(
-          :authenticate,
-          params: {
-            webauthn_token: @token
-          },
-          format: :json
-        )
+        travel_to Time.utc(2023, 1, 1, 0, 0, 3) do
+          post(
+            :authenticate,
+            params: {
+              webauthn_token: @token
+            },
+            format: :json
+          )
+        end
       end
 
       should respond_with :unauthorized
@@ -137,18 +135,20 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
           webauthn_credential: @webauthn_credential,
           client: @client
         )
-        post(
-          :authenticate,
-          params: {
-            credentials:
-              WebauthnHelpers.get_result(
-                client: @client,
-                challenge: @wrong_challenge
-              ),
-            webauthn_token: @token
-          },
-          format: :json
-        )
+        travel_to Time.utc(2023, 1, 1, 0, 0, 3) do
+          post(
+            :authenticate,
+            params: {
+              credentials:
+                WebauthnHelpers.get_result(
+                  client: @client,
+                  challenge: @wrong_challenge
+                ),
+              webauthn_token: @token
+            },
+            format: :json
+          )
+        end
       end
 
       should respond_with :unauthorized
@@ -168,21 +168,56 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
           webauthn_credential: @webauthn_credential,
           client: @client
         )
-        post(
-          :authenticate,
-          params: {
-            credentials:
-              WebauthnHelpers.get_result(
-                client: @client,
-                challenge: @challenge
-              ),
-            webauthn_token: @wrong_webuthn_token
-          },
-          format: :json
-        )
+        travel_to Time.utc(2023, 1, 1, 0, 0, 3) do
+          post(
+            :authenticate,
+            params: {
+              credentials:
+                WebauthnHelpers.get_result(
+                  client: @client,
+                  challenge: @challenge
+                ),
+              webauthn_token: @wrong_webuthn_token
+            },
+            format: :json
+          )
+        end
       end
 
       should respond_with :not_found
+    end
+
+    context "when the webauthn token has expired" do
+      setup do
+        @challenge = session[:webauthn_authentication]["challenge"]
+        @origin = "http://localhost:3000"
+        @rp_id = URI.parse(@origin).host
+        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+        WebauthnHelpers.create_credential(
+          webauthn_credential: @webauthn_credential,
+          client: @client
+        )
+        travel_to Time.utc(2023, 1, 1, 0, 3, 0) do
+          post(
+            :authenticate,
+            params: {
+              credentials:
+                WebauthnHelpers.get_result(
+                  client: @client,
+                  challenge: @challenge
+                ),
+              webauthn_token: @token
+            },
+            format: :json
+          )
+        end
+      end
+
+      should respond_with :redirect
+      should redirect_to("the homepage") { root_url }
+      should "say the token is consumed or expired" do
+        assert_equal "The token in the link you used has either expired or been used already.", flash[:alert]
+      end
     end
   end
 end

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -25,4 +25,29 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#path_token_expired?" do
+    setup do
+      travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
+        user = create(:user)
+        @verification = create(:webauthn_verification, user: user)
+      end
+    end
+
+    context "when the token is still live" do
+      should "return false" do
+        travel_to Time.utc(2023, 1, 1, 0, 0, 1) do
+          refute @verification.path_token_expired?
+        end
+      end
+    end
+
+    context "when the token has expired" do
+      should "return true" do
+        travel_to Time.utc(2023, 9, 9, 9, 9, 9) do
+          assert @verification.path_token_expired?
+        end
+      end
+    end
+  end
 end

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -37,7 +37,7 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
     context "when the token is still live" do
       should "return false" do
         travel_to Time.utc(2023, 1, 1, 0, 0, 1) do
-          refute @verification.path_token_expired?
+          refute_predicate @verification, :path_token_expired?
         end
       end
     end
@@ -45,7 +45,7 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
     context "when the token has expired" do
       should "return true" do
         travel_to Time.utc(2023, 9, 9, 9, 9, 9) do
-          assert @verification.path_token_expired?
+          assert_predicate @verification, :path_token_expired?
         end
       end
     end

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -9,4 +9,20 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
   should validate_presence_of(:path_token)
   should validate_uniqueness_of(:path_token)
   should validate_presence_of(:path_token_expires_at)
+
+  context "#expire_path_token" do
+    setup do
+      travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
+        user = create(:user)
+        @verification = create(:webauthn_verification, user: user)
+      end
+    end
+
+    should "set the path_token_expires_at to 1 second ago" do
+      travel_to Time.utc(2023, 1, 1, 0, 1, 0) do
+        @verification.expire_path_token
+        assert_equal Time.utc(2023, 1, 1, 0, 0, 59), @verification.path_token_expires_at
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What problem are you solving?

In the event that a user leaks their `/webauthn_verification/<path_token>` link after using it, an attacker can use it to obtain an OTP for MFA.

The scenario is unlikely but easy to guard against.

## What approach did you choose and why?

Two alternatives were considered. The first was to simply delete the `WebauthnVerification` record attached to a user. The second was to set `path_token_expired_at` to a past time, so that it is considered expired.

The second option was chosen, so that the UI can distinguish between tokens that are invalid (giving a 404) and tokens which have expired or been consumed (giving a 410). Deletion would have meant that all consumed tokens would give a 404, which would be confusing to users who do not know the internal logic of the system.

The downside of this approach is that the `webauthn_verifications` table can grow indefinitely. In future it will probably be necessary to add a regular job to delete tokens with an expiry date that is sufficiently old (e.g. 3 days old).

## What should reviewers focus on?

~I'm not super pleased that the handling of expired tokens occurs in `set_user` and I'm open to suggestions about better ways to split up the task of finding a user and deciding what to render.~