### PR TITLE
Add Webauthn Verification authenticate endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - test/**/*.rb
-    - 'config/routes.rb'
+    - lib/tasks/**/*.rake
+    - app/models/concerns/**/*.rb
+    - config/routes.rb
 
 Metrics/ClassLength:
   Max: 350 # TODO: Lower to 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - test/**/*.rb
+    - 'config/routes.rb'
 
 Metrics/ClassLength:
   Max: 350 # TODO: Lower to 100

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,11 +27,11 @@ Lint/UselessMethodDefinition:
   Exclude:
     - 'config/initializers/gem_version_monkeypatch.rb'
 
-# Offense count: 16
+# Offense count: 4
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 188
+  Max: 48
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -1,5 +1,5 @@
 class WebauthnVerificationsController < ApplicationController
-  before_action :set_user, only: :prompt
+  before_action :set_user
 
   def prompt
     redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?
@@ -12,6 +12,27 @@ class WebauthnVerificationsController < ApplicationController
     }
   end
 
+  def authenticate
+    # TODO: check if path token is expired
+    webauthn_credential.verify(
+      challenge,
+      public_key: user_webauthn_credential.public_key,
+      sign_count: user_webauthn_credential.sign_count
+    )
+
+    user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
+    # TODO: generate webauthn verification otp
+
+    # TODO: render html with webauthn verification otp instead of json
+    render json: { message: "success" }
+  rescue WebAuthn::Error => e
+    render json: { message: e.message }, status: :unauthorized
+  rescue ActionController::ParameterMissing
+    render json: { message: "Credentials required" }, status: :unauthorized
+  ensure
+    session.delete(:webauthn_authentication)
+  end
+
   private
 
   def set_user
@@ -21,6 +42,29 @@ class WebauthnVerificationsController < ApplicationController
     else
       @user = verification.user
     end
+  end
+
+  def webauthn_credential
+    @webauthn_credential ||= WebAuthn::Credential.from_get(credential_params)
+  end
+
+  def user_webauthn_credential
+    @user_webauthn_credential ||= @user.webauthn_credentials.find_by(
+      external_id: webauthn_credential.id
+    )
+  end
+
+  def challenge
+    session.dig(:webauthn_authentication, "challenge")
+  end
+
+  def credential_params
+    @credential_params ||= params.require(:credentials).permit(
+      :id,
+      :type,
+      :rawId,
+      response: %i[authenticatorData attestationObject clientDataJSON signature]
+    )
   end
 
   def webauthn_token_param

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -7,8 +7,7 @@ class WebauthnVerificationsController < ApplicationController
     @webauthn_options = @user.webauthn_options_for_get
 
     session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge,
-      "user" => @user.id
+      "challenge" => @webauthn_options.challenge
     }
   end
 

--- a/app/views/webauthn_verifications/prompt.html.erb
+++ b/app/views/webauthn_verifications/prompt.html.erb
@@ -6,7 +6,7 @@
     <p><%= t("settings.edit.webauthn_credential_note") %></p>
   </div>
 
-  <%= form_tag webauthn_verification_path, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
+  <%= form_tag authenticate_webauthn_verification_path, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
     <div class="form_bottom">
       <p hidden class="l-text-red-600 js-webauthn-session--error"></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,11 @@ Rails.application.routes.draw do
 
     resources :ownership_calls, only: :index
     resources :webauthn_credentials, only: :destroy
-    get 'webauthn_verification/:webauthn_token', to: 'webauthn_verifications#prompt', as: 'webauthn_verification'
+    resource :webauthn_verification, only: [] do
+      get ':webauthn_token', to: 'webauthn_verifications#prompt', as: ''
+      # TODO: add html as a valid format
+      post ':webauthn_token', to: 'webauthn_verifications#authenticate', as: :authenticate, constraints: { format: /json/ }
+    end
 
     ################################################################################
     # Clearance Overrides and Additions

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -69,4 +69,118 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "#authenticate" do
+    setup do
+      @user = create(:user)
+      @webauthn_credential = create(:webauthn_credential, user: @user)
+      @token = create(:webauthn_verification, user: @user).path_token
+      get :prompt, params: { webauthn_token: @token }
+    end
+
+    context "when verifying the challenge" do
+      setup do
+        @challenge = session[:webauthn_authentication]["challenge"]
+        @origin = "http://localhost:3000"
+        @rp_id = URI.parse(@origin).host
+        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+        WebauthnHelpers.create_credential(
+          webauthn_credential: @webauthn_credential,
+          client: @client
+        )
+        post(
+          :authenticate,
+          params: {
+            credentials:
+              WebauthnHelpers.get_result(
+                client: @client,
+                challenge: @challenge
+              ),
+            webauthn_token: @token
+          },
+          format: :json
+        )
+      end
+
+      should respond_with :success
+      should "return success message" do
+        assert_equal "success", JSON.parse(response.body)["message"]
+      end
+    end
+
+    context "when not providing credentials" do
+      setup do
+        post(
+          :authenticate,
+          params: {
+            webauthn_token: @token
+          },
+          format: :json
+        )
+      end
+
+      should respond_with :unauthorized
+      should "return error message" do
+        assert_equal "Credentials required", JSON.parse(response.body)["message"]
+      end
+    end
+
+    context "when providing wrong credentials" do
+      setup do
+        @wrong_challenge = "16b8e11ea1b46abc64aea3ecdac1c418"
+        @origin = "http://localhost:3000"
+        @rp_id = URI.parse(@origin).host
+        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+        WebauthnHelpers.create_credential(
+          webauthn_credential: @webauthn_credential,
+          client: @client
+        )
+        post(
+          :authenticate,
+          params: {
+            credentials:
+              WebauthnHelpers.get_result(
+                client: @client,
+                challenge: @wrong_challenge
+              ),
+            webauthn_token: @token
+          },
+          format: :json
+        )
+      end
+
+      should respond_with :unauthorized
+      should "return error message" do
+        assert_equal "WebAuthn::ChallengeVerificationError", JSON.parse(response.body)["message"]
+      end
+    end
+
+    context "when given an invalid webauthn token" do
+      setup do
+        @wrong_webuthn_token = "pRpwn2mTH2D18t58"
+        @challenge = session[:webauthn_authentication]["challenge"]
+        @origin = "http://localhost:3000"
+        @rp_id = URI.parse(@origin).host
+        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+        WebauthnHelpers.create_credential(
+          webauthn_credential: @webauthn_credential,
+          client: @client
+        )
+        post(
+          :authenticate,
+          params: {
+            credentials:
+              WebauthnHelpers.get_result(
+                client: @client,
+                challenge: @challenge
+              ),
+            webauthn_token: @wrong_webuthn_token
+          },
+          format: :json
+        )
+      end
+
+      should respond_with :not_found
+    end
+  end
 end

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -39,7 +39,6 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
 
         should respond_with :success
         should "set webauthn authentication" do
-          assert_equal @user.id, session[:webauthn_authentication]["user"]
           assert_not_nil session[:webauthn_authentication]["challenge"]
         end
 


### PR DESCRIPTION
## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298

Creates the endpoint for the authentication of the webauthn credential. If successful, a json payload of  `{"message": "success"}` will be returned. Otherwise,  `{"message": error_message}` would be returned.

## What approach did you choose and why?
- The logic is inspired off of the [logic in the sessions controller](https://github.com/rubygems/rubygems.org/blob/master/app/controllers/sessions_controller.rb#L22-L54). I memoized the different variables used to reduce the size of the original method.
- Removing user as a part of `session[:webauthn_authentication]`, we should be using the webauthn path token to find the user.

## What should reviewers focus on?
- Any missing test cases
- Is authenticate the right action name? Was thinking between authenticate or verify, but chose authenticate since verify might be confused with the webauthn verification object itself.

## Testing

Follow the tophat instructions from https://github.com/rubygems/rubygems.org/pull/3324 to get to the prompt page. You are able to authenticate your webauthn credential when clicking the button.

<img width="1091" alt="Screenshot 2023-01-10 at 1 52 52 PM" src="https://user-images.githubusercontent.com/42748004/211637114-0f68f968-126a-41f1-96cf-4e55d62b098c.png">
