### PR TITLE
Fix dependabot.yml syntax.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
-
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
- corrupted by automated PR https://github.com/rubygems/rubygems.org/pull/3314