### PR TITLE
Revert "Introduce timeout on OTP page"

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -304,7 +304,6 @@ de:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
-    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,7 +291,6 @@ en:
   multifactor_auths:
     recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your multi-factor authentication device or to your security device.'
     incorrect_otp: Your OTP code is incorrect.
-    session_expired: Your login page session has expired.
     otp_code: OTP code
     require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -320,7 +320,6 @@ es:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: Tu código OTP no es correcto.
-    session_expired:
     otp_code: código OTP
     require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para
       reconfigurarla, primero tendrás que desactivarla.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -323,7 +323,6 @@ fr:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: Votre clé OTP est incorrecte.
-    session_expired:
     otp_code: clé OTP
     require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous
       voulez la reconfigurer, vous devez d'abord la désactiver.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -291,7 +291,6 @@ ja:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
-    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -308,7 +308,6 @@ nl:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
-    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -319,7 +319,6 @@ pt-BR:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp:
-    session_expired:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -291,7 +291,6 @@ zh-CN:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: 你的 OTP 码 不正确。
-    session_expired:
     otp_code: OTP 码
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -292,7 +292,6 @@ zh-TW:
   multifactor_auths:
     recovery_code_html:
     incorrect_otp: 你的 OTP 碼 不正確。
-    session_expired:
     otp_code: OTP 碼
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
@@ -528,6 +527,7 @@ zh-TW:
       otp_or_recovery:
       security_device:
       verify_code:
+
   stats:
     index:
       title:

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -21,10 +21,6 @@ class SessionsControllerTest < ActionController::TestCase
     end
 
     context "on POST to mfa_create" do
-      setup do
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now
-      end
-
       context "when OTP is correct" do
         setup do
           @controller.session[:mfa_user] = @user.id
@@ -82,35 +78,6 @@ class SessionsControllerTest < ActionController::TestCase
         end
       end
     end
-
-    context "when OTP is correct but session expired" do
-      setup do
-        @controller.session[:mfa_user] = @user.id
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now
-        travel 30.minutes
-
-        post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
-      end
-
-      should set_flash.now[:notice]
-      should respond_with :unauthorized
-
-      should "clear mfa_expires_at" do
-        assert_nil @controller.session[:mfa_expires_at]
-      end
-
-      should "render sign in page" do
-        assert page.has_content? "Sign in"
-      end
-
-      should "not sign in the user" do
-        refute_predicate @controller.request.env[:clearance], :signed_in?
-      end
-
-      should "clear user name in session" do
-        assert_nil @controller.session[:mfa_user]
-      end
-    end
   end
 
   context "on POST to create" do
@@ -119,7 +86,6 @@ class SessionsControllerTest < ActionController::TestCase
         user = User.new(email_confirmed: true)
         User.expects(:authenticate).with("login", "pass").returns user
         post :create, params: { session: { who: "login", password: "pass" } }
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now
       end
 
       should respond_with :redirect
@@ -486,47 +452,6 @@ class SessionsControllerTest < ActionController::TestCase
       end
 
       should respond_with :unauthorized
-    end
-
-    context "when providing credentials but the session expired" do
-      setup do
-        @user = create(:user)
-        @webauthn_credential = create(:webauthn_credential, user: @user)
-        post(
-          :create,
-          params: { session: { who: @user.handle, password: @user.password } }
-        )
-        @challenge = session[:webauthn_authentication]["challenge"]
-        @origin = "http://localhost:3000"
-        @rp_id = URI.parse(@origin).host
-        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
-        WebauthnHelpers.create_credential(
-          webauthn_credential: @webauthn_credential,
-          client: @client
-        )
-        travel 30.minutes
-        post(
-          :webauthn_create,
-          params: {
-            credentials:
-              WebauthnHelpers.get_result(
-                client: @client,
-                challenge: @challenge
-              )
-          },
-          format: :json
-        )
-      end
-
-      should respond_with :unauthorized
-
-      should "clear mfa_expires_at" do
-        assert_nil @controller.session[:mfa_expires_at]
-      end
-
-      should "not sign in the user" do
-        refute_predicate @controller.request.env[:clearance], :signed_in?
-      end
     end
   end
 


### PR DESCRIPTION
Reverts rubygems/rubygems.org#3325 due to following exception raised in production.

**sessions_controller.rb  171  session_active?(...)**
```
NoMethodError: undefined method `>' for nil:NilClass

    session[:mfa_expires_at] > Time.current
                             ^
```