### PR TITLE
Add patch for mfa_expires_at edge condition

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -168,6 +168,7 @@ class SessionsController < Clearance::SessionsController
   end
 
   def session_active?
+    return false if session[:mfa_expires_at].nil?
     session[:mfa_expires_at] > Time.current
   end
 


### PR DESCRIPTION
There is currently an edge case where if a user is sitting idle on the MFA Auth page, and has been doing so since before the new session for expiring MFA was introduced in #3325 , they will hit a failure when trying to validate the session.

This patch checks for that condition by validating if the session is present, and if it is not, then the user will be blocked from signing in, with the same "login page session has expired" error. This means the user will have to restart the auth flow, which was the point of adding session expiry.