### PR TITLE
Remove TODO for checking if path token is expired in authenticate

### DIFF
--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -14,7 +14,6 @@ class WebauthnVerificationsController < ApplicationController
   end
 
   def authenticate
-    # TODO: check if path token is expired
     webauthn_credential.verify(
       challenge,
       public_key: user_webauthn_credential.public_key,


### PR DESCRIPTION
In https://github.com/rubygems/rubygems.org/pull/3328, `set_verification` was added as a `before_action` for the `authenticate` action. In that `set_verification`, it already checks if the token is expired.