### PR TITLE
Check webauthn OTP when verifying user OTP

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -14,7 +14,7 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def mfa_update
-    if @user.mfa_enabled? && @user.otp_verified?(params[:otp])
+    if @user.mfa_enabled? && @user.ui_otp_verified?(params[:otp])
       confirm_email
     else
       @form_url       = mfa_update_email_confirmations_url(token: @user.confirmation_token)

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -27,7 +27,7 @@ class MultifactorAuthsController < ApplicationController
   end
 
   def update
-    if current_user.otp_verified?(otp_param)
+    if current_user.ui_otp_verified?(otp_param)
       handle_new_level_param
       redirect_to session.fetch("mfa_redirect_uri", edit_settings_path)
       session.delete("mfa_redirect_uri")

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -26,7 +26,7 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def mfa_edit
-    if @user.mfa_enabled? && @user.otp_verified?(params[:otp])
+    if @user.mfa_enabled? && @user.ui_otp_verified?(params[:otp])
       render template: "passwords/edit"
     else
       @form_url       = mfa_edit_user_password_url(@user, token: @user.confirmation_token)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -173,6 +173,6 @@ class SessionsController < Clearance::SessionsController
   end
 
   def login_conditions_met?
-    @user&.mfa_enabled? && @user&.otp_verified?(params[:otp]) && session_active?
+    @user&.mfa_enabled? && @user&.ui_otp_verified?(params[:otp]) && session_active?
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -28,7 +28,7 @@ class ApiKey < ApplicationRecord
 
   def mfa_authorized?(otp)
     return true unless mfa_enabled?
-    user.otp_verified?(otp)
+    user.api_otp_verified?(otp)
   end
 
   def mfa_enabled?

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -53,7 +53,7 @@ module UserMultifactorMethods
       mfa_required? && mfa_ui_only?
     end
 
-    def otp_verified?(otp)
+    def ui_otp_verified?(otp)
       otp = otp.to_s
       return true if verify_digit_otp(mfa_seed, otp)
       return false unless mfa_recovery_codes.include? otp
@@ -63,7 +63,7 @@ module UserMultifactorMethods
 
     def api_otp_verified?(otp)
       return true if verify_webauthn_otp(otp)
-      return true if otp_verified?(otp)
+      return true if ui_otp_verified?(otp)
       false
     end
 

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -34,7 +34,7 @@ module UserMultifactorMethods
 
     def mfa_gem_signin_authorized?(otp)
       return true unless strong_mfa_level?
-      otp_verified?(otp)
+      api_otp_verified?(otp)
     end
 
     def mfa_recommended_not_yet_enabled?

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -56,10 +56,15 @@ module UserMultifactorMethods
     def otp_verified?(otp)
       otp = otp.to_s
       return true if verify_digit_otp(mfa_seed, otp)
-
       return false unless mfa_recovery_codes.include? otp
       mfa_recovery_codes.delete(otp)
       save!(validate: false)
+    end
+
+    def api_otp_verified?(otp)
+      return true if verify_webauthn_otp(otp)
+      return true if otp_verified?(otp)
+      false
     end
 
     private
@@ -85,6 +90,10 @@ module UserMultifactorMethods
       return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30)
 
       save!(validate: false)
+    end
+
+    def verify_webauthn_otp(otp)
+      webauthn_verification&.verify_otp(otp)
     end
   end
 

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -19,4 +19,20 @@ class WebauthnVerification < ApplicationRecord
     self.otp_expires_at = 2.minutes.from_now
     save!
   end
+
+  def verify_otp(otp)
+    return false if otp != self.otp || otp_expired?
+    expire_otp
+  end
+
+  private
+
+  def expire_otp
+    self.otp_expires_at = 1.second.ago
+    save!
+  end
+
+  def otp_expired?
+    otp_expires_at < Time.now.utc
+  end
 end

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -149,6 +149,49 @@ class ApiKeyTest < ActiveSupport::TestCase
     assert_contains api_key.errors[:base], "An invalid API key cannot be used. Please delete it and create a new one."
   end
 
+  context "#mfa_authorized?" do
+    setup do
+      @api_key = create(:api_key)
+    end
+
+    should "return true if mfa not enabled for api key" do
+      @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+
+      assert @api_key.mfa_authorized?(nil)
+    end
+
+    context "with totp" do
+      should "return true when correct and mfa enabled" do
+        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+
+        assert @api_key.mfa_authorized?(ROTP::TOTP.new(@api_key.user.mfa_seed).now)
+      end
+
+      should "return false when incorrect and mfa enabled" do
+        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+
+        refute @api_key.mfa_authorized?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+      end
+    end
+
+    context "with webauthn otp" do
+      should "return true when correct and mfa enabled" do
+        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        webauthn_verification = create(:webauthn_verification, user: @api_key.user)
+
+        assert @api_key.mfa_authorized?(webauthn_verification.otp)
+      end
+
+      should "return false when incorrect and mfa enabled" do
+        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        create(:webauthn_verification, user: @api_key.user, otp: "jiEm2mm2sJtRqAVx7U1i")
+        incorrect_otp = "Yxf57d1wEUSWyXrrLMRv"
+
+        refute @api_key.mfa_authorized?(incorrect_otp)
+      end
+    end
+  end
+
   context "#mfa_enabled?" do
     setup do
       @api_key = create(:api_key, index_rubygems: true)

--- a/test/unit/user_multifactor_methods_test.rb
+++ b/test/unit/user_multifactor_methods_test.rb
@@ -261,42 +261,42 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     end
   end
 
-  context "#otp_verified?" do
+  context "#ui_otp_verified?" do
     setup do
       @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
     end
 
     context "with totp" do
       should "return true when correct" do
-        assert @user.otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+        assert @user.ui_otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
       end
 
       should "return true when correct in last interval" do
         last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
-        assert @user.otp_verified?(last_otp)
+        assert @user.ui_otp_verified?(last_otp)
       end
 
       should "return true when correct in next interval" do
         next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
-        assert @user.otp_verified?(next_otp)
+        assert @user.ui_otp_verified?(next_otp)
       end
 
       should "return false when incorrect" do
-        refute @user.otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+        refute @user.ui_otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
       end
     end
 
     context "with webauthn otp" do
       should "return false" do
         webauthn_verification = create(:webauthn_verification, user: @user)
-        refute @user.otp_verified?(webauthn_verification.otp)
+        refute @user.ui_otp_verified?(webauthn_verification.otp)
       end
     end
 
     should "return true if recovery code is correct" do
       recovery_code = @user.mfa_recovery_codes.first
 
-      assert @user.otp_verified?(recovery_code)
+      assert @user.ui_otp_verified?(recovery_code)
       refute_includes @user.mfa_recovery_codes, recovery_code
     end
   end

--- a/test/unit/user_multifactor_methods_test.rb
+++ b/test/unit/user_multifactor_methods_test.rb
@@ -240,28 +240,94 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
       @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
     end
 
-    should "return true if otp is correct" do
-      assert @user.otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+    context "with totp" do
+      should "return true when correct" do
+        assert @user.otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+      end
+
+      should "return true when correct in last interval" do
+        last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
+        assert @user.otp_verified?(last_otp)
+      end
+
+      should "return true when correct in next interval" do
+        next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
+        assert @user.otp_verified?(next_otp)
+      end
+
+      should "return false when incorrect" do
+        refute @user.otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+      end
     end
 
-    should "return true for otp in last interval" do
-      last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
-      assert @user.otp_verified?(last_otp)
-    end
-
-    should "return true for otp in next interval" do
-      next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
-      assert @user.otp_verified?(next_otp)
-    end
-
-    should "return false if otp is incorrect" do
-      refute @user.otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+    context "with webauthn otp" do
+      should "return false" do
+        webauthn_verification = create(:webauthn_verification, user: @user)
+        refute @user.otp_verified?(webauthn_verification.otp)
+      end
     end
 
     should "return true if recovery code is correct" do
       recovery_code = @user.mfa_recovery_codes.first
 
       assert @user.otp_verified?(recovery_code)
+      refute_includes @user.mfa_recovery_codes, recovery_code
+    end
+  end
+
+  context "#api_otp_verified?" do
+    setup do
+      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    end
+
+    context "with totp" do
+      should "return true when correct" do
+        assert @user.api_otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+      end
+
+      should "return true when correct in last interval" do
+        last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
+        assert @user.api_otp_verified?(last_otp)
+      end
+
+      should "return true when correct in next interval" do
+        next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
+        assert @user.api_otp_verified?(next_otp)
+      end
+
+      should "return false if otp is incorrect" do
+        refute @user.api_otp_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
+      end
+    end
+
+    context "with webauthn otp" do
+      should "return true when correct" do
+        webauthn_verification = create(:webauthn_verification, user: @user)
+        assert @user.api_otp_verified?(webauthn_verification.otp)
+      end
+
+      should "return false when incorrect" do
+        create(:webauthn_verification, user: @user, otp: "jiEm2mm2sJtRqAVx")
+        incorrect_otp = "Yxf57d1wEUSWyXrr"
+
+        refute @user.api_otp_verified?(incorrect_otp)
+      end
+
+      should "return false when expired" do
+        webauthn_verification = create(:webauthn_verification, user: @user, otp_expires_at: 2.minutes.ago)
+        refute @user.api_otp_verified?(webauthn_verification.otp)
+      end
+
+      should "return false if not been generated" do
+        create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+        refute @user.api_otp_verified?("Yxf57d1wEUSWyXrr")
+      end
+    end
+
+    should "return true if recovery code is correct" do
+      recovery_code = @user.mfa_recovery_codes.first
+
+      assert @user.api_otp_verified?(recovery_code)
       refute_includes @user.mfa_recovery_codes, recovery_code
     end
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -311,12 +311,12 @@ class UserTest < ActiveSupport::TestCase
 
         should "be able to use a recovery code only once" do
           code = @user.mfa_recovery_codes.first
-          assert @user.otp_verified?(code)
-          refute @user.otp_verified?(code)
+          assert @user.ui_otp_verified?(code)
+          refute @user.ui_otp_verified?(code)
         end
 
         should "be able to verify correct OTP" do
-          assert @user.otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
+          assert @user.ui_otp_verified?(ROTP::TOTP.new(@user.mfa_seed).now)
         end
 
         should "return true for mfa status check" do
@@ -326,12 +326,12 @@ class UserTest < ActiveSupport::TestCase
 
         should "return true for otp in last interval" do
           last_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current - 30)
-          assert @user.otp_verified?(last_otp)
+          assert @user.ui_otp_verified?(last_otp)
         end
 
         should "return true for otp in next interval" do
           next_otp = ROTP::TOTP.new(@user.mfa_seed).at(Time.current + 30)
-          assert @user.otp_verified?(next_otp)
+          assert @user.ui_otp_verified?(next_otp)
         end
 
         context "blocking user with api key" do
@@ -362,7 +362,7 @@ class UserTest < ActiveSupport::TestCase
         end
 
         should "return false for verifying OTP" do
-          refute @user.otp_verified?("")
+          refute @user.ui_otp_verified?("")
         end
 
         should "return false for mfa status check" do


### PR DESCRIPTION
## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298
When webauthn authentication is successful, an OTP is generated to use as the OTP for the API request. This PR verifies the webauthn verification OTP for these requests.

## What approach did you choose and why?
`otp_verified?` currently accepts otps in the form of totps and recovery codes. This method is used to verify OTPs on the ui and on the CLI/API. I would like webauthn otps to be solely used for the API since there is a preferred way to verify webauthn in the UI. 

For this, I distinguished these concepts into `ui_otp_verified?` (used to be `otp_verified?`) and `api_otp_verified?` (`ui_otp_verified?` but also checks webauthn codes).

## What should reviewers focus on?
FYI it should be easier to review commit by commit rather than as a whole).

Does separating `otp_verified?` into a ui and api version make sense? Are there better names, should renaming `otp_verified?` be done later?

## Testing
1. Follow the steps to get an OTP here: https://github.com/rubygems/rubygems.org/pull/3368
2. Paste this OTP in the CLI prompt and MFA should be successfully verified.
