### PR TITLE
Use desktop sized Chrome in tests.

### DIFF
--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -347,7 +347,7 @@ class SignInTest < SystemTest
   end
 
   def create_webauthn_credential
-    fullscreen_headless_chrome_driver
+    headless_chrome_driver
 
     visit sign_in_path
     fill_in "Email or Username", with: @user.reload.email

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,22 @@ end
 
 Rubygem.searchkick_reindex(import: false)
 
+# copied from capybara, added window size
+# https://github.com/teamcapybara/capybara/blob/5d28453d8fe3d30f5a69ed984a28e9357e55f070/lib/capybara/registrations/drivers.rb#L31-L42
+Capybara.register_driver :selenium_chrome_headless do |app|
+  version = Capybara::Selenium::Driver.load_selenium
+  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument("--headless")
+    opts.add_argument("--disable-gpu") if Gem.win_platform?
+    opts.add_argument("--window-size=1280x1280")
+    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+    opts.add_argument("--disable-site-isolation-trials")
+  end
+
+  Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+end
+
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
   include GemHelpers
@@ -73,14 +89,6 @@ class ActiveSupport::TestCase
     Capybara.current_driver = :selenium_chrome_headless
     Capybara.default_max_wait_time = 2
     Selenium::WebDriver.logger.level = :error
-  end
-
-  def fullscreen_headless_chrome_driver
-    headless_chrome_driver
-    driver = page.driver
-    fullscreen_width = 1200
-    fullscreen_height = 1000
-    driver.resize_window_to(driver.current_window_handle, fullscreen_width, fullscreen_height)
   end
 end
 


### PR DESCRIPTION
:information_source: this is initial change to get setup visual regression testing (to be able to find out changes for some upcoming visual changes).

I would like to follow to use [driven_by](https://api.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html#method-c-driven_by), but that is currently not possible since some tests in one class are not compatible with selenium yet. I'll open following PR to refactor those tests.

Any suggestions for common testing window size are welcomed.