### PR TITLE
Move browser tests to standard Rails system tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         cp config/database.yml.sample config/database.yml
         bundle exec rake db:setup
     - name: Tests
-      run: bin/rails test
+      run: bin/rails test:all
     - name: Upload coverage to Codecov
       if: matrix.rubygems_version ==  matrix.coverage_rubygems_version && (success() || failure())
       uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Make sure that the tests run successfully before making changes.
 
 * Depending on how you setup your environment, run `docker compose up` or
   ensure elasticsearch, memcached, and postgres are running.
-* Run the tests: `bin/rails test`
+* Run the tests: `bin/rails test:all`
 * See also: [Ruby on Rails testing documentation](https://guides.rubyonrails.org/testing.html).
 
 ### Running the application

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  # TODO: remove once https://github.com/rails/rails/pull/47117 is released
+  Selenium::WebDriver.logger.ignore(:capabilities)
+end

--- a/test/system/advanced_search_test.rb
+++ b/test/system/advanced_search_test.rb
@@ -1,12 +1,9 @@
-require "test_helper"
-require "capybara/minitest"
+require "application_system_test_case"
 
-class AdvancedSearchTest < SystemTest
+class AdvancedSearchTest < ApplicationSystemTestCase
   include SearchKickHelper
 
   setup do
-    headless_chrome_driver
-
     visit advanced_search_path
   end
 
@@ -43,10 +40,5 @@ class AdvancedSearchTest < SystemTest
     fill_in "updated", with: ">2021-05-05"
 
     assert has_field? "Search Gems…", with: "name: hello summary: world description: foo downloads: >69 updated: >2021-05-05"
-  end
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -1,8 +1,7 @@
-require "test_helper"
+require "application_system_test_case"
 
-class ApiKeysTest < SystemTest
+class ApiKeysTest < ApplicationSystemTestCase
   setup do
-    headless_chrome_driver
     @user = create(:user)
     @ownership = create(:ownership, user: @user, rubygem: create(:rubygem))
 
@@ -293,10 +292,5 @@ class ApiKeysTest < SystemTest
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Confirm"
-  end
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/autocompletes_test.rb
+++ b/test/system/autocompletes_test.rb
@@ -1,12 +1,9 @@
-require "test_helper"
-require "capybara/minitest"
+require "application_system_test_case"
 
-class AutocompletesTest < SystemTest
+class AutocompletesTest < ApplicationSystemTestCase
   include SearchKickHelper
 
   setup do
-    headless_chrome_driver
-
     rubygem = create(:rubygem, name: "rubocop")
     create(:version, rubygem: rubygem, indexed: true)
     rubygem = create(:rubygem, name: "rubocop-performance")
@@ -86,10 +83,5 @@ class AutocompletesTest < SystemTest
     find("li", text: "rubocop", match: :first).click
     assert_equal current_path, search_path || "/gems/"
     assert page.has_content? "rubocop"
-  end
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -1,8 +1,7 @@
-require "test_helper"
+require "application_system_test_case"
 
-class MultifactorAuthsTest < SystemTest
+class MultifactorAuthsTest < ApplicationSystemTestCase
   setup do
-    headless_chrome_driver
     @user = create(:user, email: "testuser@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "testuser")
     @rubygem = create(:rubygem)
     create(:ownership, rubygem: @rubygem, user: @user)
@@ -12,6 +11,10 @@ class MultifactorAuthsTest < SystemTest
     )
     @seed = ROTP::Base32.random_base32
     @totp = ROTP::TOTP.new(@seed)
+  end
+
+  teardown do
+    @user.disable_mfa!
   end
 
   test "user with mfa disabled gets redirected back to adoptions after setting up mfa" do
@@ -132,11 +135,5 @@ class MultifactorAuthsTest < SystemTest
   def change_auth_level(type)
     page.select type
     click_button "Update"
-  end
-
-  teardown do
-    @user.disable_mfa!
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -1,9 +1,8 @@
-require "test_helper"
+require "application_system_test_case"
 
-class SettingsTest < SystemTest
+class SettingsTest < ApplicationSystemTestCase
   setup do
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
-    headless_chrome_driver
   end
 
   def sign_in
@@ -173,10 +172,5 @@ class SettingsTest < SystemTest
 
     refute page.has_selector?("#level > option:nth-child(4)")
     refute page.has_content? "UI Only"
-  end
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -1,0 +1,76 @@
+require "application_system_test_case"
+
+class SignInWebauthnTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
+                  mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
+                  mfa_recovery_codes: %w[0123456789ab ba9876543210])
+
+    @authenticator = create_webauthn_authenticator
+  end
+
+  teardown do
+    @authenticator.remove!
+  end
+
+  test "sign in with webauthn" do
+    visit sign_in_path
+
+    fill_in "Email or Username", with: @user.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+
+    WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true
+
+    click_on "Authenticate with security device"
+
+    assert page.has_content? "Dashboard"
+  end
+
+  test "sign in with webauthn but it expired" do
+    visit sign_in_path
+
+    fill_in "Email or Username", with: @user.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+
+    WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true
+
+    travel 30.minutes do
+      click_on "Authenticate with security device"
+
+      assert page.has_content? "Your login page session has expired."
+      assert page.has_content? "Multi-factor authentication"
+    end
+  end
+
+  def create_webauthn_authenticator
+    visit sign_in_path
+    fill_in "Email or Username", with: @user.reload.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+    visit edit_settings_path
+
+    options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new
+    authenticator = page.driver.browser.add_virtual_authenticator(options)
+    WebAuthn::PublicKeyCredentialWithAttestation.any_instance.stubs(:verify).returns true
+
+    credential_nickname = "new cred"
+    fill_in "Nickname", with: credential_nickname
+    click_on "Register device"
+
+    find("div", text: credential_nickname, match: :first)
+
+    find(:css, ".header__popup-link").click
+    click_on "Sign out"
+
+    authenticator
+  end
+end

--- a/test/system/stats_test.rb
+++ b/test/system/stats_test.rb
@@ -1,9 +1,7 @@
-require "test_helper"
-require "capybara/minitest"
+require "application_system_test_case"
 
-class StatsTest < SystemTest
+class StatsTest < ApplicationSystemTestCase
   setup do
-    headless_chrome_driver
     @rubygem = create(:rubygem, number: "0.0.1", downloads: 100)
   end
 
@@ -12,6 +10,4 @@ class StatsTest < SystemTest
     assert page.find(:css, ".stats__graph__gem__meter")
     assert page.has_content?(@rubygem.downloads)
   end
-
-  teardown { Capybara.use_default_driver }
 end

--- a/test/system/transitive_dependencies_test.rb
+++ b/test/system/transitive_dependencies_test.rb
@@ -1,9 +1,6 @@
-require "test_helper"
-require "capybara/minitest"
+require "application_system_test_case"
 
-class TransitiveDependenciesTest < SystemTest
-  setup { headless_chrome_driver }
-
+class TransitiveDependenciesTest < ApplicationSystemTestCase
   test "loading transitive dependencies using ajax" do
     version_one = create(:version)
     rubygem_one = version_one.rubygem
@@ -50,11 +47,5 @@ class TransitiveDependenciesTest < SystemTest
     find("span.deps_expanded-link").click
     assert page.has_content?(dep_dep_version.rubygem.name)
     assert page.has_content?(dep_dep_version.slug)
-  end
-
-  # Reset sessions and driver between tests
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/webauthn_credentials_test.rb
+++ b/test/system/webauthn_credentials_test.rb
@@ -1,8 +1,7 @@
-require "test_helper"
+require "application_system_test_case"
 
-class WebauthnCredentialsTest < SystemTest
+class WebauthnCredentialsTest < ApplicationSystemTestCase
   setup do
-    headless_chrome_driver
     @user = create(:user)
   end
 
@@ -68,10 +67,5 @@ class WebauthnCredentialsTest < SystemTest
 
     # Cleanup test data
     authenticator.remove!
-  end
-
-  teardown do
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end


### PR DESCRIPTION
Other step into getting tests a little better structured aiming to visual regression testing.

This introduces classic Rails default `ApplicationSystemTestCase` backed by `headless_chrome` (same as before) and utilises `test/system` directory for related tests. That should be equivalent of new Rails app these days.

`test/integration` still hosts 2 kind of tests.

- `ActionDispatch::IntegrationTest` based tests (using `get`/`post` rails helpers to navigate combined with Capybara page assertions)
- `SystemTest` based tests using Capybara style (visit, ...), but running using `rack-test` (not running in browser)

I would like to unify those two somehow. Some of the `ActionDispatch::IntegrationTest` tests could be probably migrated to `functional` folder (for example API controller ones). Some of the `ActionDispatch::IntegrationTest` could be migrated to `SystemTest` using browser like navigation instead of `get`/`post` rails helpers.

And finally `SystemTest` could be probably moved into `system` folder using custom `TestCase` (`rack-test` based one).

That would be subject of following PRs. Any suggestion is welcomed. :pray: 