### PR TITLE
Add telemetry to capture MFA login durations

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,8 +11,8 @@ class SessionsController < Clearance::SessionsController
       setup_webauthn_authentication
       setup_mfa_authentication
 
-      session[:mfa_login_started_at] = Time.now.utc
-      session[:mfa_expires_at] = 15.minutes.from_now
+      session[:mfa_login_started_at] = Time.now.utc.to_s
+      session[:mfa_expires_at] = 15.minutes.from_now.to_s
 
       render "sessions/prompt"
     else

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -132,7 +132,7 @@ class SessionsControllerTest < ActionController::TestCase
     context "when OTP is correct but session expired" do
       setup do
         @controller.session[:mfa_user] = @user.id
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now
+        @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
         travel 30.minutes
 
         post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
@@ -182,7 +182,7 @@ class SessionsControllerTest < ActionController::TestCase
         user = User.new(email_confirmed: true)
         User.expects(:authenticate).with("login", "pass").returns user
         post :create, params: { session: { who: "login", password: "pass" } }
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now
+        @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
       end
 
       should respond_with :redirect
@@ -216,7 +216,7 @@ class SessionsControllerTest < ActionController::TestCase
 
         context "when mfa is enabled" do
           setup do
-            @controller.session[:mfa_login_started_at] = Time.now.utc
+            @controller.session[:mfa_login_started_at] = Time.now.utc.to_s
             @controller.session[:mfa_user] = @user.id
             User.expects(:find).with(@user.id).returns @user
           end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -9,6 +9,10 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "on POST to create" do
       setup do
+        @current_time = Time.utc(2023, 1, 1, 0, 0, 0)
+        travel_to @current_time
+        freeze_time
+
         User.expects(:authenticate).with("login", "pass").returns @user
         post :create, params: { session: { who: "login", password: "pass" } }
       end
@@ -17,6 +21,14 @@ class SessionsControllerTest < ActionController::TestCase
       should "save user name in session" do
         assert_equal @controller.session[:mfa_user], @user.id
         assert page.has_content? "Multi-factor authentication"
+      end
+
+      should "set mfa_login_started_at in session " do
+        assert_equal @current_time, @controller.session[:mfa_login_started_at]
+      end
+
+      teardown do
+        travel_back
       end
     end
 
@@ -170,6 +182,7 @@ class SessionsControllerTest < ActionController::TestCase
 
         context "when mfa is enabled" do
           setup do
+            @controller.session[:mfa_login_started_at] = Time.now.utc
             @controller.session[:mfa_user] = @user.id
             User.expects(:find).with(@user.id).returns @user
           end
@@ -420,39 +433,41 @@ class SessionsControllerTest < ActionController::TestCase
   end
 
   context "#webauthn_create" do
-    context "when verifying the challenge" do
+    context "when providing correct credentials" do
       setup do
         @user = create(:user)
         @webauthn_credential = create(:webauthn_credential, user: @user)
-        post(
-          :create,
-          params: { session: { who: @user.handle, password: @user.password } }
-        )
-        @challenge = session[:webauthn_authentication]["challenge"]
-        @origin = "http://localhost:3000"
-        @rp_id = URI.parse(@origin).host
-        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
-        WebauthnHelpers.create_credential(
-          webauthn_credential: @webauthn_credential,
-          client: @client
-        )
-        post(
-          :webauthn_create,
-          params: {
-            credentials:
-              WebauthnHelpers.get_result(
-                client: @client,
-                challenge: @challenge
-              )
-          },
-          format: :json
-        )
+        login_to_session_with_webauthn
       end
 
-      should redirect_to :dashboard
+      context "redirect to dashboard" do
+        setup do
+          verify_challenge
+        end
+
+        should redirect_to :dashboard
+      end
 
       should "log in the user" do
+        verify_challenge
+
         assert_predicate @controller.request.env[:clearance], :signed_in?
+      end
+
+      should "record mfa login duration" do
+        start_time = Time.utc(2023, 1, 1, 0, 0, 0)
+        end_time = Time.utc(2023, 1, 1, 0, 2, 0)
+        duration = end_time - start_time
+
+        StatsD.expects(:distribution).with("login.mfa.webauthn.duration", duration)
+
+        travel_to start_time do
+          login_to_session_with_webauthn
+        end
+
+        travel_to end_time do
+          verify_challenge
+        end
       end
     end
 
@@ -624,5 +639,36 @@ class SessionsControllerTest < ActionController::TestCase
         should redirect_to("redirect uri") { rubygem_owners_path(@rubygem) }
       end
     end
+  end
+
+  private
+
+  def login_to_session_with_webauthn
+    post(
+      :create,
+      params: { session: { who: @user.handle, password: @user.password } }
+    )
+    @challenge = session[:webauthn_authentication]["challenge"]
+    @origin = "http://localhost:3000"
+    @rp_id = URI.parse(@origin).host
+    @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+    WebauthnHelpers.create_credential(
+      webauthn_credential: @webauthn_credential,
+      client: @client
+    )
+  end
+
+  def verify_challenge
+    post(
+      :webauthn_create,
+      params: {
+        credentials:
+          WebauthnHelpers.get_result(
+            client: @client,
+            challenge: @challenge
+          )
+      },
+      format: :json
+    )
   end
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -69,6 +69,7 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
+    StatsD.expects(:distribution)
     assert page.has_content? "Multi-factor authentication"
 
     within(".mfa-form") do


### PR DESCRIPTION
## 🤔 What problem are you solving?
Closes https://github.com/Shopify/ruby-dependency-security/issues/146

We hypothesize that WebAuthn improves the MFA user experience by enabling users to authenticate more quickly compared to TOTP. To verify this assumption, we'll capture login durations for Webauthn and TOTP to monitor and compare the difference.

## 🛠️ What approach did you choose and why?
1️⃣ **Starting the timer for capturing duration**
In order to capture the duration of the login flow for both WebAuthn or TOTP, we need a starting point. We store the starting time on the browser's session once the user has successfully logged in with their username and password. 

This makes sense as the starting point because the user will then be shown the 2nd factor authentication view (either prompted for TOTP code or WebAuthn).

2️⃣ **Calculate and capture duration**
Upon successfully authenticating with TOTP or WebAuthn, we'll calculate the duration of time passed (in seconds) and record it. 

## 👀 What should reviewers focus on?
I'm open to renaming the helper methods created in the tests (`login_to_session` and `verify_challenge`).

@jenshenny & I had also thought about other metrics we may want to track (e.g. tracking failed MFA attempts, potentially its duration to failure?). But we decided it was best to start with the metric we're most interested in first.

## 🧪 Acceptance testing
We can only test this the PR is shipped and we begin capturing data. 

🐶 📈 **After PR is merged**
We'll need to create a dashboard in Datadog in order to review the metrics for `login.mfa.webauthn.duration` and `login.mfa.otp.duration`.