### PR TITLE
Add caching for more API endpoints

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -27,11 +27,6 @@ class Api::CompactIndexController < Api::BaseController
 
   private
 
-  def cache_expiry_headers(fastly_expiry: 3600)
-    expires_in 60, public: true
-    fastly_expires_in fastly_expiry
-  end
-
   def render_range(response_body)
     headers["ETag"] = '"' << Digest::MD5.hexdigest(response_body) << '"'
 

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -4,8 +4,7 @@ class Api::V1::DependenciesController < Api::BaseController
   def index
     deps = GemDependent.new(gem_names).to_a
 
-    expires_in 30, public: true
-    fastly_expires_in 60
+    cache_expiry_headers(expiry: 30, fastly_expiry: 60)
     set_surrogate_key("dependencyapi", gem_names.map { |name| "gem/#{name}" })
 
     respond_to do |format|

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -17,6 +17,9 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def show
+    cache_expiry_headers
+    set_surrogate_key "gem/#{@rubygem.name}"
+
     if @rubygem.hosted? && @rubygem.public_versions.indexed.count.nonzero?
       respond_to do |format|
         format.json { render json: @rubygem }
@@ -39,6 +42,8 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def reverse_dependencies
+    cache_expiry_headers(fastly_expiry: 30)
+
     names = case params[:only]
             when "development"
               @rubygem.reverse_development_dependencies.pluck(:name)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,11 @@ class ApplicationController < ActionController::Base
     options[:password].present? && options[:name].present?
   end
 
+  def cache_expiry_headers(expiry: 60, fastly_expiry: 3600)
+    expires_in expiry, public: true
+    fastly_expires_in fastly_expiry
+  end
+
   def fastly_expires_in(seconds)
     response.headers["Surrogate-Control"] = "max-age=#{seconds}"
   end


### PR DESCRIPTION
Not a huge deal since theyre not called super often, but better than nothing

See https://ui.honeycomb.io/ruby-together/datasets/rubygems.org/result/AJLZH8Mar32?useStackedGraphs for the number of cache misses