### PR TITLE
Add new `bundle gem` placeholder to GEM_NAME_RESERVED_LIST

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -24,7 +24,9 @@ module Patterns
     thread
     unicode_normalize
     ubygems
+
     update_with_your_gem_name_prior_to_release_to_rubygems_org
+    update_with_your_gem_name_immediately_after_release_to_rubygems_org
 
     jruby
     mri


### PR DESCRIPTION
We must reserve the new placeholder, updated in rubygems/rubygems#6338.

As per https://github.com/rubygems/rubygems/pull/6338#issuecomment-1416835199