### PR TITLE
Unify Fastly lib class.

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -54,10 +54,7 @@ class Indexer
   end
 
   def purge_cdn
-    return unless ENV["FASTLY_SERVICE_ID"] && ENV["FASTLY_API_KEY"]
-
-    Fastly.purge_key("full-index")
-    log "Purged index urls from fastly"
+    log "Purged index urls from fastly" if Fastly.purge_key("full-index")
   end
 
   def minimize_specs(data)

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -10,7 +10,8 @@ class Fastly
   # These are not kwargs because delayed_job doesn't correctly support kwargs in Fastly.delay.purge
   # See: https://github.com/collectiveidea/delayed_job/issues/1134
   def self.purge(options = {})
-    return unless ENV["FASTLY_DOMAINS"]
+    return unless ENV["FASTLY_DOMAINS"].present? && ENV["FASTLY_API_KEY"].present?
+
     ENV["FASTLY_DOMAINS"].split(",").each do |domain|
       url = "https://#{domain}/#{options[:path]}"
       headers = options[:soft] ? { "Fastly-Soft-Purge" => 1 } : {}
@@ -26,6 +27,8 @@ class Fastly
   end
 
   def self.purge_key(key, soft: false)
+    return unless ENV["FASTLY_SERVICE_ID"].present? && ENV["FASTLY_API_KEY"].present?
+
     headers = { "Fastly-Key" => ENV["FASTLY_API_KEY"] }
     headers["Fastly-Soft-Purge"] = 1 if soft
     url = "https://api.fastly.com/service/#{ENV['FASTLY_SERVICE_ID']}/purge/#{key}"


### PR DESCRIPTION
- check first for all ENV dependencies to be present

As an side-effect this removes using `ENV` in `app` directory.