### PR TITLE
Move Searchkick index name configuration to constant.

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -2,7 +2,7 @@ module RubygemSearchable
   extend ActiveSupport::Concern
 
   included do
-    searchkick index_name: "rubygems-#{Rails.env}",
+    searchkick index_name: Gemcutter::SEARCH_INDEX_NAME,
       callbacks: false,
       settings: {
         number_of_shards: 1,

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,7 @@ module Gemcutter
   POPULAR_DAYS_LIMIT = 70.days
   PROTOCOL = config["protocol"]
   REMEMBER_FOR = 2.weeks
+  SEARCH_INDEX_NAME = "rubygems-#{Rails.env}".freeze
   SEARCH_MAX_PAGES = 100 # Limit max page as ES result window is upper bounded by 10_000 records
   STATS_MAX_PAGES = 10
   STATS_PER_PAGE = 10


### PR DESCRIPTION
- with this change configuration happens in `config` directory

_:thinking: There is no rocket science behind this change, but it eliminates last usage of `Rails.env` in `app` directory. It follows simple idea - configuration should happen in `config` directory. It was possible to move this to `config/rubygems.yml`, but I do not see any reason to do so since the values used._