### PR TITLE
add rubygems.team to allowed domains

### DIFF
--- a/lib/gemcutter/middleware/redirector.rb
+++ b/lib/gemcutter/middleware/redirector.rb
@@ -7,7 +7,7 @@ module Gemcutter::Middleware
     def call(env)
       request = Rack::Request.new(env)
 
-      allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org"]
+      allowed_hosts = [Gemcutter::HOST, "index.rubygems.org", "fastly.rubygems.org", "bundler.rubygems.org", "rubygems.team"]
 
       if allowed_hosts.exclude?(request.host) && request.path !~ %r{^/api|^/internal} && request.host !~ /docs/
         fake_request = Rack::Request.new(env.merge("HTTP_HOST" => Gemcutter::HOST))


### PR DESCRIPTION
Without this configuration, the app redirects away from the admin domain to the primary domain.