### PR TITLE
Fix test avo warnings by removing redundant rake tasks loading.

### DIFF
--- a/test/unit/ownership_requests_mailer_test.rb
+++ b/test/unit/ownership_requests_mailer_test.rb
@@ -5,7 +5,6 @@ class OwnershipRequestMailerTest < ActiveSupport::TestCase
     setup do
       @ownership = create(:ownership)
       create(:ownership_request, rubygem: @ownership.rubygem, created_at: 1.hour.ago)
-      Gemcutter::Application.load_tasks
       Rake::Task["ownership_request_notification:send"].invoke
       Delayed::Worker.new.work_off
     end

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -5,7 +5,6 @@ class UpdateVersionsFileTest < ActiveSupport::TestCase
     @tmp_versions_file = Tempfile.new("tmp_versions_file")
     tmp_path = @tmp_versions_file.path
     Rails.application.config.rubygems.stubs(:[]).with("versions_file_location").returns(tmp_path)
-    Gemcutter::Application.load_tasks
   end
 
   def update_versions_file


### PR DESCRIPTION
fixes following warning introduced at https://github.com/rubygems/rubygems.org/pull/3405
```
/home/retro/.gem/ruby/3.2.0/gems/avo-2.25.0/lib/tasks/tailwindcss_rails.rake:2: warning: already initialized constant ASSET_FILE
/home/retro/.gem/ruby/3.2.0/gems/avo-2.25.0/lib/tasks/tailwindcss_rails.rake:2: warning: previous definition of ASSET_FILE was here
/home/retro/.gem/ruby/3.2.0/gems/avo-2.25.0/lib/tasks/tailwindcss_rails.rake:4: warning: already initialized constant TAILWINDCSS_RAILS
/home/retro/.gem/ruby/3.2.0/gems/avo-2.25.0/lib/tasks/tailwindcss_rails.rake:4: warning: previous definition of TAILWINDCSS_RAILS was here
```