### PR TITLE
Add avo MFA reset admin action & view of audit entries

### DIFF
--- a/app/avo/actions/base_action.rb
+++ b/app/avo/actions/base_action.rb
@@ -1,0 +1,108 @@
+class BaseAction < Avo::BaseAction
+  field :comment, as: :textarea, required: true,
+    help: "A comment explaining why this action was taken.<br>Will be saved in the audit log.<br>Must be more than 10 characters."
+
+  class ActionHandler
+    include ActiveSupport::Callbacks
+    define_callbacks :handle, terminator: lambda { |target, result_lambda|
+      result_lambda.call
+      target.errored?
+    }
+
+    def initialize( # rubocop:disable Metrics/ParameterLists
+      fields:, current_user:, arguments:, resource:, action:, models: nil
+    )
+      @models = models
+      @fields = fields
+      @current_user = current_user
+      @arguments = arguments
+      @resource = resource
+
+      @action = action
+    end
+
+    attr_reader :models, :fields, :current_user, :arguments, :resource
+
+    delegate :error, :avo, :keep_modal_open, :redirect_to, :inform,
+      to: :@action
+
+    set_callback :handle, :before do
+      error "Must supply a sufficiently detailed comment" unless fields[:comment].presence&.then { _1.length >= 10 }
+    end
+
+    set_callback :handle, :around, lambda { |_, block|
+      begin
+        block.call
+      rescue StandardError => e
+        error e.message.truncate(300)
+      end
+    }
+
+    def do_handle
+      run_callbacks :handle do
+        handle
+      end
+      keep_modal_open if errored?
+    end
+
+    def errored?
+      @action.response[:messages].any? { _1[:type] == :error }
+    end
+
+    def sole_model
+      error "Expected a single model, but #{models.size} given" unless models.size == 1
+      models.sole
+    end
+
+    def in_audited_transaction(&)
+      User.transaction do
+        changed_records = {}
+        ActiveSupport::Notifications.subscribed(proc do |_name, _started, _finished, _unique_id, data|
+          data[:connection].transaction_manager.current_transaction.records.uniq(&:__id__).each do |record|
+            (changed_records[record] ||= {}).merge!(record.changes_to_save) do |_key, (old, _), (_, new)|
+              [old, new]
+            end
+          end
+        end, "sql.active_record", &)
+
+        audited_changed_records = changed_records.to_h do |record, changes|
+          [
+            record.to_global_id.uri,
+            { changes:, unchanged: record.attributes.except(*changes.keys) }
+          ]
+        end
+
+        audit = Audit.create!(
+          admin_github_user: current_user,
+          auditable: @current_model,
+          action: @action.name,
+          comment: fields[:comment],
+          audited_changes: {
+            records: audited_changed_records,
+            fields: fields.except(:comment),
+            arguments: arguments,
+            models: models.map { _1.to_global_id.uri }
+          }
+        )
+        redirect_to avo.resources_audit_path(audit)
+      end
+    end
+
+    def handle
+      models.each do |model|
+        @current_model = model
+        in_audited_transaction do
+          handle_model(model)
+        end
+      end
+      @current_model = nil
+    end
+  end
+
+  def handle(**args)
+    "#{self.class}::ActionHandler"
+      .constantize
+      .new(**args, arguments:, action: self)
+      .do_handle
+  end
+end

--- a/app/avo/actions/base_action.rb
+++ b/app/avo/actions/base_action.rb
@@ -49,11 +49,6 @@ class BaseAction < Avo::BaseAction
       @action.response[:messages].any? { _1[:type] == :error }
     end
 
-    def sole_model
-      error "Expected a single model, but #{models.size} given" unless models.size == 1
-      models.sole
-    end
-
     def in_audited_transaction(&)
       User.transaction do
         changed_records = {}

--- a/app/avo/actions/reset_user_2fa.rb
+++ b/app/avo/actions/reset_user_2fa.rb
@@ -1,0 +1,52 @@
+class ResetUser2fa < Avo::BaseAction
+  self.name = "Reset user 2fa"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+
+  self.message = lambda {
+    "Are you sure you would like to disable MFA and reset the password for #{record.handle} #{record.email}?\n" \
+      "This action will be logged."
+  }
+
+  field :comment, as: :textarea, required: true
+
+  self.confirm_button_label = "Reset MFA"
+
+  def validate(fields:, **_args)
+    unless fields[:comment].presence&.then { _1.length >= 25 }
+      error "Must supply a sufficiently detailed comment"
+      return
+    end
+
+    true
+  end
+
+  def handle(**args)
+    return keep_modal_open unless validate(**args)
+    models, fields, current_user = args.values_at(:models, :fields, :current_user)
+
+    models.each do |user|
+      user.transaction do
+        user.password = SecureRandom.hex(20).encode("UTF-8")
+        user.disable_mfa!
+        Audit.create!(
+          admin_github_user: current_user,
+          auditable: user,
+          action: self.class.name,
+          comment: fields[:comment],
+          audited_changes: {
+            records: user.class.connection.transaction_manager.current_transaction.records.to_h do |record|
+              [record.to_global_id.uri,
+               { changes: record.previous_changes,
+                 unchanged: record.attributes.except(*record.previous_changes.keys) }]
+            end,
+            fields: fields.except(:comment),
+            arguments: arguments,
+            model: user.to_global_id.uri
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/avo/actions/reset_user_2fa.rb
+++ b/app/avo/actions/reset_user_2fa.rb
@@ -1,52 +1,20 @@
-class ResetUser2fa < Avo::BaseAction
-  self.name = "Reset user 2fa"
+class ResetUser2fa < BaseAction
+  self.name = "Reset User 2FA"
   self.visible = lambda {
     current_user.team_member?("rubygems-org") && view == :show
   }
 
   self.message = lambda {
-    "Are you sure you would like to disable MFA and reset the password for #{record.handle} #{record.email}?\n" \
-      "This action will be logged."
+    "Are you sure you would like to disable MFA and reset the password for #{record.handle} #{record.email}?"
   }
-
-  field :comment, as: :textarea, required: true
 
   self.confirm_button_label = "Reset MFA"
 
-  def validate(fields:, **_args)
-    unless fields[:comment].presence&.then { _1.length >= 25 }
-      error "Must supply a sufficiently detailed comment"
-      return
-    end
-
-    true
-  end
-
-  def handle(**args)
-    return keep_modal_open unless validate(**args)
-    models, fields, current_user = args.values_at(:models, :fields, :current_user)
-
-    models.each do |user|
-      user.transaction do
-        user.password = SecureRandom.hex(20).encode("UTF-8")
-        user.disable_mfa!
-        Audit.create!(
-          admin_github_user: current_user,
-          auditable: user,
-          action: self.class.name,
-          comment: fields[:comment],
-          audited_changes: {
-            records: user.class.connection.transaction_manager.current_transaction.records.to_h do |record|
-              [record.to_global_id.uri,
-               { changes: record.previous_changes,
-                 unchanged: record.attributes.except(*record.previous_changes.keys) }]
-            end,
-            fields: fields.except(:comment),
-            arguments: arguments,
-            model: user.to_global_id.uri
-          }
-        )
-      end
+  class ActionHandler < ActionHandler
+    def handle_model(user)
+      user.disable_mfa!
+      user.password = SecureRandom.hex(20).encode("UTF-8")
+      user.save!
     end
   end
 end

--- a/app/avo/fields/audited_changes_field.rb
+++ b/app/avo/fields/audited_changes_field.rb
@@ -1,0 +1,2 @@
+class AuditedChangesField < Avo::Fields::BaseField
+end

--- a/app/avo/fields/json_viewer_field.rb
+++ b/app/avo/fields/json_viewer_field.rb
@@ -1,0 +1,12 @@
+class JsonViewerField < Avo::Fields::BaseField
+  def initialize(name, **args, &)
+    super(name, **args, &)
+    @theme = args[:theme].present? ? args[:theme].to_s : "default"
+    @height = args[:height].present? ? args[:height].to_s : "auto"
+    @tab_size = args[:tab_size].presence || 2
+    @indent_with_tabs = args[:indent_with_tabs].presence || false
+    @line_wrapping = args[:line_wrapping].presence || true
+  end
+
+  attr_reader :height, :theme, :tab_size, :indent_with_tabs, :line_wrapping
+end

--- a/app/avo/resources/audit_resource.rb
+++ b/app/avo/resources/audit_resource.rb
@@ -6,23 +6,31 @@ class AuditResource < Avo::BaseResource
   ]
 
   field :action, as: :text
-  field :auditable, as: :belongs_to,
-    polymorphic_as: :auditable,
-    types: [::User]
-  field :admin_github_user, as: :belongs_to
-  field :created_at, as: :date_time
-  field :comment, as: :text
 
-  field :audited_changes_arguments, as: :json_viewer, only_on: :show do |model|
-    model.audited_changes["arguments"]
-  end
-  field :audited_changes_fields, as: :json_viewer, only_on: :show do |model|
-    model.audited_changes["fields"]
-  end
-  field :audited_changes_models, as: :text, as_html: true, only_on: :show do
-    model.audited_changes["models"]
+  sidebar do
+    field :admin_github_user, as: :belongs_to
+    field :created_at, as: :date_time
+    field :comment, as: :text
+
+    field :auditable, as: :belongs_to,
+      polymorphic_as: :auditable,
+      types: [::User],
+      name: "Edited Record"
+
+    heading "Action Details"
+
+    field :audited_changes_arguments, as: :json_viewer, only_on: :show do |model|
+      model.audited_changes["arguments"]
+    end
+    field :audited_changes_fields, as: :json_viewer, only_on: :show do |model|
+      model.audited_changes["fields"]
+    end
+    field :audited_changes_models, as: :text, as_html: true, only_on: :show do
+      model.audited_changes["models"]
+    end
+
+    field :id, as: :id
   end
 
   field :audited_changes, as: :audited_changes
-  field :id, as: :id
 end

--- a/app/avo/resources/audit_resource.rb
+++ b/app/avo/resources/audit_resource.rb
@@ -4,9 +4,6 @@ class AuditResource < Avo::BaseResource
     admin_github_user
     auditable
   ]
-  # self.search_query = -> do
-  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
-  # end
 
   field :action, as: :text
   field :auditable, as: :belongs_to,
@@ -15,17 +12,17 @@ class AuditResource < Avo::BaseResource
   field :admin_github_user, as: :belongs_to
   field :created_at, as: :date_time
   field :comment, as: :text
-  # Fields generated from the model
+
   field :audited_changes_arguments, as: :json_viewer, only_on: :show do |model|
     model.audited_changes["arguments"]
   end
   field :audited_changes_fields, as: :json_viewer, only_on: :show do |model|
     model.audited_changes["fields"]
   end
-  field :audited_changes_model, as: :text, only_on: :show do |model|
-    model.audited_changes["model"]
+  field :audited_changes_models, as: :text, as_html: true, only_on: :show do
+    model.audited_changes["models"]
   end
+
   field :audited_changes, as: :audited_changes
   field :id, as: :id
-  # add fields here
 end

--- a/app/avo/resources/audit_resource.rb
+++ b/app/avo/resources/audit_resource.rb
@@ -1,0 +1,31 @@
+class AuditResource < Avo::BaseResource
+  self.title = :id
+  self.includes = %i[
+    admin_github_user
+    auditable
+  ]
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :action, as: :text
+  field :auditable, as: :belongs_to,
+    polymorphic_as: :auditable,
+    types: [::User]
+  field :admin_github_user, as: :belongs_to
+  field :created_at, as: :date_time
+  field :comment, as: :text
+  # Fields generated from the model
+  field :audited_changes_arguments, as: :json_viewer, only_on: :show do |model|
+    model.audited_changes["arguments"]
+  end
+  field :audited_changes_fields, as: :json_viewer, only_on: :show do |model|
+    model.audited_changes["fields"]
+  end
+  field :audited_changes_model, as: :text, only_on: :show do |model|
+    model.audited_changes["model"]
+  end
+  field :audited_changes, as: :audited_changes
+  field :id, as: :id
+  # add fields here
+end

--- a/app/avo/resources/user_resource.rb
+++ b/app/avo/resources/user_resource.rb
@@ -5,6 +5,8 @@ class UserResource < Avo::BaseResource
     scope.where("email LIKE ? OR handle LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%")
   }
 
+  action ResetUser2fa
+
   field :id, as: :id
   # Fields generated from the model
   field :email, as: :text
@@ -28,6 +30,7 @@ class UserResource < Avo::BaseResource
 
   tabs style: :pills do
     tab "Auth" do
+      field :encrypted_password, as: :password, visible: ->(_) { false }
       field :mfa_seed, as: :text, visible: ->(_) { false }
       field :mfa_level, as: :select, enum: ::User.mfa_levels
       field :mfa_recovery_codes, as: :text, visible: ->(_) { false }
@@ -51,5 +54,7 @@ class UserResource < Avo::BaseResource
     field :api_keys, as: :has_many, name: "API Keys"
     field :ownership_calls, as: :has_many
     field :ownership_requests, as: :has_many
+
+    field :audits, as: :has_many
   end
 end

--- a/app/components/avo/audited_changes_record_diff/show_component.html.erb
+++ b/app/components/avo/audited_changes_record_diff/show_component.html.erb
@@ -1,0 +1,14 @@
+<%= render Avo::PanelComponent.new(title: title_link, classes: %w[w-full]) do |c| %>
+  <% c.body do %>
+    <% next unless authorized? %>
+
+    <div class="divide-y divide-dashed">
+      <% each_field do |type, component| %>
+        <%= tag.div class: change_type_row_classes(type) do %>
+          <span class="px-1 w-4"><%= change_type_icon type %></span>
+          <%= render component %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/avo/audited_changes_record_diff/show_component.rb
+++ b/app/components/avo/audited_changes_record_diff/show_component.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Avo::AuditedChangesRecordDiff::ShowComponent < ViewComponent::Base
+  def initialize(gid:, changes:, unchanged:, user:)
+    super
+    @gid = gid
+    @changes = changes
+    @unchanged = unchanged
+    @user = user
+
+    model = GlobalID::Locator.locate(gid)
+    @resource = Avo::App.get_resource_by_name(model.class.name).hydrate(model:, user:)
+
+    @old_resource = resource.dup.hydrate(model: resource.model.class.new(**unchanged, **changes.transform_values(&:first)))
+    @new_resource = resource.dup.hydrate(model: resource.model.class.new(**unchanged, **changes.transform_values(&:last)))
+  end
+
+  attr_reader :gid, :changes, :unchanged, :user, :resource, :old_resource, :new_resource
+
+  def each_field
+    @resource.fields.each do |field|
+      next if field.is_a?(Avo::Fields::HasBaseField)
+
+      unless field.visible?
+        if changes.key?(field.id.to_s)
+          # dummy field to avoid ever printing out the contents... we just want the label
+          yield :changed, Avo::Fields::IdField::ShowComponent.new(field: field)
+        end
+        next
+      end
+
+      if changes.key?(field.id.to_s)
+        yield :new, field.component_for_view(:show).new(field: field.hydrate(model: new_resource.model), resource: new_resource)
+        yield :old, field.component_for_view(:show).new(field: field.hydrate(model: old_resource.model), resource: old_resource)
+      else
+        yield :unchanged, field.component_for_view(:show).new(field: field.hydrate(model: new_resource.model), resource: new_resource)
+      end
+    end
+  end
+
+  def authorized?
+    Pundit.policy!(user, resource.model).avo_show?
+  end
+
+  def title_link
+    link_to(resource.model_title, resource.record_path)
+  end
+
+  def change_type_icon(type)
+    case type
+    when :changed
+      helpers.svg("arrows-right-left", class: %w[h-4])
+    when :new
+      helpers.svg("forward", class: %w[h-4])
+    when :old
+      helpers.svg("backward", class: %w[h-4])
+    end
+  end
+
+  def change_type_row_classes(type)
+    case type
+    when :changed
+      %w[bg-orange-400]
+    when :new
+      %w[bg-green-400]
+    when :old
+      %w[bg-red-400]
+    else []
+    end + %w[flex flex-row items-baseline]
+  end
+end

--- a/app/components/avo/audited_changes_record_diff/show_component.rb
+++ b/app/components/avo/audited_changes_record_diff/show_component.rb
@@ -24,7 +24,7 @@ class Avo::AuditedChangesRecordDiff::ShowComponent < ViewComponent::Base
       unless field.visible?
         if changes.key?(field.id.to_s)
           # dummy field to avoid ever printing out the contents... we just want the label
-          yield :changed, Avo::Fields::IdField::ShowComponent.new(field: field)
+          yield :changed, Avo::Fields::BooleanField::ShowComponent.new(field: field)
         end
         next
       end
@@ -62,7 +62,7 @@ class Avo::AuditedChangesRecordDiff::ShowComponent < ViewComponent::Base
     when :changed
       %w[bg-orange-400]
     when :new
-      %w[bg-green-400]
+      %w[bg-green-500]
     when :old
       %w[bg-red-400]
     else []

--- a/app/components/avo/audited_changes_record_diff/show_component.rb
+++ b/app/components/avo/audited_changes_record_diff/show_component.rb
@@ -17,10 +17,14 @@ class Avo::AuditedChangesRecordDiff::ShowComponent < ViewComponent::Base
 
   attr_reader :gid, :changes, :unchanged, :user, :resource, :old_resource, :new_resource
 
-  def each_field
-    @resource.fields.each do |field|
-      next if field.is_a?(Avo::Fields::HasBaseField)
+  def sorted_fields
+    @resource.fields
+      .reject { _1.is_a?(Avo::Fields::HasBaseField) }
+      .sort_by.with_index { |f, i| [changes.key?(f.id.to_s) ? -1 : 1, i] }
+  end
 
+  def each_field
+    sorted_fields.each do |field|
       unless field.visible?
         if changes.key?(field.id.to_s)
           # dummy field to avoid ever printing out the contents... we just want the label

--- a/app/components/avo/fields/audited_changes_field/show_component.html.erb
+++ b/app/components/avo/fields/audited_changes_field/show_component.html.erb
@@ -1,0 +1,10 @@
+<%= field_wrapper **field_wrapper_args, full_width: true do %>
+  <% records&.each do |gid, changes, unchanged| %>
+    <%= render Avo::AuditedChangesRecordDiff::ShowComponent.new(
+      gid:,
+      changes:,
+      unchanged:,
+      user: resource.user,
+    ) %>
+  <% end %>
+<% end %>

--- a/app/components/avo/fields/audited_changes_field/show_component.rb
+++ b/app/components/avo/fields/audited_changes_field/show_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Avo::Fields::AuditedChangesField::ShowComponent < Avo::Fields::ShowComponent
+  def records
+    field.value["records"]&.map do |gid, body|
+      changes, unchanged = body.values_at("changes", "unchanged")
+
+      [gid, changes, unchanged]
+    end
+  end
+end

--- a/app/components/avo/fields/gravatar_field/show_component.html.erb
+++ b/app/components/avo/fields/gravatar_field/show_component.html.erb
@@ -1,0 +1,8 @@
+<%= field_wrapper **field_wrapper_args do %>
+  <%= render Avo::Fields::Common::GravatarViewerComponent.new(
+    md5: @field.md5,
+    default: @field.default,
+    size: 144,
+  )
+  %>
+<% end %>

--- a/app/components/avo/fields/gravatar_field/show_component.rb
+++ b/app/components/avo/fields/gravatar_field/show_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::GravatarField::ShowComponent < Avo::Fields::ShowComponent
+end

--- a/app/components/avo/fields/json_viewer_field/show_component.html.erb
+++ b/app/components/avo/fields/json_viewer_field/show_component.html.erb
@@ -1,0 +1,19 @@
+<%= field_wrapper **field_wrapper_args, full_width: true do %>
+  <div data-controller="code-field" style="--height: <%= @field.height %>">
+    <%= text_area_tag @field.id, pretty_json,
+      class: helpers.input_classes('w-full'),
+      placeholder: @field.placeholder,
+      disabled: true,
+      data: {
+        'code-field-target': 'element',
+        view: view,
+        language: :javascript,
+        theme: @field.theme,
+        'tab-size': @field.tab_size,
+        'read-only': true,
+        'indent-with-tabs': @field.indent_with_tabs,
+        'line-wrapping': @field.line_wrapping,
+      }
+    %>
+  </div>
+<% end %>

--- a/app/components/avo/fields/json_viewer_field/show_component.rb
+++ b/app/components/avo/fields/json_viewer_field/show_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Avo::Fields::JsonViewerField::ShowComponent < Avo::Fields::ShowComponent
+  def pretty_json
+    JSON.pretty_generate(@field.value)
+  end
+end

--- a/app/controllers/avo/audits_controller.rb
+++ b/app/controllers/avo/audits_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::AuditsController < Avo::ResourcesController
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
   has_many :ownership_calls, -> { opened }, dependent: :destroy, inverse_of: :user
   has_many :ownership_requests, -> { opened }, dependent: :destroy, inverse_of: :user
 
+  has_many :audits, as: :auditable, dependent: :nullify
+
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
   validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 

--- a/app/policies/audit_policy.rb
+++ b/app/policies/audit_policy.rb
@@ -1,0 +1,20 @@
+class AuditPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      if rubygems_org_admin?
+        scope.all
+      else
+        scope.where(admin_github_user: current_user)
+      end
+    end
+  end
+
+  def avo_index?
+    true
+  end
+
+  def avo_show?
+    true
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,6 +14,10 @@ class UserPolicy < ApplicationPolicy
     rubygems_org_admin?
   end
 
+  def act_on?
+    rubygems_org_admin?
+  end
+
   has_association :webauthn_credentials
   has_association :ownerships
   has_association :rubygems
@@ -25,4 +29,5 @@ class UserPolicy < ApplicationPolicy
   has_association :api_keys
   has_association :ownership_calls
   has_association :ownership_requests
+  has_association :audits
 end

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -18,7 +18,7 @@ Avo.configure do |config|
   ## == Authentication ==
   config.current_user_method = :admin_user
   config.authenticate_with do
-    redirect_to '/' unless admin_user&.valid?
+    redirect_to '/' unless _current_user&.valid?
   end
   config.sign_out_path_name = :admin_logout_path
 

--- a/test/policies/audit_policy_test.rb
+++ b/test/policies/audit_policy_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AuditPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -1,0 +1,98 @@
+require "application_system_test_case"
+
+class Avo::UsersSystemTest < ApplicationSystemTestCase
+  def sign_in_as(user)
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+      provider: "github",
+      uid: "1",
+      credentials: {
+        token: user.oauth_token,
+        expires: false
+      },
+      info: {
+        name: user.login
+      }
+    )
+    @octokit_stubs.post("/graphql",
+      {
+        query: GitHubOAuthable::INFO_QUERY,
+        variables: { organization_name: "rubygems" }
+      }.to_json) do |_env|
+      [200, { "Content-Type" => "application/json" }, JSON.generate(
+        data: user.info_data
+      )]
+    end
+
+    visit avo.root_path
+    click_button "Log in with GitHub"
+
+    page.assert_text user.login
+  end
+
+  test "reset mfa" do
+    Minitest::Test.make_my_diffs_pretty!
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    user = create(:user)
+    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user_attributes = user.attributes.with_indifferent_access
+
+    visit avo.resources_user_path(user)
+
+    click_button "Actions"
+    click_on "Reset User 2FA"
+
+    assert_no_changes "User.find(#{user.id}).attributes" do
+      click_button "Reset MFA"
+    end
+    page.assert_text "Must supply a sufficiently detailed comment"
+
+    fill_in "Comment", with: "A nice long comment"
+    click_button "Reset MFA"
+    page.assert_text "Action ran successfully!"
+    page.assert_text user.to_global_id.uri.to_s
+
+    page.assert_no_text user.encrypted_password
+    page.assert_no_text user_attributes[:encrypted_password]
+    page.assert_no_text user_attributes[:mfa_seed]
+    page.assert_no_text user_attributes[:mfa_recovery_codes].first
+
+    user.reload
+
+    assert_equal "disabled", user.mfa_level
+    assert_not_equal user_attributes[:encrypted_password], user.encrypted_password
+    assert_empty user.mfa_seed
+    assert_empty user.mfa_recovery_codes
+
+    audit = user.audits.sole
+
+    page.assert_text audit.id
+    assert_equal "User", audit.auditable_type
+    assert_equal "Reset User 2FA", audit.action
+    assert_equal(
+      {
+        "records" => {
+          "gid://gemcutter/User/#{user.id}" => {
+            "changes" => {
+              "mfa_level" => %w[ui_and_api disabled],
+              "updated_at" => [user_attributes[:updated_at].as_json, user.updated_at.as_json],
+              "mfa_seed" => [user_attributes[:mfa_seed], ""],
+              "mfa_recovery_codes" => [user_attributes[:mfa_recovery_codes], []],
+              "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password]
+            },
+            "unchanged" => user.attributes
+              .except("mfa_level", "updated_at", "mfa_seed", "mfa_recovery_codes", "encrypted_password")
+              .transform_values(&:as_json)
+          }
+        },
+        "fields" => {},
+        "arguments" => {},
+        "models" => ["gid://gemcutter/User/#{user.id}"]
+      },
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "A nice long comment", audit.comment
+  end
+end

--- a/test/unit/avo/actions/base_action_test.rb
+++ b/test/unit/avo/actions/base_action_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class BaseActionTest < ActiveSupport::TestCase
+  test "handles errors" do
+    raises_on_each = Class.new do
+      def each
+        raise "Cannot enumerate"
+      end
+    end.new
+    action = BaseAction.new
+
+    args = {
+      fields: {
+        comment: "Sufficiently detailed"
+      },
+      current_user: create(:admin_github_user, :is_admin),
+      resource: nil,
+      models: raises_on_each
+    }
+
+    action.handle(**args)
+
+    assert_equal [{ type: :error, body: "Cannot enumerate" }], action.response[:messages]
+    assert action.response[:keep_modal_open]
+  end
+end


### PR DESCRIPTION
Based on https://github.com/rubygems/rubygems.org/pull/3417

~~Still need to:~~

- [x] Move logic out of erb & into component
- [x] Add new component for object diff
- [x] Add separate field for arguments & fields
- [x] Remove raw json view of audited_changes
- [x] Add authz of audited records
- [x] Test the MFA reset action itself
- [x] Add base action that has validation hooks, handles auditing, etc
- [x] Look into replacing auditing logic with something that can capture multiple `save` calls

The UI flow:

Step 1, find the user in Avo

<img width="1901" alt="image" src="https://user-images.githubusercontent.com/78/218643887-9f681f17-9f34-4edd-a63d-043d9f5e64ad.png">

Step 2, visit the user page and use the Action menu to choose "Reset 2FA"

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/78/218643955-5df27fe7-871d-4b4a-a951-135e09256d7b.png">

Step 3, fill out the explanation

<img width="726" alt="image" src="https://user-images.githubusercontent.com/78/218644132-fbc0249b-2d16-41bc-93cd-8aa9e9d6b503.png">

Step 4, you're done and here is the audit log entry

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/78/218644234-28272e42-5875-44f9-82eb-1a7c4a52b1d1.png">
