### PR TITLE
Enable inline styles for avo.

### DIFF
--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -118,4 +118,8 @@ end
 
 Rails.configuration.to_prepare do
   Avo::ApplicationController.include GitHubOAuthable
+
+  Avo::ApplicationController.content_security_policy do |policy|
+    policy.style_src :self, "https://fonts.googleapis.com", :unsafe_inline
+  end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ end
 
 # Generate session nonces for permitted importmap and inline scripts
 Rails.application.config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-Rails.application.config.content_security_policy_nonce_directives = %w[script-src style-src]
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI. See:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only


### PR DESCRIPTION
fixes blocked avo inline styles

![image](https://user-images.githubusercontent.com/193936/218236680-95d8b7d1-e873-46be-9ce3-67591b7e5d2e.png)
