### PR TITLE
Add translation for credentials required

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -27,7 +27,7 @@ class EmailConfirmationsController < ApplicationController
     @challenge = session.dig(:webauthn_authentication, "challenge")
 
     if params[:credentials].blank?
-      login_failure("Credentials required")
+      login_failure(t("credentials_required"))
       return
     end
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -39,7 +39,7 @@ class PasswordsController < Clearance::PasswordsController
     @challenge = session.dig(:webauthn_authentication, "challenge")
 
     if params[:credentials].blank?
-      login_failure("Credentials required")
+      login_failure(t("credentials_required"))
       return
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,7 +25,7 @@ class SessionsController < Clearance::SessionsController
     @challenge = session.dig(:webauthn_authentication, "challenge")
 
     if params[:credentials].blank?
-      webauthn_verification_failure("Credentials required")
+      webauthn_verification_failure(t("credentials_required"))
       return
     elsif !session_active?
       webauthn_verification_failure(t("multifactor_auths.session_expired"))

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,6 @@
 ---
 de:
+  credentials_required:
   edit: Bearbeiten
   failure_when_forbidden:
   feed_latest: RubyGems.org | Neueste Gems

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
+  credentials_required: Credentials required
   edit: Edit
   failure_when_forbidden: Please double check the URL or try submitting it again.
   feed_latest: RubyGems.org | Latest Gems

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,6 @@
 ---
 es:
+  credentials_required:
   edit: Editar
   failure_when_forbidden: Por favor verifica la URL o inténtalo nuevamente.
   feed_latest: RubyGems.org | Gemas más recientes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,6 @@
 ---
 fr:
+  credentials_required:
   edit: Modification
   failure_when_forbidden: Veuillez vérifier l'URL ou réessayer.
   feed_latest: RubyGems.org | Derniers Gems

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,6 @@
 ---
 ja:
+  credentials_required:
   edit: 編集
   failure_when_forbidden: URLを確認するか、再試行してください。
   feed_latest: RubyGems.org | 最新のGemの一覧

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,6 @@
 ---
 nl:
+  credentials_required:
   edit: Wijzig
   failure_when_forbidden: Controleer het webadres, en probeer het opnieuw.
   feed_latest: RubyGems.org | Nieuwste Gems

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,6 @@
 ---
 pt-BR:
+  credentials_required:
   edit: Editar
   failure_when_forbidden: Por favor, confira a URL ou tente submetê-la novamente.
   feed_latest: RubyGems.org | Últimas Gems

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,5 +1,6 @@
 ---
 zh-CN:
+  credentials_required:
   edit: 编辑
   failure_when_forbidden: 请确认 URL 或再次提交
   feed_latest: RubyGems.org | 最新 Gems

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,5 +1,6 @@
 ---
 zh-TW:
+  credentials_required:
   edit: 編輯
   failure_when_forbidden: 請確認 URL 或再次提交
   feed_latest: RubyGems.org | 最新 Gems


### PR DESCRIPTION
## What problem are you solving?
Add translation for "Credentials required" which is used in a few spots, but was missing a translation field.

## What approach did you choose and why?
Added the missing translation to all the locale files, except the avo ones.

## What should reviewers focus on?
Not too much to focus on here, pretty basic PR 😛 

## Testing
Validate that the translations appear on UI when not providing credentials, the tests also confirm it works.