### PR TITLE
Add avo resources for ownerships & API keys

### DIFF
--- a/app/avo/resources/api_key_resource.rb
+++ b/app/avo/resources/api_key_resource.rb
@@ -1,0 +1,29 @@
+class ApiKeyResource < Avo::BaseResource
+  self.title = :name
+  self.includes = []
+
+  field :id, as: :id, hide_on: :index
+
+  field :name, as: :text, link_to_resource: true
+  field :hashed_key, as: :text, visible: ->(_) { false }
+  field :user, as: :belongs_to
+  field :last_accessed_at, as: :date_time
+  field :soft_deleted_at, as: :date_time
+  field :soft_deleted_rubygem_name, as: :text
+
+  sidebar do
+    heading "Permissions"
+
+    field :index_rubygems, as: :boolean
+    field :push_rubygem, as: :boolean
+    field :yank_rubygem, as: :boolean
+    field :add_owner, as: :boolean
+    field :remove_owner, as: :boolean
+    field :access_webhooks, as: :boolean
+    field :show_dashboard, as: :boolean
+    field :mfa, as: :boolean
+  end
+
+  field :api_key_rubygem_scope, as: :has_one
+  field :ownership, as: :has_one
+end

--- a/app/avo/resources/api_key_resource.rb
+++ b/app/avo/resources/api_key_resource.rb
@@ -11,6 +11,8 @@ class ApiKeyResource < Avo::BaseResource
   field :soft_deleted_at, as: :date_time
   field :soft_deleted_rubygem_name, as: :text
 
+  field :enabled_scopes, as: :tags
+
   sidebar do
     heading "Permissions"
 

--- a/app/avo/resources/api_key_rubygem_scope_resource.rb
+++ b/app/avo/resources/api_key_rubygem_scope_resource.rb
@@ -1,0 +1,9 @@
+class ApiKeyRubygemScopeResource < Avo::BaseResource
+  self.title = :cache_key
+  self.includes = []
+
+  field :id, as: :id
+
+  field :api_key, as: :belongs_to
+  field :ownership, as: :belongs_to
+end

--- a/app/avo/resources/ownership_resource.rb
+++ b/app/avo/resources/ownership_resource.rb
@@ -1,0 +1,26 @@
+class OwnershipResource < Avo::BaseResource
+  self.title = :cache_key
+  self.includes = []
+
+  field :id, as: :id, link_to_resource: true
+
+  field :user, as: :belongs_to
+  field :rubygem, as: :belongs_to
+
+  heading "Token"
+
+  field :token, as: :text, visible: ->(_) { false }
+  field :token_expires_at, as: :date_time
+  field :api_key_rubygem_scopes, as: :has_many
+
+  heading "Notifications"
+
+  field :push_notifier, as: :boolean
+  field :owner_notifier, as: :boolean
+  field :ownership_request_notifier, as: :boolean
+
+  heading "Authorization"
+
+  field :authorizer, as: :belongs_to
+  field :confirmed_at, as: :date_time
+end

--- a/app/controllers/avo/api_key_rubygem_scopes_controller.rb
+++ b/app/controllers/avo/api_key_rubygem_scopes_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ApiKeyRubygemScopesController < Avo::ResourcesController
+end

--- a/app/controllers/avo/api_keys_controller.rb
+++ b/app/controllers/avo/api_keys_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ApiKeysController < Avo::ResourcesController
+end

--- a/app/controllers/avo/ownerships_controller.rb
+++ b/app/controllers/avo/ownerships_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::OwnershipsController < Avo::ResourcesController
+end

--- a/app/policies/api_key_policy.rb
+++ b/app/policies/api_key_policy.rb
@@ -1,0 +1,14 @@
+class ApiKeyPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_show?
+    Pundit.policy!(user, record.user).avo_show?
+  end
+
+  has_association :api_key_rubygem_scope
+  has_association :ownership
+end

--- a/app/policies/api_key_rubygem_scope_policy.rb
+++ b/app/policies/api_key_rubygem_scope_policy.rb
@@ -1,0 +1,11 @@
+class ApiKeyRubygemScopePolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_show?
+    Pundit.policy!(user, record.ownership).avo_show?
+  end
+end

--- a/app/policies/ownership_policy.rb
+++ b/app/policies/ownership_policy.rb
@@ -1,4 +1,4 @@
-class DependencyPolicy < ApplicationPolicy
+class OwnershipPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       scope.all
@@ -8,4 +8,6 @@ class DependencyPolicy < ApplicationPolicy
   def avo_show?
     rubygems_org_admin?
   end
+
+  has_association :api_key_rubygem_scopes
 end

--- a/test/policies/api_key_policy_test.rb
+++ b/test/policies/api_key_policy_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ApiKeyPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/api_key_policy_test.rb
+++ b/test/policies/api_key_policy_test.rb
@@ -1,18 +1,41 @@
 require "test_helper"
 
 class ApiKeyPolicyTest < ActiveSupport::TestCase
+  setup do
+    @api_key = FactoryBot.create(:api_key)
+    @admin = FactoryBot.create(:admin_github_user, :is_admin)
+    @non_admin = FactoryBot.create(:admin_github_user)
+  end
+
   def test_scope
+    assert_equal [@api_key], Pundit.policy_scope!(
+      @admin,
+      ApiKey
+    ).to_a
   end
 
-  def test_show
+  def test_avo_index
+    refute_predicate Pundit.policy!(@admin, ApiKey), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, ApiKey), :avo_index?
   end
 
-  def test_create
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @api_key), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @api_key), :avo_show?
   end
 
-  def test_update
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, ApiKey), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, ApiKey), :avo_create?
   end
 
-  def test_destroy
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @api_key), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @api_key), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @api_key), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @api_key), :avo_destroy?
   end
 end

--- a/test/policies/api_key_rubygem_scope_policy_test.rb
+++ b/test/policies/api_key_rubygem_scope_policy_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ApiKeyRubygemScopePolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/api_key_rubygem_scope_policy_test.rb
+++ b/test/policies/api_key_rubygem_scope_policy_test.rb
@@ -1,18 +1,41 @@
 require "test_helper"
 
 class ApiKeyRubygemScopePolicyTest < ActiveSupport::TestCase
+  setup do
+    @scope = FactoryBot.create(:api_key_rubygem_scope)
+    @admin = FactoryBot.create(:admin_github_user, :is_admin)
+    @non_admin = FactoryBot.create(:admin_github_user)
+  end
+
   def test_scope
+    assert_equal [@scope], Pundit.policy_scope!(
+      @admin,
+      ApiKeyRubygemScope
+    ).to_a
   end
 
-  def test_show
+  def test_avo_index
+    refute_predicate Pundit.policy!(@admin, ApiKeyRubygemScope), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, ApiKeyRubygemScope), :avo_index?
   end
 
-  def test_create
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @scope), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @scope), :avo_show?
   end
 
-  def test_update
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, ApiKeyRubygemScope), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, ApiKeyRubygemScope), :avo_create?
   end
 
-  def test_destroy
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @scope), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @scope), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @scope), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @scope), :avo_destroy?
   end
 end

--- a/test/policies/ownership_policy_test.rb
+++ b/test/policies/ownership_policy_test.rb
@@ -1,18 +1,41 @@
 require "test_helper"
 
 class OwnershipPolicyTest < ActiveSupport::TestCase
+  setup do
+    @ownership = FactoryBot.create(:ownership)
+    @admin = FactoryBot.create(:admin_github_user, :is_admin)
+    @non_admin = FactoryBot.create(:admin_github_user)
+  end
+
   def test_scope
+    assert_equal [@ownership], Pundit.policy_scope!(
+      @admin,
+      Ownership
+    ).to_a
   end
 
-  def test_show
+  def test_avo_index
+    refute_predicate Pundit.policy!(@admin, Ownership), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, Ownership), :avo_index?
   end
 
-  def test_create
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @ownership), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @ownership), :avo_show?
   end
 
-  def test_update
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, Ownership), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, Ownership), :avo_create?
   end
 
-  def test_destroy
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @ownership), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @ownership), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @ownership), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @ownership), :avo_destroy?
   end
 end

--- a/test/policies/ownership_policy_test.rb
+++ b/test/policies/ownership_policy_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class OwnershipPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Disallow index, since they only need to be reachable from other resources

Ownership:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/218897866-b9ee9f0c-c8ed-4c71-b3f3-b492861b66c3.png">

User API keys:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/218898320-29d924ee-6502-4405-b268-aaf71f528b2b.png">

Single API key:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/218898416-a7f672e9-089c-461e-9ee4-cc182364ca1e.png">

API Key with rubygem scope:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/218898881-58bafeb2-8e39-4e61-a709-bc4be5a689cf.png">
