### PR TITLE
Version is responsible for setting own canonical version

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -93,7 +93,6 @@ class Pusher
     sha256 = Digest::SHA2.base64digest(body.string)
 
     @version = @rubygem.versions.new number: spec.version.to_s,
-                                     canonical_number: spec.version.canonical_segments.join("."),
                                      platform: spec.original_platform.to_s,
                                      size: size,
                                      sha256: sha256,

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -280,7 +280,7 @@ class PusherTest < ActiveSupport::TestCase
     setup do
       spec = mock
       spec.expects(:name).returns "some name"
-      spec.expects(:version).times(2).returns Gem::Version.new("1.3.3.7")
+      spec.expects(:version).returns Gem::Version.new("1.3.3.7")
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
       @cutter.stubs(:spec).returns spec


### PR DESCRIPTION
Ensures the canonical version is set as needed, instead of requiring passing it in whenever creating a new version object

Will make writing seeds easier