### PR TITLE
Tune the datadog config

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -7,6 +7,8 @@ Datadog.configure do |c|
 
   c.runtime_metrics.enabled = Rails.env.production? || Rails.env.staging?
 
+  c.logger.instance = Rails.logger
+
   c.tracing.report_hostname = true
   c.tracing.distributed_tracing.propagation_inject_style << 'tracecontext'
   c.tracing.distributed_tracing.propagation_extract_style << 'tracecontext'
@@ -22,9 +24,15 @@ Datadog.configure do |c|
   c.tracing.instrument :aws
   c.tracing.instrument :dalli
   c.tracing.instrument :delayed_job
-  c.tracing.instrument :faraday, split_by_domain: true
+  c.tracing.instrument :faraday, split_by_domain: true, service_name: c.service
+  c.tracing.instrument :http, service_name: c.service
   c.tracing.instrument :pg
   c.tracing.instrument :rails
-  c.tracing.instrument :rest_client, split_by_domain: true
+  c.tracing.instrument :rest_client, split_by_domain: true, service_name: c.service
   c.tracing.instrument :shoryuken
 end
+
+Datadog::Tracing.before_flush(
+  # Remove spans for the /internal/ping endpoint
+  Datadog::Tracing::Pipeline::SpanFilter.new { |span| span.resource == "Internal::PingController#index" }
+)


### PR DESCRIPTION
- Set service name for outbound HTTP requests (so http/faraday dont show as separate services)
- Use the standard rails logger
- Filter out ping requests, they get noisy