### PR TITLE
Move expired_or_already_used translation to webauthn_verifications

### DIFF
--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -41,7 +41,7 @@ class WebauthnVerificationsController < ApplicationController
     @verification = WebauthnVerification.find_by(path_token: webauthn_token_param)
 
     render_not_found and return unless @verification
-    redirect_to root_path, alert: t(".expired_or_already_used") if @verification.path_token_expired?
+    redirect_to root_path, alert: t("webauthn_verifications.expired_or_already_used") if @verification.path_token_expired?
   end
 
   def set_user

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -351,13 +351,12 @@ de:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,13 +340,12 @@ en:
       owner_request_heading: Ownership Request Notifications
       push_heading: Push Notifications
   webauthn_verifications:
+    expired_or_already_used: The token in the link you used has either expired or been used already.
     prompt:
       title: Authenticate with Security Device
       authenticating_as: Authenticating as
       authenticate: Authenticate
       no_webauthn_devices: You don't have any security devices enabled
-    authenticate:
-      expired_or_already_used: The token in the link you used has either expired or been used already.
   owners:
     confirm:
       confirmed_email: You were added as an owner to %{gem} gem

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -373,13 +373,12 @@ es:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -376,13 +376,12 @@ fr:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -338,13 +338,12 @@ ja:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -355,13 +355,12 @@ nl:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -366,13 +366,12 @@ pt-BR:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -338,13 +338,12 @@ zh-CN:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -339,13 +339,12 @@ zh-TW:
       owner_request_heading:
       push_heading:
   webauthn_verifications:
+    expired_or_already_used:
     prompt:
       title:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-    authenticate:
-      expired_or_already_used:
   owners:
     confirm:
       confirmed_email:

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -15,6 +15,20 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
     end
 
+    context "when the webauthn token has expired" do
+      setup do
+        @user = create(:user)
+        @token = create(:webauthn_verification, user: @user, path_token_expires_at: 1.second.ago).path_token
+        get :prompt, params: { webauthn_token: @token }
+      end
+
+      should respond_with :redirect
+      should redirect_to("the homepage") { root_url }
+      should "say the token is consumed or expired" do
+        assert_equal "The token in the link you used has either expired or been used already.", flash[:alert]
+      end
+    end
+
     context "when given a valid webauthn token param" do
       setup do
         @user = create(:user)


### PR DESCRIPTION
## What problem are you solving?
If accessing prompt when the webauthn verification path token is expired or already used, the translation is missing. The translation should be available for both the prompt and authenticate actions.

## What approach did you choose and why?
Moved the translation to a higher scope so all actions are able to use the translation.

Before
![Screenshot 2023-02-17 at 9 42 23 AM](https://user-images.githubusercontent.com/42748004/219685397-0c4ee7cb-93e1-42d9-9d2e-5532febabe41.png)

After
![Screenshot 2023-02-17 at 9 40 45 AM](https://user-images.githubusercontent.com/42748004/219685008-9c25cbd4-4c05-404e-98a4-fa1516b07830.png)
