### PR TITLE
Handle when webauthn and request OTP are nil when verifying OTP

### DIFF
--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -21,7 +21,7 @@ class WebauthnVerification < ApplicationRecord
   end
 
   def verify_otp(otp)
-    return false if otp != self.otp || otp_expired?
+    return false if self.otp.nil? || otp != self.otp || otp_expired?
     expire_otp
   end
 

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -344,9 +344,18 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         refute @user.api_otp_verified?(webauthn_verification.otp)
       end
 
-      should "return false if not been generated" do
-        create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
-        refute @user.api_otp_verified?("Yxf57d1wEUSWyXrr")
+      context "when webauthn otp has not been generated" do
+        setup do
+          create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+        end
+
+        should "return false for an otp" do
+          refute @user.api_otp_verified?("Yxf57d1wEUSWyXrr")
+        end
+
+        should "return false if otp is nil" do
+          refute @user.api_otp_verified?(nil)
+        end
       end
     end
 

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -125,6 +125,34 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
       end
     end
 
+    context "when webauthn otp has not been generated" do
+      setup do
+        @verification = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+      end
+
+      context "with a nil otp" do
+        should "return false" do
+          refute @verification.verify_otp(nil)
+        end
+
+        should "not update expiry" do
+          @verification.verify_otp(nil)
+          assert_nil @verification.otp_expires_at
+        end
+      end
+
+      context "with a non nil otp" do
+        should "return false" do
+          refute @verification.verify_otp("Yxf57d1wEUSWyXrrLMRv")
+        end
+
+        should "not update expiry" do
+          @verification.verify_otp("Yxf57d1wEUSWyXrrLMRv")
+          assert_nil @verification.otp_expires_at
+        end
+      end
+    end
+
     teardown do
       travel_back
     end


### PR DESCRIPTION
## What problem are you solving?
If a webauthn OTP has not been created and the OTP sent via an API request is also nil, an error occurs because a nil expiry can't be compared to the current time.

```
NoMethodError: undefined method `<' for nil:NilClass

    otp_expires_at < Time.now.utc
                   ^
    app/models/webauthn_verification.rb:36:in `otp_expired?'
    app/models/webauthn_verification.rb:24:in `verify_otp'
```

## What approach did you choose and why?
Instead of returning false for `otp_expired?` when the `otp_expires_at` is nil, I added a check in the method that calls `otp_expired?` to check if the webauthn otp has been generated or not (if it's nil or not).
