### PR TITLE
Explicitly set sample rate on MFA login timers

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -184,6 +184,6 @@ class SessionsController < Clearance::SessionsController
     started_at = Time.zone.parse(session[:mfa_login_started_at]).utc
     duration = Time.now.utc - started_at
 
-    StatsD.distribution("login.mfa.#{mfa_type}.duration", duration)
+    StatsD.distribution("login.mfa.#{mfa_type}.duration", duration, sample_rate: 1.0)
   end
 end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -108,7 +108,7 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         should "record duration on successful OTP login" do
-          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
+          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration, sample_rate: 1.0)
 
           travel_to @end_time do
             post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
@@ -116,7 +116,7 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         should "record duration on successful recovery code login" do
-          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
+          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration, sample_rate: 1.0)
 
           travel_to @end_time do
             post :mfa_create, params: { otp: @user.mfa_recovery_codes.first }
@@ -493,7 +493,7 @@ class SessionsControllerTest < ActionController::TestCase
         end_time = Time.utc(2023, 1, 1, 0, 2, 0)
         duration = end_time - start_time
 
-        StatsD.expects(:distribution).with("login.mfa.webauthn.duration", duration)
+        StatsD.expects(:distribution).with("login.mfa.webauthn.duration", duration, sample_rate: 1.0)
 
         travel_to start_time do
           login_to_session_with_webauthn


### PR DESCRIPTION
## 🤔 What problem are you solving?
Closes https://github.com/Shopify/ruby-dependency-security/issues/146

We're observing missing data in DataDog that seems to emulate sampling behaviour. The default sample rate [should be 1.0](https://github.com/Shopify/statsd-instrument/blob/eb706f41a6e9aa85f4863782490cf57213bfc878/lib/statsd/instrument/client.rb#L149). However, when we login, we don't always observe timing data in DataDog.

This PR tests this hypothesis.

## 🛠️ What approach did you choose and why?
We're explicitly setting the `sample_rate` to 1.0 which [sends metrics 100% of the time](https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#sample-rates). This is being set for both OTP and WebAuthn mfa login durations.

If we don't observe changed behaviour, then we will revert this PR. Otherwise, if there is changed behaviour, we'd propose explicitly setting the sample rate for all other metrics since it appears they're being sampled as well.

## 🧪 Acceptance testing
We can only test this once the PR is shipped and we begin capturing data. 

🐶 📈 **After PR is merged**
We'll need to verify that the login duration data always appears in DataDog.


