### PR TITLE
Add basic tracing tags where helpful for datadog

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -99,6 +99,7 @@ class Api::BaseController < ApplicationController
     hashed_key = Digest::SHA256.hexdigest(params_key)
     @api_key   = ApiKey.find_by_hashed_key(hashed_key)
     return render_unauthorized unless @api_key
+    set_tags "gemcutter.user.id" => @api_key.user_id, "gemcutter.user.api_key_id" => @api_key.id
     render_soft_deleted_api_key if @api_key.soft_deleted?
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Clearance::Authentication
   include Clearance::Authorization
   include ApplicationMultifactorMethods
+  include TraceTagger
 
   helper ActiveSupport::NumberHelper
 
@@ -11,6 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :reject_null_char_param
   before_action :reject_null_char_cookie
+  before_action :set_user_tag
 
   add_flash_types :notice_html
 
@@ -21,6 +23,10 @@ class ApplicationController < ActionController::Base
     session[:locale] = params[:locale] if params[:locale]
   rescue I18n::InvalidLocale
     I18n.locale = I18n.default_locale
+  end
+
+  def set_user_tag
+    set_tag "gemcutter.user.id", current_user.id if signed_in?
   end
 
   rescue_from(ActionController::ParameterMissing) do |e|

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -1,5 +1,6 @@
 class Indexer
   extend StatsD::Instrument
+  include TraceTagger
 
   def perform
     log "Updating the index"
@@ -45,12 +46,18 @@ class Indexer
   end
 
   def update_index
-    upload("specs.4.8.gz", specs_index)
-    log "Uploaded all specs index"
-    upload("latest_specs.4.8.gz", latest_index)
-    log "Uploaded latest specs index"
-    upload("prerelease_specs.4.8.gz", prerelease_index)
-    log "Uploaded prerelease specs index"
+    trace("gemcutter.indexer.index", resource: "specs.4.8.gz") do
+      upload("specs.4.8.gz", specs_index)
+      log "Uploaded all specs index"
+    end
+    trace("gemcutter.indexer.index", resource: "latest_specs.4.8.gz") do
+      upload("latest_specs.4.8.gz", latest_index)
+      log "Uploaded latest specs index"
+    end
+    trace("gemcutter.indexer.index", resource: "prerelease_specs.4.8.gz") do
+      upload("prerelease_specs.4.8.gz", prerelease_index)
+      log "Uploaded prerelease specs index"
+    end
   end
 
   def purge_cdn

--- a/app/jobs/notifier.rb
+++ b/app/jobs/notifier.rb
@@ -2,6 +2,7 @@ require "timeout"
 
 Notifier = Struct.new(:url, :protocol, :host_with_port, :rubygem, :version, :api_key) do
   extend StatsD::Instrument
+  include TraceTagger
 
   def payload
     rubygem.payload(version, protocol, host_with_port).to_json
@@ -12,6 +13,8 @@ Notifier = Struct.new(:url, :protocol, :host_with_port, :rubygem, :version, :api
   end
 
   def perform
+    set_tag "gemcutter.notifier.url", url
+
     timeout(5) do
       RestClient.post url,
         payload,

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -1,6 +1,8 @@
 require "digest/sha2"
 
 class Pusher
+  include TraceTagger
+
   attr_reader :user, :spec, :message, :code, :rubygem, :body, :version, :version_id, :size
 
   def initialize(user, body, remote_ip = "", scoped_rubygem = nil)
@@ -13,7 +15,9 @@ class Pusher
   end
 
   def process
-    pull_spec && find && authorize && verify_gem_scope && verify_mfa_requirement && validate && save
+    trace("gemcutter.pusher.process", tags: { "gemcutter.user.id" => user.id }) do
+      pull_spec && find && authorize && verify_gem_scope && verify_mfa_requirement && validate && save
+    end
   end
 
   def authorize
@@ -72,6 +76,7 @@ class Pusher
 
   def find
     name = spec.name.to_s
+    set_tag "gemcutter.rubygem.name", name
 
     @rubygem = Rubygem.name_is(name).first || Rubygem.new(name: name)
 
@@ -98,6 +103,8 @@ class Pusher
                                      sha256: sha256,
                                      pusher: user,
                                      cert_chain: spec.cert_chain
+
+    set_tags "gemcutter.rubygem.version" => @version.number, "gemcutter.rubygem.platform" => @version.platform
 
     true
   end

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -7,6 +7,12 @@ class Net::HTTP::Purge < Net::HTTPRequest
 end
 
 class Fastly
+  concerning :TraceTagging do
+    class_methods do
+      include TraceTagger
+    end
+  end
+
   # These are not kwargs because delayed_job doesn't correctly support kwargs in Fastly.delay.purge
   # See: https://github.com/collectiveidea/delayed_job/issues/1134
   def self.purge(options = {})
@@ -14,30 +20,36 @@ class Fastly
 
     ENV["FASTLY_DOMAINS"].split(",").each do |domain|
       url = "https://#{domain}/#{options[:path]}"
-      headers = options[:soft] ? { "Fastly-Soft-Purge" => 1 } : {}
-      headers["Fastly-Key"] = ENV["FASTLY_API_KEY"]
+      trace("gemcutter.fastly.purge", resource: url,
+            tags: { "gemcutter.fastly.domain" => domain, "gemcutter.fastly.path" => options[:path], "gemcutter.fastly.soft" => options[:soft] }) do
+        headers = options[:soft] ? { "Fastly-Soft-Purge" => 1 } : {}
+        headers["Fastly-Key"] = ENV["FASTLY_API_KEY"]
 
-      response = RestClient::Request.execute(method: :purge,
-                                             url: url,
-                                             timeout: 10,
-                                             headers: headers)
-      json = JSON.parse(response)
-      Rails.logger.debug { "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}" }
+        response = RestClient::Request.execute(method: :purge,
+                                              url: url,
+                                              timeout: 10,
+                                              headers: headers)
+        json = JSON.parse(response)
+        Rails.logger.debug { "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}" }
+      end
     end
   end
 
   def self.purge_key(key, soft: false)
-    return unless ENV["FASTLY_SERVICE_ID"].present? && ENV["FASTLY_API_KEY"].present?
+    service_id = ENV["FASTLY_SERVICE_ID"]
+    return unless service_id.present? && ENV["FASTLY_API_KEY"].present?
 
-    headers = { "Fastly-Key" => ENV["FASTLY_API_KEY"] }
-    headers["Fastly-Soft-Purge"] = 1 if soft
-    url = "https://api.fastly.com/service/#{ENV['FASTLY_SERVICE_ID']}/purge/#{key}"
-    response = RestClient::Request.execute(method: :post,
-                                           url: url,
-                                           timeout: 10,
-                                           headers: headers)
-    json = JSON.parse(response)
-    Rails.logger.debug { "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}" }
-    json
+    trace("gemcutter.fastly.purge_key", resource: key, tags: { "gemcutter.fastly.service_id" => service_id, "gemcutter.fastly.soft" => soft }) do
+      headers = { "Fastly-Key" => ENV["FASTLY_API_KEY"] }
+      headers["Fastly-Soft-Purge"] = 1 if soft
+      url = "https://api.fastly.com/service/#{service_id}/purge/#{key}"
+      response = RestClient::Request.execute(method: :post,
+                                            url: url,
+                                            timeout: 10,
+                                            headers: headers)
+      json = JSON.parse(response)
+      Rails.logger.debug { "Fastly purge url=#{url} status=#{json['status']} id=#{json['id']}" }
+      json
+    end
   end
 end

--- a/lib/trace_tagger.rb
+++ b/lib/trace_tagger.rb
@@ -1,0 +1,13 @@
+module TraceTagger
+  extend ActiveSupport::Concern
+
+  included do
+    delegate :set_tag, :set_tags, to: "Datadog::Tracing.active_span", allow_nil: true
+
+    def trace(...)
+      return yield unless Datadog::Tracing.enabled?
+
+      Datadog::Tracing.trace(...)
+    end
+  end
+end


### PR DESCRIPTION
Specifically:

- User IDs for both HTML and API
- Admin user IDs
- Updating the index (out longest running job)
- Notifier URLs (where we otherwise swallow errors)
- Pusher gem information