### PR TITLE
Add a cookie rotator to migrate to SHA256

### DIFF
--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -1,0 +1,14 @@
+Rails.application.config.after_initialize do
+  Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+    salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
+    secret_key_base = Rails.application.secret_key_base
+
+    key_generator = ActiveSupport::KeyGenerator.new(
+      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+    )
+    key_len = ActiveSupport::MessageEncryptor.key_len
+    secret = key_generator.generate_key(salt, key_len)
+
+    cookies.rotate :encrypted, secret
+  end
+end

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -23,7 +23,7 @@
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and


### PR DESCRIPTION
Following https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256