### PR TITLE
Block user via admin panel

### DIFF
--- a/app/avo/actions/block_user.rb
+++ b/app/avo/actions/block_user.rb
@@ -1,0 +1,18 @@
+class BlockUser < BaseAction
+  self.name = "Block User"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+
+  self.message = lambda {
+    "Are you sure you would like to block user #{record.handle} with #{record.email}?"
+  }
+
+  self.confirm_button_label = "Block User"
+
+  class ActionHandler < ActionHandler
+    def handle_model(user)
+      user.block!
+    end
+  end
+end

--- a/app/avo/resources/user_resource.rb
+++ b/app/avo/resources/user_resource.rb
@@ -6,6 +6,7 @@ class UserResource < Avo::BaseResource
   }
 
   action ResetUser2fa
+  action BlockUser
 
   field :id, as: :id
   # Fields generated from the model

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -95,4 +95,86 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     assert_equal admin_user, audit.admin_github_user
     assert_equal "A nice long comment", audit.comment
   end
+
+  test "block user" do
+    Minitest::Test.make_my_diffs_pretty!
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    user = create(:user)
+    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user_attributes = user.attributes.with_indifferent_access
+
+    visit avo.resources_user_path(user)
+
+    click_button "Actions"
+    click_on "Block User"
+
+    assert_no_changes "User.find(#{user.id}).attributes" do
+      click_button "Block User"
+    end
+    page.assert_text "Must supply a sufficiently detailed comment"
+
+    fill_in "Comment", with: "A nice long comment"
+    click_button "Block User"
+    page.assert_text "Action ran successfully!"
+    page.assert_text user.to_global_id.uri.to_s
+
+    page.assert_no_text user.encrypted_password
+    page.assert_no_text user_attributes[:encrypted_password]
+    page.assert_no_text user_attributes[:mfa_seed]
+    page.assert_no_text user_attributes[:mfa_recovery_codes].first
+
+    user.reload
+
+    assert_equal "disabled", user.mfa_level
+    assert_not_equal user_attributes[:encrypted_password], user.encrypted_password
+    assert_empty user.mfa_seed
+    assert_empty user.mfa_recovery_codes
+
+    audit = user.audits.sole
+
+    page.assert_text audit.id
+    assert_equal "User", audit.auditable_type
+    assert_equal "Block User", audit.action
+    assert_equal(
+      {
+        "records" => {
+          "gid://gemcutter/User/#{user.id}" => {
+            "changes" => {
+              "email" => [user_attributes[:email], user.email],
+              "updated_at" => [user_attributes[:updated_at].as_json, user.updated_at.as_json],
+              "confirmation_token" => [user_attributes[:confirmation_token], nil],
+              "mfa_level" => %w[ui_and_api disabled],
+              "mfa_seed" => [user_attributes[:mfa_seed], ""],
+              "mfa_recovery_codes" => [user_attributes[:mfa_recovery_codes], []],
+              "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password],
+              "api_key" => ["secret123", nil],
+              "remember_token" => [user_attributes[:remember_token], nil],
+              "blocked_email" => [nil, user_attributes[:email]],
+            },
+            "unchanged" => user.attributes
+              .except(
+                "api_key",
+                "blocked_email",
+                "confirmation_token",
+                "email",
+                "encrypted_password",
+                "mfa_level",
+                "mfa_recovery_codes",
+                "mfa_seed",
+                "remember_token",
+                "updated_at"
+              ).transform_values(&:as_json)
+          }
+        },
+        "fields" => {},
+        "arguments" => {},
+        "models" => ["gid://gemcutter/User/#{user.id}"]
+      },
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "A nice long comment", audit.comment
+  end
 end

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -151,7 +151,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
               "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password],
               "api_key" => ["secret123", nil],
               "remember_token" => [user_attributes[:remember_token], nil],
-              "blocked_email" => [nil, user_attributes[:email]],
+              "blocked_email" => [nil, user_attributes[:email]]
             },
             "unchanged" => user.attributes
               .except(


### PR DESCRIPTION
We have a script which we used to block users account in
case we need to. This PR makes it possible to do via
admin panel so that we don't have to do it via a script.

* Added an avo action to block a user
* Used this new action on user's show page in admin.

This is how it looks in UI

![Monosnap handle9 — RubyGems org (development) 2023-02-20 6 pm-42-46](https://user-images.githubusercontent.com/3948/220118459-c1aa9623-37ff-437a-bb07-081247949a67.png)
