### PR TITLE
Revert "Explicitly set sample rate on MFA login timers"

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -184,6 +184,6 @@ class SessionsController < Clearance::SessionsController
     started_at = Time.zone.parse(session[:mfa_login_started_at]).utc
     duration = Time.now.utc - started_at
 
-    StatsD.distribution("login.mfa.#{mfa_type}.duration", duration, sample_rate: 1.0)
+    StatsD.distribution("login.mfa.#{mfa_type}.duration", duration)
   end
 end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -108,7 +108,7 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         should "record duration on successful OTP login" do
-          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration, sample_rate: 1.0)
+          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
 
           travel_to @end_time do
             post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
@@ -116,7 +116,7 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         should "record duration on successful recovery code login" do
-          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration, sample_rate: 1.0)
+          StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
 
           travel_to @end_time do
             post :mfa_create, params: { otp: @user.mfa_recovery_codes.first }
@@ -493,7 +493,7 @@ class SessionsControllerTest < ActionController::TestCase
         end_time = Time.utc(2023, 1, 1, 0, 2, 0)
         duration = end_time - start_time
 
-        StatsD.expects(:distribution).with("login.mfa.webauthn.duration", duration, sample_rate: 1.0)
+        StatsD.expects(:distribution).with("login.mfa.webauthn.duration", duration)
 
         travel_to start_time do
           login_to_session_with_webauthn


### PR DESCRIPTION
## 🤔 What problem are you solving?
Contributes to https://github.com/Shopify/ruby-dependency-security/issues/146

Reverts rubygems/rubygems.org#3460 since the changes in that PR did not produce the desired effect of sending 100% of the login durations metrics to Datadog. Instead, it appears that all login duration metrics are now missing. 

## 🛠️ What approach did you choose and why?
Reverting the changes from rubygems/rubygems.org#3460

## 🧪 Acceptance testing
We can only test this once the PR is shipped and we begin capturing data. 

🐶 📈 **After PR is merged**
We'll need to verify that the login duration data _sometimes_ appears in DataDog as it did before introducing  rubygems/rubygems.org#3460.




