### PR TITLE
Rewrite homepage to be fully static, even for logged in users, to improve caching

### DIFF
--- a/app/assets/javascripts/mobile-nav.js
+++ b/app/assets/javascripts/mobile-nav.js
@@ -1,14 +1,14 @@
-$(function() {
+function bindMobileNav() {
   // cache jQuery lookups into variables
   // so we don't have to traverse the DOM every time
-  var sandwichIcon     = $('.header__club-sandwich');
-  var header           = $('.header');
-  var main             = $('main');
-  var footer           = $('.footer');
-  var signUpLink       = $('.header__nav-link.js-sign-up-trigger');
-  var navExpandedClass = 'mobile-nav-is-expanded';
-  var headerSearch     = $('.header__search');
-  var headerLogo       = $('.header__logo-wrap');
+  var sandwichIcon = $(".header__club-sandwich");
+  var header = $(".header");
+  var main = $("main");
+  var footer = $(".footer");
+  var signUpLink = $(".header__nav-link.js-sign-up-trigger");
+  var navExpandedClass = "mobile-nav-is-expanded";
+  var headerSearch = $(".header__search");
+  var headerLogo = $(".header__logo-wrap");
 
   // variable to support mobile nav tab behaviour
   // * skipSandwichIcon is for skipping sandwich icon
@@ -16,7 +16,7 @@ $(function() {
   // * tabDirection is for hiding and showing navbar
   //   when you tab in and out
   var skipSandwichIcon = true;
-  var tabDirection     = true;
+  var tabDirection = true;
 
   function removeNavExpandedClass() {
     header.removeClass(navExpandedClass);
@@ -42,20 +42,20 @@ $(function() {
     }
   }
 
-  sandwichIcon.click(function(e){
-    var nav = {expandedClass: navExpandedClass, popUp: header}
+  sandwichIcon.click(function (e) {
+    var nav = { expandedClass: navExpandedClass, popUp: header };
     handleClick(e, nav, removeNavExpandedClass, addNavExpandedClass);
   });
 
-  sandwichIcon.on('focusin', handleFocusIn);
+  sandwichIcon.on("focusin", handleFocusIn);
 
-  signUpLink.on('focusin', function() {
+  signUpLink.on("focusin", function () {
     if (!tabDirection) {
       addNavExpandedClass();
     }
   });
 
-  signUpLink.on('focusout', function() {
+  signUpLink.on("focusout", function () {
     if (tabDirection) {
       tabDirection = false;
       removeNavExpandedClass();
@@ -64,4 +64,4 @@ $(function() {
       addNavExpandedClass();
     }
   });
-});
+}

--- a/app/assets/javascripts/nav_profile_links.js
+++ b/app/assets/javascripts/nav_profile_links.js
@@ -1,0 +1,33 @@
+$(function () {
+  var getNavProfileLinks = "/nav_profile_links";
+  var navProfileLinksSelector = "#nav_profile_links";
+  var getMobileNavProfileLinks = "/mobile_nav_profile_links";
+  var mobileNavProfileLinksSelector = "#mobile_nav_profile_links";
+
+  $.ajax({
+    type: "get",
+    url: getNavProfileLinks,
+    success: function (resp) {
+      renderProfileLinks(navProfileLinksSelector, resp);
+      // function defined in popup-nav.js
+      bindPopupNav();
+    },
+  });
+  $.ajax({
+    type: "get",
+    url: getMobileNavProfileLinks,
+    success: function (resp) {
+      renderProfileLinks(mobileNavProfileLinksSelector, resp);
+      // function defined in mobile-nav.js
+      bindMobileNav();
+    },
+  });
+
+  function renderProfileLinks(selector, response) {
+    var nav = $(selector);
+    if (!!response.trim()) {
+      nav.html(response);
+    }
+    nav.addClass("nav-loaded");
+  }
+});

--- a/app/assets/javascripts/popup-nav.js
+++ b/app/assets/javascripts/popup-nav.js
@@ -1,8 +1,8 @@
-$(function() {
-  var arrowIcon        = $('.header__popup-link');
-  var popupNav         = $('.header__popup__nav-links');
+function bindPopupNav() {
+  var arrowIcon = $(".header__popup-link");
+  var popupNav = $(".header__popup__nav-links");
 
-  var navExpandedClass = 'is-expanded';
+  var navExpandedClass = "is-expanded";
 
   function removeNavExpandedClass() {
     popupNav.removeClass(navExpandedClass);
@@ -12,9 +12,8 @@ $(function() {
     popupNav.addClass(navExpandedClass);
   }
 
-  arrowIcon.click(function(e){
-    var nav = {expandedClass: navExpandedClass, popUp: popupNav}
+  arrowIcon.click(function (e) {
+    var nav = { expandedClass: navExpandedClass, popUp: popupNav };
     handleClick(e, nav, removeNavExpandedClass, addNavExpandedClass);
   });
-});
-
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,4 +5,18 @@ class HomeController < ApplicationController
       format.html
     end
   end
+
+  def nav_profile_links
+    respond_to do |format|
+      format.html
+      render template: "layouts/_nav_profile_links", layout: false
+    end
+  end
+
+  def mobile_nav_profile_links
+    respond_to do |format|
+      format.html
+      render template: "layouts/_mobile_nav_profile_links", layout: false
+    end
+  end
 end

--- a/app/views/layouts/_mobile_nav_profile_links.erb
+++ b/app/views/layouts/_mobile_nav_profile_links.erb
@@ -1,0 +1,7 @@
+<% if signed_in? %>
+  <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link mobile__header__nav-link">
+    <span><%= current_user.name %></span>
+    <%= gravatar 80, "user_gravatar" %>
+  </a>
+<% end %>
+  

--- a/app/views/layouts/_nav_profile_links.erb
+++ b/app/views/layouts/_nav_profile_links.erb
@@ -1,0 +1,16 @@
+<% if signed_in? %>
+  <% i18n_scope = %i[layouts application header] %>
+  <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
+    <span><%= current_user.name %></span>
+    <%= gravatar 80, "user_gravatar" %>
+  </a>
+  <a href="#" class="header__popup-link" data-icon="▼">
+    <span class="t-hidden">More items</span>
+  </a>
+  <div class="header__popup__nav-links">
+    <%= link_to t('settings', scope: i18n_scope), edit_settings_path, class: "header__nav-link" %>
+    <%= link_to t('dashboard', scope: i18n_scope), dashboard_path, class: "header__nav-link" %>
+    <%= link_to t('edit_profile', scope: i18n_scope), edit_profile_path, class: "header__nav-link" %>
+    <%= link_to t('sign_out', scope: i18n_scope), sign_out_path, method: :delete, class: "header__nav-link" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,12 +44,8 @@
           <% end %>
 
           <nav class="header__nav-links">
-            <% if signed_in? %>
-              <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link mobile__header__nav-link">
-                <span><%= current_user.name %></span>
-                <%= gravatar 80, "user_gravatar" %>
-              </a>
-            <% end %>
+            <span id="mobile_nav_profile_links">
+            </span>
 
             <%= link_to "Releases", news_url, class: "header__nav-link #{active?(news_path)}" %>
             <%= link_to t('.footer.blog'), "https://blog.rubygems.org", class: "header__nav-link" %>
@@ -62,26 +58,12 @@
 
             <%= link_to t('.footer.guides'), "https://guides.rubygems.org", class: "header__nav-link" %>
 
-            <% if signed_in? %>
-              <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
-                <span><%= current_user.name %></span>
-                <%= gravatar 80, "user_gravatar" %>
-              </a>
-              <a href="#" class="header__popup-link" data-icon="▼">
-                <span class="t-hidden">More items</span>
-              </a>
-              <div class="header__popup__nav-links">
-                <%= link_to t('.header.settings'), edit_settings_path, class: "header__nav-link" %>
-                <%= link_to t('.header.dashboard'), dashboard_path, class: "header__nav-link" %>
-                <%= link_to t('.header.edit_profile'), edit_profile_path, class: "header__nav-link" %>
-                <%= link_to t('.header.sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
-              </div>
-            <% else %>
+            <span id="nav_profile_links">
               <%= link_to t('.header.sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_in'}" %>
               <% if Clearance.configuration.allow_sign_up? %>
                 <%= link_to t('.header.sign_up'), sign_up_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_up'}" %>
               <% end %>
-            <% end %>
+            </span>
           </nav>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,8 @@ Rails.application.routes.draw do
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
     get '/sign_up' => 'users#new', as: 'sign_up' if Clearance.configuration.allow_sign_up?
+    get '/nav_profile_links' => 'home#nav_profile_links'
+    get '/mobile_nav_profile_links' => 'home#mobile_nav_profile_links'
   end
 
   ################################################################################

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -21,25 +21,28 @@ class EmailConfirmationTest < SystemTest
   end
 
   test "requesting confirmation mail with email of existing user" do
+    fullscreen_headless_chrome_driver
     request_confirmation_mail @user.email
 
     link = last_email_link
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
   end
 
   test "re-using confirmation link does not sign in user" do
+    fullscreen_headless_chrome_driver
     request_confirmation_mail @user.email
 
     link = last_email_link
     visit link
+    click_link "More items"
     click_link "Sign out"
 
     visit link
-    assert page.has_content? "Sign in"
+    assert page.has_content? :all, "Sign in"
     assert page.has_selector? "#flash_alert", text: "Please double check the URL or try submitting it again."
   end
 
@@ -56,6 +59,7 @@ class EmailConfirmationTest < SystemTest
 
   test "requesting confirmation mail with mfa enabled" do
     @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    fullscreen_headless_chrome_driver
     request_confirmation_mail @user.email
 
     link = last_email_link
@@ -65,7 +69,7 @@ class EmailConfirmationTest < SystemTest
     fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
     click_button "Authenticate"
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "requesting confirmation mail with webauthn enabled" do

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -9,6 +9,7 @@ class OwnerTest < SystemTest
     @rubygem = create(:rubygem, number: "1.0.0")
     @ownership = create(:ownership, user: @user, rubygem: @rubygem)
 
+    fullscreen_headless_chrome_driver
     sign_in_as(@user)
     ActionMailer::Base.deliveries.clear
   end
@@ -73,8 +74,10 @@ class OwnerTest < SystemTest
 
     visit_ownerships_page
 
-    within_element owner_row(@other_user) do
-      click_button "Remove"
+    accept_alert do
+      within_element owner_row(@other_user) do
+        click_button "Remove"
+      end
     end
 
     refute page.has_selector? ".owners__table a[href='#{profile_path(@other_user)}']"
@@ -90,8 +93,10 @@ class OwnerTest < SystemTest
   test "removing last owner shows error message" do
     visit_ownerships_page
 
-    within_element owner_row(@user) do
-      click_button "Remove"
+    accept_alert do
+      within_element owner_row(@user) do
+        click_button "Remove"
+      end
     end
 
     assert page.has_selector?("a[href='#{profile_path(@user.display_id)}']")
@@ -164,6 +169,7 @@ class OwnerTest < SystemTest
   end
 
   test "hides ownership link when not owner" do
+    click_link "More items"
     page.find("a[href='/sign_out']").click
     sign_in_as(@other_user)
     visit rubygem_path(@rubygem)
@@ -171,12 +177,14 @@ class OwnerTest < SystemTest
   end
 
   test "hides ownership link when not signed in" do
+    click_link "More items"
     page.find("a[href='/sign_out']").click
     visit rubygem_path(@rubygem)
     refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem)}']")
   end
 
   test "shows resend confirmation link when unconfirmed" do
+    click_link "More items"
     page.find("a[href='/sign_out']").click
     create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
     sign_in_as(@other_user)

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -28,6 +28,7 @@ class PasswordResetTest < SystemTest
   end
 
   test "resetting password without handle" do
+    fullscreen_headless_chrome_driver
     forgot_password_with @user.email
 
     visit password_reset_link
@@ -38,6 +39,7 @@ class PasswordResetTest < SystemTest
     click_button "Save this password"
     assert_equal dashboard_path, page.current_path
 
+    click_link "More items"
     click_link "Sign out"
 
     visit sign_in_path
@@ -45,7 +47,7 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "resetting a password with a blank password" do
@@ -83,6 +85,7 @@ class PasswordResetTest < SystemTest
   end
 
   test "restting password when mfa is enabled" do
+    fullscreen_headless_chrome_driver
     @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
     forgot_password_with @user.email
 
@@ -94,7 +97,7 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
 
-    assert page.has_content?("Sign out")
+    assert page.has_content?(:all, "Sign out")
   end
 
   test "resetting password when webauthn is enabled" do
@@ -122,6 +125,7 @@ class PasswordResetTest < SystemTest
   end
 
   test "resetting password with pending email change" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
 
     email = @user.email
@@ -140,6 +144,7 @@ class PasswordResetTest < SystemTest
 
     assert_equal new_email, @user.reload.unconfirmed_email
 
+    click_link "More items"
     click_link "Sign out"
 
     forgot_password_with email

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -13,6 +13,7 @@ class ProfileTest < SystemTest
   end
 
   test "changing handle" do
+    fullscreen_headless_chrome_driver
     sign_in
 
     visit profile_path("nick1")
@@ -23,7 +24,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert page.has_content? "nick2"
+    assert page.has_content? :all, "nick2"
   end
 
   test "changing to an existing handle" do
@@ -41,6 +42,7 @@ class ProfileTest < SystemTest
   end
 
   test "changing to invalid handle does not affect rendering" do
+    fullscreen_headless_chrome_driver
     sign_in
     visit profile_path("nick1")
     click_link "Edit Profile"
@@ -94,6 +96,7 @@ class ProfileTest < SystemTest
   end
 
   test "adding Twitter username" do
+    fullscreen_headless_chrome_driver
     sign_in
     visit profile_path("nick1")
 
@@ -102,6 +105,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
+    click_link "More items"
     click_link "Sign out"
     visit profile_path("nick1")
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -9,21 +9,22 @@ class SignInTest < SystemTest
   end
 
   test "signing in" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
-
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with uppercase email" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "Nick@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with wrong password" do
@@ -64,6 +65,7 @@ class SignInTest < SystemTest
   end
 
   test "signing in with current valid otp when mfa enabled" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -77,7 +79,7 @@ class SignInTest < SystemTest
       click_button "Verify code"
     end
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with current valid otp when mfa enabled but 30 minutes has passed" do
@@ -117,6 +119,7 @@ class SignInTest < SystemTest
   end
 
   test "signing in with valid recovery code when mfa enabled" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -129,7 +132,7 @@ class SignInTest < SystemTest
       click_button "Verify code"
     end
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with invalid recovery code when mfa enabled" do
@@ -156,6 +159,7 @@ class SignInTest < SystemTest
       rubygem_id: rubygem.id
     )
 
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -165,7 +169,7 @@ class SignInTest < SystemTest
                       "Your account will be required to have MFA enabled in the future."
     assert page.has_selector? "#flash_notice", text: expected_notice
     assert_current_path(new_multifactor_auth_path)
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with mfa enabled on `ui_only` with gem ownership that exceeds the recommended download threshold" do
@@ -176,6 +180,7 @@ class SignInTest < SystemTest
       rubygem_id: rubygem.id
     )
 
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -193,7 +198,7 @@ class SignInTest < SystemTest
                       "on one of these levels in the future."
     assert page.has_selector? "#flash_notice", text: expected_notice
     assert_current_path(edit_settings_path)
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with mfa enabled on `ui_and_gem_signin` with gem ownership that exceeds the recommended download threshold" do
@@ -205,6 +210,7 @@ class SignInTest < SystemTest
       rubygem_id: rubygem.id
     )
 
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -218,7 +224,7 @@ class SignInTest < SystemTest
 
     assert_current_path(dashboard_path)
     refute page.has_selector? "#flash_notice"
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing in with mfa enabled on `ui_and_api` with gem ownership that exceeds the recommended download threshold" do
@@ -230,6 +236,7 @@ class SignInTest < SystemTest
       rubygem_id: rubygem.id
     )
 
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -243,12 +250,13 @@ class SignInTest < SystemTest
 
     assert_current_path(dashboard_path)
     refute page.has_selector? "#flash_notice"
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "siging in when user does not have handle" do
     @mfa_user.update_attribute(:handle, nil)
 
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "john@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -260,17 +268,18 @@ class SignInTest < SystemTest
       fill_in "OTP or recovery code", with: ROTP::TOTP.new("thisisonemfaseed").now
       click_button "Verify code"
     end
-
-    assert page.has_content? "john@example.com"
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "john@example.com"
+    assert page.has_content? :all, "Sign out"
   end
 
   test "signing out" do
+    fullscreen_headless_chrome_driver
     visit sign_in_path
     fill_in "Email or Username", with: "nick@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
+    click_link "More items"
     click_link "Sign out"
 
     assert page.has_content? "Sign in"

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -63,6 +63,7 @@ class SignUpTest < SystemTest
   end
 
   test "email confirmation" do
+    fullscreen_headless_chrome_driver
     visit sign_up_path
 
     fill_in "Email", with: "email@person.com"
@@ -74,7 +75,7 @@ class SignUpTest < SystemTest
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? :all, "Sign out"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,7 +134,10 @@ class SystemTest < ActionDispatch::IntegrationTest
     Capybara.current_driver = :rack_test
   end
 
-  teardown { reset_session! }
+  teardown do
+    reset_session!
+    Capybara.use_default_driver
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Async fetch the a menu in the top right that shows your logged in user info and a menu using a JS request.

Once we have this set up, we can force Fastly to cache the homepage even if users have a cookie.

Because we're using js to fetch the partials now, some tests need to use selenium as the driver instead of rack test. The changes in the test are due to a different driver.

I thought about writing more "modern" javascript but didn't want to worry about reconfiguring any asset pipeline stuff (I considered hotwire and stimulus). But since the site has gone this long with such minimal js, it felt like overkill.