### PR TITLE
Add brownout ranges for deprecated dependency api

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -1,5 +1,19 @@
 class Api::V1::DependenciesController < Api::BaseController
+  before_action :check_brownout
   before_action :check_gem_count
+
+  mattr_reader :brownout_ranges, default: [
+    # March 22 at 00:00 UTC (4pm PT / 7pm ET) for 5 minutes
+    [Time.utc(2023, 3, 22), 5.minutes],
+    # March 29 at the top of every hour UTC for 10 minutes
+    *(0..23).map do |h|
+      [Time.utc(2023, 3, 29, h), 10.minutes]
+    end,
+    # April 03 for the entire day UTC
+    [Time.utc(2023, 4, 3), 1.day]
+  ].map { |start, duration| start..(start + duration) } <<
+    # April 10 from 00:00 UTC onward
+    (Time.utc(2023, 4, 10)...)
 
   def index
     deps = GemDependent.new(gem_names).to_a
@@ -14,6 +28,17 @@ class Api::V1::DependenciesController < Api::BaseController
   end
 
   private
+
+  def check_brownout
+    current_time = Time.current.utc
+    return if brownout_ranges.none? { |r| r.cover?(current_time) }
+
+    respond_to do |format|
+      error = "The dependency API is going away. See https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html for more information"
+      format.marshal { render plain: error, status: :not_found }
+      format.json { render json: { error: error, code: 404 }, status: :not_found }
+    end
+  end
 
   def check_gem_count
     return render plain: "" if gem_names.empty?


### PR DESCRIPTION
Pursuant to the rfc / [blog post](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html)

Brownout ranges resolve to:

```
[2023-03-22 00:00:00 UTC..2023-03-22 00:05:00 UTC,
 2023-03-29 00:00:00 UTC..2023-03-29 00:10:00 UTC,
 2023-03-29 01:00:00 UTC..2023-03-29 01:10:00 UTC,
 2023-03-29 02:00:00 UTC..2023-03-29 02:10:00 UTC,
 2023-03-29 03:00:00 UTC..2023-03-29 03:10:00 UTC,
 2023-03-29 04:00:00 UTC..2023-03-29 04:10:00 UTC,
 2023-03-29 05:00:00 UTC..2023-03-29 05:10:00 UTC,
 2023-03-29 06:00:00 UTC..2023-03-29 06:10:00 UTC,
 2023-03-29 07:00:00 UTC..2023-03-29 07:10:00 UTC,
 2023-03-29 08:00:00 UTC..2023-03-29 08:10:00 UTC,
 2023-03-29 09:00:00 UTC..2023-03-29 09:10:00 UTC,
 2023-03-29 10:00:00 UTC..2023-03-29 10:10:00 UTC,
 2023-03-29 11:00:00 UTC..2023-03-29 11:10:00 UTC,
 2023-03-29 12:00:00 UTC..2023-03-29 12:10:00 UTC,
 2023-03-29 13:00:00 UTC..2023-03-29 13:10:00 UTC,
 2023-03-29 14:00:00 UTC..2023-03-29 14:10:00 UTC,
 2023-03-29 15:00:00 UTC..2023-03-29 15:10:00 UTC,
 2023-03-29 16:00:00 UTC..2023-03-29 16:10:00 UTC,
 2023-03-29 17:00:00 UTC..2023-03-29 17:10:00 UTC,
 2023-03-29 18:00:00 UTC..2023-03-29 18:10:00 UTC,
 2023-03-29 19:00:00 UTC..2023-03-29 19:10:00 UTC,
 2023-03-29 20:00:00 UTC..2023-03-29 20:10:00 UTC,
 2023-03-29 21:00:00 UTC..2023-03-29 21:10:00 UTC,
 2023-03-29 22:00:00 UTC..2023-03-29 22:10:00 UTC,
 2023-03-29 23:00:00 UTC..2023-03-29 23:10:00 UTC,
 2023-04-03 00:00:00 UTC..2023-04-04 00:00:00 UTC,
 2023-04-10 00:00:00 UTC...]
```