### PR TITLE
Enable secure gravatar even locally.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
   end
 
   def gravatar(size, id = "gravatar", user = current_user)
-    image_tag user.gravatar_url(size: size, secure: request.ssl?).html_safe,
+    image_tag user.gravatar_url(size: size, secure: true).html_safe,
       id: id,
       width: size,
       height: size


### PR DESCRIPTION
- fixes gravatar CSP during development, only HTTPS one is enabled in CSP