### PR TITLE
Remove Datadog log tags in development.

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -14,6 +14,14 @@ Datadog.configure do |c|
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled
 
+  unless enabled
+    # TODO: https://github.com/DataDog/dd-trace-rb/issues/2542
+    # disable log tags loaded super early by ddtrace/auto_instrument
+    # required in Gemfile, since they are polluting development log
+    original_tags = Array.wrap(Rails.application.config.log_tags).reject! { |tag| tag&.source_location&.include?('datadog') }
+    Rails.application.config.log_tags = original_tags
+  end
+
   # Configuring the datadog library
 
   c.logger.instance = Rails.logger


### PR DESCRIPTION
- they are super extensive and polluting classic Rails dev log
- related to https://github.com/DataDog/dd-trace-rb/issues/2542

### before

```
[retro@retro  rubygems.org (master *%=)]❤ bin/rails s                                                                                                                                         
=> Booting Puma                                                                                                                                                                               
=> Rails 7.0.4.2 application starting in development                                                                                                                                          
=> Run `bin/rails server --help` for more startup options                                                                                                                                     
Puma starting in single mode...                                                                                                                                                               
* Puma version: 6.1.0 (ruby 3.2.0-p0) ("The Way Up")                                           
*  Min threads: 0                                                                                                                                                                             
*  Max threads: 5                                                                                                                                                                             
*  Environment: development                                                                                                                                                                   
*          PID: 4050752                                                                                                                                                                       
* Listening on http://127.0.0.1:3000                                                                                                                                                          
* Listening on http://[::1]:3000                                                                                                                                                              
Use Ctrl-C to stop                                                                                                                                                                            
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0] Started GET "/" for ::1 at 2023-02-22 22:23:30 +
0100                                                                                                                                                                                          
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   ActiveRecord::SchemaMigration Pluck (0.8ms)  S
ELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC                                                                                       
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0] Processing by HomeController#index as HTML      
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   User Load (0.5ms)  SELECT "users".* FROM "user
s" WHERE "users"."remember_token" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["remember_token", "eb66f55214de86f5c7b0ca3c28dc5d24d1f4f839"], ["LIMIT", 1]]                                     
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   ↳ config/initializers/clearance.rb:19:in `curr
ent_user'                                                                                                                                                                                     
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   GemDownload Pluck (0.4ms)  SELECT "gem_downloa
ds"."count" FROM "gem_downloads" WHERE "gem_downloads"."rubygem_id" = $1 AND "gem_downloads"."version_id" = $2 LIMIT $3  [["rubygem_id", 0], ["version_id", 0], ["LIMIT", 1]]                 
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   ↳ app/models/gem_download.rb:79:in `count_for'
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   Rendering layout layouts/application.html.erb 
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   Rendering home/index.html.erb within layouts/a
pplication                                                                                                                                                                                    
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   Rendered home/index.html.erb within layouts/ap
plication (Duration: 3.1ms | Allocations: 2393)                                                
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   Rendered layouts/_feeds.html.erb (Duration: 1.
0ms | Allocations: 556)                                                                        
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0]   Rendered layout layouts/application.html.erb (
Duration: 54.1ms | Allocations: 46377)                                                                                                                                                        
[dd.env=development dd.service=rubygems.org dd.version=19a1e214ae31037e7be323e804789098b2a25556 dd.trace_id=1786634401773716474 dd.span_id=0] Completed 200 OK in 87ms (Views: 55.8ms | Active
Record: 6.1ms | Allocations: 66281)                                                                                                                                                           
```

### after

```
[retro@retro  rubygems.org (master *%=)]❤ bin/rails s                                          
=> Booting Puma                              
=> Rails 7.0.4.2 application starting in development                                           
=> Run `bin/rails server --help` for more startup options                              
Puma starting in single mode...                
* Puma version: 6.1.0 (ruby 3.2.0-p0) ("The Way Up")
*  Min threads: 0                                                                              
*  Max threads: 5                                                                              
*  Environment: development                                                                    
*          PID: 4051565
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000                                                               
Use Ctrl-C to stop
Started GET "/" for ::1 at 2023-02-22 22:26:20 +0100
  ActiveRecord::SchemaMigration Pluck (0.9ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by HomeController#index as HTML
  User Load (0.5ms)  SELECT "users".* FROM "users" WHERE "users"."remember_token" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["remember_token", "eb66f55214de86f5c7b0ca3c28dc5d24d1f4f839"], ["
LIMIT", 1]]                                                                                    
  ↳ config/initializers/clearance.rb:19:in `current_user'                         
  GemDownload Pluck (0.5ms)  SELECT "gem_downloads"."count" FROM "gem_downloads" WHERE "gem_downloads"."rubygem_id" = $1 AND "gem_downloads"."version_id" = $2 LIMIT $3  [["rubygem_id", 0], [
"version_id", 0], ["LIMIT", 1]]                                                                
  ↳ app/models/gem_download.rb:79:in `count_for'              
  Rendering layout layouts/application.html.erb               
  Rendering home/index.html.erb within layouts/application
  Rendered home/index.html.erb within layouts/application (Duration: 3.3ms | Allocations: 2393) 
  Rendered layouts/_feeds.html.erb (Duration: 0.9ms | Allocations: 556)
  Rendered layout layouts/application.html.erb (Duration: 58.0ms | Allocations: 46222)
Completed 200 OK in 92ms (Views: 59.6ms | ActiveRecord: 6.3ms | Allocations: 66107)
```