### PR TITLE
Enable secure gravatar even locally for profile/show

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,11 +25,12 @@ module ApplicationHelper
     end
   end
 
-  def gravatar(size, id = "gravatar", user = current_user)
+  def gravatar(size, id = "gravatar", user = current_user, **options)
     image_tag user.gravatar_url(size: size, secure: true).html_safe,
       id: id,
       width: size,
-      height: size
+      height: size,
+      **options
   end
 
   def download_count(rubygem)

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,7 +4,7 @@
       <div id="avatar-frame">
         <%=
           image_tag(
-            @user.gravatar_url(size: 300, secure: request.ssl?).html_safe,
+            @user.gravatar_url(size: 300, secure: true).html_safe,
             id: "profile_gravatar",
             width: 300,
             height: 300,

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,15 +2,7 @@
   <header class="profile__header">
     <div class="profile__header__name-wrap">
       <div id="avatar-frame">
-        <%=
-          image_tag(
-            @user.gravatar_url(size: 300, secure: true).html_safe,
-            id: "profile_gravatar",
-            width: 300,
-            height: 300,
-            class: 'profile__header__avatar'
-          )
-        %>
+        <%= gravatar(300, 'profile_gravatar', @user, class: 'profile__header__avatar') %>
       </div>
 
       <h1 id="profile-name" class="profile__header__name t-display">


### PR DESCRIPTION
Enable secure gravatar even locally for profile/show that seems to be the only one missing