### PR TITLE
Use ActiveJob to purge fastly

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/fastly_purge_job.rb
+++ b/app/jobs/fastly_purge_job.rb
@@ -1,0 +1,7 @@
+class FastlyPurgeJob < ApplicationJob
+  queue_as :default
+
+  def perform(path:, soft:)
+    Fastly.purge({ path:, soft: })
+  end
+end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -64,8 +64,8 @@ class Deletion < ApplicationRecord
   end
 
   def purge_fastly
-    Fastly.delay.purge(path: "gems/#{@version.full_name}.gem")
-    Fastly.delay.purge(path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz")
+    FastlyPurgeJob.perform_later(path: "gems/#{@version.full_name}.gem", soft: false)
+    FastlyPurgeJob.perform_later(path: "quick/Marshal.4.8/#{@version.full_name}.gemspec.rz", soft: false)
   end
 
   def update_search_index

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -3,11 +3,11 @@ class GemCachePurger
     # We need to purge from Fastly and from Memcached
     ["info/#{gem_name}", "names"].each do |path|
       Rails.cache.delete(path)
-      Fastly.delay.purge(path: path, soft: true)
+      FastlyPurgeJob.perform_later(path:, soft: true)
     end
 
     Rails.cache.delete("deps/v1/#{gem_name}")
-    Fastly.delay.purge(path: "versions", soft: true)
-    Fastly.delay.purge(path: "gem/#{gem_name}", soft: true)
+    FastlyPurgeJob.perform_later(path: "versions", soft: true)
+    FastlyPurgeJob.perform_later(path: "gem/#{gem_name}", soft: true)
   end
 end

--- a/test/jobs/fastly_purge_job_test.rb
+++ b/test/jobs/fastly_purge_job_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class FastlyPurgeJobTest < ActiveJob::TestCase
+  test "calls Fastly.purge with soft: true" do
+    Fastly.expects(:purge).with({ path: "path", soft: true })
+    FastlyPurgeJob.perform_now(path: "path", soft: true)
+  end
+
+  test "calls Fastly.purge with soft: false" do
+    Fastly.expects(:purge).with({ path: "path", soft: false })
+    FastlyPurgeJob.perform_now(path: "path", soft: false)
+  end
+end

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PusherTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     @user = create(:user, email: "user@example.com")
     @gem = gem_file
@@ -494,8 +496,10 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
-      assert_difference "Delayed::Job.count", 7 do
-        @cutter.save
+      assert_difference "Delayed::Job.count", 3 do
+        assert_enqueued_jobs 4, only: FastlyPurgeJob do
+          @cutter.save
+        end
       end
     end
   end

--- a/test/unit/gem_cache_purger_test.rb
+++ b/test/unit/gem_cache_purger_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class GemCachePurgerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   context "#call" do
     setup do
       @gem_name = "test123"
@@ -24,7 +26,7 @@ class GemCachePurgerTest < ActiveSupport::TestCase
       Fastly.expects(:purge).with({ path: "versions", soft: true })
 
       GemCachePurger.call(@gem_name)
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs
     end
   end
 end


### PR DESCRIPTION
Rather than using Delayed::Job directly, so we can prepare to switch backends