### PR TITLE
Add avo resource for delayed jobs

### DIFF
--- a/app/avo/resources/delayed_job_resource.rb
+++ b/app/avo/resources/delayed_job_resource.rb
@@ -1,0 +1,21 @@
+class DelayedJobResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  self.model_class = ::Delayed::Job
+
+  field :id, as: :id, link_to_resource: true
+  field :name, as: :text, format_using: ->(value) { view == :index ? value.truncate(50) : value }
+  field :queue, as: :text
+  field :priority, as: :number, sortable: true
+  field :attempts, as: :number, sortable: true
+  field :handler, as: :code, language: :yaml
+  field :last_error, as: :textarea
+
+  field :max_attempts, as: :number, sortable: true
+  field :max_run_time, as: :number, sortable: true
+  field :run_at, as: :date_time, sortable: true
+  field :locked_at, as: :date_time, sortable: true
+  field :failed_at, as: :date_time, sortable: true
+  field :reschedule_at, as: :date_time, sortable: true
+  field :locked_by, as: :text
+end

--- a/app/controllers/avo/delayed_jobs_controller.rb
+++ b/app/controllers/avo/delayed_jobs_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::DelayedJobsController < Avo::ResourcesController
+end

--- a/app/policies/delayed/backend/active_record/job_policy.rb
+++ b/app/policies/delayed/backend/active_record/job_policy.rb
@@ -1,0 +1,19 @@
+class Delayed::Backend::ActiveRecord::JobPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_index?
+    rubygems_org_admin?
+  end
+
+  def avo_show?
+    rubygems_org_admin?
+  end
+
+  def avo_destroy?
+    rubygems_org_admin?
+  end
+end

--- a/test/integration/avo/delayed_jobs_test.rb
+++ b/test/integration/avo/delayed_jobs_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Avo::DelayedJobsTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
+  test "getting users as admin" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_delayed_jobs_path
+    assert_response :success
+
+    delayed_job = Fastly.delay.purge({ path: "path", soft: true })
+
+    get avo.resources_delayed_jobs_path
+    assert_response :success
+    assert page.has_content? delayed_job.name
+
+    get avo.resources_delayed_job_path(delayed_job)
+    assert_response :success
+    assert page.has_content? delayed_job.name
+  end
+end

--- a/test/policies/delayed/backend/active_record/job_policy_test.rb
+++ b/test/policies/delayed/backend/active_record/job_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class Delayed::Backend::ActiveRecord::JobPolicyTest < ActiveSupport::TestCase
+  setup do
+    Fastly.delay.purge
+    @delayed_job = Delayed::Job.sole
+    @admin = FactoryBot.create(:admin_github_user, :is_admin)
+    @non_admin = FactoryBot.create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@delayed_job], Pundit.policy_scope!(
+      @admin,
+      Delayed::Job
+    ).to_a
+  end
+
+  def test_avo_index
+    refute_predicate Pundit.policy!(@admin, ApiKey), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, ApiKey), :avo_index?
+  end
+
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @delayed_job), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @delayed_job), :avo_show?
+  end
+
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, ApiKey), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, ApiKey), :avo_create?
+  end
+
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @delayed_job), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @delayed_job), :avo_update?
+  end
+
+  def test_avo_destroy
+    assert_predicate Pundit.policy!(@admin, @delayed_job), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @delayed_job), :avo_destroy?
+  end
+end


### PR DESCRIPTION
Will make it easier to monitor the rollout of active jobs

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/221336877-67664407-0511-43bb-84e1-603b7eb655ea.png">
