### PR TITLE
Add seeds to enable logging in as admin without GitHub

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -21,6 +21,12 @@ class OAuthController < ApplicationController
     render_forbidden params.require(:message)
   end
 
+  def development_log_in_as
+    user = Admin::GitHubUser.find(params[:admin_github_user_id])
+    log_in_as(user:)
+    redirect_to "/admin"
+  end
+
   private
 
   def check_valid_omniauth

--- a/app/views/avo/login.html.erb
+++ b/app/views/avo/login.html.erb
@@ -17,6 +17,15 @@
             <span>Log in with GitHub</span>
           </button>
         <% end %>
+
+        <% if Gemcutter::ENABLE_DEVELOPMENT_ADMIN_LOG_IN %>
+          <h2>Log in as a fake user, for development only</h2>
+          <ul>
+            <% Admin::GitHubUser.find_each do |user| %>
+              <li><%= link_to user.login, controller: :oauth, action: :development_log_in_as, admin_github_user_id: user.id %></li>
+            <% end %>
+          </ul>
+        <% end%>
       </div>
     </div>
   </body>

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,4 +87,5 @@ module Gemcutter
   GEM_REQUEST_LIMIT = 400
   VERSIONS_PER_PAGE = 100
   SEPARATE_ADMIN_HOST = config["separate_admin_host"]
+  ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.development?
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,5 +87,5 @@ module Gemcutter
   GEM_REQUEST_LIMIT = 400
   VERSIONS_PER_PAGE = 100
   SEPARATE_ADMIN_HOST = config["separate_admin_host"]
-  ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.development?
+  ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.development? || Rails.env.test?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,5 +254,7 @@ Rails.application.routes.draw do
   scope :oauth, constraints: { format: :html }, defaults: { format: 'html' } do
     get ':provider/callback', to: 'oauth#create'
     get 'failure', to: 'oauth#failure'
+
+    get 'development_log_in_as/:admin_github_user_id', to: 'oauth#development_log_in_as' if Gemcutter::ENABLE_DEVELOPMENT_ADMIN_LOG_IN
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,6 +52,77 @@ Version.create_with(
 user.web_hooks.find_or_create_by!(url: "https://example.com/rubygem0", rubygem: rubygem0)
 user.web_hooks.find_or_create_by!(url: "http://example.com/all", rubygem: nil)
 
+Admin::GitHubUser.create_with(
+  is_admin: true,
+  oauth_token: 'fake',
+  info_data: {
+  "viewer": {
+    "name": "Rad Admin",
+    "login": "rad_admin",
+    "email": "rad_admin@rubygems.team",
+    "avatarUrl": "/favicon.ico",
+    "organization": {
+      "login": "rubygems",
+      "name": "RubyGems",
+      "viewerIsAMember": true,
+      "teams": {
+        "edges": [
+          {
+            "node": {
+              "name": "Infrastructure",
+              "slug": "infrastructure"
+            }
+          },
+          {
+            "node": {
+              "name": "Maintainers",
+              "slug": "maintainers"
+            }
+          },
+          {
+            "node": {
+              "name": "Monitoring",
+              "slug": "monitoring"
+            }
+          },
+          {
+            "node": {
+              "name": "RubyGems.org",
+              "slug": "rubygems-org"
+            }
+          },
+          {
+            "node": {
+              "name": "Rubygems.org Deployers",
+              "slug": "rubygems-org-deployers"
+            }
+          },
+          {
+            "node": {
+              "name": "Security",
+              "slug": "security"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+).find_or_create_by!(github_id: "FAKE-rad_admin")
+
+Admin::GitHubUser.create_with(
+  is_admin: false,
+  info_data: {
+  "viewer": {
+    "name": "Not An Admin",
+    "login": "not_an_admin",
+    "email": "not_an_admin@rubygems.team",
+    "avatarUrl": "/favicon.ico",
+    "organization": nil
+  }
+}
+).find_or_create_by!(github_id: "FAKE-not_an_admin")
+
 puts <<~MESSAGE # rubocop:disable Rails/Output
   Three users  were created, you can login with following combinations:
     - email: #{author.email}, password: #{password} -> gem author owning few example gems

--- a/lib/github_oauthable.rb
+++ b/lib/github_oauthable.rb
@@ -61,15 +61,19 @@ module GitHubOAuthable
 
       if user.is_admin
         request.flash.now[:warning] = "Logged in as a admin via GitHub as #{user.name}"
-        cookies.encrypted[admin_cookie_name] = {
-          value: user.id,
-          expires: 1.hour,
-          same_site: :lax
-        }
+        log_in_as(user)
       else
         request.flash[:error] = "#{user.name} on GitHub is not a valid admin"
         raise is_admin_error
       end
+    end
+
+    def log_in_as(user:, expires: 1.hour)
+      cookies.encrypted[admin_cookie_name] = {
+        value: user.id,
+        expires: expires,
+        same_site: :lax
+      }
     end
 
     def admin_cookie_name

--- a/lib/github_oauthable.rb
+++ b/lib/github_oauthable.rb
@@ -61,7 +61,7 @@ module GitHubOAuthable
 
       if user.is_admin
         request.flash.now[:warning] = "Logged in as a admin via GitHub as #{user.name}"
-        log_in_as(user)
+        log_in_as(user:)
       else
         request.flash[:error] = "#{user.name} on GitHub is not a valid admin"
         raise is_admin_error

--- a/test/functional/oauth_controller_test.rb
+++ b/test/functional/oauth_controller_test.rb
@@ -18,4 +18,25 @@ class OAuthControllerTest < ActionController::TestCase
       should respond_with :not_found
     end
   end
+
+  context "on GET to development login" do
+    context "with valid ID" do
+      setup do
+        @admin_user = create(:admin_github_user)
+      end
+
+      should "login into admin" do
+        get :development_log_in_as, params: { admin_github_user_id: @admin_user.id }
+        assert_response :redirect
+        assert_redirected_to "/admin"
+      end
+    end
+
+    context "with invalid ID" do
+      should "not login into admin" do
+        get :development_log_in_as, params: { admin_github_user_id: 0 }
+        assert_response :not_found
+      end
+    end
+  end
 end

--- a/test/system/admin_test.rb
+++ b/test/system/admin_test.rb
@@ -1,0 +1,13 @@
+require "application_system_test_case"
+
+class AdminTest < ApplicationSystemTestCase
+  test "development login as an admin" do
+    @admin_user = create(:admin_github_user, :is_admin)
+
+    visit "/admin"
+    assert_content("Log in with GitHub")
+    assert_content(@admin_user.login)
+    click_link @admin_user.login
+    assert_content("Welcome to the RubyGems.org admin dashboard!")
+  end
+end


### PR DESCRIPTION
To make development not require GH credentials, and also allow development from folks outside of the rubygems admin team