### PR TITLE
'Beautify' the admin login page.

### DIFF
--- a/app/views/avo/login.html.erb
+++ b/app/views/avo/login.html.erb
@@ -12,7 +12,7 @@
         <img height="530" alt="422 error" src="/images/sea_level.svg">
       </div>
       <div class="content">
-        <p>To reach admin panel, please login via GitHub first.</p>
+        <p>To reach the admin panel, please log in via GitHub.</p>
         <%= form_tag ActionDispatch::Http::URL.path_for(path: '/oauth/github', params: { origin: request.fullpath }) do %>
           <button id="github-login" type="submit" autofocus>
             <svg viewBox="0 0 16 16" height="48" width="48" focusable="false" role="img" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -23,15 +23,15 @@
         <% end %>
 
         <% if Gemcutter::ENABLE_DEVELOPMENT_ADMIN_LOG_IN %>
-          <p>Alternativelly (since app is running in development mode) you can select admin user manually.</p>
+          <p>Since this is development mode, you can choose any admin from the list below to log in as that admin.</p>
           <% if Admin::GitHubUser.any? %>
-          <ul class="admin-list">
-            <% Admin::GitHubUser.find_each do |user| %>
-              <li><%= link_to "login as #{user.login}", controller: :oauth, action: :development_log_in_as, admin_github_user_id: user.id %></li>
-            <% end %>
-          </ul>
+            <ul class="admin-list">
+              <% Admin::GitHubUser.find_each do |user| %>
+                <li><%= link_to "login as #{user.login}", controller: :oauth, action: :development_log_in_as, admin_github_user_id: user.id %></li>
+              <% end %>
+            </ul>
           <% else %>
-            <p>Unfortunatelly there are no local admin users created yet.<br />You can create them by running <code>bin/rails db:seed</code>.</p>
+            <p>(To create an admin user for this list, run <code>bin/rails db:seed</code>.)</p>
           <% end %>
         <% end%>
 

--- a/app/views/avo/login.html.erb
+++ b/app/views/avo/login.html.erb
@@ -8,7 +8,11 @@
   </head>
   <body>
     <div class="wrapper">
+      <div class="image__wrapper">
+        <img height="530" alt="422 error" src="/images/sea_level.svg">
+      </div>
       <div class="content">
+        <p>To reach admin panel, please login via GitHub first.</p>
         <%= form_tag ActionDispatch::Http::URL.path_for(path: '/oauth/github', params: { origin: request.fullpath }) do %>
           <button id="github-login" type="submit" autofocus>
             <svg viewBox="0 0 16 16" height="48" width="48" focusable="false" role="img" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -19,13 +23,21 @@
         <% end %>
 
         <% if Gemcutter::ENABLE_DEVELOPMENT_ADMIN_LOG_IN %>
-          <h2>Log in as a fake user, for development only</h2>
-          <ul>
+          <p>Alternativelly (since app is running in development mode) you can select admin user manually.</p>
+          <% if Admin::GitHubUser.any? %>
+          <ul class="admin-list">
             <% Admin::GitHubUser.find_each do |user| %>
-              <li><%= link_to user.login, controller: :oauth, action: :development_log_in_as, admin_github_user_id: user.id %></li>
+              <li><%= link_to "login as #{user.login}", controller: :oauth, action: :development_log_in_as, admin_github_user_id: user.id %></li>
             <% end %>
           </ul>
+          <% else %>
+            <p>Unfortunatelly there are no local admin users created yet.<br />You can create them by running <code>bin/rails db:seed</code>.</p>
+          <% end %>
         <% end%>
+
+        <p>
+          <a href="/">Back to RubyGems.org →</a>
+        </p>
       </div>
     </div>
   </body>

--- a/public/stylesheets/static.css
+++ b/public/stylesheets/static.css
@@ -80,7 +80,6 @@ button#github-login {
   background-color: black;
   color: white;
   margin: auto;
-  margin-top: 30vh;
   padding: 15px 20px;
   border-radius: 6px;
   display: flex;
@@ -88,4 +87,8 @@ button#github-login {
   gap: 20px;
   font-size: 18px;
   font-weight: bold;
+}
+
+.admin-list {
+  list-style-type: none;
 }


### PR DESCRIPTION
Yes, it is just utility page useful just for few admins. But there is no need to keep it sad and empty (as it currently is IMHO). I have used image from [403](https://rubygems.org/403.html) page. We can try to find (or ask original author for) better image later.

# production version
![image](https://user-images.githubusercontent.com/193936/221393365-1e0037ac-ede7-4ffe-b5bf-55c9f89f6e9d.png)

# local with admin users
![image](https://user-images.githubusercontent.com/193936/221393419-aec0522f-5678-4140-ab46-2f4d459b4397.png)

# local with no admin users
![image](https://user-images.githubusercontent.com/193936/221393399-552660ec-df49-4f0c-8b91-f0307e147e0a.png)
