### PR TITLE
Report CSP violations to datadog

### DIFF
--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -26,7 +26,8 @@
         "client_id": "EJ[1:YVJ0VwGrcSYWmu7lQOJPUdkXYI5VBgGXLla1+Fo1eA8=:jnplUfdfAMq/te3PyIN3SejasXCukW/g:0LsAhlffVl+6W4k5sRLWpew4D8ohT5ym3Ou+O1CsZgd/fvu16YWRpgvX345ewip0]",
         "github_key": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3ZtgHbbvis6EJ5UymIZBWPwc+Zvf722/:gcsPiEVuVZIitCZ3t2216Jn5re2vBTyN7FElhowCKpQUglwU]",
         "github_secret": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3bGij9eYVzE6mJ4XmIT/QBBRmnCi9nMs:8jcKV1Hl8TYTMQaQ8SV+agQ6c9UA9lb1DHKy2J/W//gdlJ2r/r4qlKeI/zoWMX2e461aB1Dx7XQ=]",
-        "avo_license_key": "EJ[1:6oWEkRT4PhQJLxAVEt3F66gOvAd2bB/J7cF+DpFv4Gk=:atX3EOd7BdoSBqJFPaqASO6/u6R2MLlR:G4TyGlkc1EZWpUJ0mQTS9Bw1O5V9Hww3DZtV+MQuDg9pzw8n7frV+GQek4wDqI29QLk0Kg==]"
+        "avo_license_key": "EJ[1:6oWEkRT4PhQJLxAVEt3F66gOvAd2bB/J7cF+DpFv4Gk=:atX3EOd7BdoSBqJFPaqASO6/u6R2MLlR:G4TyGlkc1EZWpUJ0mQTS9Bw1O5V9Hww3DZtV+MQuDg9pzw8n7frV+GQek4wDqI29QLk0Kg==]",
+        "datadog_csp_api_key": "EJ[1:MJLOVnheQZD8mqT8Q5xlN8u6Qd9eH4sbO1kcsg/TTR4=:0eAj1g7msiS86qexeMNsWU+1vy3pXSKK:4YT1qDTiBirwkNsbNdhN90lPlF51qiMNChue7uMpEYuAiKTI3TnwOWJd7sk0PmARVsIn]"
       }
     }
   }

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -26,7 +26,8 @@
         "client_id": "EJ[1:G3QtTGP/Pf0HRv8+b6zf3xI3TmNiOPmidA24ZSgQgjU=:AZtoluRkpeCK96i3FxPgamAkAlwRuTKq:NrpTfXVR1rAA0UyJzYVmCvJvQ5lr/VLyAoHDz0IY0cmC0aJLO8HWKsAYWq3T4w2D]",
         "github_key": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:XX+D9g9OUcALhAK1aRB5uK4hmUOhmq+a:kEEf22rN2vnyXE2I5me5Fc+2rCu070VA8IpcsbeJ8Xh/3261]",
         "github_secret": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:0aEWndKlt5UpeGXSNfX8jWtc5UqnKk1g:MmBDQQEzb9tUaxVIL7bUUBbg2/UvhyvbnHcvlfqWztdSVHAFuvGe+tVtHjEdCdMzrJzG5d6UVBo=]",
-        "avo_license_key": "EJ[1:TD6sa+BG2xSLyZddF8CUdq8egeXQfz1oeMaSD/DV/z8=:iXP5X+kGqtPPjluF93iyxTRiwA4sq5ch:My9uCrd+KqROpd1l3x8HgQYvi/gRs+FBQ41IdmqouwbVJBRipuHotXYGHBcqOtvFwpk1/w==]"
+        "avo_license_key": "EJ[1:TD6sa+BG2xSLyZddF8CUdq8egeXQfz1oeMaSD/DV/z8=:iXP5X+kGqtPPjluF93iyxTRiwA4sq5ch:My9uCrd+KqROpd1l3x8HgQYvi/gRs+FBQ41IdmqouwbVJBRipuHotXYGHBcqOtvFwpk1/w==]",
+        "datadog_csp_api_key": "EJ[1:M1xidXJHz2i/vKthLOnwYbEnkFjYneq+d6Ryj6TXdFQ=:fxMZfI3MptOYF/hXcrnrWK/SDTU1SzZC:Gn807pB1wSTTNIyTJ5cpGCvN5+vplIZUxi/a8/s+UFDJE52zeM5KyhvmK6f0J8mDa2vh]"
       }
     },
     "nginx-basic-auth": {

--- a/config/deploy/unicorn.yaml.erb
+++ b/config/deploy/unicorn.yaml.erb
@@ -168,6 +168,11 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: avo_license_key
+          - name: DATADOG_CSP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: <%= environment %>
+                key: datadog_csp_api_key
           <% if environment == 'staging' %>
           - name: DISABLE_SIGNUP
             value: "true"

--- a/script/dev
+++ b/script/dev
@@ -3,5 +3,6 @@
 export GITHUB_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/zsq3oitss3rbo4njqpjfd5r5cm/GITHUB_KEY"
 export GITHUB_SECRET="op://bq25xfqpafelzdxwqu3mdq6rza/zsq3oitss3rbo4njqpjfd5r5cm/GITHUB_SECRET"
 export AVO_LICENSE_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/netp2leghd7zqdxlkp5asy67d4/license key"
+export DATADOG_CSP_API_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/eisktguwm3pcfkwm7avqamdnxq/credential"
 
 exec op run --account 5MS5DHTO5NH7BAHTSIGT5NOAIE -- "${@}"


### PR DESCRIPTION
Following https://www.datadoghq.com/blog/content-security-policy-reporting-with-datadog/#csp-reporting-with-datadog

They show up under https://app.datadoghq.com/logs?query=source%3Acsp-report&agg_q=%40env&cols=host%2Cservice%2C%40env%2C%40dd.version&index=%2A&messageDisplay=inline&sort_m=count&sort_t=count&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=false&from_ts=1677526306872&to_ts=1677527206872&live=true