### PR TITLE
Fix flakiness in seed tests

### DIFF
--- a/test/unit/seeds_test.rb
+++ b/test/unit/seeds_test.rb
@@ -1,6 +1,12 @@
 require "test_helper"
 
 class SeedsTest < ActiveSupport::TestCase
+  def all_records
+    ApplicationRecord.descendants.reject(&:abstract_class?).map do |record_class|
+      [record_class.name, record_class.all.map(&:attributes)]
+    end
+  end
+
   def load_seed
     capture_io { Rails.application.load_seed }
   end
@@ -8,7 +14,7 @@ class SeedsTest < ActiveSupport::TestCase
   test "can load seeds idempotently" do
     load_seed
 
-    assert_no_changes -> { ApplicationRecord.descendants.map { |d| [d.name, d.all.map(&:attributes)] } } do
+    assert_no_changes -> { all_records } do
       load_seed
     end
   end


### PR DESCRIPTION
Caused by GoodJob::BaseJob being required. As an abstract class, calling .all.map() materializes a query against an empty table name, which causes an exception deep in the PG adapter

Fix by not querying abstract classes