### PR TITLE
Use HookRelay to send webhooks

### DIFF
--- a/app/controllers/api/v1/hook_relay_controller.rb
+++ b/app/controllers/api/v1/hook_relay_controller.rb
@@ -1,0 +1,35 @@
+class Api::V1::HookRelayController < Api::BaseController
+  before_action :set_hook_relay_report_params
+  before_action :authenticate_hook_relay_report
+
+  rescue_from ActiveSupport::SecureCompareRotator::InvalidMatch, with: :render_not_found
+
+  def report
+    Rails.logger.info({ hook_relay_report: @hook_relay_report_params }.to_json)
+
+    stream = @hook_relay_report_params.require(:stream).slice(/:webhook_id-(\d+)\z/, 1)&.to_i
+    hook = WebHook.find(stream)
+    hook.increment! :failure_count if @hook_relay_report_params.require(:status) == "failure"
+
+    respond_to do |format|
+      format.json { render json: {} }
+    end
+  end
+
+  private
+
+  def set_hook_relay_report_params
+    @hook_relay_report_params = params.permit(
+      :attempts, :account_id, :hook_id, :id, :max_attempts,
+      :status, :stream, :failure_reason, :completed_at,
+      :created_at, request: [:target_url]
+    )
+  end
+
+  def authenticate_hook_relay_report
+    account_id, hook_id = @hook_relay_report_params.require(%i[account_id hook_id])
+
+    ActiveSupport::SecureCompareRotator.new(ENV.fetch("HOOK_RELAY_ACCOUNT_ID", "")).secure_compare!(account_id)
+    ActiveSupport::SecureCompareRotator.new(ENV.fetch("HOOK_RELAY_HOOK_ID", "")).secure_compare!(hook_id)
+  end
+end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -32,11 +32,10 @@ class Api::V1::WebHooksController < Api::BaseController
     webhook = @api_key.user.web_hooks.new(url: @url)
     @rubygem ||= Rubygem.find_by_name("gemcutter")
 
-    begin
-      webhook.fire(request.protocol.delete("://"), request.host_with_port,
-        @rubygem.versions.most_recent, delayed: false)
+    if webhook.fire(request.protocol.delete("://"), request.host_with_port,
+                    @rubygem.versions.most_recent, delayed: false)
       render plain: webhook.deployed_message(@rubygem)
-    rescue *NotifyWebHookJob::ERRORS
+    else
       render plain: webhook.failed_message(@rubygem), status: :bad_request
     end
   end

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -32,10 +32,11 @@ class Api::V1::WebHooksController < Api::BaseController
     webhook = @api_key.user.web_hooks.new(url: @url)
     @rubygem ||= Rubygem.find_by_name("gemcutter")
 
-    if webhook.fire(request.protocol.delete("://"), request.host_with_port,
-      @rubygem.versions.most_recent, delayed: false)
+    begin
+      webhook.fire(request.protocol.delete("://"), request.host_with_port,
+        @rubygem.versions.most_recent, delayed: false)
       render plain: webhook.deployed_message(@rubygem)
-    else
+    rescue *NotifyWebHookJob::ERRORS
       render plain: webhook.failed_message(@rubygem), status: :bad_request
     end
   end

--- a/app/jobs/notify_web_hook_job.rb
+++ b/app/jobs/notify_web_hook_job.rb
@@ -3,7 +3,10 @@ class NotifyWebHookJob < ApplicationJob
   include TraceTagger
 
   queue_as :default
+  queue_with_priority PRIORITIES.fetch(:web_hook)
   self.queue_adapter = :good_job
+
+  TIMEOUT_SEC = 5
 
   before_perform { @kwargs = arguments.last.then { _1 if Hash.ruby2_keywords_hash?(_1) } }
   before_perform { @webhook = @kwargs.fetch(:webhook) }
@@ -14,23 +17,26 @@ class NotifyWebHookJob < ApplicationJob
 
   attr_reader :webhook, :protocol, :host_with_port, :version, :rubygem
 
+  ERRORS = (HTTP_ERRORS + [RestClient::Exception, SocketError, SystemCallError, OpenSSL::SSL::SSLError]).freeze
+  retry_on(*ERRORS)
+
+  # has to come after the retry on
+  discard_on(RestClient::UnprocessableEntity) do |j, e|
+    raise unless j.use_hook_relay?
+    Rails.logger.info({ webhook_id: j.webhook.id, url: j.webhook.url, response: JSON.parse(e.response.body) }.to_json)
+    j.webhook.increment! :failure_count
+  end
+
   def perform(*)
     url = webhook.url
     set_tag "gemcutter.notifier.url", url
     set_tag "gemcutter.notifier.webhook_id", webhook.id
 
-    timeout(5) do
-      RestClient.post url,
-        payload,
-        :timeout        => 5,
-        :open_timeout   => 5,
-        "Content-Type"  => "application/json",
-        "Authorization" => authorization
+    if use_hook_relay?
+      post_hook_relay
+    else
+      post_directly
     end
-    true
-  rescue *(HTTP_ERRORS + [RestClient::Exception, SocketError, SystemCallError]) => _e
-    webhook.increment! :failure_count
-    false
   end
   statsd_count_success :perform, "Webhook.perform"
 
@@ -40,6 +46,46 @@ class NotifyWebHookJob < ApplicationJob
 
   def authorization
     Digest::SHA2.hexdigest([rubygem.name, version.number, webhook.api_key].compact.join)
+  end
+
+  def hook_relay_url
+    "https://api.hookrelay.dev/hooks/#{ENV['HOOK_RELAY_ACCOUNT_ID']}/#{ENV['HOOK_RELAY_HOOK_ID']}/webhook_id-#{webhook.id}"
+  end
+
+  def use_hook_relay?
+    # can't use hook relay for `perform_now` (aka an unenqueued job)
+    # because then we won't actually hit the webhook URL synchronously
+    enqueued_at.present? && ENV["HOOK_RELAY_ACCOUNT_ID"].present? && ENV["HOOK_RELAY_HOOK_ID"].present?
+  end
+
+  def post_hook_relay
+    response = post(hook_relay_url)
+    delivery_id = JSON.parse(response).fetch("id")
+    Rails.logger.info({ webhook_id: webhook.id, url: webhook.url, delivery_id:, full_name: version.full_name }.to_json)
+    true
+  end
+
+  def post_directly
+    post(webhook.url)
+  rescue *ERRORS
+    webhook.increment! :failure_count
+    false
+  end
+
+  def post(url)
+    timeout(TIMEOUT_SEC) do
+      RestClient::Request.execute method: :post,
+        url: url,
+        payload: payload,
+        timeout: TIMEOUT_SEC,
+        open_timeout: TIMEOUT_SEC,
+        headers: {
+          "Content-Type"    => "application/json",
+          "Authorization"   => authorization,
+          "HR_TARGET_URL"   => webhook.url,
+          "HR_MAX_ATTEMPTS" => "3"
+        }
+    end
   end
 
   private

--- a/app/jobs/notify_web_hook_job.rb
+++ b/app/jobs/notify_web_hook_job.rb
@@ -67,6 +67,7 @@ class NotifyWebHookJob < ApplicationJob
 
   def post_directly
     post(webhook.url)
+    true
   rescue *ERRORS
     webhook.increment! :failure_count
     false

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "952a7d74123607aba495fea6b6bdb2009eebc024151ef3297547e9f2a690d0b8",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/api/v1/hook_relay_controller.rb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit(:attempts, :account_id, :hook_id, :id, :max_attempts, :status, :stream, :failure_reason, :completed_at, :created_at, :request => ([:target_url]))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::V1::HookRelayController",
+        "method": "set_hook_relay_report_params"
+      },
+      "user_input": ":account_id",
+      "confidence": "High",
+      "cwe_id": [
+        915
+      ],
+      "note": "account_id is used to validate that the request indeed comes from hook relay"
+    }
+  ],
+  "updated": "2023-03-01 02:46:07 -0800",
+  "brakeman_version": "5.4.1"
+}

--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -27,7 +27,9 @@
         "github_key": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3ZtgHbbvis6EJ5UymIZBWPwc+Zvf722/:gcsPiEVuVZIitCZ3t2216Jn5re2vBTyN7FElhowCKpQUglwU]",
         "github_secret": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3bGij9eYVzE6mJ4XmIT/QBBRmnCi9nMs:8jcKV1Hl8TYTMQaQ8SV+agQ6c9UA9lb1DHKy2J/W//gdlJ2r/r4qlKeI/zoWMX2e461aB1Dx7XQ=]",
         "avo_license_key": "EJ[1:6oWEkRT4PhQJLxAVEt3F66gOvAd2bB/J7cF+DpFv4Gk=:atX3EOd7BdoSBqJFPaqASO6/u6R2MLlR:G4TyGlkc1EZWpUJ0mQTS9Bw1O5V9Hww3DZtV+MQuDg9pzw8n7frV+GQek4wDqI29QLk0Kg==]",
-        "datadog_csp_api_key": "EJ[1:MJLOVnheQZD8mqT8Q5xlN8u6Qd9eH4sbO1kcsg/TTR4=:0eAj1g7msiS86qexeMNsWU+1vy3pXSKK:4YT1qDTiBirwkNsbNdhN90lPlF51qiMNChue7uMpEYuAiKTI3TnwOWJd7sk0PmARVsIn]"
+        "datadog_csp_api_key": "EJ[1:MJLOVnheQZD8mqT8Q5xlN8u6Qd9eH4sbO1kcsg/TTR4=:0eAj1g7msiS86qexeMNsWU+1vy3pXSKK:4YT1qDTiBirwkNsbNdhN90lPlF51qiMNChue7uMpEYuAiKTI3TnwOWJd7sk0PmARVsIn]",
+        "hook_relay_account_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:JsT1PTsSpMaxE0FV7ODyJ5E1FQAzv9v/:tMUgIFIUJH+WhT+kHS5pne5Uw9qvdLqLd2aAfJ9EehzIYpH6Bl6EQg==]",
+        "hook_relay_hook_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:Vt1tMd8/9ZhSHL80yrWIWUy2wMOh8Iqt:MUwOcVrjWl7i8RRNg68Sb/Fa+RYsLL54yc+adRK84i5jWWa9fmSgRg==]"
       }
     }
   }

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -27,7 +27,9 @@
         "github_key": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:XX+D9g9OUcALhAK1aRB5uK4hmUOhmq+a:kEEf22rN2vnyXE2I5me5Fc+2rCu070VA8IpcsbeJ8Xh/3261]",
         "github_secret": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:0aEWndKlt5UpeGXSNfX8jWtc5UqnKk1g:MmBDQQEzb9tUaxVIL7bUUBbg2/UvhyvbnHcvlfqWztdSVHAFuvGe+tVtHjEdCdMzrJzG5d6UVBo=]",
         "avo_license_key": "EJ[1:TD6sa+BG2xSLyZddF8CUdq8egeXQfz1oeMaSD/DV/z8=:iXP5X+kGqtPPjluF93iyxTRiwA4sq5ch:My9uCrd+KqROpd1l3x8HgQYvi/gRs+FBQ41IdmqouwbVJBRipuHotXYGHBcqOtvFwpk1/w==]",
-        "datadog_csp_api_key": "EJ[1:M1xidXJHz2i/vKthLOnwYbEnkFjYneq+d6Ryj6TXdFQ=:fxMZfI3MptOYF/hXcrnrWK/SDTU1SzZC:Gn807pB1wSTTNIyTJ5cpGCvN5+vplIZUxi/a8/s+UFDJE52zeM5KyhvmK6f0J8mDa2vh]"
+        "datadog_csp_api_key": "EJ[1:M1xidXJHz2i/vKthLOnwYbEnkFjYneq+d6Ryj6TXdFQ=:fxMZfI3MptOYF/hXcrnrWK/SDTU1SzZC:Gn807pB1wSTTNIyTJ5cpGCvN5+vplIZUxi/a8/s+UFDJE52zeM5KyhvmK6f0J8mDa2vh]",
+        "hook_relay_account_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:OUkdjS28VFFsXWnK0c2zBubgen83JLIZ:r9s3A3e3UuNrYRelD3HzIKsNvEGlGhvKmZayZt7wZGHrxB+yTb8gQQ==]",
+        "hook_relay_hook_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:n1YqUGXM5FdcwoAJjIXXgHxWqiF/voeL:sj7Gbn405v2hw4CKkU6N7Fhgb3J/5RnrAZpp+Xcn61ZTNJq0qFXBiA==]"
       }
     },
     "nginx-basic-auth": {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
         collection do
           delete :remove
           post :fire
+          post :hook_relay_report, to: 'hook_relay#report', defaults: { format: :json }
         end
       end
 

--- a/script/dev
+++ b/script/dev
@@ -4,5 +4,7 @@ export GITHUB_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/zsq3oitss3rbo4njqpjfd5r5cm/GI
 export GITHUB_SECRET="op://bq25xfqpafelzdxwqu3mdq6rza/zsq3oitss3rbo4njqpjfd5r5cm/GITHUB_SECRET"
 export AVO_LICENSE_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/netp2leghd7zqdxlkp5asy67d4/license key"
 export DATADOG_CSP_API_KEY="op://bq25xfqpafelzdxwqu3mdq6rza/eisktguwm3pcfkwm7avqamdnxq/credential"
+export HOOK_RELAY_ACCOUNT_ID="op://bq25xfqpafelzdxwqu3mdq6rza/s3fs2zznjssijxouugddmwnuma/username"
+export HOOK_RELAY_HOOK_ID="op://bq25xfqpafelzdxwqu3mdq6rza/s3fs2zznjssijxouugddmwnuma/credential"
 
 exec op run --account 5MS5DHTO5NH7BAHTSIGT5NOAIE -- "${@}"

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -77,7 +77,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for all gems" do
         setup do
-          RestClient.stubs(:post)
+          RestClient::Request.stubs(:execute)
           post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
                                 url: @url }
         end
@@ -91,7 +91,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for all gems that fails" do
         setup do
-          RestClient.stubs(:post).raises(RestClient::Exception.new)
+          RestClient::Request.stubs(:execute).raises(RestClient::Exception.new)
           post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
                                 url: @url }
         end
@@ -123,7 +123,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for a specific gem" do
         setup do
-          RestClient.stubs(:post)
+          RestClient::Request.stubs(:execute)
           post :fire, params: { gem_name: @rubygem.name,
                                 url: @url }
         end
@@ -136,7 +136,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for a specific gem that fails" do
         setup do
-          RestClient.stubs(:post).raises(RestClient::Exception.new)
+          RestClient::Request.stubs(:execute).raises(RestClient::Exception.new)
           post :fire, params: { gem_name: @rubygem.name,
                                 url: @url }
         end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PushTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     Dir.chdir(Dir.mktmpdir)
     @key = "12345"
@@ -140,6 +142,97 @@ class PushTest < ActionDispatch::IntegrationTest
     push_gem "sandworm-2.0.0.gem"
     assert_response :forbidden
     assert_match(/You have added cert_chain in gemspec but signature was empty/, response.body)
+  end
+
+  setup do
+    @act = ENV["HOOK_RELAY_ACCOUNT_ID"]
+    @id = ENV["HOOK_RELAY_HOOK_ID"]
+    ENV["HOOK_RELAY_ACCOUNT_ID"] = "act"
+    ENV["HOOK_RELAY_HOOK_ID"] = "id"
+  end
+
+  teardown do
+    ENV["HOOK_RELAY_ACCOUNT_ID"] = @act
+    ENV["HOOK_RELAY_HOOK_ID"] = @id
+  end
+
+  test "publishing a gem with webhook subscribers" do
+    hook = create(:global_web_hook)
+
+    build_gem "sandworm", "2.0.0"
+    push_gem "sandworm-2.0.0.gem"
+
+    assert_response :success
+
+    RestClient::Request.expects(:execute).with(has_entries(
+                                                 method: :post,
+                                                 url: "https://api.hookrelay.dev/hooks/act/id/webhook_id-#{hook.id}",
+                                                 headers: has_entries(
+                                                   "Content-Type" => "application/json",
+                                                   "HR_TARGET_URL" => hook.url,
+                                                   "HR_MAX_ATTEMPTS" => "3"
+                                                 )
+                                               )).returns({ id: :id123 }.to_json)
+    perform_enqueued_jobs only: NotifyWebHookJob
+
+    assert_predicate hook.reload.failure_count, :zero?
+
+    post hook_relay_report_api_v1_web_hooks_path,
+      params: {
+        attempts: 3,
+        account_id: "act",
+        hook_id: "id",
+        id: "01GTE93BNWPD0VF0V4QCJ7NDSF",
+        created_at: "2023-03-01T09:47:18Z",
+        request: {
+          body: "{}",
+            headers: {
+              Authorization: "51bf53d06ac382585b83e6f3241c950710ee53368e948ac309b7869c974338e9",
+                "User-Agent": "rest-client/2.1.0 (darwin22 arm64) ruby/3.2.1p31",
+                Accept: "*/*",
+                "Content-Type": "application/json"
+            },
+            target_url: "https://example.com/rubygem0"
+        },
+        report_url: "https://rubygems.org/api/v1/web_hooks/hook_relay_report",
+        max_attempts: 3,
+        status: "success",
+        last_attempted_at: "2023-03-01T09:50:31+00:00",
+        stream: "hook:act:id:webhook_id-#{hook.id}",
+        completed_at: "2023-03-01T09:50:31+00:00"
+      },
+      as: :json
+    assert_response :success
+    assert_predicate hook.reload.failure_count, :zero?
+
+    post hook_relay_report_api_v1_web_hooks_path,
+      params: {
+        attempts: 3,
+        account_id: "act",
+        hook_id: "id",
+        id: "01GTE93BNWPD0VF0V4QCJ7NDSF",
+        created_at: "2023-03-01T09:47:18Z",
+        request: {
+          body: "{}",
+            headers: {
+              Authorization: "51bf53d06ac382585b83e6f3241c950710ee53368e948ac309b7869c974338e9",
+                "User-Agent": "rest-client/2.1.0 (darwin22 arm64) ruby/3.2.1p31",
+                Accept: "*/*",
+                "Content-Type": "application/json"
+            },
+            target_url: "https://example.com/rubygem0"
+        },
+        report_url: "https://rubygems.org/api/v1/web_hooks/hook_relay_report",
+        max_attempts: 3,
+        status: "failure",
+        last_attempted_at: "2023-03-01T09:50:31+00:00",
+        stream: "hook:act:id:webhook_id-#{hook.id}",
+        failure_reason: "Exhausted attempts",
+        completed_at: "2023-03-01T09:50:31+00:00"
+      },
+      as: :json
+    assert_response :success
+    assert_equal 1, hook.reload.failure_count
   end
 
   def push_gem(path)

--- a/test/models/web_hook_test.rb
+++ b/test/models/web_hook_test.rb
@@ -147,7 +147,7 @@ class WebHookTest < ActiveSupport::TestCase
 
     should "include an Authorization header" do
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number + @hook.user.api_key)
-      RestClient.expects(:post).with(anything, anything, has_entries("Authorization" => authorization))
+      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
 
       @hook.fire("https", "rubygems.org", @version)
     end
@@ -155,7 +155,7 @@ class WebHookTest < ActiveSupport::TestCase
     should "include an Authorization header for a user with no API key" do
       @hook.user.update(api_key: nil)
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number)
-      RestClient.expects(:post).with(anything, anything, has_entries("Authorization" => authorization))
+      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
 
       @hook.fire("https", "rubygems.org", @version)
     end
@@ -164,7 +164,7 @@ class WebHookTest < ActiveSupport::TestCase
       @hook.user.update(api_key: nil)
       create(:api_key, user: @hook.user)
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number + @hook.user.api_keys.first.hashed_key)
-      RestClient.expects(:post).with(anything, anything, has_entries("Authorization" => authorization))
+      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
 
       @hook.fire("https", "rubygems.org", @version)
     end


### PR DESCRIPTION
See https://www.hookrelay.dev for docs

This way, we can have nice things like retries & delivery tracking without building it ourselves

Next step will be recording more info on receiving reports in the DB, so we can automatically disable consistently failing webhooks