### PR TITLE
Removed RubyTogether logo from footer

### DIFF
--- a/app/assets/stylesheets/modules/footer.css
+++ b/app/assets/stylesheets/modules/footer.css
@@ -98,51 +98,45 @@
   @media (max-width: 1039px) {
     .footer__sponsor {
       width: 100px; }
-    .footer__sponsor:nth-child(1) {
-      background-position: 0 -6px; }
     .footer__sponsor:nth-child(2) {
-      background-position: 0 -119px; }
-    .footer__sponsor:nth-child(3) {
       background-position: 0 -232px; }
-    .footer__sponsor:nth-child(4) {
+    .footer__sponsor:nth-child(3) {
       background-position: 0 -330px; }
-    .footer__sponsor:nth-child(5) {
+    .footer__sponsor:nth-child(4) {
       background-position: 0 -417px; }
-    .footer__sponsor:nth-child(6) {
+    .footer__sponsor:nth-child(5) {
       background-position: 0 -695px; }
-    .footer__sponsor:nth-child(7) {
+    .footer__sponsor:nth-child(6) {
       background-position: 0 -526px; }
-    .footer__sponsor:nth-child(8) {
+    .footer__sponsor:nth-child(7) {
       background-position: 0 -606px; }
-    .footer__sponsor:nth-child(9) {
+    .footer__sponsor:nth-child(8) {
       background-position: 0 -804px; }
-    .footer__sponsor:nth-child(10) {
+    .footer__sponsor:nth-child(9) {
       background-position: 0 -892px; }
-    .footer__sponsor:nth-child(11) {
+    .footer__sponsor:nth-child(10) {
       background-position: 0 -983px; }
     }
   @media (min-width: 1040px) {
     .footer__sponsor {
       width: 90px; }
     .footer__sponsor:nth-child(2) {
-      background-position: 0 -105px; }
-    .footer__sponsor:nth-child(3) {
       background-position: 0 -204px; }
-    .footer__sponsor:nth-child(4) {
+    .footer__sponsor:nth-child(3) {
       background-position: 0 -291px; }
-    .footer__sponsor:nth-child(5) {
+    .footer__sponsor:nth-child(4) {
       background-position: 0 -372px; }
-    .footer__sponsor:nth-child(6) {
+    .footer__sponsor:nth-child(5) {
       background-position: 0 -634px; }
-    .footer__sponsor:nth-child(7) {
+    .footer__sponsor:nth-child(6) {
       background-position: 0 -469px; }
-    .footer__sponsor:nth-child(8) {
+    .footer__sponsor:nth-child(7) {
       background-position: 0 -541px; }
-    .footer__sponsor:nth-child(9) {
+    .footer__sponsor:nth-child(8) {
       background-position: 0 -717px; }
-    .footer__sponsor:nth-child(10) {
+    .footer__sponsor:nth-child(9) {
       background-position: 0 -804px; }
-    .footer__sponsor:nth-child(11) {
+    .footer__sponsor:nth-child(10) {
       background-position: 0 -885px; }
     }
   @media (max-width: 579px) {


### PR DESCRIPTION
Resolve https://github.com/rubygems/rubygems.org/issues/2535 again.

Before:

![Screenshot 2023-03-02 at 11 49 12](https://user-images.githubusercontent.com/12301/222318473-7861be77-11a2-443b-83fa-b8f9e35bdee4.png)

After:

![Screenshot 2023-03-02 at 11 49 06](https://user-images.githubusercontent.com/12301/222318496-7103ade8-b6ec-4576-abb2-82d48308e1a7.png)
