### PR TITLE
Add review env to run in ephemeral namespaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Rails/UnknownEnv:
     - development
     - staging
     - test
+    - review
 
 Rails/UniqueValidationWithoutIndex:
   Enabled: false

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module Gemcutter
     # Using true enables origin-checking CSRF mitigation. Our API can"t use this check.
     config.action_controller.forgery_protection_origin_check = false
 
-    config.rubygems = Application.config_for :rubygems
+    config.rubygems = Application.config_for :rubygems || raise("No rubygems config found for environment #{Rails.env.inspect}")
 
     config.time_zone = "UTC"
     config.encoding  = "utf-8"
@@ -87,5 +87,5 @@ module Gemcutter
   GEM_REQUEST_LIMIT = 400
   VERSIONS_PER_PAGE = 100
   SEPARATE_ADMIN_HOST = config["separate_admin_host"]
-  ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.development? || Rails.env.test?
+  ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.development? || Rails.env.test? || Rails.env.review?
 end

--- a/config/deploy/cache.yaml.erb
+++ b/config/deploy/cache.yaml.erb
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache
+  annotations:
+    shipit.shopify.io/restart: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cache
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/memcached.logs: '[{"source":"memcached","service":"rubygems.org","version": <%= current_sha.dump %>}]'
+      labels:
+        name: cache
+    spec:
+      containers:
+        - name: memcached
+          image: memcached:1.4.35
+          resources:
+            limits:
+              cpu: 200m
+              memory: 2000Mi
+            requests:
+              cpu: 100m
+              memory: 1000Mi
+          ports:
+            - containerPort: 11211
+              protocol: TCP
+          args:
+            - -m 2047
+            - -I 50M
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache
+  labels:
+    name: cache
+  annotations: {}
+spec:
+  type: NodePort
+  ports:
+    - port: 11211
+  selector:
+    name: cache

--- a/config/deploy/db-migrate.yaml.erb
+++ b/config/deploy/db-migrate.yaml.erb
@@ -15,7 +15,7 @@ spec:
     args: ["rails", "db:migrate"]
     env:
       - name: RAILS_ENV
-        value: "<%= environment %>"
+        value: "<%= rails_env %>"
       - name: ENV
         value: "<%= environment %>"
       - name: DD_AGENT_HOST
@@ -35,76 +35,76 @@ spec:
       - name: SECRET_KEY_BASE
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: secret_key_base
       - name: AWS_REGION
         value: "us-west-2"
       - name: S3_KEY
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: aws_access_key_id
       - name: S3_SECRET
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: aws_secret_access_key
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: aws_access_key_id
       - name: AWS_SECRET_ACCESS_KEY
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: aws_secret_access_key
       - name: HONEYBADGER_API_KEY
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: honeybadger_api_key
       - name: FASTLY_API_KEY
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: fastly_api_key
       - name: FASTLY_SERVICE_ID
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: fastly_service_id
       - name: FASTLY_DOMAINS
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: fastly_domains
       - name: ELASTICSEARCH_URL
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: elasticsearch_url
       - name: MEMCACHED_ENDPOINT
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: memcached_endpoint
       - name: SENDGRID_USERNAME
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: sendgrid_username
       - name: SENDGRID_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: sendgrid_password
       - name: DISABLE_SIGNUP
         value: "true"
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:
-            name: <%= environment %>
+            name: <%= rails_env %>
             key: database_url
     # resources:
     #   requests:

--- a/config/deploy/db.yaml.erb
+++ b/config/deploy/db.yaml.erb
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pv-claim
+spec:
+  storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+  annotations:
+    shipit.shopify.io/restart: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: db
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/postgres.logs: '[{"source":"postgres","service":"rubygems.org","version": <%= current_sha.dump %>}]'
+      labels:
+        name: db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:11.13
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: <%= rails_env %>
+                  key: database_password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: <%= rails_env %>
+                  key: database_name
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-pv-storage
+          resources:
+            requests:
+              cpu: 200m
+              memory: 250Mi
+            limits:
+              cpu: 500m
+              memory: 1.2Gi
+          readinessProbe:
+            exec:
+              command: ["psql", "-Upostgres", "-c", "SELECT 1"]
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["psql", "-Upostgres", "-c", "SELECT 1"]
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+      volumes:
+        - name: postgres-pv-storage
+          persistentVolumeClaim:
+            claimName: postgres-pv-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  labels:
+    name: db
+  annotations: {}
+spec:
+  type: NodePort
+  ports:
+    - port: 5432
+  selector:
+    name: db

--- a/config/deploy/delayed_job_statsd.yaml.erb
+++ b/config/deploy/delayed_job_statsd.yaml.erb
@@ -36,22 +36,22 @@ spec:
           - name: PG_DATABASE
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_name
           - name: PG_HOST
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_host
           - name: PG_USER
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_user
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_password
         securityContext:
           privileged: false

--- a/config/deploy/deploy
+++ b/config/deploy/deploy
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require "open3"
+
+# kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.23/deploy/local-path-storage.yaml
+
+def deploy(environment:, rails_env:, revision:, context:, only: nil)
+  render = %W[krane render --bindings=environment=#{environment},rails_env=#{rails_env} --current-sha=#{revision}]
+  (only || [nil]).each do |path|
+    render << '-f' << "config/deploy/#{rails_env}#{"/#{path}" if path}"
+  end
+  deploy = %W[krane deploy rubygems-#{environment} #{context} --stdin -f config/deploy/#{rails_env}/secrets.ejson]
+  deploy << '--no-prune' if only
+
+  status_list = Open3.pipeline(
+    render,
+    deploy
+  )
+  raise "Pipeline failed" unless status_list.all?(&:success?)
+end
+
+environment, revision, review_app = ENV.values_at("ENVIRONMENT", "REVISION", "REVIEW_APP")
+rails_env = environment
+# environment = "pr0"
+# revision = "4985a916480e04e9876d3e76ccdc87cb5beabe9b"
+# review_app = true
+# context = "minikube"
+context = "rubygems"
+rails_env = "review" if review_app
+
+# TODO: include search
+deploy(environment:, context:, revision:, rails_env:, only: %w[db.yaml.erb cache.yaml.erb]) if review_app
+deploy(environment:, context:, revision:, rails_env:)

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -43,7 +43,7 @@ spec:
           <% end %>
         env:
           - name: RAILS_ENV
-            value: "<%= environment %>"
+            value: "<%= rails_env %>"
           - name: ENV
             value: "<%= environment %>"
           - name: DD_AGENT_HOST
@@ -63,7 +63,7 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: secret_key_base
           - name: AWS_REGION
             value: "us-west-2"
@@ -72,67 +72,67 @@ spec:
           - name: S3_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: S3_SECRET
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: HONEYBADGER_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: honeybadger_api_key
           - name: FASTLY_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_api_key
           - name: FASTLY_SERVICE_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_service_id
           - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: elasticsearch_url
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: memcached_endpoint
           - name: SENDGRID_USERNAME
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_username
           - name: SENDGRID_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_password
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_url
         securityContext:
           privileged: false
@@ -172,7 +172,7 @@ spec:
           periodSeconds: 10
         env:
           - name: RAILS_ENV
-            value: "<%= environment %>"
+            value: "<%= rails_env %>"
           - name: ENV
             value: "<%= environment %>"
           - name: GOOD_JOB_PROBE_PORT
@@ -194,7 +194,7 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: secret_key_base
           - name: AWS_REGION
             value: "us-west-2"
@@ -203,67 +203,67 @@ spec:
           - name: S3_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: S3_SECRET
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: HONEYBADGER_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: honeybadger_api_key
           - name: FASTLY_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_api_key
           - name: FASTLY_SERVICE_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_service_id
           - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: elasticsearch_url
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: memcached_endpoint
           - name: SENDGRID_USERNAME
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_username
           - name: SENDGRID_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_password
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_url
         securityContext:
           privileged: false

--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -116,7 +116,7 @@ data:
           proxy_pass http://127.0.0.1:3000;
         }
 
-         <% if environment == 'staging' %>
+         <% if environment == 'staging' || environment == 'review' %>
         location /internal {
           limit_req zone=abusers burst=10;
           proxy_pass http://127.0.0.1:3000;

--- a/config/deploy/ownership-requests-notify-daily.yaml.erb
+++ b/config/deploy/ownership-requests-notify-daily.yaml.erb
@@ -37,7 +37,7 @@ spec:
               <% end %>
             env:
             - name: RAILS_ENV
-              value: "<%= environment %>"
+              value: "<%= rails_env %>"
             - name: ENV
               value: "<%= environment %>"
             - name: DD_AGENT_HOST
@@ -57,27 +57,27 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: secret_key_base
             - name: CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: client_id
             - name: SLACK_HOOK
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: slack_hook
             - name: HONEYBADGER_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: honeybadger_api_key
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: database_url
             volumeMounts:
             - mountPath: /app/lib/tasks/users_verify.rake

--- a/config/deploy/review/cache.yaml.erb
+++ b/config/deploy/review/cache.yaml.erb
@@ -1,0 +1,1 @@
+../cache.yaml.erb

--- a/config/deploy/review/db-migrate.yaml.erb
+++ b/config/deploy/review/db-migrate.yaml.erb
@@ -1,0 +1,1 @@
+../db-migrate.yaml.erb

--- a/config/deploy/review/db.yaml.erb
+++ b/config/deploy/review/db.yaml.erb
@@ -1,0 +1,1 @@
+../db.yaml.erb

--- a/config/deploy/review/delayed_job_statsd.yaml.erb
+++ b/config/deploy/review/delayed_job_statsd.yaml.erb
@@ -1,0 +1,1 @@
+../delayed_job_statsd.yaml.erb

--- a/config/deploy/review/ingress.yaml.erb
+++ b/config/deploy/review/ingress.yaml.erb
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - host: <%= environment %>.review.rubygems.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 80

--- a/config/deploy/review/jobs.yaml.erb
+++ b/config/deploy/review/jobs.yaml.erb
@@ -1,0 +1,1 @@
+../jobs.yaml.erb

--- a/config/deploy/review/nginx-configmap.yaml.erb
+++ b/config/deploy/review/nginx-configmap.yaml.erb
@@ -1,0 +1,1 @@
+../nginx-configmap.yaml.erb

--- a/config/deploy/review/secrets.ejson
+++ b/config/deploy/review/secrets.ejson
@@ -1,0 +1,40 @@
+{
+  "_public_key": "0f0e7f255735dce31c9a899a04c6914f7fc033c8a58972fc37feeaf0576f0921",
+  "kubernetes_secrets": {
+    "review": {
+      "_type": "Opaque",
+      "data": {
+        "secret_key_base": "EJ[1:TIPqim4JchergystRuthOvgiRBztQen7clcnw50tQxE=:9peVlESjE+MJ1aVcwMKjmGy593q6hrz7:6NqNcqrinPDdDE3PdYfP11SfZqPw]",
+        "_database_url": "postgresql://db.rubygems-pr0:5432",
+        "_database_host": "db.rubygems-pr0",
+        "_database_name": "rubygems_staging",
+        "_database_user": "postgres",
+        "_database_password": "password",
+        "aws_access_key_id": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:KOv059ol+sGa+etTyhk6K2ll1bJ1DmBo:+c1v8fi2Y4c3OltKNPafOg==]",
+        "aws_secret_access_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:EdMYlZCOylcpprN0IEUA/eiRNGHNpLS9:8H3sf8JBIxQXNyDm6vnjNQ==]",
+        "honeybadger_api_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:bhxQJwFFWx/5+To11Vvaf/Em2SEcdnJ9:WBZ+roiedPLhAiYlqvSr1Q==]",
+        "fastly_api_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:BOxVWi0OY/e6WYS3VR6dPOlL2OKv88QE:kZKZW/uLHLwLDVNpDe7WJw==]",
+        "fastly_service_id": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:ndT+JQLt1vy04CCMxA0mQNYBa1ZyYCb6:KBqPfTwdq/rpqxNpAEOeRg==]",
+        "_fastly_domains": "review.rubygems.org",
+        "elasticsearch_url": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:R6nW+O3wrpXS9QYGGuH03qeSO5j9CGVX:Nvpl4mZZecjEfZ8yxGhFcg==]",
+        "_memcached_endpoint": "cache.rubygems-pr0:11211",
+        "sendgrid_username": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:kLAEXxlcYFnpLmfyCNoRKtse4yJjMLZ8:mAI/Ngu8cEqRMeZyBsiyKA==]",
+        "sendgrid_password": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:iZGDMHZQvUcfBb/h48wfyFjg6yI5q74g:6nq/POte7hnI6iiNr5tG1g==]",
+        "sendgrid_webhook_username": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:BRmFXQx4juQdvKLjHJJpougtnbt67BFm:kWisD6/Ekd+iIoSW+ERPMQ==]",
+        "sendgrid_webhook_password": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:zBBgIlRxHuN0cdm1Hf7Lmrj56ZLHhHME:fnQeir60tYLZGwFUCdZyXQ==]",
+        "slack_hook": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:7b9zmvkU48FoIszeCeUYVuB50o2R7h1d:QfuSXhN7/NgFOjUYMAzc4g==]",
+        "client_id": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:4YZD8UteBB/xwVZ5myZe+gHe/XLDKioe:NvoVkgROtAzXe/spHPei1Q==]",
+        "github_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:Uy4hFGENDMjKMWnRiCxS8mCNHGXPg2Ut:vYliHR9nZ27v/raYo1OS5g==]",
+        "github_secret": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:Nxop6E9j2WPZs0HlA8YCziLYPVASLAkx:ygw4N/vif/NNXWII1KAFAw==]",
+        "avo_license_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:8yRdW8h+sZQlEKSCkJkfWzA6Yt/S+Fvl:YBKzNS/PvmlpekExVyXAWQ==]",
+        "datadog_csp_api_key": "EJ[1:+oyu4I3+iD9sk8sDqx+N+8UCFihf2KjQNNO4vvypQVk=:4LBW1nmb8a2+0hZcRCaZ99WhYyJdkBMu:5hpiMDFcprfaE7dE4LMTNw==]"
+      }
+    },
+  "nginx-basic-auth": {
+      "_type": "Opaque",
+      "data": {
+        "_.htpasswd": "rubygems-review:$apr1$sd51m0hj$teftmZIhQFzQExTFgaT9K0"
+      }
+    }
+  }
+}

--- a/config/deploy/review/service.yaml.erb
+++ b/config/deploy/review/service.yaml.erb
@@ -1,0 +1,1 @@
+../service.yaml.erb

--- a/config/deploy/review/web.yaml.erb
+++ b/config/deploy/review/web.yaml.erb
@@ -1,0 +1,1 @@
+../web.yaml.erb

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -42,7 +42,7 @@ spec:
           <% end %>
         env:
           - name: RAILS_ENV
-            value: "<%= environment %>"
+            value: "<%= rails_env %>"
           - name: ENV
             value: "<%= environment %>"
           - name: DD_AGENT_HOST
@@ -62,7 +62,7 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: secret_key_base
           - name: AWS_REGION
             value: "us-west-2"
@@ -71,69 +71,69 @@ spec:
           - name: S3_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: S3_SECRET
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: HONEYBADGER_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: honeybadger_api_key
           - name: FASTLY_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_api_key
           - name: FASTLY_SERVICE_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_service_id
           - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: elasticsearch_url
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: memcached_endpoint
           - name: SENDGRID_USERNAME
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_username
           - name: SENDGRID_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_password
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_url
           - name: SQS_QUEUE
-            value: "fastly_logs_<%= environment %>"
+            value: "fastly_logs_<%= rails_env %>"
         securityContext:
           privileged: false

--- a/config/deploy/users-verify-daily.yaml.erb
+++ b/config/deploy/users-verify-daily.yaml.erb
@@ -37,7 +37,7 @@ spec:
               <% end %>
             env:
             - name: RAILS_ENV
-              value: "<%= environment %>"
+              value: "<%= rails_env %>"
             - name: ENV
               value: "<%= environment %>"
             - name: DD_AGENT_HOST
@@ -57,27 +57,27 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: secret_key_base
             - name: CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: client_id
             - name: SLACK_HOOK
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: slack_hook
             - name: HONEYBADGER_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: honeybadger_api_key
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: database_url
             volumeMounts:
             - mountPath: /app/lib/tasks/users_verify.rake

--- a/config/deploy/versions-list-update-monthly.yaml.erb
+++ b/config/deploy/versions-list-update-monthly.yaml.erb
@@ -37,7 +37,7 @@ spec:
               <% end %>
             env:
             - name: RAILS_ENV
-              value: "<%= environment %>"
+              value: "<%= rails_env %>"
             - name: ENV
               value: "<%= environment %>"
             - name: DD_AGENT_HOST
@@ -57,39 +57,39 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: secret_key_base
             - name: AWS_REGION
               value: "us-west-2"
             - name: S3_KEY
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: aws_access_key_id
             - name: S3_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: aws_secret_access_key
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: aws_access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: aws_secret_access_key
             - name: HONEYBADGER_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: honeybadger_api_key
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: <%= environment %>
+                  name: <%= rails_env %>
                   key: database_url
             securityContext:
               privileged: false

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: puma
         image: quay.io/rubygems/rubygems.org:<%= current_sha %>
-        args: ["puma", "--environment", "<%= environment %>", "--config", "/app/config/puma.rb"]
+        args: ["puma", "--environment", "<%= rails_env %>", "--config", "/app/config/puma.rb"]
         ports:
         - containerPort: 3000
           name: http-puma
@@ -55,7 +55,7 @@ spec:
           <% end %>
         env:
           - name: RAILS_ENV
-            value: "<%= environment %>"
+            value: "<%= rails_env %>"
           - name: ENV
             value: "<%= environment %>"
           - name: DD_AGENT_HOST
@@ -63,6 +63,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
+          - name: WEB_CONCURRENCY
+            value: "1"
           - name: STATSD_IMPLEMENTATION
             value: "datadog"
           - name: STATSD_HOST
@@ -75,7 +77,7 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: secret_key_base
           - name: RAILS_SERVE_STATIC_FILES
             value: "true"
@@ -86,94 +88,94 @@ spec:
           - name: S3_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: S3_SECRET
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_access_key_id
           - name: AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: aws_secret_access_key
           - name: HONEYBADGER_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: honeybadger_api_key
           - name: FASTLY_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_api_key
           - name: FASTLY_SERVICE_ID
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_service_id
           - name: FASTLY_DOMAINS
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: fastly_domains
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: elasticsearch_url
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: memcached_endpoint
           - name: SENDGRID_USERNAME
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_username
           - name: SENDGRID_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_password
           - name: SENDGRID_WEBHOOK_USERNAME
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_webhook_username
           - name: SENDGRID_WEBHOOK_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: sendgrid_webhook_password
           - name: GITHUB_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: github_key
           - name: GITHUB_SECRET
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: github_secret
           - name: AVO_LICENSE_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: avo_license_key
           - name: DATADOG_CSP_API_KEY
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: datadog_csp_api_key
-          <% if environment == 'staging' %>
+          <% if rails_env == 'staging' %>
           - name: DISABLE_SIGNUP
             value: "true"
           - name: RAILS_LOG_LEVEL
@@ -182,7 +184,7 @@ spec:
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: <%= environment %>
+                name: <%= rails_env %>
                 key: database_url
         securityContext:
           privileged: false
@@ -225,7 +227,7 @@ spec:
             mountPath: /var/log/nginx
           - name: nginxcache
             mountPath: /var/lib/nginx/cache
-          <% if environment == 'staging' %>
+          <% if rails_env == 'staging' || rails_env == 'review' %>
           - name: nginxbasicauth
             mountPath: /etc/nginxbasicauth
             readOnly: true
@@ -252,12 +254,12 @@ spec:
               - key: logging
                 path: conf.d/logging.conf
               - key: rubygems
-                path: sites-enabled/<%= environment %>.ruybgems.conf
+                path: sites-enabled/<%= rails_env %>.ruybgems.conf
         - name: nginxlog
           emptyDir: {}
         - name: nginxcache
           emptyDir: {}
-        <% if environment == 'staging' %>
+        <% if rails_env == 'staging' || rails_env == 'review' %>
         - name: nginxbasicauth
           secret:
             secretName: nginx-basic-auth

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -1,0 +1,122 @@
+require Rails.root.join("config", "secret") if Rails.root.join("config", "secret.rb").file?
+require_relative "../../lib/gemcutter/middleware/redirector"
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
+  # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
+  # `config/secrets.yml.key`.
+  # config.read_encrypted_secrets = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'max-age=315360000, public',
+    'Expires' => 'Thu, 31 Dec 2037 23:55:55 GMT'
+  }
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :terser
+  config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+  config.ssl_options = {
+    hsts: { expires: 365.days, subdomains: false },
+    redirect: {
+      exclude: ->(request) { request.path.start_with?('/internal') }
+    }
+  }
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV['RAILS_LOG_LEVEL'].present? ? ENV['RAILS_LOG_LEVEL'].to_sym : :info
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :request_id ]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "gemcutter_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { host: Gemcutter::HOST,
+                                               protocol: Gemcutter::PROTOCOL }
+
+  # roadie-rails recommends not setting action_mailer.asset_host and use its own configuration for URL options
+  config.roadie.url_options = { host: Gemcutter::HOST, scheme: Gemcutter::PROTOCOL }
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = [:en]
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  # config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  # if ENV["RAILS_LOG_TO_STDOUT"].present?
+  #   logger           = ActiveSupport::Logger.new($stdout)
+  #   logger.formatter = config.log_formatter
+  #   config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  # end
+
+  # Custom logging config.
+  config.logger = ActiveSupport::Logger.new($stdout)
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  config.cache_store = :mem_cache_store, ENV['MEMCACHED_ENDPOINT'], {
+    failover: true,
+    socket_timeout: 1.5,
+    socket_failure_delay: 0.2,
+    compress: true,
+    compression_min_size: 524_288,
+    value_max_bytes: 2_097_152 # 2MB
+  }
+
+  config.middleware.use Gemcutter::Middleware::Redirector
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -9,7 +9,7 @@ Datadog.configure do |c|
 
   # Enabling datadog functionality
 
-  enabled = (Rails.env.production? || Rails.env.staging?) && ENV["DD_AGENT_HOST"].present?
+  enabled = (Rails.env.production? || Rails.env.staging? || Rails.env.review?) && ENV["DD_AGENT_HOST"].present?
   c.runtime_metrics.enabled = enabled
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -25,7 +25,7 @@ if Rails.env.development?
 end
 
 Searchkick.client = OpenSearch::Client.new(**options.compact) do |f|
-  if Rails.env.staging? || Rails.env.production?
+  if Rails.env.staging? || Rails.env.production? || Rails.env.review?
     f.request :aws_sigv4,
       service: 'es',
       region: ENV['AWS_REGION'],

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,4 +1,4 @@
-if Rails.env.production? || Rails.env.staging?
+if Rails.env.production? || Rails.env.staging? || Rails.env.review?
   require_relative "../../lib/lograge/formatters/datadog"
 
   Rails.application.configure do

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,4 +1,4 @@
-if Rails.env.production? || Rails.env.staging?
+if Rails.env.production? || Rails.env.staging? || Rails.env.review?
   ActionMailer::Base.smtp_settings = {
     address:              'smtp.sendgrid.net',
     port:                 587,

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,5 +1,5 @@
 WebAuthn.configure do |config|
-  config.origin = if Rails.env.staging? || Rails.env.production?
+  config.origin = if Rails.env.staging? || Rails.env.production? || Rails.env.review?
                     "#{Rails.application.config.rubygems.protocol}://#{Rails.application.config.rubygems.host}"
                   else
                     ENV.fetch("WEBAUTHN_ORIGIN", "http://localhost:3000")

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -30,3 +30,11 @@ production:
   s3_endpoint: s3-us-west-2.amazonaws.com
   versions_file_location: "./config/versions.list"
   separate_admin_host: rubygems.team
+
+review:
+  protocol: https
+  host: <%= ENV["ENV"] %>.review.rubygems.org
+  s3_bucket: oregon.<%= ENV["ENV"] %>.s3.rubygems.org
+  s3_region: us-west-2
+  s3_endpoint: s3-us-west-2.amazonaws.com
+  versions_file_location: "./config/versions.list"

--- a/shipit.yml
+++ b/shipit.yml
@@ -8,11 +8,11 @@ dependencies:
 
 deploy:
   override:
-    - krane render -f config/deploy/$ENVIRONMENT --bindings=environment=$ENVIRONMENT --current-sha=$REVISION | krane deploy rubygems-$ENVIRONMENT rubygems --stdin -f config/deploy/$ENVIRONMENT/secrets.ejson
+    - ./config/deploy/deploy
 
 rollback:
   override:
-    - krane render -f config/deploy/$ENVIRONMENT --bindings=environment=$ENVIRONMENT --current-sha=$REVISION | krane deploy rubygems-$ENVIRONMENT rubygems  --stdin -f config/deploy/$ENVIRONMENT/secrets.ejson
+    - ./config/deploy/deploy
 
 tasks:
   restart:


### PR DESCRIPTION
This is a WIP to support https://github.com/Shopify/shipit-engine/blob/9b0bde8fec419b09424be990c8fd92639f473683/docs/review_stacks.md .

It still requires a rubygems/shipit change to add a provisioning handler to create the namespace & the ejson secret, and then destroy the namespace when the stack is no longer needed