### PR TITLE
Migrate Indexer to GoodJob ActiveJob adapter.

### DIFF
--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -1,6 +1,9 @@
-class Indexer
+class Indexer < ApplicationJob
   extend StatsD::Instrument
   include TraceTagger
+
+  self.queue_adapter = :good_job
+  queue_with_priority PRIORITIES.fetch(:push)
 
   def perform
     log "Updating the index"
@@ -10,25 +13,6 @@ class Indexer
   end
   statsd_count_success :perform, "Indexer.perform"
   statsd_measure :perform, "Indexer.perform"
-
-  def write_gem(body, spec)
-    original_name = spec.original_name
-
-    gem_path = "gems/#{original_name}.gem"
-    gem_contents = body.string
-
-    spec.abbreviate
-    spec.sanitize
-    spec_path = "quick/Marshal.4.8/#{original_name}.gemspec.rz"
-    spec_contents = Gem.deflate(Marshal.dump(spec))
-
-    # do all processing _before_ we upload anything to S3, so we lower the chances of orphaned files
-    RubygemFs.instance.store(gem_path, gem_contents)
-    RubygemFs.instance.store(spec_path, spec_contents)
-
-    Fastly.purge(path: gem_path)
-    Fastly.purge(path: spec_path)
-  end
 
   private
 

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -43,12 +43,12 @@ class Deletion < ApplicationRecord
 
   def remove_from_index
     @version.update!(indexed: false, yanked_at: Time.now.utc)
-    Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
+    Indexer.perform_later
   end
 
   def restore_to_index
     version.update!(indexed: true, yanked_at: nil, yanked_info_checksum: nil)
-    Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
+    Indexer.perform_later
   end
 
   def remove_from_storage

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -9,7 +9,6 @@ class Pusher
     @user = user
     @body = StringIO.new(body.read)
     @size = @body.size
-    @indexer = Indexer.new
     @remote_ip = remote_ip
     @scoped_rubygem = scoped_rubygem
   end
@@ -46,7 +45,7 @@ class Pusher
     # Restructured so that if we fail to write the gem (ie, s3 is down)
     # can clean things up well.
     return notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403) unless update
-    @indexer.write_gem @body, @spec
+    write_gem @body, @spec
   rescue ArgumentError => e
     @version.destroy
     Rails.error.report(e, handled: true)
@@ -124,7 +123,7 @@ class Pusher
     version.rubygem.push_notifiable_owners.each do |notified_user|
       Mailer.delay.gem_pushed(user.id, @version_id, notified_user.id)
     end
-    Delayed::Job.enqueue Indexer.new, priority: PRIORITIES[:push]
+    Indexer.perform_later
     rubygem.delay.reindex
     GemCachePurger.call(rubygem.name)
     RackAttackReset.gem_push_backoff(@remote_ip, @user.display_id) if @remote_ip.present?
@@ -196,5 +195,24 @@ class Pusher
 
   def version_mfa_required?
     ActiveRecord::Type::Boolean.new.cast(spec.metadata["rubygems_mfa_required"])
+  end
+
+  def write_gem(body, spec)
+    original_name = spec.original_name
+
+    gem_path = "gems/#{original_name}.gem"
+    gem_contents = body.string
+
+    spec.abbreviate
+    spec.sanitize
+    spec_path = "quick/Marshal.4.8/#{original_name}.gemspec.rz"
+    spec_contents = Gem.deflate(Marshal.dump(spec))
+
+    # do all processing _before_ we upload anything to S3, so we lower the chances of orphaned files
+    RubygemFs.instance.store(gem_path, gem_contents)
+    RubygemFs.instance.store(spec_path, spec_contents)
+
+    Fastly.purge(path: gem_path)
+    Fastly.purge(path: spec_path)
   end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -312,10 +312,12 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
           assert_equal "Successfully registered gem: test (1.0.0)", @response.body
         end
         should "enqueue jobs" do
-          assert_difference "Delayed::Job.count", 3 do
+          assert_difference "Delayed::Job.count", 2 do
             assert_enqueued_jobs 4, only: FastlyPurgeJob do
               assert_enqueued_jobs 1, only: NotifyWebHookJob do
-                post :create, body: gem_file("test-1.0.0.gem").read
+                assert_enqueued_jobs 1, only: Indexer do
+                  post :create, body: gem_file("test-1.0.0.gem").read
+                end
               end
             end
           end

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -76,9 +76,11 @@ class DeletionTest < ActiveSupport::TestCase
   end
 
   should "enque job for updating ES index, spec index and purging cdn" do
-    assert_difference "Delayed::Job.count", 3 do
+    assert_difference "Delayed::Job.count", 2 do
       assert_enqueued_jobs 6, only: FastlyPurgeJob do
-        delete_gem
+        assert_enqueued_jobs 1, only: Indexer do
+          delete_gem
+        end
       end
     end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -422,7 +422,7 @@ class PusherTest < ActiveSupport::TestCase
       @cutter.stubs(:version).returns @rubygem.versions[0]
       @cutter.stubs(:spec).returns(@spec)
       @rubygem.stubs(:update_attributes_from_gem_specification!)
-      Indexer.any_instance.stubs(:write_gem)
+      @cutter.stubs(:write_gem)
     end
 
     context "when cutter is saved" do
@@ -496,9 +496,11 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
-      assert_difference "Delayed::Job.count", 3 do
+      assert_difference "Delayed::Job.count", 2 do
         assert_enqueued_jobs 4, only: FastlyPurgeJob do
-          @cutter.save
+          assert_enqueued_jobs 1, only: Indexer do
+            @cutter.save
+          end
         end
       end
     end
@@ -514,7 +516,7 @@ class PusherTest < ActiveSupport::TestCase
       @rubygem.stubs(:update_attributes_from_gem_specification!)
       @cutter.stubs(:version).returns @version
       GemCachePurger.stubs(:call)
-      Indexer.any_instance.stubs(:write_gem)
+      @cutter.stubs(:write_gem)
       @cutter.save
     end
 


### PR DESCRIPTION
Moved `write_gem` from `Indexer` into `Pusher`, since `Pusher` is the only place to call it and it is well isolated method not using any other parts of `Indexer`.