### PR TITLE
Migrate all mailers into ActionMailer backed by ActiveJob.

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -62,7 +62,7 @@ class Api::V1::ApiKeysController < Api::BaseController
 
   def save_and_respond(api_key, key)
     if api_key.save
-      Mailer.delay.api_key_created(api_key.id)
+      Mailer.api_key_created(api_key.id).deliver_later
       respond_with key
     else
       respond_with api_key.errors.full_messages.to_sentence, status: :unprocessable_entity

--- a/app/controllers/api/v1/github_secret_scanning_controller.rb
+++ b/app/controllers/api/v1/github_secret_scanning_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::GitHubSecretScanningController < Api::BaseController
   private
 
   def schedule_revoke_email(api_key, url)
-    Mailer.delay.api_key_revoked(api_key.user_id, api_key.name, api_key.enabled_scopes.join(", "), url)
+    Mailer.api_key_revoked(api_key.user_id, api_key.name, api_key.enabled_scopes.join(", "), url).deliver_later
   end
 
   def secret_scanning_key(key_id)

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::OwnersController < Api::BaseController
     if owner
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
-        OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
+        OwnersMailer.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id).deliver_later
         render plain: response_with_mfa_warning("Owner removed successfully.")
       else
         render plain: response_with_mfa_warning("Unable to remove owner."), status: :forbidden

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -35,7 +35,7 @@ class ApiKeysController < ApplicationController
     end
 
     if @api_key.save
-      Mailer.delay.api_key_created(@api_key.id)
+      Mailer.api_key_created(@api_key.id).deliver_later
 
       session[:api_key] = key
       redirect_to profile_api_keys_path, flash: { notice: t(".success") }

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -16,7 +16,7 @@ class NotifiersController < ApplicationController
       current_user.ownerships.update_push_notifier(to_enable_push, to_disable_push)
       current_user.ownerships.update_owner_notifier(to_enable_owner, to_disable_owner)
       current_user.ownerships.update_ownership_request_notifier(to_enable_ownership_request, to_disable_ownership_request)
-      Mailer.delay.notifiers_changed(current_user.id)
+      Mailer.notifiers_changed(current_user.id).deliver_later
     end
 
     redirect_to notifier_path, notice: t(".update.success")

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -44,7 +44,7 @@ class OwnersController < ApplicationController
   def destroy
     @ownership = @rubygem.ownerships_including_unconfirmed.find_by_owner_handle!(handle_params)
     if @ownership.safe_destroy
-      OwnersMailer.delay.owner_removed(@ownership.user_id, current_user.id, @ownership.rubygem_id)
+      OwnersMailer.owner_removed(@ownership.user_id, current_user.id, @ownership.rubygem_id).deliver_later
       redirect_to rubygem_owners_path(@ownership.rubygem), notice: t(".removed_notice", owner_name: @ownership.owner_name)
     else
       index_with_error t(".failed_notice"), :forbidden
@@ -68,10 +68,12 @@ class OwnersController < ApplicationController
 
   def notify_owner_added(ownership)
     ownership.rubygem.ownership_notifiable_owners.each do |notified_user|
-      OwnersMailer.delay.owner_added(notified_user.id,
+      OwnersMailer.owner_added(
+        notified_user.id,
         ownership.user_id,
         ownership.authorizer.id,
-        ownership.rubygem_id)
+        ownership.rubygem_id
+      ).deliver_later
     end
   end
 

--- a/app/controllers/ownership_requests_controller.rb
+++ b/app/controllers/ownership_requests_controller.rb
@@ -45,18 +45,20 @@ class OwnershipRequestsController < ApplicationController
   end
 
   def notify_request_closed
-    OwnersMailer.delay.ownership_request_closed(@ownership_request.id) unless @ownership_request.user == current_user
+    OwnersMailer.ownership_request_closed(@ownership_request.id).deliver_later unless @ownership_request.user == current_user
   end
 
   def notify_request_approved
     @rubygem.ownership_notifiable_owners.each do |notified_user|
-      OwnersMailer.delay.owner_added(notified_user.id,
+      OwnersMailer.owner_added(
+        notified_user.id,
         @ownership_request.user_id,
         current_user.id,
-        @ownership_request.rubygem_id)
+        @ownership_request.rubygem_id
+      ).deliver_later
     end
 
-    OwnersMailer.delay.ownership_request_approved(@ownership_request.id)
+    OwnersMailer.ownership_request_approved(@ownership_request.id).deliver_later
   end
 
   def status_params

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -87,8 +87,7 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def deliver_email(user)
-    mail = ::ClearanceMailer.change_password(user)
-    mail.deliver_later
+    ::ClearanceMailer.change_password(user).deliver_later
   end
 
   def setup_mfa_authentication

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -25,12 +25,17 @@ class Mailer < ApplicationMailer
 
   def email_confirmation(user)
     @user = user
-    mail to: @user.email,
-         subject: I18n.t("mailer.confirmation_subject",
-         default: "Please confirm your email address with RubyGems.org") do |format|
-           format.html
-           format.text
-         end
+
+    if @user.confirmation_token
+      mail to: @user.email,
+           subject: I18n.t("mailer.confirmation_subject",
+           default: "Please confirm your email address with RubyGems.org") do |format|
+             format.html
+             format.text
+           end
+    else
+      Rails.logger.info("[mailer:email_confirmation] confirmation token not found. skipping sending mail for #{@user.handle}")
+    end
   end
 
   def deletion_complete(email)

--- a/app/mailers/owners_mailer.rb
+++ b/app/mailers/owners_mailer.rb
@@ -14,10 +14,10 @@ class OwnersMailer < ApplicationMailer
     @user = @ownership.user
     @rubygem = @ownership.rubygem
     mail to: @user.email,
-         subject: t("mailer.ownership_confirmation.subject", gem: @rubygem.name) do |format|
-           format.html
-           format.text
-         end
+      subject: t("mailer.ownership_confirmation.subject", gem: @rubygem.name) do |format|
+        format.html
+        format.text
+      end
   end
 
   def owner_removed(user_id, remover_id, gem_id)

--- a/lib/tasks/mfa_notification.rake
+++ b/lib/tasks/mfa_notification.rake
@@ -27,7 +27,7 @@ namespace :mfa_notification do
 
     i = 0
     notify_users.find_each do |user|
-      Mailer.delay.mfa_notification(user.id) if mx_exists?(user.email)
+      Mailer.mfa_notification(user.id).deliver_later if mx_exists?(user.email)
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
     end

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -27,7 +27,7 @@ namespace :mfa_policy do
 
     i = 0
     users.each do |user|
-      Mailer.delay.mfa_recommendation_announcement(user.id) if mx_exists?(user.email)
+      Mailer.mfa_recommendation_announcement(user.id).deliver_later if mx_exists?(user.email)
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
     end
@@ -46,7 +46,7 @@ namespace :mfa_policy do
 
     i = 0
     users.each do |user|
-      Mailer.delay.mfa_required_soon_announcement(user.id) if mx_exists?(user.email)
+      Mailer.mfa_required_soon_announcement(user.id).deliver_later if mx_exists?(user.email)
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total_users * 100.0, i, total_users)
     end
@@ -68,7 +68,7 @@ namespace :mfa_policy do
     unsent_mailer_emails = []
     users.each do |user|
       if mx_exists?(user.email)
-        Mailer.delay.mfa_required_popular_gems_announcement(user.id)
+        Mailer.mfa_required_popular_gems_announcement(user.id).deliver_later
         mailers_sent += 1
         print format("\r%.2f%% (%d/%d) complete", mailers_sent.to_f / total_users * 100.0, mailers_sent, total_users)
       else

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -590,8 +590,9 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       context "when mfa for UI and API is disabled" do
         context "user is not the only confirmed owner" do
           setup do
-            delete :destroy, params: { rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json }
-            Delayed::Worker.new.work_off
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { rubygem_id: @rubygem.to_param, email: @second_user.email, format: :json }
+            end
           end
 
           should "remove user as gem owner" do

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ApiKeysControllerTest < ActionController::TestCase
+  include ActiveJob::TestHelper
+
   context "when not logged in" do
     context "on GET to index" do
       setup { get :index }
@@ -94,8 +96,9 @@ class ApiKeysControllerTest < ActionController::TestCase
     context "on POST to create" do
       context "with successful save" do
         setup do
-          post :create, params: { api_key: { name: "test", add_owner: true } }
-          Delayed::Worker.new.work_off
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            post :create, params: { api_key: { name: "test", add_owner: true } }
+          end
         end
 
         should redirect_to("the key index page") { profile_api_keys_path }

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -344,9 +344,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
     context "user does not exist" do
       should "not deliver confirmation email" do
-        Mailer.expects(:email_confirmation).times(0)
         post :create, params: { email_confirmation: { email: "someone@else.com" } }
-        Delayed::Worker.new.work_off
+
+        assert_no_enqueued_emails
       end
     end
   end

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -49,7 +49,9 @@ class OwnersControllerTest < ActionController::TestCase
       context "when user owns the gem" do
         context "with invalid handle" do
           setup do
-            post :create, params: { handle: "no_user", rubygem_id: @rubygem.name }
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              post :create, params: { handle: "no_user", rubygem_id: @rubygem.name }
+            end
           end
 
           should respond_with :unprocessable_entity
@@ -61,8 +63,6 @@ class OwnersControllerTest < ActionController::TestCase
           end
 
           should "not send confirmation email" do
-            Delayed::Worker.new.work_off
-
             assert_emails 0
           end
         end
@@ -97,9 +97,9 @@ class OwnersControllerTest < ActionController::TestCase
             setup { @rubygem.owners_including_unconfirmed.last.destroy }
 
             should "not send confirmation email" do
-              Delayed::Worker.new.work_off
-
-              assert_equal 0, Delayed::Job.where.not(last_error: nil).count
+              assert_raises(ActiveJob::DeserializationError) do
+                perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
+              end
               assert_emails 0
             end
           end
@@ -173,7 +173,9 @@ class OwnersControllerTest < ActionController::TestCase
           setup do
             @second_user = create(:user)
             @ownership = create(:ownership, rubygem: @rubygem, user: @second_user)
-            delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
+            end
           end
           should redirect_to("ownership index") { rubygem_owners_path(@rubygem) }
 
@@ -181,8 +183,6 @@ class OwnersControllerTest < ActionController::TestCase
             refute_includes @rubygem.owners_including_unconfirmed, @second_user
           end
           should "send email notifications about owner removal" do
-            Delayed::Worker.new.work_off
-
             assert_emails 1
             assert_contains last_email.subject, "You were removed as an owner from #{@rubygem.name} gem"
             assert_equal [@second_user.email], last_email.to
@@ -193,7 +193,9 @@ class OwnersControllerTest < ActionController::TestCase
           setup do
             @second_user = create(:user)
             @ownership = create(:ownership, :unconfirmed, rubygem: @rubygem, user: @second_user)
-            delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
+            end
           end
           should redirect_to("ownership index") { rubygem_owners_path(@rubygem) }
 
@@ -201,8 +203,6 @@ class OwnersControllerTest < ActionController::TestCase
             refute_includes @rubygem.owners_including_unconfirmed, @second_user
           end
           should "send email notifications about owner removal" do
-            Delayed::Worker.new.work_off
-
             assert_emails 1
             assert_contains last_email.subject, "You were removed as an owner from #{@rubygem.name} gem"
             assert_equal [@second_user.email], last_email.to
@@ -212,7 +212,9 @@ class OwnersControllerTest < ActionController::TestCase
         context "with handle of last owner" do
           setup do
             @last_owner = @rubygem.owners.last
-            delete :destroy, params: { rubygem_id: @rubygem.name, handle: @last_owner.display_id }
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { rubygem_id: @rubygem.name, handle: @last_owner.display_id }
+            end
           end
           should respond_with :forbidden
 
@@ -223,8 +225,6 @@ class OwnersControllerTest < ActionController::TestCase
             assert_equal "Can't remove the only owner of the gem", flash[:alert]
           end
           should "not send email notifications about owner removal" do
-            Delayed::Worker.new.work_off
-
             assert_emails 0
           end
         end
@@ -295,7 +295,9 @@ class OwnersControllerTest < ActionController::TestCase
       context "when unconfirmed ownership exists" do
         setup do
           create(:ownership, :unconfirmed, rubygem: @rubygem, user: @new_owner)
-          get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          end
         end
 
         should redirect_to("rubygem show") { rubygem_path(@rubygem) }
@@ -305,9 +307,6 @@ class OwnersControllerTest < ActionController::TestCase
           assert_equal success_flash, flash[:notice]
         end
         should "resend confirmation email" do
-          assert_enqueued_emails 1
-          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
-
           assert_emails 1
           assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
           assert_equal [@new_owner.email], last_email.to
@@ -316,13 +315,14 @@ class OwnersControllerTest < ActionController::TestCase
 
       context "when ownership doesn't exist" do
         setup do
-          get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          end
         end
 
         should respond_with :not_found
-        should "not resend confirmation email" do
-          Delayed::Worker.new.work_off
 
+        should "not resend confirmation email" do
           assert_emails 0
         end
       end
@@ -330,13 +330,14 @@ class OwnersControllerTest < ActionController::TestCase
       context "when confirmed ownership exists" do
         setup do
           create(:ownership, rubygem: @rubygem, user: @new_owner)
-          get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            get :resend_confirmation, params: { rubygem_id: @rubygem.name }
+          end
         end
 
         should respond_with :not_found
-        should "not resend confirmation email" do
-          Delayed::Worker.new.work_off
 
+        should "not resend confirmation email" do
           assert_emails 0
         end
       end
@@ -403,7 +404,9 @@ class OwnersControllerTest < ActionController::TestCase
 
       context "when token has not expired" do
         setup do
-          get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          end
           @ownership.reload
         end
 
@@ -418,8 +421,6 @@ class OwnersControllerTest < ActionController::TestCase
         end
 
         should "send email notifications about new owner" do
-          Delayed::Worker.new.work_off
-
           owner_added_email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
           assert_contains owner_added_email_subjects, "You were added as an owner to #{@rubygem.name} gem"
@@ -434,7 +435,9 @@ class OwnersControllerTest < ActionController::TestCase
       context "when token has expired" do
         setup do
           travel_to 3.days.from_now
-          get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            get :confirm, params: { rubygem_id: @rubygem.name, token: @ownership.token }
+          end
         end
 
         should "warn about invalid token" do
@@ -444,8 +447,6 @@ class OwnersControllerTest < ActionController::TestCase
         end
 
         should "not send email notification about owner added" do
-          Delayed::Worker.new.work_off
-
           assert_emails 0
         end
       end

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -35,12 +35,12 @@ class NotificationSettingsTest < SystemTest
       choose notifier_off_radio(ownership2, "owner")
       choose notifier_off_radio(ownership2, "ownership_request")
 
-      click_button I18n.t("notifiers.show.update")
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        click_button I18n.t("notifiers.show.update")
+      end
     end
 
-    assert_changes :mails_count, from: 0, to: 1 do
-      Delayed::Worker.new.work_off
-    end
+    assert_emails 1
 
     assert_equal I18n.t("mailer.notifiers_changed.subject"), last_email.subject
 

--- a/test/integration/ownership_request_test.rb
+++ b/test/integration/ownership_request_test.rb
@@ -37,9 +37,7 @@ class OwnershipRequestsTest < SystemTest
 
     click_button "Approve"
 
-    Delayed::Worker.new.work_off
-
-    assert_emails 3
+    assert_enqueued_emails 3
     assert_includes(rubygem.owners, user)
   end
 
@@ -54,9 +52,7 @@ class OwnershipRequestsTest < SystemTest
     click_button "Close"
 
     assert_empty rubygem.ownership_requests
-    Delayed::Worker.new.work_off
-
-    assert_no_emails
+    assert_enqueued_emails 0
   end
 
   test "close ownership request by owner" do
@@ -67,11 +63,11 @@ class OwnershipRequestsTest < SystemTest
 
     visit_rubygem_adoptions_path(rubygem, @owner)
 
-    page.find_by_id("owner_close_request").click
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      page.find_by_id("owner_close_request").click
+    end
 
     assert_empty rubygem.ownership_requests
-    Delayed::Worker.new.work_off
-
     assert_emails 1
     assert_equal "Your ownership request was closed.", last_email.subject
   end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -62,7 +62,9 @@ class ProfileTest < SystemTest
     fill_in "Email address", with: "nick2@example.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
 
-    click_button "Update"
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      click_button "Update"
+    end
 
     assert page.has_selector? "input[value='nick@example.com']"
     assert page.has_selector? "#flash_notice", text: "You will receive " \

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -69,7 +69,10 @@ class SignUpTest < SystemTest
     fill_in "Email", with: "email@person.com"
     fill_in "Username", with: "nick"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
-    click_button "Sign up"
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      click_button "Sign up"
+    end
 
     link = last_email_link
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,11 @@ SimpleCov.start "rails" do
   add_filter "app/jobs/*_mailer.rb"
   add_filter "app/jobs/delete_user.rb"
 
+  # to be deleted after initial deploy of mailer migration to AM/AJ
+  add_filter "app/jobs/email_confirmation_mailer.rb"
+  add_filter "app/jobs/email_reset_mailer.rb"
+  add_filter "app/jobs/ownership_confirmation_mailer.rb"
+
   if ENV["CI"]
     require "simplecov-cobertura"
     formatter SimpleCov::Formatter::CoberturaFormatter

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -9,8 +9,9 @@ class MailerTest < ActionMailer::TestCase
       @user = create(:user)
       create(:rubygem, owners: [@user], downloads: MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_recommendation"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_recommendation"].execute }
+      end
     end
 
     should "send mail to users" do
@@ -30,8 +31,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "disabled")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      end
 
       refute_empty ActionMailer::Base.deliveries
       email = ActionMailer::Base.deliveries.last
@@ -47,8 +49,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "ui_only")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      end
 
       refute_empty ActionMailer::Base.deliveries
       email = ActionMailer::Base.deliveries.last
@@ -64,8 +67,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "ui_and_api")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      end
 
       assert_empty ActionMailer::Base.deliveries
       assert_match "Sending 0 MFA reminder email", @io_output
@@ -75,8 +79,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user)
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY - 1)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:reminder_enable_mfa"].execute }
+      end
 
       assert_empty ActionMailer::Base.deliveries
       assert_match "Sending 0 MFA reminder email", @io_output
@@ -88,8 +93,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "disabled")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      end
 
       refute_empty ActionMailer::Base.deliveries
       email = ActionMailer::Base.deliveries.last
@@ -105,8 +111,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "ui_only")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      end
 
       refute_empty ActionMailer::Base.deliveries
       email = ActionMailer::Base.deliveries.last
@@ -122,8 +129,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user, mfa_level: "ui_and_api")
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      end
 
       assert_empty ActionMailer::Base.deliveries
       assert_match "Sending 0 MFA required for popular gems email", @io_output
@@ -133,8 +141,9 @@ class MailerTest < ActionMailer::TestCase
       user = create(:user)
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY - 1)
 
-      @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
-      Delayed::Worker.new.work_off
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        @io_output, _error = capture_io { Rake::Task["mfa_policy:announce_enforcement_for_popular_gems"].execute }
+      end
 
       assert_empty ActionMailer::Base.deliveries
       assert_match "Sending 0 MFA required for popular gems email", @io_output


### PR DESCRIPTION
@segiddins I got my take on this as well, I have cherry-picked some of your [PR changes](https://github.com/rubygems/rubygems.org/pull/3538) in here and added you as a co-author.

The main difference is by addressing more mailing code in this PR (api gh scan for example, rake tasks, ...).

