### PR TITLE
Add letter_opener_web as mail deliverer for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,8 @@ end
 group :development do
   gem "rails-erd"
   gem "listen"
+  gem "letter_opener"
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,13 @@ GEM
     kaminari-core (1.2.2)
     launchy (2.5.2)
       addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     libdatadog (1.0.1.1.0)
     libddwaf (1.5.1.0.1)
       ffi (~> 1.0)
@@ -611,6 +618,8 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
+  letter_opener
+  letter_opener_web
   listen
   lograge
   m (~> 1.5)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,8 +35,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/letter_opener.rb
+++ b/config/initializers/letter_opener.rb
@@ -1,0 +1,8 @@
+return unless Rails.env.development?
+
+Rails.configuration.to_prepare do
+  LetterOpenerWeb::ApplicationController.content_security_policy do |policy|
+    policy.style_src :self, :unsafe_inline
+    policy.img_src :self, 'data:'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,4 +264,9 @@ Rails.application.routes.draw do
 
     get 'development_log_in_as/:admin_github_user_id', to: 'oauth#development_log_in_as' if Gemcutter::ENABLE_DEVELOPMENT_ADMIN_LOG_IN
   end
+
+  ################################################################################
+  # Development routes
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
So it is easy to see what emails would be sent while developing!

Adds this page at `/letter_opener` in development:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1946610/223287886-eed2105f-c338-40d2-9719-924f6b6ed954.png">
