### PR TITLE
Add job concurrency limits where helpful

### DIFF
--- a/app/jobs/fastly_log_processor_job.rb
+++ b/app/jobs/fastly_log_processor_job.rb
@@ -2,6 +2,16 @@ class FastlyLogProcessorJob < ApplicationJob
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:stats)
 
+  include GoodJob::ActiveJobExtensions::Concurrency
+  good_job_control_concurrency_with(
+    # Maximum number of jobs with the concurrency key to be
+    # concurrently performed (excludes enqueued jobs)
+    #
+    # Limited to avoid overloading the gem_download table with
+    # Too many concurrent conflicting updates
+    perform_limit: 5
+  )
+
   def perform(bucket:, key:)
     FastlyLogProcessor.new(bucket, key).perform
   end

--- a/app/jobs/indexer.rb
+++ b/app/jobs/indexer.rb
@@ -4,6 +4,16 @@ class Indexer < ApplicationJob
 
   queue_with_priority PRIORITIES.fetch(:push)
 
+  include GoodJob::ActiveJobExtensions::Concurrency
+  good_job_control_concurrency_with(
+    # Maximum number of jobs with the concurrency key to be
+    # concurrently enqueued (excludes performing jobs)
+    #
+    # Because the indexer job only uses current state at time of perform,
+    # it makes no sense to enqueue more than one at a time
+    enqueue_limit: 1
+  )
+
   def perform
     log "Updating the index"
     update_index


### PR DESCRIPTION
Hopefully will allow jobs to drain and stop the fastly stats jobs from taking forever due to contention