### PR TITLE
Disable datadog in rails console

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -9,7 +9,7 @@ Datadog.configure do |c|
 
   # Enabling datadog functionality
 
-  enabled = (Rails.env.production? || Rails.env.staging?) && ENV["DD_AGENT_HOST"].present?
+  enabled = (Rails.env.production? || Rails.env.staging?) && ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
   c.runtime_metrics.enabled = enabled
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled


### PR DESCRIPTION
Will make working in the production rails console significantly cleaner