### PR TITLE
Fix Rubocop test exclusion not always being read correctly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 350 # TODO: Lower to 100
   Exclude:
-    - test/**/*.rb
+    - test/**/*
 
 Metrics/CyclomaticComplexity:
   Max: 9 # TODO: Lower to 6


### PR DESCRIPTION
Tiny fix to remove an annoying behavior in VSCode where the entire test file gets highlighted. This fixes it without altering any behavior in rubocop.