### PR TITLE
Add "gem" to reserve gem names list.

### DIFF
--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -33,6 +33,7 @@ module Patterns
     mruby
     ruby
     rubygems
+    gem
     update_rubygems
     install
     uninstall


### PR DESCRIPTION
This has the effect of refusing to allow uploads of this gem and showing the gem as reserved when loading the gem page (screenshot).

<img width="589" alt="Screenshot 2023-03-10 at 11 17 16 AM" src="https://user-images.githubusercontent.com/989/224406484-25809002-601e-4292-98d0-e2e55b46ae50.png">

I don't think it blocks downloading the existing gem, however. If we want to yank it after this is deployed, that could resolve any confusing that could be caused by this gem, especially with the `gem exec gem` behavior added in rubygems 3.4.8.