### PR TITLE
Close the LaunchDarkly client in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,6 +67,10 @@ class ActiveSupport::TestCase
     Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new("", config)
   end
 
+  teardown do
+    Rails.configuration.launch_darkly_client.close
+  end
+
   def page
     Capybara::Node::Simple.new(@response.body)
   end


### PR DESCRIPTION
Otherwise, it would leak threads since we create a new one for each test case