### PR TITLE
Clear GoodJob Queue at the end of each test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,6 +69,7 @@ class ActiveSupport::TestCase
 
   teardown do
     Rails.configuration.launch_darkly_client.close
+    GoodJob::Job.delete_all
   end
 
   def page


### PR DESCRIPTION
I'm not sure if this is the best way to clear the queue. I opened bensheldon/good_job#887 to ask if there's a better way.

The problem I had is that a few jobs were left in the queue that did not have the actual Job class in the branch. They would not clear on their own and caused certain tests to fail.