### PR TITLE
Purge gem/$name surrogate key

### DIFF
--- a/app/jobs/fastly_purge_job.rb
+++ b/app/jobs/fastly_purge_job.rb
@@ -1,7 +1,20 @@
 class FastlyPurgeJob < ApplicationJob
   queue_as :default
 
-  def perform(path:, soft:)
-    Fastly.purge({ path:, soft: })
+  class PassPathXorKeyError < ArgumentError
+  end
+
+  discard_on PassPathXorKeyError
+
+  before_perform do
+    raise PassPathXorKeyError, arguments.first.inspect if arguments.first.slice(:path, :key).compact.size != 1
+  end
+
+  def perform(soft:, path: nil, key: nil)
+    if path
+      Fastly.purge({ path:, soft: })
+    elsif key
+      Fastly.purge_key(key, soft:)
+    end
   end
 end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -4,3 +4,5 @@ Rails.autoloaders.main.ignore(Rails.root.join("lib/tasks"))
 # does not require autoload. ignore SqsWorker to supress following:
 # expected file lib/shoryuken/sqs_worker.rb to define constant Shoryuken::SqsWorker
 Rails.autoloaders.main.ignore(Rails.root.join("lib/shoryuken"))
+
+Rails.autoloaders.once.inflector.inflect("http" => "HTTP")

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -1,10 +1,4 @@
-require "net/http"
-
-class Net::HTTP::Purge < Net::HTTPRequest
-  METHOD = "PURGE".freeze
-  REQUEST_HAS_BODY = false
-  RESPONSE_HAS_BODY = true
-end
+require "net/http/purge"
 
 class Fastly
   concerning :TraceTagging do

--- a/lib/fastly.rb
+++ b/lib/fastly.rb
@@ -1,5 +1,3 @@
-require "net/http/purge"
-
 class Fastly
   concerning :TraceTagging do
     class_methods do

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -9,5 +9,6 @@ class GemCachePurger
     Rails.cache.delete("deps/v1/#{gem_name}")
     FastlyPurgeJob.perform_later(path: "versions", soft: true)
     FastlyPurgeJob.perform_later(path: "gem/#{gem_name}", soft: true)
+    FastlyPurgeJob.perform_later(key: "gem/#{gem_name}", soft: true)
   end
 end

--- a/lib/net/http/purge.rb
+++ b/lib/net/http/purge.rb
@@ -1,5 +1,3 @@
-require "net/http"
-
 class Net::HTTP::Purge < Net::HTTPRequest
   METHOD = "PURGE".freeze
   REQUEST_HAS_BODY = false

--- a/lib/net/http/purge.rb
+++ b/lib/net/http/purge.rb
@@ -1,0 +1,7 @@
+require "net/http"
+
+class Net::HTTP::Purge < Net::HTTPRequest
+  METHOD = "PURGE".freeze
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -326,7 +326,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         end
         should "enqueue jobs" do
           assert_difference "Delayed::Job.count", 1 do
-            assert_enqueued_jobs 4, only: FastlyPurgeJob do
+            assert_enqueued_jobs 5, only: FastlyPurgeJob do
               assert_enqueued_jobs 1, only: NotifyWebHookJob do
                 assert_enqueued_jobs 1, only: Indexer do
                   assert_enqueued_jobs 1, only: ReindexRubygemJob do

--- a/test/jobs/fastly_purge_job_test.rb
+++ b/test/jobs/fastly_purge_job_test.rb
@@ -10,4 +10,9 @@ class FastlyPurgeJobTest < ActiveJob::TestCase
     Fastly.expects(:purge).with({ path: "path", soft: false })
     FastlyPurgeJob.perform_now(path: "path", soft: false)
   end
+
+  test "calls Fastly.purge_key" do
+    Fastly.expects(:purge_key).with("key", soft: false)
+    FastlyPurgeJob.perform_now(key: "key", soft: false)
+  end
 end

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -79,7 +79,7 @@ class DeletionTest < ActiveSupport::TestCase
 
   should "enque job for updating ES index, spec index and purging cdn" do
     assert_difference "Delayed::Job.count", 1 do
-      assert_enqueued_jobs 6, only: FastlyPurgeJob do
+      assert_enqueued_jobs 7, only: FastlyPurgeJob do
         assert_enqueued_jobs 1, only: Indexer do
           assert_enqueued_jobs 1, only: ReindexRubygemJob do
             delete_gem

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -513,7 +513,7 @@ class PusherTest < ActiveSupport::TestCase
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
       assert_difference "Delayed::Job.count", 1 do
-        assert_enqueued_jobs 4, only: FastlyPurgeJob do
+        assert_enqueued_jobs 5, only: FastlyPurgeJob do
           assert_enqueued_jobs 1, only: Indexer do
             assert_enqueued_jobs 1, only: ReindexRubygemJob do
               @cutter.save


### PR DESCRIPTION
Will keep endpoints like /api/v1/versions/$name.json from potentially returning stale data