### PR TITLE
Bump good-job memory limit in production

### DIFF
--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -149,7 +149,7 @@ spec:
             memory: 1.4Gi
           limits:
             cpu: 1000m
-            memory: 1.6Gi
+            memory: 2.0Gi
           <% else %>
           requests:
             cpu: 200m


### PR DESCRIPTION
Since we got a few OOMs last week

Net/net we still come out ahead from the switch from delayed job since we went from 5->3 job pod replicas

Slack convo: https://bundler.slack.com/archives/C0494GDTKHP/p1678592436281539