### PR TITLE
Allow to pass an argument to import:process with brackets style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ can try running:
 
 * A good way to get some test data is to import from a local gem directory.
 `gem env` will tell you where rubygems stores your gems. Run
-`bundle exec rake "gemcutter:import:process[#{INSTALLATION_DIRECTORY}/cache'"`
+`bundle exec rake "gemcutter:import:process[#{INSTALLATION_DIRECTORY}/cache]"`
 
 * If you see "Processing 0 gems" you’ve probably specified the wrong
 directory. The proper directory will be full of .gem files.

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -13,8 +13,8 @@ namespace :gemcutter do
 
   namespace :import do
     desc "Bring the gems through the gemcutter process"
-    task process: :environment do
-      gems = Dir[File.join(ARGV[1] || "#{Gem.path.first}/cache", "*.gem")].reverse
+    task :process, %i[gems_cache_path] => :environment do |_task, args|
+      gems = Dir[File.join(args[:gems_cache_path] || "#{Gem.path.first}/cache", "*.gem")].reverse
       puts "Processing #{gems.size} gems..."
       gems.each do |path|
         puts "Processing #{path}"


### PR DESCRIPTION
I tried [Getting the test data](https://github.com/rubygems/rubygems.org/blob/master/CONTRIBUTING.md#getting-the-test-data) which is described in Contribution Guidelines, but it didn't work.

This is because the doc suggests using brackets to pass a path,  but `import::process` task doesn't implement that. 
I think passing arguments with brackets is standard in Rake. So I fixed the rake task to accept that.
Also, I fixed a typo in the doc.
