### PR TITLE
Update tests to use webmock vs stubbing rest client

### DIFF
--- a/config/initializers/net_http_purge.rb
+++ b/config/initializers/net_http_purge.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Net::HTTP::Purge < Net::HTTPRequest
-  METHOD = "PURGE".freeze
+  METHOD = "PURGE"
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end

--- a/test/functional/api/v1/web_hooks_controller_test.rb
+++ b/test/functional/api/v1/web_hooks_controller_test.rb
@@ -83,7 +83,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for all gems" do
         setup do
-          RestClient::Request.stubs(:execute)
+          stub_request(:post, @url)
           post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
                                 url: @url }
         end
@@ -98,7 +98,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for all gems that fails" do
         setup do
-          RestClient::Request.stubs(:execute).raises(RestClient::Exception.new)
+          stub_request(:post, @url).to_timeout
           post :fire, params: { gem_name: WebHook::GLOBAL_PATTERN,
                                 url: @url }
         end
@@ -132,7 +132,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for a specific gem" do
         setup do
-          RestClient::Request.stubs(:execute)
+          stub_request(:post, @url)
           post :fire, params: { gem_name: @rubygem.name,
                                 url: @url }
         end
@@ -145,7 +145,7 @@ class Api::V1::WebHooksControllerTest < ActionController::TestCase
 
       context "On POST to fire for a specific gem that fails" do
         setup do
-          RestClient::Request.stubs(:execute).raises(RestClient::Exception.new)
+          stub_request(:post, @url).to_return(status: 404)
           post :fire, params: { gem_name: @rubygem.name,
                                 url: @url }
         end

--- a/test/integration/api/v1/github_secret_scanning_test.rb
+++ b/test/integration/api/v1/github_secret_scanning_test.rb
@@ -20,7 +20,13 @@ class Api::V1::GitHubSecretScanningTest < ActionDispatch::IntegrationTest
 
       h = KEYS_RESPONSE_BODY.dup
       h["public_keys"][0]["key"] = @public_key_pem
-      GitHubSecretScanning.stubs(:secret_scanning_keys).returns(JSON.dump(h))
+
+      stub_request(:get, GitHubSecretScanning::KEYS_URI)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: h.to_json
+        )
 
       @tokens = [
         { "token" => "some_token", "type" => "some_type", "url" => "some_url" }

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -79,15 +79,13 @@ class OAuthTest < ActionDispatch::IntegrationTest
         }
       }
     }
-    @octokit_stubs.post("/graphql",
-      {
-        query: GitHubOAuthable::INFO_QUERY,
-        variables: { organization_name: "rubygems" }
-      }.to_json) do |_env|
-      [200, { "Content-Type" => "application/json" }, JSON.generate(
-        data: info_data
-      )]
-    end
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(data: info_data)
+      )
 
     do_login
 
@@ -114,20 +112,20 @@ class OAuthTest < ActionDispatch::IntegrationTest
   end
 
   test "fails when user is not a member of the rubygems org" do
-    @octokit_stubs.post("/graphql", {
-      query: GitHubOAuthable::INFO_QUERY,
-      variables: { organization_name: "rubygems" }
-    }.to_json) do
-      [200, { "Content-Type" => "application/json" }, JSON.generate(
-        data: {
-          viewer: {
-            login: "jackson-keeling",
-            id: "95144751",
-            organization: nil
-          }
-        }
-      )]
-    end
+    info_data = {
+      viewer: {
+        login: "jackson-keeling",
+        id: "95144751",
+        organization: nil
+      }
+    }
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(data: info_data)
+      )
 
     do_login
 
@@ -163,15 +161,13 @@ class OAuthTest < ActionDispatch::IntegrationTest
           }
         }
       }
-      @octokit_stubs.post("/graphql",
-        {
-          query: GitHubOAuthable::INFO_QUERY,
-          variables: { organization_name: "rubygems" }
-        }.to_json) do |_env|
-        [200, { "Content-Type" => "application/json" }, JSON.generate(
-          data: info_data
-        )]
-      end
+      stub_request(:post, "https://api.github.com/graphql")
+        .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate(data: info_data)
+        )
       OmniAuth.config.mock_auth[:github].credentials.token += "_update"
 
       do_login
@@ -201,15 +197,13 @@ class OAuthTest < ActionDispatch::IntegrationTest
           organization: nil
         }
       }
-      @octokit_stubs.post("/graphql",
-        {
-          query: GitHubOAuthable::INFO_QUERY,
-          variables: { organization_name: "rubygems" }
-        }.to_json) do |_env|
-        [200, { "Content-Type" => "application/json" }, JSON.generate(
-          data: info_data
-        )]
-      end
+      stub_request(:post, "https://api.github.com/graphql")
+        .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate(data: info_data)
+        )
 
       do_login
 
@@ -254,15 +248,13 @@ class OAuthTest < ActionDispatch::IntegrationTest
             }
           }
         }
-        @octokit_stubs.post("/graphql",
-          {
-            query: GitHubOAuthable::INFO_QUERY,
-            variables: { organization_name: "rubygems" }
-          }.to_json) do |_env|
-          [200, { "Content-Type" => "application/json" }, JSON.generate(
-            data: info_data
-          )]
-        end
+        stub_request(:post, "https://api.github.com/graphql")
+          .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.generate(data: info_data)
+          )
 
         do_login
 
@@ -287,15 +279,13 @@ class OAuthTest < ActionDispatch::IntegrationTest
             organization: nil
           }
         }
-        @octokit_stubs.post("/graphql",
-          {
-            query: GitHubOAuthable::INFO_QUERY,
-            variables: { organization_name: "rubygems" }
-          }.to_json) do |_env|
-          [200, { "Content-Type" => "application/json" }, JSON.generate(
-            data: info_data
-          )]
-        end
+        stub_request(:post, "https://api.github.com/graphql")
+          .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.generate(data: info_data)
+          )
 
         do_login
 

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -177,15 +177,13 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    RestClient::Request.expects(:execute).with(has_entries(
-                                                 method: :post,
-                                                 url: "https://api.hookrelay.dev/hooks/act/id/webhook_id-#{hook.id}",
-                                                 headers: has_entries(
-                                                   "Content-Type" => "application/json",
-                                                   "HR_TARGET_URL" => hook.url,
-                                                   "HR_MAX_ATTEMPTS" => "3"
-                                                 )
-                                               )).returns({ id: :id123 }.to_json)
+    stub_request(:post, "https://api.hookrelay.dev/hooks/act/id/webhook_id-#{hook.id}").with(
+      headers: {
+        "Content-Type" => "application/json",
+        "HR_TARGET_URL" => hook.url,
+        "HR_MAX_ATTEMPTS" => "3"
+      }
+    ).and_return(status: 200, body: { id: :id123 }.to_json)
     perform_enqueued_jobs only: NotifyWebHookJob
 
     assert_predicate hook.reload.failure_count, :zero?

--- a/test/models/web_hook_test.rb
+++ b/test/models/web_hook_test.rb
@@ -162,7 +162,7 @@ class WebHookTest < ActiveSupport::TestCase
 
     should "include an Authorization header" do
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number + @hook.user.api_key)
-      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
+      stub_request(:post, @url).with(headers: { "Authorization" => authorization })
 
       perform_enqueued_jobs only: NotifyWebHookJob do
         @hook.fire("https", "rubygems.org", @version)
@@ -172,7 +172,7 @@ class WebHookTest < ActiveSupport::TestCase
     should "include an Authorization header for a user with no API key" do
       @hook.user.update(api_key: nil)
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number)
-      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
+      stub_request(:post, @url).with(headers: { "Authorization" => authorization })
 
       perform_enqueued_jobs only: NotifyWebHookJob do
         @hook.fire("https", "rubygems.org", @version)
@@ -183,7 +183,7 @@ class WebHookTest < ActiveSupport::TestCase
       @hook.user.update(api_key: nil)
       create(:api_key, user: @hook.user)
       authorization = Digest::SHA2.hexdigest(@rubygem.name + @version.number + @hook.user.api_keys.first.hashed_key)
-      RestClient::Request.expects(:execute).with(has_entries(headers: has_entries("Authorization" => authorization)))
+      stub_request(:post, @url).with(headers: { "Authorization" => authorization })
 
       perform_enqueued_jobs only: NotifyWebHookJob do
         @hook.fire("https", "rubygems.org", @version)

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -13,15 +13,13 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
         name: user.login
       }
     )
-    @octokit_stubs.post("/graphql",
-      {
-        query: GitHubOAuthable::INFO_QUERY,
-        variables: { organization_name: "rubygems" }
-      }.to_json) do |_env|
-      [200, { "Content-Type" => "application/json" }, JSON.generate(
-        data: user.info_data
-      )]
-    end
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(data: user.info_data)
+      )
 
     visit avo.root_path
     click_button "Log in with GitHub"

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -13,15 +13,13 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
         name: user.login
       }
     )
-    @octokit_stubs.post("/graphql",
-      {
-        query: GitHubOAuthable::INFO_QUERY,
-        variables: { organization_name: "rubygems" }
-      }.to_json) do |_env|
-      [200, { "Content-Type" => "application/json" }, JSON.generate(
-        data: user.info_data
-      )]
-    end
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(data: user.info_data)
+      )
 
     visit avo.root_path
     click_button "Log in with GitHub"

--- a/test/system/avo/web_hooks_test.rb
+++ b/test/system/avo/web_hooks_test.rb
@@ -13,15 +13,13 @@ class Avo::WebHooksSystemTest < ApplicationSystemTestCase
         name: user.login
       }
     )
-    @octokit_stubs.post("/graphql",
-      {
-        query: GitHubOAuthable::INFO_QUERY,
-        variables: { organization_name: "rubygems" }
-      }.to_json) do |_env|
-      [200, { "Content-Type" => "application/json" }, JSON.generate(
-        data: user.info_data
-      )]
-    end
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: { query: GitHubOAuthable::INFO_QUERY, variables: { organization_name: "rubygems" } }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: JSON.generate(data: user.info_data)
+      )
 
     visit avo.root_path
     click_button "Log in with GitHub"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,11 +70,6 @@ class ActiveSupport::TestCase
     Unpwn.offline = true
     OmniAuth.config.mock_auth.clear
 
-    Octokit.middleware = Octokit.middleware.dup.tap do |builder|
-      @octokit_stubs = Faraday::Adapter::Test::Stubs.new
-      builder.adapter :test, @octokit_stubs
-    end
-
     @launch_darkly = LaunchDarkly::Integrations::TestData.data_source
     config = LaunchDarkly::Config.new(data_source: @launch_darkly, send_events: false)
     Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new("", config)

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -15,20 +15,19 @@ class FastlyTest < ActiveSupport::TestCase
 
   context ".purge" do
     should "purge for each domain" do
-      RestClient::Request.expects(:execute).times(2).returns("{}")
+      stub_request(:purge, "https://domain1.example.com/some-url?Fastly-Key=api-key")
+        .to_return(status: 200, body: "{}")
+      stub_request(:purge, "https://domain2.example.com/some-url?Fastly-Key=api-key")
+        .to_return(status: 200, body: "{}")
       Fastly.purge(path: "some-url")
     end
   end
 
   context ".purge_key" do
     should "send a post request" do
-      params = {
-        method: :post,
-        url: "https://api.fastly.com/service/service-id/purge/some-key",
-        timeout: 10,
-        headers: { "Fastly-Key" => "api-key" }
-      }
-      RestClient::Request.expects(:execute).with(**params).returns("{}")
+      stub_request(:post, "https://api.fastly.com/service/service-id/purge/some-key")
+        .with(headers: { "Fastly-Key" => "api-key" })
+        .to_return(status: 200, body: "{}")
       Fastly.purge_key("some-key")
     end
   end

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -15,9 +15,11 @@ class FastlyTest < ActiveSupport::TestCase
 
   context ".purge" do
     should "purge for each domain" do
-      stub_request(:purge, "https://domain1.example.com/some-url?Fastly-Key=api-key")
+      stub_request(:purge, "https://domain1.example.com/some-url")
+        .with(headers: { "Fastly-Key" => "api-key" })
         .to_return(status: 200, body: "{}")
-      stub_request(:purge, "https://domain2.example.com/some-url?Fastly-Key=api-key")
+      stub_request(:purge, "https://domain2.example.com/some-url")
+        .with(headers: { "Fastly-Key" => "api-key" })
         .to_return(status: 200, body: "{}")
       Fastly.purge(path: "some-url")
     end

--- a/test/unit/github_secret_scanning_test.rb
+++ b/test/unit/github_secret_scanning_test.rb
@@ -2,24 +2,24 @@ require "test_helper"
 
 class GitHubSecretScanningTest < ActiveSupport::TestCase
   should "return false when empty json" do
-    GitHubSecretScanning.stubs(:secret_scanning_keys).returns("{}")
-    key = GitHubSecretScanning.new("key_id")
-
-    refute key.valid_github_signature?("", "")
-
-    GitHubSecretScanning.stubs(:secret_scanning_keys).returns("{\"public_keys\": {}}")
+    stub_request(:get, GitHubSecretScanning::KEYS_URI)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {}.to_json
+      )
     key = GitHubSecretScanning.new("key_id")
 
     refute key.valid_github_signature?("", "")
   end
 
   should "return false if no public key is found" do
-    GitHubSecretScanning.stubs(:secret_scanning_keys).returns("{}")
-    key = GitHubSecretScanning.new("key_id")
-
-    refute key.valid_github_signature?("", "")
-
-    GitHubSecretScanning.stubs(:secret_scanning_keys).returns("{\"public_keys\": {}}")
+    stub_request(:get, GitHubSecretScanning::KEYS_URI)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { public_keys: {} }.to_json
+      )
     key = GitHubSecretScanning.new("key_id")
 
     refute key.valid_github_signature?("", "")


### PR DESCRIPTION
Makes it a no-test change to swap out the HTTP library we use, which is coming in a follow-up