### PR TITLE
Audit avo create/update/destroy

### DIFF
--- a/app/avo/concerns/auditable.rb
+++ b/app/avo/concerns/auditable.rb
@@ -1,0 +1,51 @@
+module Auditable
+  extend ActiveSupport::Concern
+
+  included do
+    include SemanticLogger::Loggable
+
+    def merge_changes!(changes, changes_to_save)
+      changes.merge!(changes_to_save) do |_key, (old, _), (_, new)|
+        [old, new]
+      end
+    end
+
+    def in_audited_transaction(auditable:, admin_github_user:, action:, fields:, arguments:, models:, &) # rubocop:disable Metrics
+      logger.debug { "Auditing changes to #{auditable}: #{fields}" }
+
+      User.transaction do
+        changed_records = {}
+        value = ActiveSupport::Notifications.subscribed(proc do |_name, _started, _finished, _unique_id, data|
+          records = data[:connection].transaction_manager.current_transaction.records || []
+          records.uniq(&:__id__).each do |record|
+            merge_changes!((changed_records[record] ||= {}), record.attributes.transform_values { [nil, _1] }) if record.new_record?
+            merge_changes!((changed_records[record] ||= {}), record.changes_to_save)
+          end
+        end, "sql.active_record", &)
+
+        audited_changed_records = changed_records.to_h do |record, changes|
+          key = record.to_global_id.uri
+          changes = merge_changes!(changes, record.attributes.slice("id").transform_values { [_1, _1] }) if changes.key?("id")
+          changes = merge_changes!(changes, record.attributes.compact.transform_values { [_1, nil] }) if record.destroyed?
+
+          [key, { changes:, unchanged: record.attributes.except(*changes.keys) }]
+        end
+
+        audit = Audit.create!(
+          admin_github_user:,
+          auditable:,
+          action:,
+          comment: fields.fetch(:comment),
+          audited_changes: {
+            records: audited_changed_records,
+            fields: fields.except(:comment),
+            arguments: arguments,
+            models: models.map { _1.to_global_id.uri }
+          }
+        )
+
+        [value, audit]
+      end
+    end
+  end
+end

--- a/app/avo/resources/audit_resource.rb
+++ b/app/avo/resources/audit_resource.rb
@@ -32,5 +32,5 @@ class AuditResource < Avo::BaseResource
     field :id, as: :id
   end
 
-  field :audited_changes, as: :audited_changes
+  field :audited_changes, as: :audited_changes, except_on: :index
 end

--- a/app/avo/resources/concerns/avo_auditable_resource.rb
+++ b/app/avo/resources/concerns/avo_auditable_resource.rb
@@ -1,0 +1,20 @@
+module Concerns::AvoAuditableResource
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def inherited(base)
+      super
+      base.items_holder = Avo::ItemsHolder.new
+      base.items_holder.items.replace items_holder.items.deep_dup
+      base.items_holder.invalid_fields.replace items_holder.invalid_fields.deep_dup
+    end
+  end
+
+  included do
+    panel "Auditable" do
+      field :comment, as: :textarea, required: true,
+        help: "A comment explaining why this action was taken.<br>Will be saved in the audit log.<br>Must be more than 10 characters.",
+        only_on: %i[new edit]
+    end
+  end
+end

--- a/app/avo/resources/gem_download_resource.rb
+++ b/app/avo/resources/gem_download_resource.rb
@@ -21,7 +21,7 @@ class GemDownloadResource < Avo::BaseResource
 
   field :rubygem, as: :belongs_to
   field :version, as: :belongs_to
-  field :count, as: :number, sortable: true, index_text_align: :right, format_using: ->(value) { value.to_fs(:delimited) }
+  field :count, as: :number, sortable: true, index_text_align: :right, format_using: ->(value) { value.to_fs(:delimited) }, default: 0
 
   field :id, as: :id, hide_on: :index
 end

--- a/app/controllers/concerns/avo_auditable.rb
+++ b/app/controllers/concerns/avo_auditable.rb
@@ -1,0 +1,42 @@
+module AvoAuditable
+  extend ActiveSupport::Concern
+
+  prepended do
+    include Auditable
+  end
+
+  def perform_action_and_record_errors(&)
+    super do
+      action = params.fetch(:action)
+      logger.error(permitted_params:)
+      fields = action == "destroy" ? {} : cast_nullable(model_params)
+
+      @model.errors.add :comment, "must supply a sufficiently detailed comment" if fields[:comment]&.then { _1.length < 10 }
+      raise ActiveRecord::RecordInvalid, @model if @model.errors.present?
+      action_name = "Manual #{action} of #{@model.class}"
+
+      value, @audit = in_audited_transaction(
+        auditable: @model,
+        admin_github_user: _current_user,
+        action: action_name,
+        fields: fields.reverse_merge(comment: action_name),
+        arguments: {},
+        models: [@model],
+        &
+      )
+      value
+    end
+  end
+
+  def after_update_path
+    return avo.resources_audit_path(@audit) if @audit.present?
+
+    super
+  end
+
+  def after_create_path
+    return avo.resources_audit_path(@audit) if @audit.present?
+
+    super
+  end
+end

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -116,6 +116,8 @@ end
 
 Rails.configuration.to_prepare do
   Avo::ApplicationController.include GitHubOAuthable
+  Avo::BaseController.prepend AvoAuditable
+  Avo::BaseResource.include Concerns::AvoAuditableResource
 
   Avo::ApplicationController.content_security_policy do |policy|
     policy.style_src :self, "https://fonts.googleapis.com", :unsafe_inline

--- a/test/system/avo/manual_changes_test.rb
+++ b/test/system/avo/manual_changes_test.rb
@@ -1,0 +1,166 @@
+require "application_system_test_case"
+
+class Avo::ManualChangesSystemTest < ApplicationSystemTestCase
+  make_my_diffs_pretty!
+
+  def sign_in_as(user)
+    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+      provider: "github",
+      uid: "1",
+      credentials: {
+        token: user.oauth_token,
+        expires: false
+      },
+      info: {
+        name: user.login
+      }
+    )
+
+    stub_github_info_request(user.info_data)
+
+    visit avo.root_path
+    click_button "Log in with GitHub"
+
+    page.assert_text user.login
+  end
+
+  test "auditing changes" do
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    LogTicketPolicy.any_instance.stubs(:avo_create?).returns(true)
+    LogTicketPolicy.any_instance.stubs(:avo_update?).returns(true)
+    LogTicketPolicy.any_instance.stubs(:avo_destroy?).returns(true)
+
+    visit avo.resources_log_tickets_path
+    click_on "Create new log ticket"
+
+    fill_in "Key", with: "key"
+    fill_in "Directory", with: "dir"
+    fill_in "Processed count", with: "0"
+    fill_in "Comment", with: "A nice long comment"
+    click_on "Save"
+
+    page.assert_text "key"
+    page.assert_text "dir"
+    page.assert_text "A nice long comment"
+    page.assert_text "Manual create of LogTicket"
+
+    log_ticket = LogTicket.sole
+
+    page.assert_text log_ticket.id
+    audit = Audit.sole
+
+    page.assert_text audit.id
+    assert_equal log_ticket, audit.auditable
+    assert_equal "LogTicket", audit.auditable_type
+    assert_equal "Manual create of LogTicket", audit.action
+    assert_equal(
+      {
+        "records" => {
+          "gid://gemcutter/LogTicket/#{log_ticket.id}" => {
+            "changes" => log_ticket.attributes.transform_values { [nil, _1.as_json] },
+            "unchanged" => {}
+          }
+        },
+        "fields" => {
+          "key" => "key",
+          "directory" => "dir",
+          "backend" => "s3",
+          "status" => "pending",
+          "processed_count" => "0"
+        },
+        "arguments" => {},
+        "models" => ["gid://gemcutter/LogTicket/#{log_ticket.id}"]
+      },
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "A nice long comment", audit.comment
+
+    find('div[data-field-id="auditable"]').click_on log_ticket.to_param
+
+    click_on "Edit"
+
+    fill_in "Key", with: "Other Key"
+    fill_in "Processed count", with: "2"
+    select "failed", from: "Status"
+    fill_in "Comment", with: "Another comment"
+    click_on "Save"
+
+    page.assert_text "Another comment"
+
+    assert_equal 2, Audit.all.count
+
+    audit = Audit.last
+
+    page.assert_text audit.id
+    assert_equal log_ticket, audit.auditable
+    assert_equal "LogTicket", audit.auditable_type
+    assert_equal "Manual update of LogTicket", audit.action
+    assert_equal(
+      {
+        "records" => {
+          "gid://gemcutter/LogTicket/#{log_ticket.id}" => {
+            "changes" => {
+              "key" => ["key", "Other Key"],
+              "status" => %w[pending failed],
+              "updated_at" => audit.audited_changes.dig("records", "gid://gemcutter/LogTicket/#{log_ticket.id}", "changes", "updated_at"),
+              "processed_count" => [0, 2]
+            },
+            "unchanged" => log_ticket.reload.attributes.except("key", "status", "updated_at", "processed_count")
+          }
+        },
+        "fields" => {
+          "key" => "Other Key",
+          "directory" => "dir",
+          "backend" => "s3",
+          "status" => "failed",
+          "processed_count" => "2"
+        },
+        "arguments" => {},
+        "models" => ["gid://gemcutter/LogTicket/#{log_ticket.id}"]
+      }.as_json,
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "Another comment", audit.comment
+
+    find('div[data-field-id="auditable"]').click_on log_ticket.to_param
+
+    accept_alert("Are you sure?") do
+      click_on "Delete"
+    end
+
+    page.assert_text "Record destroyed"
+
+    assert_raise(ActiveRecord::RecordNotFound) { log_ticket.reload }
+
+    assert_equal 3, Audit.all.count
+    audit = Audit.last
+    visit avo.resources_audit_path(audit)
+
+    page.assert_text "Manual destroy of LogTicket"
+
+    assert_nil audit.auditable
+    assert_equal log_ticket.id, audit.auditable_id
+    assert_equal "LogTicket", audit.auditable_type
+    assert_equal "Manual destroy of LogTicket", audit.action
+    assert_equal(
+      {
+        "records" => {
+          "gid://gemcutter/LogTicket/#{log_ticket.id}" => {
+            "changes" => log_ticket.attributes.transform_values { [_1, nil] },
+            "unchanged" => {}
+          }
+        },
+        "fields" => {},
+        "arguments" => {},
+        "models" => ["gid://gemcutter/LogTicket/#{log_ticket.id}"]
+      }.as_json,
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "Manual destroy of LogTicket", audit.comment
+  end
+end

--- a/test/unit/avo/actions/base_action_test.rb
+++ b/test/unit/avo/actions/base_action_test.rb
@@ -172,18 +172,20 @@ class BaseActionTest < ActiveSupport::TestCase
       "audited_changes" => {
         "records" => {
           webhook.to_global_id.uri.to_s => {
-            "changes" => { "user_id" => [nil, user.id], "url" => [nil, "https://example.com/path"] },
-            "unchanged" => {
-              "id" => webhook.id,
-              "failure_count" => 0,
-              "rubygem_id" => nil,
-         "disabled_reason" => nil,
-         "disabled_at" => nil,
-         "last_success" => nil,
-         "last_failure" => nil,
-         "successes_since_last_failure" => 0,
-         "failures_since_last_success" => 0
-            }
+            "changes" => {
+              "id" => [nil, webhook.id],
+              "user_id" => [nil, user.id],
+              "url" => [nil, webhook.url],
+              "failure_count" => [nil, 0],
+              "rubygem_id" => [nil, nil],
+              "disabled_reason" => [nil, nil],
+              "disabled_at" => [nil, nil],
+              "last_success" => [nil, nil],
+              "last_failure" => [nil, nil],
+              "successes_since_last_failure" => [nil, 0],
+              "failures_since_last_success" => [nil, 0]
+            },
+           "unchanged" => {}
           }
         },
         "fields" => {},


### PR DESCRIPTION
Allows auditing manually create/update/destroy actions in avo _if the policies allow those actions_ (there is no change to the policies, therefore this support won't be used by anything at the moment, though I will use it later when prototyping things and it would be helpful to be able to manually change certain new resources)

- [x] Move the hacky action
- [x] Test going through the controller
- [x] Pass things from controller instead of using send
- [x] Look into hacking in a comment field for update/create
- [ ] Add field-level pundit authorization?