### PR TITLE
Add MFA usage metrics job

### DIFF
--- a/app/jobs/mfa_usage_stats_job.rb
+++ b/app/jobs/mfa_usage_stats_job.rb
@@ -1,0 +1,15 @@
+class MfaUsageStatsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    non_mfa_users = User.where(mfa_level: 0).where.not(id: WebauthnCredential.select(:user_id)).count
+    otp_only_users = User.where.not(mfa_level: 0).where.not(id: WebauthnCredential.select(:user_id)).count
+    webauthn_only_users = User.where(mfa_level: 0).where(id: WebauthnCredential.select(:user_id)).count
+    webauthn_and_otp_users = User.where.not(mfa_level: 0).where(id: WebauthnCredential.select(:user_id)).count
+
+    StatsD.gauge("mfa_usage_stats.non_mfa_users", non_mfa_users)
+    StatsD.gauge("mfa_usage_stats.otp_only_users", otp_only_users)
+    StatsD.gauge("mfa_usage_stats.webauthn_only_users", webauthn_only_users)
+    StatsD.gauge("mfa_usage_stats.webauthn_and_otp_users", webauthn_and_otp_users)
+  end
+end

--- a/app/jobs/mfa_usage_stats_job.rb
+++ b/app/jobs/mfa_usage_stats_job.rb
@@ -2,10 +2,10 @@ class MfaUsageStatsJob < ApplicationJob
   queue_as :default
 
   def perform
-    non_mfa_users = User.where(mfa_level: 0).where.not(id: WebauthnCredential.select(:user_id)).count
-    otp_only_users = User.where.not(mfa_level: 0).where.not(id: WebauthnCredential.select(:user_id)).count
-    webauthn_only_users = User.where(mfa_level: 0).where(id: WebauthnCredential.select(:user_id)).count
-    webauthn_and_otp_users = User.where.not(mfa_level: 0).where(id: WebauthnCredential.select(:user_id)).count
+    non_mfa_users = User.where(mfa_level: :disabled).where.not(id: WebauthnCredential.select(:user_id)).count
+    otp_only_users = User.where.not(mfa_level: :disabled).where.not(id: WebauthnCredential.select(:user_id)).count
+    webauthn_only_users = User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).count
+    webauthn_and_otp_users = User.where.not(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).count
 
     StatsD.gauge("mfa_usage_stats.non_mfa_users", non_mfa_users)
     StatsD.gauge("mfa_usage_stats.otp_only_users", otp_only_users)

--- a/app/jobs/mfa_usage_stats_job.rb
+++ b/app/jobs/mfa_usage_stats_job.rb
@@ -1,5 +1,5 @@
 class MfaUsageStatsJob < ApplicationJob
-  queue_as :default
+  queue_as "stats"
 
   def perform
     non_mfa_users = User.where(mfa_level: :disabled).where.not(id: WebauthnCredential.select(:user_id)).count

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -13,6 +13,12 @@ Rails.application.configure do
       class: "GoodJobStatsDJob",
       set: { priority: 10 },
       description: "Sending GoodJob metrics to statsd every 15s"
+    },
+    mfa_usage_stats: {
+      cron: "every hour",
+      class: "MfaUsageStatsJob",
+      set: { priority: 10 },
+      description: "Sending MFA usage metrics to statsd every hour"
     }
   }
 

--- a/test/jobs/mfa_usage_stats_job_test.rb
+++ b/test/jobs/mfa_usage_stats_job_test.rb
@@ -4,10 +4,10 @@ class MfaUsageStatsJobTest < ActiveJob::TestCase
   include StatsD::Instrument::Assertions
 
   setup do
-    create(:user, mfa_level: 0) # non-mfa user
-    2.times { create(:user, mfa_level: 1) } # otp-only users
-    3.times { create(:webauthn_credential, user: create(:user, mfa_level: 0)) } # webauthn-only users
-    4.times { create(:webauthn_credential, user: create(:user, mfa_level: 1)) } # webauthn-and-otp users
+    create(:user, mfa_level: :disabled) # non-mfa user
+    2.times { create(:user, mfa_level: :ui_and_api) } # otp-only users
+    3.times { create(:webauthn_credential, user: create(:user, mfa_level: :disabled)) } # webauthn-only users
+    4.times { create(:webauthn_credential, user: create(:user, mfa_level: :ui_and_api)) } # webauthn-and-otp users
   end
 
   test "it sends the count of non-MFA users to statsd" do

--- a/test/jobs/mfa_usage_stats_job_test.rb
+++ b/test/jobs/mfa_usage_stats_job_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class MfaUsageStatsJobTest < ActiveJob::TestCase
+  include StatsD::Instrument::Assertions
+
+  setup do
+    create(:user, mfa_level: 0) # non-mfa user
+    2.times { create(:user, mfa_level: 1) } # otp-only users
+    3.times { create(:webauthn_credential, user: create(:user, mfa_level: 0)) } # webauthn-only users
+    4.times { create(:webauthn_credential, user: create(:user, mfa_level: 1)) } # webauthn-and-otp users
+  end
+
+  test "it sends the count of non-MFA users to statsd" do
+    assert_statsd_gauge("mfa_usage_stats.non_mfa_users", 1) do
+      MfaUsageStatsJob.perform_now
+    end
+  end
+
+  test "it sends the count of OTP-only users to statsd" do
+    assert_statsd_gauge("mfa_usage_stats.otp_only_users", 2) do
+      MfaUsageStatsJob.perform_now
+    end
+  end
+
+  test "it sends the count of WebAuthn-only users to statsd" do
+    assert_statsd_gauge("mfa_usage_stats.webauthn_only_users", 3) do
+      MfaUsageStatsJob.perform_now
+    end
+  end
+
+  test "it sends the count of WebAuthn-and-OTP users to statsd" do
+    assert_statsd_gauge("mfa_usage_stats.webauthn_and_otp_users", 4) do
+      MfaUsageStatsJob.perform_now
+    end
+  end
+end


### PR DESCRIPTION
## What problem are you solving?

Currently we do not have easy observability of MFA uptake on rubygems.org. To obtain statistics the practice has been to log into the database and run manual queries. We would like to be able to use DataDog to observe the counts of four classes of users:

* Users who have no MFA enabled at all.
* Users who have enabled only OTP.
* Users who have enabled only WebAuthn.
* Users who have enabled both OTP & WebAuthn.

## What approach did you choose and why?

The `MfaUsageStatsJob` works by first counting the users in each category and then posting these to DataDog via StatsD instrumentation. The job is run hourly so that we can see trends over time.

## What should reviewers focus on?

* Are the ActiveRecord queries correct?
* Is the cron configuration correct?