### PR TITLE
Admin Tool: Yank Rubygem

### DIFF
--- a/app/avo/actions/yank_rubygem.rb
+++ b/app/avo/actions/yank_rubygem.rb
@@ -1,0 +1,34 @@
+class YankRubygem < BaseAction
+  OPTION_ALL = "All".freeze
+
+  field :version, as: :select,
+    options: lambda { |model:, resource:, view:, field:|
+      [OPTION_ALL] + model.versions.indexed.pluck(:number, :id)
+    },
+    help: "Select Version which needs to be yanked."
+
+    self.name = "Yank Rubygem"
+    self.visible = lambda {
+      current_user.team_member?("rubygems-org") &&
+      view == :show &&
+      resource.model.versions.indexed.present?
+    }
+
+    self.message = lambda {
+      "Are you sure you would like to yank gem #{record.name}?"
+    }
+
+    self.confirm_button_label = "Yank Rubygem"
+
+    class ActionHandler < ActionHandler
+      def handle_model(rubygem)
+        version_id = fields["version"]
+        security_user = User.find_by!(email: "security@rubygems.org")
+        versions_to_yank = version_id == OPTION_ALL ? rubygem.versions : rubygem.versions.where(id: version_id)
+
+        versions_to_yank.each do |version|
+          security_user.deletions.create!(version: version) unless version.yanked?
+        end
+      end
+    end
+end

--- a/app/avo/actions/yank_rubygem.rb
+++ b/app/avo/actions/yank_rubygem.rb
@@ -2,33 +2,33 @@ class YankRubygem < BaseAction
   OPTION_ALL = "All".freeze
 
   field :version, as: :select,
-    options: lambda { |model:, resource:, view:, field:|
+    options: lambda { |model:, resource:, view:, field:| # rubocop:disable Lint/UnusedBlockArgument
       [OPTION_ALL] + model.versions.indexed.pluck(:number, :id)
     },
     help: "Select Version which needs to be yanked."
 
-    self.name = "Yank Rubygem"
-    self.visible = lambda {
-      current_user.team_member?("rubygems-org") &&
+  self.name = "Yank Rubygem"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") &&
       view == :show &&
       resource.model.versions.indexed.present?
-    }
+  }
 
-    self.message = lambda {
-      "Are you sure you would like to yank gem #{record.name}?"
-    }
+  self.message = lambda {
+    "Are you sure you would like to yank gem #{record.name}?"
+  }
 
-    self.confirm_button_label = "Yank Rubygem"
+  self.confirm_button_label = "Yank Rubygem"
 
-    class ActionHandler < ActionHandler
-      def handle_model(rubygem)
-        version_id = fields["version"]
-        security_user = User.find_by!(email: "security@rubygems.org")
-        versions_to_yank = version_id == OPTION_ALL ? rubygem.versions : rubygem.versions.where(id: version_id)
+  class ActionHandler < ActionHandler
+    def handle_model(rubygem)
+      version_id = fields["version"]
+      security_user = User.find_by!(email: "security@rubygems.org")
+      versions_to_yank = version_id == OPTION_ALL ? rubygem.versions : rubygem.versions.where(id: version_id)
 
-        versions_to_yank.each do |version|
-          security_user.deletions.create!(version: version) unless version.yanked?
-        end
+      versions_to_yank.each do |version|
+        security_user.deletions.create!(version: version) unless version.yanked?
       end
     end
+  end
 end

--- a/app/avo/resources/rubygem_resource.rb
+++ b/app/avo/resources/rubygem_resource.rb
@@ -15,6 +15,7 @@ class RubygemResource < Avo::BaseResource
   }
 
   action ReleaseReservedNamespace
+  action YankRubygem
 
   class IndexedFilter < ScopeBooleanFilter; end
   filter IndexedFilter, arguments: { default: { with_versions: true, without_versions: true } }

--- a/app/avo/resources/version_resource.rb
+++ b/app/avo/resources/version_resource.rb
@@ -35,7 +35,7 @@ class VersionResource < Avo::BaseResource
         field :summary, as: :textarea
         field :description, as: :textarea
         field :authors, as: :textarea
-        field :licenses, as: :tags
+        field :licenses, as: :textarea
         field :cert_chain, as: :textarea
         field :built_at, as: :date_time, sortable: true
         field :metadata, as: :key_value, stacked: true

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -76,7 +76,6 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     assert_equal "A nice long comment", audit.comment
   end
 
-
   test "Yank a rubygem" do
     Minitest::Test.make_my_diffs_pretty!
     admin_user = create(:admin_github_user, :is_admin)

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -75,4 +75,152 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     assert_equal admin_user, audit.admin_github_user
     assert_equal "A nice long comment", audit.comment
   end
+
+
+  test "Yank a rubygem" do
+    Minitest::Test.make_my_diffs_pretty!
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    security_user = create(:user, email: "security@rubygems.org")
+    rubygem = create(:rubygem)
+    version = create(:version, rubygem: rubygem)
+
+    visit avo.resources_rubygem_path(rubygem)
+
+    click_button "Actions"
+    click_on "Yank Rubygem"
+
+    assert_no_changes "Rubygem.find(#{rubygem.id}).attributes" do
+      click_button "Yank Rubygem"
+    end
+    page.assert_text "Must supply a sufficiently detailed comment"
+
+    fill_in "Comment", with: "A nice long comment"
+    select(version.number, from: "Version")
+
+    click_button "Yank Rubygem"
+
+    page.assert_text "Action ran successfully!"
+    page.assert_text rubygem.to_global_id.uri.to_s
+
+    rubygem.reload
+    version.reload
+
+    assert_not_nil version.yanked_at
+    assert_not_nil version.yanked_info_checksum
+
+    audit = rubygem.audits.sole
+    deletion = security_user.deletions.first
+
+    page.assert_text audit.id
+    assert_equal "Rubygem", audit.auditable_type
+    assert_equal "Yank Rubygem", audit.action
+    assert_equal(
+      {
+        "fields" => { "version" => version.id.to_s },
+        "arguments" => {},
+        "models" => ["gid://gemcutter/Rubygem/#{rubygem.id}"],
+        "records" =>
+        audit.audited_changes["records"].select do |k, _|
+          k =~ %r{gid://gemcutter/Delayed::Backend::ActiveRecord::Job/\d+}
+        end.merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Version/#{version.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Deletion/#{deletion.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Rubygem/#{rubygem.id}}
+          end
+        )
+      },
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "A nice long comment", audit.comment
+  end
+
+  test "Yank all version of rubygem" do
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    security_user = create(:user, email: "security@rubygems.org")
+    rubygem = create(:rubygem)
+    version1 = create(:version, rubygem: rubygem)
+    version2 = create(:version, rubygem: rubygem)
+
+    visit avo.resources_rubygem_path(rubygem)
+
+    click_button "Actions"
+    click_on "Yank Rubygem"
+
+    assert_no_changes "Rubygem.find(#{rubygem.id}).attributes" do
+      click_button "Yank Rubygem"
+    end
+    page.assert_text "Must supply a sufficiently detailed comment"
+
+    fill_in "Comment", with: "A nice long comment"
+    select("All", from: "Version")
+
+    click_button "Yank Rubygem"
+
+    page.assert_text "Action ran successfully!"
+    page.assert_text rubygem.to_global_id.uri.to_s
+
+    rubygem.reload
+    version1.reload
+    version2.reload
+
+    assert_not_nil version1.yanked_at
+    assert_not_nil version1.yanked_info_checksum
+    assert_not_nil version2.yanked_at
+    assert_not_nil version2.yanked_info_checksum
+
+    audit = rubygem.audits.sole
+    deletion1 = security_user.deletions.first
+    deletion2 = security_user.deletions.last
+
+    page.assert_text audit.id
+    assert_equal "Rubygem", audit.auditable_type
+    assert_equal "Yank Rubygem", audit.action
+
+    assert_equal(
+      {
+        "fields" => { "version" => "All" },
+        "arguments" => {},
+        "models" => ["gid://gemcutter/Rubygem/#{rubygem.id}"],
+        "records" =>
+        audit.audited_changes["records"].select do |k, _|
+          k =~ %r{gid://gemcutter/Delayed::Backend::ActiveRecord::Job/\d+}
+        end.merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Version/#{version1.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Version/#{version2.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Deletion/#{deletion1.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Deletion/#{deletion2.id}}
+          end
+        ).merge(
+          audit.audited_changes["records"].select do |k, _|
+            k =~ %r{gid://gemcutter/Rubygem/#{rubygem.id}}
+          end
+        )
+      },
+      audit.audited_changes
+    )
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal "A nice long comment", audit.comment
+  end
 end


### PR DESCRIPTION
We currently have a script to yank Rubygem.
This PR makes it possible to do it via Admin UI so that
we don't have to do it via a script.

* Added an avo action to yank a rubygem. Allows to yank all or a particular version.
* Used this new action to Rubygem admin show page.

This is how it looks in the UI


![Monosnap RubyGem1 — RubyGems org (development) 2023-03-27 6 pm-23-09](https://user-images.githubusercontent.com/3948/227945242-37d7baa7-b8b5-4fd3-9001-611f581bfe39.png)

