### PR TITLE
Disable LaunchDarkly in local environments.

### DIFF
--- a/config/initializers/launchdarkly.rb
+++ b/config/initializers/launchdarkly.rb
@@ -1,7 +1,11 @@
 Rails.application.configure do
-  LaunchDarkly::Config.singleton_class.prepend(Module.new do
-    def default_logger = SemanticLogger[LaunchDarkly]
-  end)
+  ld_config = LaunchDarkly::Config.new(
+    logger: SemanticLogger[LaunchDarkly],
+    offline: Rails.application.secrets.launch_darkly_sdk_key.blank?
+  )
 
-  config.launch_darkly_client = LaunchDarkly::LDClient.new(ENV["LAUNCH_DARKLY_SDK_KEY"].presence || "")
+  config.launch_darkly_client = LaunchDarkly::LDClient.new(
+    Rails.application.secrets.launch_darkly_sdk_key.to_s,
+    ld_config
+  )
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,14 +10,19 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+default: &default
+  launch_darkly_sdk_key: '<%= ENV["LAUNCH_DARKLY_SDK_KEY"] %>'
+
 # Dummy sendgrid configuration used for development.
 development:
+  <<: *default
   secret_key_base: 01ade4a4dc594f4e2f1711f225adc0ad38b1f4e0b965191a43eea8a658a97d8d5f7a1255791c491f14ca638d4bbc7d82d8990040e266e3d898670605f2e5676f
   sendgrid_webhook_username: development_sendgrid_webhook_user
   sendgrid_webhook_password: 279a2b980eedbfb71132d73e0ad63989b420ebf3c37f159749f58f2003737734ddd409278157ab171182b9a5bf6d4b4215b6a5535a4b6c2829e88ff14ce74644
 
 # Dummy sendgrid configuration used for testing.
 test:
+  <<: *default
   secret_key_base: 482e75fe0b819896e400fa4be69a0535382e73a98f147d9f898d6bf2d2d705c85834a91b765b0a4ba018493c38ebaf355acae8ca1f9e654e9c52c6fa969042ac
   sendgrid_webhook_username: test_sendgrid_webhook_user
   sendgrid_webhook_password: ecf2a26928de3dbb5b90f38216fc3453f3739774fc4f24e61434e9608d355748beac3d70d49a455ff59e17133cdbd316417da2c7d8f11bdd7cd07f85c4fb321j
@@ -25,11 +30,13 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 staging:
+  <<: *default
   secret_key_base: '<%= ENV["SECRET_KEY_BASE"] %>'
   sendgrid_webhook_username: '<%= ENV["SENDGRID_WEBHOOK_USERNAME"] %>'
   sendgrid_webhook_password: '<%= ENV["SENDGRID_WEBHOOK_PASSWORD"] %>'
 
 production:
+  <<: *default
   secret_key_base: '<%= ENV["SECRET_KEY_BASE"] %>'
   sendgrid_webhook_username: '<%= ENV["SENDGRID_WEBHOOK_USERNAME"] %>'
   sendgrid_webhook_password: '<%= ENV["SENDGRID_WEBHOOK_PASSWORD"] %>'


### PR DESCRIPTION
motivation: In current setup LaunchDarkly "calls home" on every console/server start in development. That seems not developer friendly default. I manged to do a little refactoring of setup at the same time using `rubygems.yml` and `secrets.yml` to config app and keys. It is still easy to enable this locally if needed for testing. 

- use secrets to host SDK key
- setup logger using config