### PR TITLE
Prevent Hostess (dev only) from matching paths too aggressively

### DIFF
--- a/lib/gemcutter/middleware/hostess.rb
+++ b/lib/gemcutter/middleware/hostess.rb
@@ -26,17 +26,17 @@ module Gemcutter::Middleware
     end
 
     def can_serve(path)
-      super(path) || gem_download_path(path) || path =~ %r{/quick/Marshal\.4\.8/.*\.gemspec.rz}
+      super(path) || gem_download_path(path) || path =~ %r{^/quick/Marshal\.4\.8/.*\.gemspec.rz}
     end
 
     def gem_download_path(path)
-      Regexp.last_match(1) if path =~ %r{/gems/(.*)\.gem}
+      Regexp.last_match(1) if path =~ %r{^/gems/([^/]*)\.gem}
     end
 
     def call(env)
       path = env["PATH_INFO"]
 
-      return [302, { "Location" => "/gems/#{Regexp.last_match(1)}.gem" }, []] if path =~ %r{/downloads/(.*)\.gem}
+      return [302, { "Location" => "/gems/#{Regexp.last_match(1)}.gem" }, []] if path =~ %r{^/downloads/([^/]*)\.gem}
 
       download_path = gem_download_path(path)
       name = Version.rubygem_name_for(download_path) if download_path

--- a/test/unit/gemcutter/middleware/hostess_test.rb
+++ b/test/unit/gemcutter/middleware/hostess_test.rb
@@ -10,7 +10,7 @@ class Gemcutter::Middleware::HostessTest < ActiveSupport::TestCase
   end
 
   def app
-    Gemcutter::Middleware::Hostess.new(-> { [200, {}, ""] })
+    Gemcutter::Middleware::Hostess.new(->(_) { [202, {}, "passthrough"] })
   end
 
   def touch(path)
@@ -39,6 +39,13 @@ class Gemcutter::Middleware::HostessTest < ActiveSupport::TestCase
 
       assert_equal 200, last_response.status
     end
+  end
+
+  should "not capture paths that are not the gem download path" do
+    get "/gems/rails/versions/3.0.0/contents/rails.gemspec"
+
+    assert_equal 202, last_response.status
+    assert_equal "passthrough", last_response.body
   end
 
   context "with gem" do


### PR DESCRIPTION
This was blocking access to contents that had `.gem` in the filename, like `rake.gemspec`. It only affects local development.