### PR TITLE
Remove not used on_worker_boot block in puma config.

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -44,13 +44,6 @@ before_fork do
   sleep 1
 end
 
-on_worker_boot do
-  Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV["LAUNCH_DARKLY_SDK_KEY"].presence || "") if defined?(Rails)
-
-  # Re-open appenders after forking the process
-  SemanticLogger.reopen if defined?(SemanticLogger)
-end
-
 on_restart do
   Rails.configuration.launch_darkly_client&.close
 end


### PR DESCRIPTION
- it is not used since app is not preloaded currently