### PR TITLE
Fix flaky test by making Rubygem#protected_days stop at zero

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -325,7 +325,12 @@ class Rubygem < ApplicationRecord
   # returns days left before the reserved namespace will be released
   # 100 + 1 days are added so that last_protected_day / 1.day = 1
   def protected_days
-    (updated_at + 101.days - Time.zone.now).to_i / 1.day
+    days = (updated_at - 101.days.ago).to_i / 1.day
+    days.positive? ? days : 0
+  end
+
+  def release_reserved_namespace!
+    update_attribute(:updated_at, 101.days.ago)
   end
 
   def reverse_dependencies
@@ -359,10 +364,6 @@ class Rubygem < ApplicationRecord
     else
       public_versions.last.number
     end
-  end
-
-  def release_reserved_namespace!
-    update_attribute(:updated_at, 101.days.ago)
   end
 
   def version_manifest(number, platform = nil)

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -824,11 +824,26 @@ class RubygemTest < ActiveSupport::TestCase
   context "#protected_days" do
     setup do
       @rubygem = create(:rubygem)
-      @rubygem.update_attribute(:updated_at, 99.days.ago)
     end
 
-    should "return number of days left till the gem namespace is protected" do
+    should "return 100 days left of gem namespace protection after 0 days" do
+      assert_equal 100, @rubygem.protected_days
+    end
+
+    should "return 1 day left of gem namespace protection after 99 days" do
+      @rubygem.update_attribute(:updated_at, 99.days.ago)
+
       assert_equal 1, @rubygem.protected_days
+    end
+
+    should "return 0 days left of gem namespace protection after protected time has passed" do
+      @rubygem.update_attribute(:updated_at, 101.days.ago)
+
+      assert_equal 0, @rubygem.protected_days
+
+      @rubygem.update_attribute(:updated_at, 103.days.ago)
+
+      assert_equal 0, @rubygem.protected_days
     end
   end
 
@@ -839,7 +854,9 @@ class RubygemTest < ActiveSupport::TestCase
     end
 
     should "update set `updated_at` to 101 days ago" do
-      assert_equal (Time.zone.today - 101.days), @rubygem.updated_at.to_date
+      freeze_time
+
+      assert_in_delta 101.days.ago, @rubygem.updated_at, 5.seconds
     end
   end
 

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -26,8 +26,10 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     admin_user = create(:admin_github_user, :is_admin)
     sign_in_as admin_user
 
-    rubygem = create(:rubygem)
+    rubygem = create(:rubygem, created_at: 40.days.ago)
     rubygem_attributes = rubygem.attributes.with_indifferent_access
+
+    refute_predicate rubygem, :pushable?
 
     visit avo.resources_rubygem_path(rubygem)
 
@@ -48,6 +50,7 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     rubygem.reload
 
     assert_equal 0, rubygem.protected_days
+    assert_predicate rubygem, :pushable?
 
     audit = rubygem.audits.sole
 


### PR DESCRIPTION
Fixes a test failure that showed up in #3634 which was expecting 0 protected days, but getting -1, which happens if it takes at least 1 second (or crosses a 1 second rounding threshold) between update and assert.

Always return 0 when the gem is no longer protected, saving us from 1 second variations in the calculation. A negative number of days until I can use this protected namespace doesn't make sense.