### PR TITLE
Extract getCredentials JS function

### DIFF
--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -102,31 +102,35 @@
     });
   });
 
+  var getCredentials = function(event, csrfToken) {
+    var form = handleEvent(event);
+    var options = JSON.parse(form.dataset.options);
+    options.challenge = base64urlToBuffer(options.challenge);
+    options.allowCredentials = credentialsToBuffer(options.allowCredentials);
+    return navigator.credentials.get({
+      publicKey: options
+    }).then(function (credentials) {
+      return fetch(form.action, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "X-CSRF-Token": csrfToken,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          credentials: credentialsToBase64(credentials)
+        })
+      });
+    })
+  };
+
   $(function() {
     var cliSessionForm = $(".js-webauthn-session-cli--form");
     var cliSessionError = $(".js-webauthn-session-cli--error");
     var csrfToken = $("[name='csrf-token']").attr("content");
 
     cliSessionForm.submit(function(event) {
-      var form = handleEvent(event);
-      var options = JSON.parse(form.dataset.options);
-      options.challenge = base64urlToBuffer(options.challenge);
-      options.allowCredentials = credentialsToBuffer(options.allowCredentials);
-      navigator.credentials.get({
-        publicKey: options
-      }).then(function (credentials) {
-        return fetch(form.action, {
-          method: "POST",
-          credentials: "same-origin",
-          headers: {
-            "X-CSRF-Token": csrfToken,
-            "Content-Type": "application/json"
-          },
-          body: JSON.stringify({
-            credentials: credentialsToBase64(credentials)
-          })
-        });
-      }).then(function (response) {
+      getCredentials(event, csrfToken).then(function (response) {
         response.text().then(function (text) {
           if (text == "success") {
             window.location.href = `${location.origin}/webauthn_verification/successful_verification`
@@ -147,25 +151,7 @@
     var csrfToken = $("[name='csrf-token']").attr("content");
 
     sessionForm.submit(function(event) {
-      var form = handleEvent(event);
-      var options = JSON.parse(form.dataset.options);
-      options.challenge = base64urlToBuffer(options.challenge);
-      options.allowCredentials = credentialsToBuffer(options.allowCredentials);
-      navigator.credentials.get({
-        publicKey: options
-      }).then(function (credentials) {
-        return fetch(form.action, {
-          method: "POST",
-          credentials: "same-origin",
-          headers: {
-            "X-CSRF-Token": csrfToken,
-            "Content-Type": "application/json"
-          },
-          body: JSON.stringify({
-            credentials: credentialsToBase64(credentials)
-          })
-        });
-      }).then(function (response) {
+      getCredentials(event, csrfToken).then(function (response) {
         handleHtmlResponse(sessionSubmit, sessionError, response);
       }).catch(function (error) {
         setError(sessionSubmit, sessionError, error);


### PR DESCRIPTION
Since we get the webauthn credentials in the same way upon signin on either the web or CLI, this extracts a getCredentials() function to reduce duplication and make it easier to see the similarities/differences between the two approaches. 