### PR TITLE
Add check for api_key based auth

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -1,23 +1,36 @@
 # This controller generates a single-use link as part of the Webauthn CLI flow. It does not challenge
 # the user with a Webauthn login. That is done in controllers/webauthn_verifications_controller.
 class Api::V1::WebauthnVerificationsController < Api::BaseController
-  def create
-    authenticate_or_request_with_http_basic do |username, password|
-      user = User.authenticate(username.strip, password)
+  before_action :authenticate_with_credentials
 
-      if user&.webauthn_credentials.present?
-        verification = user.refresh_webauthn_verification
-        webauthn_path = webauthn_verification_url(verification.path_token)
-        respond_to do |format|
-          format.any(:all) { render plain: webauthn_path }
-          format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
-          format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
-        end
-      elsif user # the user exists but hasn't configured any credentials
-        render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
-      else # invalid user
-        false
+  def create
+    if @user.webauthn_credentials.present?
+      verification = @user.refresh_webauthn_verification
+      webauthn_path = webauthn_verification_url(verification.path_token)
+      respond_to do |format|
+        format.any(:all) { render plain: webauthn_path }
+        format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
+        format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
       end
+    else
+      render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def authenticate_with_credentials
+    params_key = request.headers["Authorization"] || ""
+    hashed_key = Digest::SHA256.hexdigest(params_key)
+    api_key = ApiKey.find_by_hashed_key(hashed_key)
+
+    @user = authenticated_user(api_key)
+  end
+
+  def authenticated_user(api_key)
+    return api_key.user if api_key
+    authenticate_or_request_with_http_basic do |username, password|
+      User.authenticate(username.strip, password)
     end
   end
 end

--- a/test/functional/api/v1/webauthn_verifications_controller_test.rb
+++ b/test/functional/api/v1/webauthn_verifications_controller_test.rb
@@ -76,6 +76,19 @@ class Api::V1::WebauthnVerificationsControllerTest < ActionController::TestCase
       end
     end
 
+    context "when authenticating with an api key" do
+      setup do
+        @api_key = create(:api_key, key: "12345", push_rubygem: true)
+        @user = @api_key.user
+        create(:webauthn_credential, user: @user)
+        @request.env["HTTP_AUTHORIZATION"] = "12345"
+        post :create
+        @token = @user.webauthn_verification.path_token
+      end
+
+      should respond_with :success
+    end
+
     context "user has enabled webauthn" do
       should_respond_to_format :yaml
       should_respond_to_format :json


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When users were signed into the CLI with an api_key, instead of basic auth, they were not being given a webauthn url. They were instead prompted to use OTP, even if webauthn was enabled. 

## What is your fix for the problem, implemented in this PR?

This adds a check for a users api_key, so that they can sign in with either basic auth or an api_key to the webauthn_verification endpoint. 
