### PR TITLE
Remove WebAuthn warning from settings edit

### DIFF
--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -30,7 +30,7 @@
 
   <h2><%= t(".webauthn_credentials") %></h2>
 
-  <p><%= t(".webauthn_credential_note")%> <b><%= t(".webauthn_warning")%></b></p>
+  <p><%= t(".webauthn_credential_note")%></p>
 
   <% if @user.webauthn_credentials.none? %>
     <p><i><%= t(".no_webauthn_credentials") %></i></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -416,7 +416,6 @@ de:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: Sind Sie sicher? Das kann nicht rückgängig gemacht werden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,7 +415,6 @@ en:
       webauthn_credentials: Security device
       no_webauthn_credentials: You don't have any security devices
       webauthn_credential_note: A security device can be can be any device that complies with the FIDO2 standard such as security and biometric keys.
-      webauthn_warning: Once enabled, devices can only be used for UI login currently. It is not a replacement for OTP based multi-factor authentication until support with the command line is completed.
       otp_code: OTP code or recovery code
       api_access:
         confirm_reset: Are you sure? This cannot be undone.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -438,7 +438,6 @@ es:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: "¿Seguro? Este cambio no puede deshacerse."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -440,7 +440,6 @@ fr:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: Êtes-vous sûr ? Cette action ne peut être annulée.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -403,7 +403,6 @@ ja:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: この操作は取り消せませんが、本当によろしいですか?

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -420,7 +420,6 @@ nl:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: Weet je het zeker? Dit kan niet ongedaan worden gemaakt.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -431,7 +431,6 @@ pt-BR:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: Tem certeza?

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -403,7 +403,6 @@ zh-CN:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: 确定要重置吗？此动作执行后将无法撤销

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -404,7 +404,6 @@ zh-TW:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:
-      webauthn_warning:
       otp_code:
       api_access:
         confirm_reset: 確定要重設嗎？此動作無法還原


### PR DESCRIPTION
Part of: https://github.com/rubygems/rubygems.org/pull/3298

Removing the warning that webauthn devices are supported on the UI only since CLI support has now been implemented