### PR TITLE
Allow fastly to serve stale content for a bit while revalidating/on error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,8 +52,12 @@ class ApplicationController < ActionController::Base
     fastly_expires_in fastly_expiry
   end
 
-  def fastly_expires_in(seconds)
-    response.headers["Surrogate-Control"] = "max-age=#{seconds}"
+  def fastly_expires_in(seconds, stale_while_revalidate: seconds / 2, stale_if_error: seconds / 2)
+    response.headers["Surrogate-Control"] = {
+      "max-age" => seconds,
+      "stale-while-revalidate" => stale_while_revalidate,
+      "stale-if-error" => stale_if_error
+    }.compact.map { |k, v| "#{k}=#{v}" }.join(", ")
   end
 
   def set_surrogate_key(*surrogate_keys)

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -123,7 +123,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     get versions_path
 
     assert_equal "versions", @response.headers["Surrogate-Key"]
-    assert_equal "max-age=30", @response.headers["Surrogate-Control"]
+    assert_equal "max-age=30, stale-while-revalidate=15, stale-if-error=15", @response.headers["Surrogate-Control"]
   end
 
   test "/info with existing gem" do


### PR DESCRIPTION
To try to avoid a bunch of requests hitting the backend before the shield POP gets pages like the versions endpoint cached