### PR TITLE
Follow redirect in fetch to verify credentials

### DIFF
--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -113,6 +113,7 @@
       return fetch(form.action, {
         method: "POST",
         credentials: "same-origin",
+        redirect: "follow",
         headers: {
           "X-CSRF-Token": csrfToken,
           "Content-Type": "application/json"


### PR DESCRIPTION
## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298
Webauthn verification doesn't work on safari. This is because redirects aren't being followed to localhost.
<img width="1316" alt="Screenshot 2023-03-31 at 9 54 02 AM" src="https://user-images.githubusercontent.com/42748004/229139455-d606422a-d94e-4726-a81d-cc7df4b6c747.png">

## What approach did you choose and why?
As suggested by @segiddins, added `redirect: 'follow'` to the fetch request.

## Testing
1. run `RUBYGEMS_HOST=http://localhost:3000 ruby -Ilib bin/gem signin` on https://github.com/rubygems/rubygems/pull/6560 branch.
2. Open the webauthn verification link on safari and webauthn works
3. Run the same command without these changes and webauthn verification doesn't work