### PR TITLE
Replace dependency API route with search in encoding test

### DIFF
--- a/test/integration/encoding_test.rb
+++ b/test/integration/encoding_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class EncodingTest < ActionDispatch::IntegrationTest
   test "invalid utf-8 characters should be sanitized" do
-    get "/api/v1/dependencies?gems=vagrant,vagrant-login,vagrant-share,vagrant%ADvbguest"
+    get "/api/v1/search.json?query=vagrant%ADvbguest"
 
     assert_response :success
   end


### PR DESCRIPTION
Dependency API is being deprecated (https://github.com/rubygems/rubygems.org/pull/3477) which is causing CI to fail (eg. https://github.com/rubygems/rubygems.org/actions/runs/4598741468/jobs/8123197937).

Changing the test route to search.

## What should reviewers focus on?
I think I'm testing this correctly - I'm not sure what happens if utf-8 characters are not sanitized