### PR TITLE
Add pop-up when a WebAuthn credential is deleted

### DIFF
--- a/app/views/webauthn_credentials/_webauthn_credential.html.erb
+++ b/app/views/webauthn_credentials/_webauthn_credential.html.erb
@@ -1,4 +1,8 @@
 <div class="l-flex l-mb-4 l-items-center l-gap-2">
   <div class="t-text"><%= webauthn_credential.nickname %></div>
-  <%= button_to t(".delete"), webauthn_credential, method: :delete, class: "form__submit form__submit--small" %>
+  <%= button_to t(".delete"),
+    webauthn_credential,
+    method: :delete,
+    class: "form__submit form__submit--small",
+    data: { confirm: t(".confirm")} %>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -676,6 +676,7 @@ de:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,6 +674,7 @@ en:
       confirm_delete: "Credential deleted"
       delete_failed: "Could not delete credential"
       delete: Delete
+      confirm: Are you sure you want to delete this credential?
       saved: Security device succesfully created
     form:
       new_device: Register a new security device

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -721,6 +721,7 @@ es:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -727,6 +727,7 @@ fr:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -664,6 +664,7 @@ ja:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -679,6 +679,7 @@ nl:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -702,6 +702,7 @@ pt-BR:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -662,6 +662,7 @@ zh-CN:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -663,6 +663,7 @@ zh-TW:
       confirm_delete:
       delete_failed:
       delete:
+      confirm:
       saved:
     form:
       new_device:


### PR DESCRIPTION
## What problem are you solving?
When deleting a WebAuthn device, there should be a pop-up or alert to make sure that this action was not made by accident.

## What approach did you choose and why?
Like when deleting an API key, added a confirmation associated with the delete button

## What should reviewers focus on?
The phrasing of the confirmation message

## Testing
1. Have a Webauthn device on a user account
2. When the delete button is pressed an alert pops up confirming the removal of the device.
<img width="830" alt="Screenshot 2023-04-13 at 11 31 36 AM" src="https://user-images.githubusercontent.com/42748004/231810029-f131c014-2698-472e-8bc5-0da21bd6886d.png">
