### PR TITLE
Always render plain text in WebauthnVerification#authenticate

### DIFF
--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -130,17 +130,23 @@
     var cliSessionError = $(".js-webauthn-session-cli--error");
     var csrfToken = $("[name='csrf-token']").attr("content");
 
+    function failed_verification_url(message) {
+      var url =  new URL(`${location.origin}/webauthn_verification/failed_verification`);
+      url.searchParams.append("error", message);
+      return url.href;
+    };
+
     cliSessionForm.submit(function(event) {
       getCredentials(event, csrfToken).then(function (response) {
         response.text().then(function (text) {
           if (text == "success") {
-            window.location.href = `${location.origin}/webauthn_verification/successful_verification`
+            window.location.href = `${location.origin}/webauthn_verification/successful_verification`;
           } else {
-            window.location.href = `${location.origin}/webauthn_verification/failed_verification`
+            window.location.href = failed_verification_url(text);
           }
         });
-      }).catch(function (_) {
-        window.location.href = `${location.origin}/webauthn_verification/failed_verification`
+      }).catch(function (error) {
+        window.location.href = failed_verification_url(error.message);
       });
     });
   });

--- a/app/assets/stylesheets/modules/status-icon.css
+++ b/app/assets/stylesheets/modules/status-icon.css
@@ -23,6 +23,10 @@
   margin: 20px 0 60px;
   font-size: 1.25rem; }
 
+.status p {
+  margin-bottom: 1rem;
+}
+
 .status.error {
   color: #D06079; }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,7 @@ class ApplicationController < ActionController::Base
       format.html { render file: Rails.public_path.join("404.html"), status: :not_found, layout: false }
       format.json { render json: { error: t(:not_found) }, status: :not_found }
       format.yaml { render yaml: { error: t(:not_found) }, status: :not_found }
-      format.any(:all) { render text: t(:not_found), status: :not_found }
+      format.any(:all) { render plain: t(:not_found), status: :not_found }
     end
   end
 

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -42,6 +42,11 @@ class WebauthnVerificationsController < ApplicationController
     session.delete(:webauthn_authentication)
   end
 
+  def failed_verification
+    @message = params.permit(:error).fetch(:error, "")
+    logger.info("WebAuthn Verification failed", error: @message)
+  end
+
   private
 
   def set_verification

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -35,10 +35,9 @@ class WebauthnVerificationsController < ApplicationController
 
     redirect_to(URI.parse("http://localhost:#{port}?code=#{@verification.otp}").to_s, allow_other_host: true)
   rescue WebAuthn::Error => e
-    # TODO: render plain text for both endpoints
-    render json: { message: e.message }, status: :unauthorized
+    render plain: e.message, status: :unauthorized
   rescue ActionController::ParameterMissing
-    render json: { message: "Credentials required" }, status: :unauthorized
+    render plain: t("credentials_required"), status: :unauthorized
   ensure
     session.delete(:webauthn_authentication)
   end
@@ -49,8 +48,7 @@ class WebauthnVerificationsController < ApplicationController
     @verification = WebauthnVerification.find_by(path_token: webauthn_token_param)
 
     render_not_found and return unless @verification
-    # TODO: Return a message if format is plain text
-    redirect_to root_path, alert: t("webauthn_verifications.expired_or_already_used") if @verification.path_token_expired?
+    render_expired if @verification.path_token_expired?
   end
 
   def set_user
@@ -82,5 +80,12 @@ class WebauthnVerificationsController < ApplicationController
 
   def webauthn_token_param
     params.permit(:webauthn_token).require(:webauthn_token)
+  end
+
+  def render_expired
+    respond_to do |format|
+      format.html { redirect_to root_path, alert: t("webauthn_verifications.expired_or_already_used") }
+      format.text { render plain: t("webauthn_verifications.expired_or_already_used"), status: :unauthorized }
+    end
   end
 end

--- a/app/views/webauthn_verifications/failed_verification.html.erb
+++ b/app/views/webauthn_verifications/failed_verification.html.erb
@@ -6,5 +6,8 @@
     <line class="path line" fill="none" stroke="#D06079" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" x1="34.4" y1="37.9" x2="95.8" y2="92.3"/>
     <line class="path line" fill="none" stroke="#D06079" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" x1="95.8" y1="38" x2="34.4" y2="92.2"/>
   </svg>
-  <p class="status error"><%= t(".close_browser") %></p>
+  <div class="status error">
+    <p><%= @message %></p>
+    <p><%= t(".close_browser") %></p>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,8 +188,6 @@ Rails.application.routes.draw do
       get 'successful_verification'
       get 'failed_verification'
       get ':webauthn_token', to: 'webauthn_verifications#prompt', as: ''
-      # TODO: add plain text as a valid format
-      post ':webauthn_token', to: 'webauthn_verifications#authenticate', as: :authenticate, constraints: { format: /json/ }
     end
 
     ################################################################################
@@ -230,6 +228,12 @@ Rails.application.routes.draw do
   scope constraints: { format: :json }, defaults: { format: :json } do
     resources :webauthn_credentials, only: :create do
       post :callback, on: :collection
+    end
+  end
+
+  scope constraints: { format: :text }, defaults: { format: :text } do
+    resource :webauthn_verification, only: [] do
+      post ':webauthn_token', to: 'webauthn_verifications#authenticate', as: :authenticate
     end
   end
 

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -148,7 +148,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should respond_with :unauthorized
 
       should "return error message" do
-        assert_equal "Credentials required", JSON.parse(response.body)["message"]
+        assert_equal "Credentials required", response.body
       end
 
       should "not expire the path token" do
@@ -180,7 +180,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should respond_with :unauthorized
 
       should "return error message" do
-        assert_equal "WebAuthn::ChallengeVerificationError", JSON.parse(response.body)["message"]
+        assert_equal "WebAuthn::ChallengeVerificationError", response.body
       end
 
       should "not generate OTP" do
@@ -204,6 +204,10 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should respond_with :not_found
+
+      should "say not found" do
+        assert_equal "Not Found", response.body
+      end
     end
 
     context "when the webauthn token has expired" do
@@ -219,11 +223,10 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
         authenticate_request(time: Time.utc(2023, 1, 1, 0, 3, 0))
       end
 
-      should respond_with :redirect
-      should redirect_to("the homepage") { root_url }
+      should respond_with :unauthorized
 
       should "say the token is consumed or expired" do
-        assert_equal "The token in the link you used has either expired or been used already.", flash[:alert]
+        assert_equal "The token in the link you used has either expired or been used already.", response.body
       end
     end
 
@@ -288,7 +291,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             ),
           webauthn_token: token
         },
-        format: :json
+        format: :text
       )
     end
   end


### PR DESCRIPTION
## What problem are you solving?
There's a couple of TODOs left from https://github.com/rubygems/rubygems.org/pull/3298. They all refer to how `WebauthnVerification:authenticate` should have a consistent response format.

## What approach did you choose and why?
Chose to return plain text as the response from the client is plain text. Made sure that not found, and expired token return plain and errors in the authenticate action all return plain.

Since all the responses are plain text, it is simpler to display the error to the user rather than swallowing it. If the result of the verification is not successful, the message with be stored as a param and rendered in the failed verification view.

## Testing
1. run `RUBYGEMS_HOST=http://localhost:3000 gem signin` as a user with a webauthn device. access the webauthn link
2. Wait 2+ minutes, and authenticate. The failed verification page will have the appropriate message.
<img width="1072" alt="Screenshot 2023-04-17 at 11 29 47 AM" src="https://user-images.githubusercontent.com/42748004/232535843-53f337c1-2222-42f1-a657-67d093d0ee54.png">

3. Do step 1 and Control C in the terminal before authenticating. The failed verification page will have the appropriate message.
<img width="919" alt="Screenshot 2023-04-17 at 11 30 39 AM" src="https://user-images.githubusercontent.com/42748004/232536057-4a4fb8c3-a6b3-41a9-8b94-288da162b506.png">
4. Do step 1 and authenticate, the success page would look the same.
<img width="1043" alt="Screenshot 2023-04-17 at 11 36 50 AM" src="https://user-images.githubusercontent.com/42748004/232537569-cb59731b-8f7c-40fc-942e-24873eafaf43.png">
