### PR TITLE
Advertise that the compact index actions accept range requests

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -29,6 +29,7 @@ class Api::CompactIndexController < Api::BaseController
 
   def render_range(response_body)
     headers["ETag"] = '"' << Digest::MD5.hexdigest(response_body) << '"'
+    headers["Accept-Ranges"] = "bytes"
 
     ranges = Rack::Utils.byte_ranges(request.env, response_body.bytesize)
     if ranges


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges

Needed for nginx to respect the range header according to https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_force_ranges