### PR TITLE
try removing nginx version caching

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -88,12 +88,6 @@ data:
 
         location /versions {
           limit_req zone=minutely burst=10 nodelay;
-          proxy_cache cache-versions;
-          proxy_cache_background_update on;
-          proxy_cache_key "/versions";
-          proxy_cache_lock on;
-          proxy_cache_use_stale updating;
-          proxy_cache_valid 200 10s;
           proxy_pass http://127.0.0.1:3000/versions;
         }
 


### PR DESCRIPTION
Try removing Nginx caching for /versions. In theory, this should mean that Fastly will then take over all caching. With stale-while-revalidate enabled (which it currently is), that should dramatically reduce the number of end user requests that make it through Fastly and get served by Nginx and Rails. I hope.
