### PR TITLE
Refactor WebAuthn Verification logic

### DIFF
--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -17,9 +17,6 @@ module WebauthnVerifiable
     if params[:credentials].blank?
       @webauthn_error = t("credentials_required")
       return false
-    elsif !session_active?
-      @webauthn_error = t("multifactor_auths.session_expired")
-      return false
     end
 
     @credential = WebAuthn::Credential.from_get(params[:credentials])

--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -1,10 +1,11 @@
 module WebauthnVerifiable
   extend ActiveSupport::Concern
 
-  def setup_webauthn_authentication(session_options: {})
+  def setup_webauthn_authentication(form_url:, session_options: {})
     return if @user.webauthn_credentials.none?
 
     @webauthn_options = @user.webauthn_options_for_get
+    @webauthn_verification_url = form_url
 
     session[:webauthn_authentication] = {
       "challenge" => @webauthn_options.challenge

--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -37,5 +37,10 @@ module WebauthnVerifiable
     @webauthn_credential.update!(sign_count: @credential.sign_count)
 
     true
+  rescue WebAuthn::Error => e
+    @webauthn_error = e.message
+    false
+  ensure
+    session.delete(:webauthn_authentication)
   end
 end

--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -12,16 +12,15 @@ module WebauthnVerifiable
     }
   end
 
-  def verify_webauthn_credential
-    @user = User.find(session.dig(:webauthn_authentication, "user"))
+  def webauthn_credential_verified?
     @challenge = session.dig(:webauthn_authentication, "challenge")
 
     if params[:credentials].blank?
-      webauthn_verification_failure(t("credentials_required"))
-      return
+      @webauthn_error = t("credentials_required")
+      return false
     elsif !session_active?
-      webauthn_verification_failure(t("multifactor_auths.session_expired"))
-      return
+      @webauthn_error = t("multifactor_auths.session_expired")
+      return false
     end
 
     @credential = WebAuthn::Credential.from_get(params[:credentials])
@@ -35,7 +34,8 @@ module WebauthnVerifiable
       public_key: @webauthn_credential.public_key,
       sign_count: @webauthn_credential.sign_count
     )
-
     @webauthn_credential.update!(sign_count: @credential.sign_count)
+
+    true
   end
 end

--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -1,15 +1,14 @@
 module WebauthnVerifiable
   extend ActiveSupport::Concern
 
-  def setup_webauthn_authentication
+  def setup_webauthn_authentication(session_options: {})
     return if @user.webauthn_credentials.none?
 
     @webauthn_options = @user.webauthn_options_for_get
 
     session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge,
-      "user" => @user.id
-    }
+      "challenge" => @webauthn_options.challenge
+    }.merge(session_options)
   end
 
   def webauthn_credential_verified?

--- a/app/controllers/concerns/webauthn_verifiable.rb
+++ b/app/controllers/concerns/webauthn_verifiable.rb
@@ -1,0 +1,41 @@
+module WebauthnVerifiable
+  extend ActiveSupport::Concern
+
+  def setup_webauthn_authentication
+    return if @user.webauthn_credentials.none?
+
+    @webauthn_options = @user.webauthn_options_for_get
+
+    session[:webauthn_authentication] = {
+      "challenge" => @webauthn_options.challenge,
+      "user" => @user.id
+    }
+  end
+
+  def verify_webauthn_credential
+    @user = User.find(session.dig(:webauthn_authentication, "user"))
+    @challenge = session.dig(:webauthn_authentication, "challenge")
+
+    if params[:credentials].blank?
+      webauthn_verification_failure(t("credentials_required"))
+      return
+    elsif !session_active?
+      webauthn_verification_failure(t("multifactor_auths.session_expired"))
+      return
+    end
+
+    @credential = WebAuthn::Credential.from_get(params[:credentials])
+
+    @webauthn_credential = @user.webauthn_credentials.find_by(
+      external_id: @credential.id
+    )
+
+    @credential.verify(
+      @challenge,
+      public_key: @webauthn_credential.public_key,
+      sign_count: @webauthn_credential.sign_count
+    )
+
+    @webauthn_credential.update!(sign_count: @credential.sign_count)
+  end
+end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -26,8 +26,7 @@ class EmailConfirmationsController < ApplicationController
   def update
     if @user.mfa_enabled? || @user.webauthn_credentials.any?
       setup_mfa_authentication
-      setup_webauthn_authentication
-      @form_webauthn_url = webauthn_update_email_confirmations_url(token: @user.confirmation_token)
+      setup_webauthn_authentication(form_url: webauthn_update_email_confirmations_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
 

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -48,6 +48,11 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def webauthn_update
+    unless session_active?
+      login_failure(t("multifactor_auths.session_expired"))
+      return
+    end
+
     return login_failure(@webauthn_error) unless webauthn_credential_verified?
 
     confirm_email

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,5 +1,6 @@
 class PasswordsController < Clearance::PasswordsController
   include MfaExpiryMethods
+  include WebauthnVerifiable
 
   before_action :validate_confirmation_token, only: %i[edit mfa_edit webauthn_edit]
   after_action :delete_mfa_expiry_session, only: %i[mfa_edit webauthn_edit]
@@ -8,6 +9,7 @@ class PasswordsController < Clearance::PasswordsController
     if @user.mfa_enabled? || @user.webauthn_credentials.any?
       setup_mfa_authentication
       setup_webauthn_authentication
+      @form_webauthn_url = webauthn_edit_user_password_url(@user, token: @user.confirmation_token)
 
       create_new_mfa_expiry
 
@@ -43,32 +45,9 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def webauthn_edit
-    @challenge = session.dig(:webauthn_authentication, "challenge")
+    return login_failure(@webauthn_error) unless webauthn_credential_verified?
 
-    if params[:credentials].blank?
-      login_failure(t("credentials_required"))
-      return
-    elsif !session_active?
-      login_failure(t("multifactor_auths.session_expired"))
-      return
-    end
-
-    @credential = WebAuthn::Credential.from_get(params[:credentials])
-
-    @webauthn_credential = @user.webauthn_credentials.find_by(
-      external_id: @credential.id
-    )
-
-    @credential.verify(
-      @challenge,
-      public_key: @webauthn_credential.public_key,
-      sign_count: @webauthn_credential.sign_count
-    )
-
-    @webauthn_credential.update!(sign_count: @credential.sign_count)
     render template: "passwords/edit"
-  rescue WebAuthn::Error => e
-    login_failure(e.message)
   end
 
   private
@@ -93,18 +72,6 @@ class PasswordsController < Clearance::PasswordsController
   def setup_mfa_authentication
     return if @user.mfa_disabled?
     @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
-  end
-
-  def setup_webauthn_authentication
-    return if @user.webauthn_credentials.none?
-
-    @form_webauthn_url = webauthn_edit_user_password_url(@user, token: @user.confirmation_token)
-
-    @webauthn_options = @user.webauthn_options_for_get
-
-    session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge
-    }
   end
 
   def mfa_edit_conditions_met?

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -8,8 +8,7 @@ class PasswordsController < Clearance::PasswordsController
   def edit
     if @user.mfa_enabled? || @user.webauthn_credentials.any?
       setup_mfa_authentication
-      setup_webauthn_authentication
-      @form_webauthn_url = webauthn_edit_user_password_url(@user, token: @user.confirmation_token)
+      setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -45,6 +45,11 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def webauthn_edit
+    unless session_active?
+      login_failure(t("multifactor_auths.session_expired"))
+      return
+    end
+
     return login_failure(@webauthn_error) unless webauthn_credential_verified?
 
     render template: "passwords/edit"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < Clearance::SessionsController
   include MfaExpiryMethods
+  include WebauthnVerifiable
 
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify authenticate]
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: %i[verify authenticate]
@@ -154,17 +155,6 @@ class SessionsController < Clearance::SessionsController
 
     flash.now.alert = t(".account_blocked")
     render template: "sessions/new", status: :unauthorized
-  end
-
-  def setup_webauthn_authentication
-    return if @user.webauthn_credentials.none?
-
-    @webauthn_options = @user.webauthn_options_for_get
-
-    session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge,
-      "user" => @user.id
-    }
   end
 
   def setup_mfa_authentication

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < Clearance::SessionsController
     @user = find_user
 
     if @user && (@user.mfa_enabled? || @user.webauthn_credentials.any?)
-      setup_webauthn_authentication(session_options: { "user" => @user.id })
+      setup_webauthn_authentication(form_url: webauthn_create_session_path, session_options: { "user" => @user.id })
       setup_mfa_authentication
 
       session[:mfa_login_started_at] = Time.now.utc.to_s

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,10 +31,7 @@ class SessionsController < Clearance::SessionsController
     record_mfa_login_duration(mfa_type: "webauthn")
 
     do_login
-  rescue WebAuthn::Error => e
-    webauthn_verification_failure(e.message)
   ensure
-    session.delete(:webauthn_authentication)
     session.delete(:mfa_login_started_at)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,6 +26,11 @@ class SessionsController < Clearance::SessionsController
 
   def webauthn_create
     @user = User.find(session.dig(:webauthn_authentication, "user"))
+
+    unless session_active?
+      webauthn_verification_failure(t("multifactor_auths.session_expired"))
+      return
+    end
     return webauthn_verification_failure(@webauthn_error) unless webauthn_credential_verified?
 
     record_mfa_login_duration(mfa_type: "webauthn")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < Clearance::SessionsController
     @user = find_user
 
     if @user && (@user.mfa_enabled? || @user.webauthn_credentials.any?)
-      setup_webauthn_authentication
+      setup_webauthn_authentication(session_options: { "user" => @user.id })
       setup_mfa_authentication
 
       session[:mfa_login_started_at] = Time.now.utc.to_s

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,29 +26,7 @@ class SessionsController < Clearance::SessionsController
 
   def webauthn_create
     @user = User.find(session.dig(:webauthn_authentication, "user"))
-    @challenge = session.dig(:webauthn_authentication, "challenge")
-
-    if params[:credentials].blank?
-      webauthn_verification_failure(t("credentials_required"))
-      return
-    elsif !session_active?
-      webauthn_verification_failure(t("multifactor_auths.session_expired"))
-      return
-    end
-
-    @credential = WebAuthn::Credential.from_get(params[:credentials])
-
-    @webauthn_credential = @user.webauthn_credentials.find_by(
-      external_id: @credential.id
-    )
-
-    @credential.verify(
-      @challenge,
-      public_key: @webauthn_credential.public_key,
-      sign_count: @webauthn_credential.sign_count
-    )
-
-    @webauthn_credential.update!(sign_count: @credential.sign_count)
+    return webauthn_verification_failure(@webauthn_error) unless webauthn_credential_verified?
 
     record_mfa_login_duration(mfa_type: "webauthn")
 

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -45,29 +45,6 @@ class WebauthnVerificationsController < ApplicationController
     @user = @verification.user
   end
 
-  def webauthn_credential
-    @webauthn_credential ||= WebAuthn::Credential.from_get(credential_params)
-  end
-
-  def user_webauthn_credential
-    @user_webauthn_credential ||= @user.webauthn_credentials.find_by(
-      external_id: webauthn_credential.id
-    )
-  end
-
-  def challenge
-    session.dig(:webauthn_authentication, "challenge")
-  end
-
-  def credential_params
-    @credential_params ||= params.require(:credentials).permit(
-      :id,
-      :type,
-      :rawId,
-      response: %i[authenticatorData attestationObject clientDataJSON signature]
-    )
-  end
-
   def webauthn_token_param
     params.permit(:webauthn_token).require(:webauthn_token)
   end

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -1,18 +1,15 @@
 # This controller is for the user interface Webauthn challenge after a user follows a link generated
 # by the APIv1 WebauthnVerificationsController (controllers/api/v1/webauthn_verifications_controller).
 class WebauthnVerificationsController < ApplicationController
+  include WebauthnVerifiable
+
   before_action :set_verification, :set_user, except: %i[successful_verification failed_verification]
 
   def prompt
     redirect_to root_path, alert: t(".no_port") unless (port = params[:port])
     redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?
 
-    @webauthn_options = @user.webauthn_options_for_get
-
-    session[:webauthn_authentication] = {
-      "challenge" => @webauthn_options.challenge,
-      "port" => port
-    }
+    setup_webauthn_authentication(session_options: { "port" => port })
   end
 
   def authenticate

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -9,7 +9,7 @@ class WebauthnVerificationsController < ApplicationController
     redirect_to root_path, alert: t(".no_port") unless (port = params[:port])
     redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?
 
-    setup_webauthn_authentication(session_options: { "port" => port })
+    setup_webauthn_authentication(form_url: authenticate_webauthn_verification_path, session_options: { "port" => port })
   end
 
   def authenticate

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -7,7 +7,7 @@
         <div class="t-body">
           <p><%= t("sessions.prompt.webauthn_credential_note") %></p>
         </div>
-        <%= form_tag @form_webauthn_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
+        <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
           <div class="form_bottom">
             <p hidden class="l-text-red-600 js-webauthn-session--error"></p>
 

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -8,7 +8,7 @@
         <p><%= t(".webauthn_credential_note") %></p>
       </div>
 
-      <%= form_tag webauthn_create_session_path, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
+      <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
         <div class="form_bottom">
           <p hidden class="l-text-red-600 js-webauthn-session--error"></p>
 

--- a/app/views/webauthn_verifications/prompt.html.erb
+++ b/app/views/webauthn_verifications/prompt.html.erb
@@ -9,7 +9,7 @@
     <p><%= t("settings.edit.webauthn_credential_note") %></p>
   </div>
 
-  <%= form_tag authenticate_webauthn_verification_path, method: :post, class: "js-webauthn-session-cli--form", data: { options: @webauthn_options.to_json } do %>
+  <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session-cli--form", data: { options: @webauthn_options.to_json } do %>
     <div class="form_bottom">
       <p hidden class="l-text-red-600 js-webauthn-session-cli--error"></p>
 

--- a/test/functional/concerns/webauthn_verifiable_test.rb
+++ b/test/functional/concerns/webauthn_verifiable_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-class WebauthnVerifiableTestController < ApplicationController
+class TestWebauthnAuthenticationController < ApplicationController
   include WebauthnVerifiable
 
   def prompt
     @user = User.find(params[:user_id])
-    setup_webauthn_authentication(form_url: webauthn_verifiable_test_authenticate_path)
+    setup_webauthn_authentication(form_url: test_webauthn_authenticate_path)
 
     render json: { webauthn_options: @webauthn_options.to_json, webauthn_verification_url: @webauthn_verification_url }
   end
@@ -13,7 +13,7 @@ class WebauthnVerifiableTestController < ApplicationController
   def prompt_with_session_options
     @user = User.find(params[:user_id])
     setup_webauthn_authentication(
-      form_url: webauthn_verifiable_test_authenticate_path,
+      form_url: test_webauthn_authenticate_path,
       session_options: { "foo" => "bar", "baz" => "qux" }
     )
 
@@ -30,15 +30,15 @@ end
 
 class WebauthnVerifiableTest < ActionController::TestCase
   setup do
-    @controller = WebauthnVerifiableTestController.new
+    @controller = TestWebauthnAuthenticationController.new
     @user = create(:user)
     @webauthn_credential = create(:webauthn_credential, user: @user)
 
     Rails.application.routes.draw do
-      scope controller: "webauthn_verifiable_test" do
+      scope controller: "test_webauthn_authentication" do
         get :prompt
         get :prompt_with_session_options
-        post :authenticate, as: :webauthn_verifiable_test_authenticate
+        post :authenticate, as: :test_webauthn_authenticate
       end
     end
   end
@@ -50,7 +50,7 @@ class WebauthnVerifiableTest < ActionController::TestCase
     end
 
     should "set webauthn_verification_url" do
-      assert_equal webauthn_verifiable_test_authenticate_path, @json_response["webauthn_verification_url"]
+      assert_equal test_webauthn_authenticate_path, @json_response["webauthn_verification_url"]
     end
 
     should "set webauthn_options" do

--- a/test/functional/concerns/webauthn_verifiable_test.rb
+++ b/test/functional/concerns/webauthn_verifiable_test.rb
@@ -1,0 +1,161 @@
+require "test_helper"
+
+class WebauthnVerifiableTestController < ApplicationController
+  include WebauthnVerifiable
+
+  def prompt
+    @user = User.find(params[:user_id])
+    setup_webauthn_authentication(form_url: webauthn_verifiable_test_authenticate_path)
+
+    render json: { webauthn_options: @webauthn_options.to_json, webauthn_verification_url: @webauthn_verification_url }
+  end
+
+  def prompt_with_session_options
+    @user = User.find(params[:user_id])
+    setup_webauthn_authentication(
+      form_url: webauthn_verifiable_test_authenticate_path,
+      session_options: { "foo" => "bar", "baz" => "qux" }
+    )
+
+    render json: { webauthn_options: @webauthn_options.to_json, webauthn_verification_url: @webauthn_verification_url }
+  end
+
+  def authenticate
+    @user = User.find(params[:user_id])
+    return render plain: @webauthn_error, status: :unauthorized unless webauthn_credential_verified?
+
+    render plain: "success"
+  end
+end
+
+class WebauthnVerifiableTest < ActionController::TestCase
+  setup do
+    @controller = WebauthnVerifiableTestController.new
+    @user = create(:user)
+    @webauthn_credential = create(:webauthn_credential, user: @user)
+
+    Rails.application.routes.draw do
+      scope controller: "webauthn_verifiable_test" do
+        get :prompt
+        get :prompt_with_session_options
+        post :authenticate, as: :webauthn_verifiable_test_authenticate
+      end
+    end
+  end
+
+  context "#prompt" do
+    setup do
+      get :prompt, params: { user_id: @user.id }
+      @json_response = JSON.parse(@response.body)
+    end
+
+    should "set webauthn_verification_url" do
+      assert_equal webauthn_verifiable_test_authenticate_path, @json_response["webauthn_verification_url"]
+    end
+
+    should "set webauthn_options" do
+      refute_nil @json_response["webauthn_options"]["challenge"]
+      refute_nil @json_response["webauthn_options"]["allowCredentials"]
+    end
+
+    should "set webauthn_challenge in session" do
+      refute_nil session[:webauthn_authentication]["challenge"]
+    end
+  end
+
+  context "#prompt with session options" do
+    setup do
+      get :prompt_with_session_options, params: { user_id: @user.id }
+    end
+
+    should "set session options in session" do
+      assert_equal "bar", session[:webauthn_authentication]["foo"]
+      assert_equal "qux", session[:webauthn_authentication]["baz"]
+    end
+  end
+
+  context "#authenticate" do
+    setup do
+      get :prompt, params: { user_id: @user.id }
+      @challenge = session[:webauthn_authentication]["challenge"]
+      @origin = "http://localhost:3000"
+      @rp_id = URI.parse(@origin).host
+      @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+      WebauthnHelpers.create_credential(
+        webauthn_credential: @webauthn_credential,
+        client: @client
+      )
+    end
+
+    context "with valid credentials" do
+      setup do
+        post(
+          :authenticate,
+          params: {
+            credentials:
+              WebauthnHelpers.get_result(
+                client: @client,
+                challenge: @challenge
+              ),
+            user_id: @user.id
+          }
+        )
+      end
+
+      should "return success" do
+        assert_equal "success", @response.body
+      end
+
+      should "clear webauthn_authentication in session" do
+        assert_nil session[:webauthn_authentication]
+      end
+    end
+
+    context "with missing credential params" do
+      setup do
+        post :authenticate, params: { user_id: @user.id }
+      end
+
+      should respond_with :unauthorized
+
+      should "return credentials required" do
+        assert_equal "Credentials required", @response.body
+      end
+
+      should "clear webauthn_authentication in session" do
+        assert_nil session[:webauthn_authentication]
+      end
+    end
+
+    context "when a Webauthn error occurs" do
+      setup do
+        @wrong_challenge = SecureRandom.hex
+        post(
+          :authenticate,
+          params: {
+            credentials:
+              WebauthnHelpers.get_result(
+                client: @client,
+                challenge: @wrong_challenge
+              ),
+            user_id: @user.id
+          }
+        )
+      end
+
+      should respond_with :unauthorized
+
+      should "return error" do
+        assert_equal "WebAuthn::ChallengeVerificationError", @response.body
+      end
+
+      should "clear webauthn_authentication in session" do
+        assert_nil session[:webauthn_authentication]
+      end
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+end


### PR DESCRIPTION
## What problem are you solving?
There's a lot of duplication of the WebAuthn verification logic between the sessions, email confirmation, password and webauthn verification controllers.

## What approach did you choose and why?
Created a controller concern `WebauthnVerifiable` that extracts the behaviour of 

1. Setting up webauthn verification by storing the challenge in the session and setting the json options for authentication.
2. Verifying the webauthn credential using the challenge and credential params

All behaviour should remain the same, commits would show how the all logic is consolidated into the concern.

## What should reviewers focus on?
- Better refactors
- Areas where behaviour will be different
- I created a mock controller and temporary routes to test the concern to isolate testing that logic + gives an example of the interface. The concern is already indirectly tested through the other controllers.

## Testing
Should be able to MFA using webauthn when signing in, reset password, change email and gem signin