### PR TITLE
Introduce SHA-256 based Digest header for Compact Index API responses.

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -29,6 +29,7 @@ class Api::CompactIndexController < Api::BaseController
 
   def render_range(response_body)
     headers["ETag"] = '"' << Digest::MD5.hexdigest(response_body) << '"'
+    headers["Digest"] = "sha-256=#{Digest::SHA256.hexdigest(response_body)}"
     headers["Accept-Ranges"] = "bytes"
 
     ranges = Rack::Utils.byte_ranges(request.env, response_body.bytesize)

--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -29,7 +29,7 @@ class Api::CompactIndexController < Api::BaseController
 
   def render_range(response_body)
     headers["ETag"] = '"' << Digest::MD5.hexdigest(response_body) << '"'
-    headers["Digest"] = "sha-256=#{Digest::SHA256.hexdigest(response_body)}"
+    headers["Digest"] = "sha-256=#{Base64.encode64(Digest::SHA256.digest(response_body)).strip}"
     headers["Accept-Ranges"] = "bytes"
 
     ranges = Rack::Utils.byte_ranges(request.env, response_body.bytesize)

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -7,7 +7,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
   end
 
   def digest(body)
-    "sha-256=#{Digest::SHA256.hexdigest(body)}"
+    "sha-256=#{Base64.encode64(Digest::SHA256.digest(body)).strip}"
   end
 
   setup do


### PR DESCRIPTION
:information_source: PR to use this in bundler compact index client will follow, but this can be merged and deploy on its own.

@misdoro This is initial step on the road to properly handle ETag as reported at https://github.com/rubygems/rubygems/pull/6632.