### PR TITLE
Handle ArgumentError in User.normalize_email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,13 @@ class User < ApplicationRecord
     where(ownerships: { ownership_request_notifier: true })
   end
 
+  def self.normalize_email(email)
+    super
+  rescue ArgumentError => e
+    Rails.error.report(e, handled: true)
+    ""
+  end
+
   def name
     handle || email
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -833,4 +833,14 @@ class UserTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context ".normalize_email" do
+    should "return the normalized email" do
+      assert_equal "user@example.com", User.normalize_email(:"UsEr@ example . COM")
+    end
+
+    should "return an empty string on invalid inputs" do
+      assert_equal "", User.normalize_email("\u9999".force_encoding("ascii"))
+    end
+  end
 end


### PR DESCRIPTION
To stop 500s that are happening due to errors when calling `downcase` in .normalize_email from Rack::Attack