### PR TITLE
Cache activities API endpoint

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -16,6 +16,9 @@ class Api::V1::ActivitiesController < Api::BaseController
       version.rubygem.payload(version)
     end
 
+    set_surrogate_key "api/v1/activities"
+    cache_expiry_headers
+
     respond_to do |format|
       format.json { render json: rubygems }
       format.yaml { render yaml: rubygems }

--- a/lib/gem_cache_purger.rb
+++ b/lib/gem_cache_purger.rb
@@ -10,5 +10,6 @@ class GemCachePurger
     FastlyPurgeJob.perform_later(path: "versions", soft: true)
     FastlyPurgeJob.perform_later(path: "gem/#{gem_name}", soft: true)
     FastlyPurgeJob.perform_later(key: "gem/#{gem_name}", soft: true)
+    FastlyPurgeJob.perform_later(key: "api/v1/activities", soft: true)
   end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -326,7 +326,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         end
         should "enqueue jobs" do
           assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
-            assert_enqueued_jobs 5, only: FastlyPurgeJob do
+            assert_enqueued_jobs 6, only: FastlyPurgeJob do
               assert_enqueued_jobs 1, only: NotifyWebHookJob do
                 assert_enqueued_jobs 1, only: Indexer do
                   assert_enqueued_jobs 1, only: ReindexRubygemJob do

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -96,7 +96,7 @@ class DeletionTest < ActiveSupport::TestCase
 
   should "enque job for updating ES index, spec index and purging cdn" do
     assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
-      assert_enqueued_jobs 7, only: FastlyPurgeJob do
+      assert_enqueued_jobs 8, only: FastlyPurgeJob do
         assert_enqueued_jobs 1, only: Indexer do
           assert_enqueued_jobs 1, only: ReindexRubygemJob do
             delete_gem

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -512,7 +512,7 @@ class PusherTest < ActiveSupport::TestCase
 
     should "enqueue job for email, updating ES index, spec index and purging cdn" do
       assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
-        assert_enqueued_jobs 5, only: FastlyPurgeJob do
+        assert_enqueued_jobs 6, only: FastlyPurgeJob do
           assert_enqueued_jobs 1, only: Indexer do
             assert_enqueued_jobs 1, only: ReindexRubygemJob do
               @cutter.save


### PR DESCRIPTION
DataDog shows that the queries for these endpoints can take quite a while, so cache the responses & purge when gems are pushed