### PR TITLE
Stop deleting `pusher_id` on versions when the parent user is deleted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
   has_many :subscribed_gems, -> { order("name ASC") }, through: :subscriptions, source: :rubygem
 
-  has_many :pushed_versions, -> { by_created_at }, dependent: :nullify, inverse_of: :pusher, class_name: "Version", foreign_key: :pusher_id
+  has_many :pushed_versions, -> { by_created_at }, inverse_of: :pusher, class_name: "Version", foreign_key: :pusher_id
 
   has_many :deletions, dependent: :nullify
   has_many :web_hooks, dependent: :destroy

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -843,4 +843,19 @@ class UserTest < ActiveSupport::TestCase
       assert_equal "", User.normalize_email("\u9999".force_encoding("ascii"))
     end
   end
+
+  context ".pushed_versions" do
+    setup do
+      @user = create(:user)
+      @version = create(:version, pusher: @user)
+    end
+    should "return version objects for each version the user has pushed" do
+      assert_includes @user.pushed_versions, @version
+    end
+
+    should "not delete pusher_id from Version when deleted" do
+      @user.destroy!
+      assert_equal @user.id, @version.reload.pusher_id
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR deletes the `dependent: :nullify` option that, when a User was deleted, was setting the `pusher_id` of all their `Version` objects to nil.

## Risks

This approach does not add any risk (since the IDs are opaque), but it does create the somewhat strange condition that there will be `Version`s pointing at non-existent users. Rails handles this for optional relationships by simply returning `nil` as if there isn't an ID at all, which is fine. The alternative approach would be to switch to soft-deletion for users. However, this could present its own set of problems due to the retention of "private" data past the user's explicit request to delete it.

For now, I propose we stop nulling out the ID, and leave soft-deletion to another PR.