### PR TITLE
Typo fix for EMAIL_TOKEN_EXPIRES_AFTER

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,7 +190,7 @@ class User < ApplicationRecord
   def generate_confirmation_token(reset_unconfirmed_email: true)
     self.unconfirmed_email = nil if reset_unconfirmed_email
     self.confirmation_token = Clearance::Token.new
-    self.token_expires_at = Time.zone.now + Gemcutter::EMAIL_TOKEN_EXPRIES_AFTER
+    self.token_expires_at = Time.zone.now + Gemcutter::EMAIL_TOKEN_EXPIRES_AFTER
   end
 
   def _generate_confirmation_token_no_reset_unconfirmed_email

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,7 +65,7 @@ module Gemcutter
 
   DEFAULT_PAGE = 1
   DEFAULT_PAGINATION = 20
-  EMAIL_TOKEN_EXPRIES_AFTER = 3.hours
+  EMAIL_TOKEN_EXPIRES_AFTER = 3.hours
   HOST = config["host"]
   NEWS_DAYS_LIMIT = 7.days
   NEWS_MAX_PAGES = 10


### PR DESCRIPTION
Typo fix for EMAIL_TOKEN_EXPIRES_AFTER

`EMAIL_TOKEN_EXPRIES_AFTER => EMAIL_TOKEN_EXPIRES_AFTER`