### PR TITLE
Lengthen max-age in fastly surrogate-control for /versions

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -9,7 +9,7 @@ class Api::CompactIndexController < Api::BaseController
 
   def versions
     set_surrogate_key "versions"
-    cache_expiry_headers(fastly_expiry: 30)
+    cache_expiry_headers
     versions_path = Rails.application.config.rubygems["versions_file_location"]
     versions_file = CompactIndex::VersionsFile.new(versions_path)
     from_date = versions_file.updated_at

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -132,7 +132,7 @@ class CompactIndexTest < ActionDispatch::IntegrationTest
     get versions_path
 
     assert_equal "versions", @response.headers["Surrogate-Key"]
-    assert_equal "max-age=30, stale-while-revalidate=15, stale-if-error=15", @response.headers["Surrogate-Control"]
+    assert_equal "max-age=3600, stale-while-revalidate=1800, stale-if-error=1800", @response.headers["Surrogate-Control"]
   end
 
   test "/info with existing gem" do


### PR DESCRIPTION
Because we explicitly purge when new context is available, allow fastly to cache for more than 30/45s, preventing a thundering herd when that time limit expires and fastly is no longer able to use request coalescing to give us a single request to respond to