### PR TITLE
Increase the number of puma threads from 1 to 5

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,10 +7,9 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-# max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
-# min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
-# threads min_threads_count, max_threads_count
-threads 1, 1 # TODO: switch to threaded after initial puma deploy
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
 
 require "concurrent"
 


### PR DESCRIPTION
Currently, we place a hard limit on puma to have a thread pool size of 1. This means a single worker is only responding to a single request at any one time. We want to make better use of our available resources to reduce the number of requests being queued during peak times.

