### PR TITLE
Dont set acl when putting objects into compact-index bucket

### DIFF
--- a/app/jobs/upload_versions_file_job.rb
+++ b/app/jobs/upload_versions_file_job.rb
@@ -28,6 +28,7 @@ class UploadVersionsFileJob < ApplicationJob
 
     response = RubygemFs.compact_index.store(
       "versions", response_body,
+      public_acl: false, # the compact-index bucket does not have ACLs enabled
       metadata: { "surrogate-key" => "versions s3-compact-index s3-versions" },
       cache_control: "max-age=60, public",
       content_type: "text/plain; charset=utf-8",

--- a/lib/rubygem_fs.rb
+++ b/lib/rubygem_fs.rb
@@ -61,7 +61,7 @@ module RubygemFs
       self.class.new(path_for(dir))
     end
 
-    def store(key, body, **kwargs)
+    def store(key, body, public_acl: true, **kwargs) # rubocop:disable Lint/UnusedMethodArgument
       path = path_for key
       @metadata&.store(key, JSON.generate(kwargs.merge(key: key))) if kwargs.present?
       path.dirname.mkpath
@@ -160,12 +160,12 @@ module RubygemFs
       self.class.new(@config.merge(bucket: bucket))
     end
 
-    def store(key, body, metadata: {}, **kwargs)
+    def store(key, body, public_acl: true, metadata: {}, **kwargs)
       allowed_args = kwargs.slice(:content_type, :checksum_sha256, :content_encoding, :cache_control, :content_md5)
       s3.put_object(key: key,
                     body: body,
                     bucket: bucket,
-                    acl: "public-read",
+                    acl: public_acl ? "public-read" : nil,
                     metadata: metadata,
                     cache_control: "max-age=31536000",
                     **allowed_args)


### PR DESCRIPTION
The bucket does not have acls enabled, all access is controlled via IAM policies

Confirmed uploads work to the staging compact-index bucket without an acl