### PR TITLE
Add mailers for user MFA updates

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -113,6 +113,14 @@ class Mailer < ApplicationMailer
       subject: I18n.t("mailer.webauthn_credential_removed.subject")
   end
 
+  def mfa_enabled(user_id, enabled_at)
+    @user = User.find(user_id)
+    @enabled_at = enabled_at
+
+    mail to: @user.email,
+      subject: I18n.t("mailer.mfa_enabled.subject")
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -121,6 +121,14 @@ class Mailer < ApplicationMailer
       subject: I18n.t("mailer.mfa_enabled.subject")
   end
 
+  def mfa_disabled(user_id, disabled_at)
+    @user = User.find(user_id)
+    @disabled_at = disabled_at
+
+    mail to: @user.email,
+      subject: I18n.t("mailer.mfa_disabled.subject")
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -13,6 +13,7 @@ module UserMultifactorMethods
       self.mfa_seed = ""
       self.mfa_recovery_codes = []
       save!(validate: false)
+      Mailer.mfa_disabled(id, Time.now.utc).deliver_later
     end
 
     def verify_and_enable_mfa!(seed, level, otp, expiry)

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -30,6 +30,7 @@ module UserMultifactorMethods
       self.mfa_seed = seed
       self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
       save!(validate: false)
+      Mailer.mfa_enabled(id, Time.now.utc).deliver_later
     end
 
     def mfa_gem_signin_authorized?(otp)

--- a/app/views/mailer/mfa_disabled.html.erb
+++ b/app/views/mailer/mfa_disabled.html.erb
@@ -1,0 +1,35 @@
+<% @title = t("mailer.mfa_disabled.title") %>
+<% @sub_title = t("mailer.mfa_disabled.subtitle", handle: @user.handle) %>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Multi-factor authentication has been disabled for your account on RubyGems.org.
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+        <p>
+          Disabled at: <strong><%= @disabled_at.to_formatted_s(:rfc822) %></strong>
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+        <p>If you did disable MFA on your account, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this change to your settings is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+
+        <%= render "compromised_instructions" %>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>

--- a/app/views/mailer/mfa_enabled.html.erb
+++ b/app/views/mailer/mfa_enabled.html.erb
@@ -1,0 +1,35 @@
+<% @title = t("mailer.mfa_enabled.title") %>
+<% @sub_title = t("mailer.mfa_enabled.subtitle", handle: @user.handle) %>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Multi-factor authentication has been enabled for your account on RubyGems.org.
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+        <p>
+          Enabled at: <strong><%= @enabled_at.to_formatted_s(:rfc822) %></strong>
+        </p>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+        <p>If you did enable MFA on your account, you do not need to take further action. Please keep your MFA recovery codes in a secure location.</p>
+        <p>
+          <strong>Only if this change to your settings is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+
+        <%= render "compromised_instructions" %>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -223,6 +223,14 @@ de:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,10 @@ en:
       subject: Multi-factor authentication enabled on RubyGems.org
       title: MFA ENABLED
       subtitle: Hi %{handle}!
+    mfa_disabled:
+      subject: Multi-factor authentication disabled on RubyGems.org
+      title: MFA DISABLED
+      subtitle: Hi %{handle}!
     email_reset_update:
       subject: You have requested email address update on RubyGems.org
       title: EMAIL UPDATE REQUESTED

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,10 @@ en:
       subject: Security device removed on RubyGems.org
       title: SECURITY DEVICE REMOVED
       subtitle: Hi %{handle}!
+    mfa_enabled:
+      subject: Multi-factor authentication enabled on RubyGems.org
+      title: MFA ENABLED
+      subtitle: Hi %{handle}!
     email_reset_update:
       subject: You have requested email address update on RubyGems.org
       title: EMAIL UPDATE REQUESTED

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -241,6 +241,14 @@ es:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -243,6 +243,14 @@ fr:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -225,6 +225,14 @@ ja:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -228,6 +228,14 @@ nl:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -240,6 +240,14 @@ pt-BR:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -222,6 +222,14 @@ zh-CN:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -222,6 +222,14 @@ zh-TW:
       subject:
       title:
       subtitle:
+    mfa_enabled:
+      subject:
+      title:
+      subtitle:
+    mfa_disabled:
+      subject:
+      title:
+      subtitle:
     email_reset_update:
       subject:
       title:

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -185,4 +185,16 @@ class MailerPreview < ActionMailer::Preview
 
     Mailer.webauthn_credential_removed(user_id, webauthn_credential_nickname, Time.now.utc)
   end
+
+  def mfa_enabled
+    user_id = User.last.id
+
+    Mailer.mfa_enabled(user_id, Time.now.utc)
+  end
+
+  def mfa_disabled
+    user_id = User.last.id
+
+    Mailer.mfa_disabled(user_id, Time.now.utc)
+  end
 end


### PR DESCRIPTION
At the moment, when enabling/disabling [MFA (OTP)](https://guides.rubygems.org/setting-up-otp-mfa/) on an account, the user does not receive an email. This PR adds a `mfa_enabled` and `mfa_disabled` mailer.

## Testing

1. Setup OTP MFA at http://localhost:3000/settings/edit
2. Go to http://localhost:3000/letter_opener and verify MFA Enabled mailer was sent
3. Disable OTP MFA at http://localhost:3000/settings/edit
4. Go to http://localhost:3000/letter_opener and verify MFA Disabled mailer was sent

---

Thank you @jenshenny for pairing on this!

Closes https://github.com/rubygems/rubygems.org/issues/3729