### PR TITLE
push back final API disable by 2 weeks

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -18,8 +18,8 @@ class Api::V1::DependenciesController < Api::BaseController
     [Time.utc(2023, 5, 3), 1.day],
     [Time.utc(2023, 5, 5), 1.day]
   ].map { |start, duration| start..(start + duration) } <<
-    # May 10 from 00:00 UTC onward
-    (Time.utc(2023, 5, 10)...)
+    # May 24 from 00:00 UTC onward
+    (Time.utc(2023, 5, 24)...)
 
   def index
     deps = GemDependent.new(gem_names).to_a


### PR DESCRIPTION
We were asked to provide additional time for some users to try to
execute remediation actions with their customers.