### PR TITLE
Ensure x-amz-meta-Surrogate-Control is set for /versions from S3

### DIFF
--- a/app/jobs/upload_versions_file_job.rb
+++ b/app/jobs/upload_versions_file_job.rb
@@ -30,6 +30,7 @@ class UploadVersionsFileJob < ApplicationJob
       "versions", response_body,
       public_acl: false, # the compact-index bucket does not have ACLs enabled
       metadata: {
+        "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
         "surrogate-key" => "versions s3-compact-index s3-versions",
         "sha256" => checksum_sha256,
         "md5" => content_md5

--- a/test/jobs/upload_versions_file_job_test.rb
+++ b/test/jobs/upload_versions_file_job_test.rb
@@ -21,6 +21,7 @@ class UploadVersionsFileJobTest < ActiveJob::TestCase
     assert_equal(
       {
         metadata: {
+          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
           "surrogate-key" => "versions s3-compact-index s3-versions",
           "sha256" => Digest::SHA256.base64digest(content),
           "md5" => Digest::MD5.base64digest(content)


### PR DESCRIPTION
This should help fastly not 503 when downloading the S3 compact index files