### PR TITLE
Add some final brownout dates before May 24

### DIFF
--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -16,7 +16,13 @@ class Api::V1::DependenciesController < Api::BaseController
     [Time.utc(2023, 4, 24), 1.day],
     [Time.utc(2023, 5, 1), 1.day],
     [Time.utc(2023, 5, 3), 1.day],
-    [Time.utc(2023, 5, 5), 1.day]
+    [Time.utc(2023, 5, 5), 1.day],
+    # May 12, 15, 17, 19, 22 for the entire day UTC
+    [Time.utc(2023, 5, 12), 1.day],
+    [Time.utc(2023, 5, 15), 1.day],
+    [Time.utc(2023, 5, 17), 1.day],
+    [Time.utc(2023, 5, 19), 1.day],
+    [Time.utc(2023, 5, 22), 1.day]
   ].map { |start, duration| start..(start + duration) } <<
     # May 24 from 00:00 UTC onward
     (Time.utc(2023, 5, 24)...)
@@ -39,6 +45,11 @@ class Api::V1::DependenciesController < Api::BaseController
   end
 
   def check_brownout
+    # Unfortunately Rails itself overwrites the Vary header anytime the request includes an Accept header,
+    # as seen in https://github.com/rails/rails/pull/36213/files. We'll have to update the Vary header in Fastly
+    # instead of being able to set it here.
+    # self.headers["Vary"] = [headers["Vary"], "x-dependency-api-allowed"].compact.join(", ")
+
     return if Patterns::JAVA_HTTP_USER_AGENT.match?(request.user_agent)
 
     current_time = Time.current.utc

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::DependenciesController < Api::BaseController
   before_action :check_brownout
   before_action :check_gem_count
-  after_action :vary_on_allowed_header
 
   mattr_reader :brownout_ranges, default: [
     # March 22 at 00:00 UTC (4pm PT / 7pm ET) for 5 minutes
@@ -60,7 +59,8 @@ class Api::V1::DependenciesController < Api::BaseController
     end
   end
 
-  def vary_on_allowed_header
+  def _set_vary_header
+    super
     self.headers["Vary"] = [headers["Vary"], "x-dependency-api-allowed"].compact.join(", ")
   end
 

--- a/app/controllers/api/v1/dependencies_controller.rb
+++ b/app/controllers/api/v1/dependencies_controller.rb
@@ -45,6 +45,7 @@ class Api::V1::DependenciesController < Api::BaseController
   end
 
   def check_brownout
+    return if request.headers["x-dependency-api-allowed"]
     return if Patterns::JAVA_HTTP_USER_AGENT.match?(request.user_agent)
 
     current_time = Time.current.utc
@@ -61,7 +62,7 @@ class Api::V1::DependenciesController < Api::BaseController
 
   def _set_vary_header
     super
-    self.headers["Vary"] = [headers["Vary"], "x-dependency-api-allowed"].compact.join(", ")
+    headers["Vary"] = [headers["Vary"], "x-dependency-api-allowed"].compact.join(", ")
   end
 
   def check_gem_count

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -261,7 +261,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         }
 
         assert_equal result, JSON.load(response.body)
-        assert_equal "x-dependency-api-allowed", @response.headers["Vary"]
+        assert_equal "Accept, x-dependency-api-allowed", @response.headers["Vary"]
       end
     end
 

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -224,26 +224,18 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     end
 
     context "with Java user agent" do
-      setup do
+      should "return 200" do
         request.user_agent = "Java/1.2.3"
         get :index, params: { gems: "" }, format: "json"
-      end
-
-      should "return 200" do
         assert_response :success
+        assert_equal "x-dependency-api-allowed", @response.headers["Vary"]
       end
     end
 
     context "with empty gems param --> JSON" do
-      setup do
-        get :index, params: { gems: "" }, format: "json"
-      end
-
       should "return 404" do
+        get :index, params: { gems: "" }, format: "json"
         assert_response :not_found
-      end
-
-      should "return body" do
         result = {
           "error" => "The dependency API is going away. See " \
                      "https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html " \
@@ -252,19 +244,31 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
         }
 
         assert_equal result, JSON.load(response.body)
+        assert_equal "x-dependency-api-allowed", @response.headers["Vary"]
+      end
+    end
+
+    context "with gems param and Accept --> JSON" do
+      should "return 404" do
+        request.headers["Accept"] = "application/json"
+        get :index, params: { gems: "testgem" }
+        assert_response :not_found
+        result = {
+          "error" => "The dependency API is going away. See " \
+                     "https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html " \
+                     "for more information",
+          "code" => 404
+        }
+
+        assert_equal result, JSON.load(response.body)
+        assert_equal "x-dependency-api-allowed", @response.headers["Vary"]
       end
     end
 
     context "with gems --> Marshal" do
-      setup do
+      should "return 404" do
         get :index, params: { gems: "testgem" }, format: "marshal"
-      end
-
-      should "return 200" do
         assert_response :not_found
-      end
-
-      should "return error body" do
         assert_equal "The dependency API is going away. See " \
                      "https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html " \
                      "for more information",

--- a/test/functional/api/v1/dependencies_controller_test.rb
+++ b/test/functional/api/v1/dependencies_controller_test.rb
@@ -227,6 +227,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
       should "return 200" do
         request.user_agent = "Java/1.2.3"
         get :index, params: { gems: "" }, format: "json"
+
         assert_response :success
         assert_equal "x-dependency-api-allowed", @response.headers["Vary"]
       end
@@ -235,6 +236,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     context "with empty gems param --> JSON" do
       should "return 404" do
         get :index, params: { gems: "" }, format: "json"
+
         assert_response :not_found
         result = {
           "error" => "The dependency API is going away. See " \
@@ -252,6 +254,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
       should "return 404" do
         request.headers["Accept"] = "application/json"
         get :index, params: { gems: "testgem" }
+
         assert_response :not_found
         result = {
           "error" => "The dependency API is going away. See " \
@@ -268,6 +271,7 @@ class Api::V1::DependenciesControllerTest < ActionController::TestCase
     context "with gems --> Marshal" do
       should "return 404" do
         get :index, params: { gems: "testgem" }, format: "marshal"
+
         assert_response :not_found
         assert_equal "The dependency API is going away. See " \
                      "https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html " \


### PR DESCRIPTION
Now that we've heard from effected groups of users and agreed on a path forward, set some final brownout dates before the dependency API is shut off for non-Java users. For Java users, we read a header from Fastly to bypass the block (and include that header in `Vary` so Fastly can cache the responses correctly). Those users should not be impacted by these brownout dates, and will instead lose access on August 8, 2023.

