### PR TITLE
Add development environment a default mailer port configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,7 @@ Metrics/BlockLength:
     - lib/github_oauthable.rb
     - app/models/concerns/**/*.rb
     - config/routes.rb
+    - config/environments/development.rb
 
 Metrics/ClassLength:
   Max: 356 # TODO: Lower to 100

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: Gemcutter::HOST,
+                                               port: ENV.fetch("PORT", "3000"),
                                                protocol: Gemcutter::PROTOCOL }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: Gemcutter::HOST,
+                                               port: "31337",
                                                protocol: Gemcutter::PROTOCOL }
 
   # Print deprecation notices to the stderr.

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -15,7 +15,7 @@ module EmailHelpers
   def confirmation_link
     refute_empty ActionMailer::Base.deliveries
     body = last_email.parts[1].body.decoded.to_s
-    link = %r{http://localhost/email_confirmations([^";]*)}.match(body)
+    link = %r{http://localhost(?::\d+)?/email_confirmations([^";]*)}.match(body)
     link[0]
   end
 end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -5,7 +5,7 @@ class PasswordResetTest < SystemTest
 
   def password_reset_link
     body = ActionMailer::Base.deliveries.last.parts[1].body.decoded.to_s
-    link = %r{http://localhost/users([^";]*)}.match(body)
+    link = %r{http://localhost(?::\d+)?/users([^";]*)}.match(body)
     link[0]
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,7 @@ WebMock.disable_net_connect!(
 Capybara.default_max_wait_time = 2
 Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
 Capybara.always_include_port = true
+Capybara.server_port = 31_337
 Capybara.server = :puma
 
 GoodJob::Execution.delete_all


### PR DESCRIPTION
At the moment, when opening a mailer link in development mode it does not include the port so it has to be manually added. This PR addresses such problem by adding a default port in the configuration.

- A constant created within the Gemcutter module is possible, but decided to minimize changes.
- Only changed development and test environment to minimize modifications.
- Used a default port on test environment to test the URL link does contain the port but can be removed and will work, there just won't be a test for it.
- This PR does not address starting the app with a custom port like `rails s -p 3001` as considering such scenario requires code that could be considered "[hacky](https://stackoverflow.com/a/45047326)".

# Testing
1. Go to http://localhost:3001/rails/mailers/
1. Open a mailer that contains a link to the application
1. Verify that the link contains the current application port

---

Closes https://github.com/rubygems/rubygems.org/issues/3728