### PR TITLE
Rename user OTP methods to reference OTP instead of MFA [2/4]

### DIFF
--- a/app/avo/actions/reset_user_2fa.rb
+++ b/app/avo/actions/reset_user_2fa.rb
@@ -12,7 +12,7 @@ class ResetUser2fa < BaseAction
 
   class ActionHandler < ActionHandler
     def handle_model(user)
-      user.disable_mfa!
+      user.disable_otp!
       user.password = SecureRandom.hex(20).encode("UTF-8")
       user.save!
     end

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -14,7 +14,7 @@ class MultifactorAuthsController < ApplicationController
   end
 
   def create
-    current_user.verify_and_enable_mfa!(@seed, :ui_and_api, otp_param, @expire)
+    current_user.verify_and_enable_otp!(@seed, :ui_and_api, otp_param, @expire)
     if current_user.errors.any?
       flash[:error] = current_user.errors[:base].join
       redirect_to edit_settings_url

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -76,7 +76,7 @@ class MultifactorAuthsController < ApplicationController
     case level_param
     when "disabled"
       flash[:success] = t("multifactor_auths.destroy.success")
-      current_user.disable_mfa!
+      current_user.disable_otp!
     when "ui_only"
       flash[:error] = t("multifactor_auths.ui_only_warning")
     else

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -13,13 +13,13 @@ module UserOtpMethods
     if expiry < Time.now.utc
       errors.add(:base, I18n.t("multifactor_auths.create.qrcode_expired"))
     elsif verify_digit_otp(seed, otp)
-      enable_mfa!(seed, level)
+      enable_otp!(seed, level)
     else
       errors.add(:base, I18n.t("multifactor_auths.incorrect_otp"))
     end
   end
 
-  def enable_mfa!(seed, level)
+  def enable_otp!(seed, level)
     self.mfa_level = level
     self.mfa_seed = seed
     self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -9,7 +9,7 @@ module UserOtpMethods
     Mailer.mfa_disabled(id, Time.now.utc).deliver_later
   end
 
-  def verify_and_enable_mfa!(seed, level, otp, expiry)
+  def verify_and_enable_otp!(seed, level, otp, expiry)
     if expiry < Time.now.utc
       errors.add(:base, I18n.t("multifactor_auths.create.qrcode_expired"))
     elsif verify_digit_otp(seed, otp)

--- a/app/models/concerns/user_otp_methods.rb
+++ b/app/models/concerns/user_otp_methods.rb
@@ -1,7 +1,7 @@
 module UserOtpMethods
   extend ActiveSupport::Concern
 
-  def disable_mfa!
+  def disable_otp!
     mfa_disabled!
     self.mfa_seed = ""
     self.mfa_recovery_codes = []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,7 +222,7 @@ class User < ApplicationRecord
     transaction do
       update_attribute(:email, "security+locked-#{SecureRandom.hex(4)}-#{display_handle.downcase}@rubygems.org")
       confirm_email!
-      disable_mfa!
+      disable_otp!
       update_attribute(:password, SecureRandom.alphanumeric)
       update!(
         remember_token: nil,

--- a/script/disable_mfa
+++ b/script/disable_mfa
@@ -15,7 +15,7 @@ require_relative "../config/environment"
 begin
   user = User.find_by_name(name)
   puts "Found user: #{user.handle} #{user.email}"
-  user.disable_mfa!
+  user.disable_otp!
   user.password = SecureRandom.hex(20).encode("UTF-8")
   user.save!
   puts "Done."

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -224,7 +224,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     context "when user has enabled MFA for UI and API" do
       setup do
         @user = create(:user)
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
@@ -234,7 +234,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     context "when user has enabled MFA for UI and gem signin" do
       setup do
         @user = create(:user)
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
@@ -383,7 +383,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     context "when a user provides an OTP code" do
       setup do
         @user = create(:user)
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
         authorize_with("#{@user.email}:#{@user.password}")
         @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
         post :create, params: { name: "test-key", index_rubygems: "true" }, format: "text"
@@ -431,7 +431,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
     context "when user has enabled MFA for UI and API" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
@@ -440,7 +440,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
     context "when user has enabled MFA for UI and gem signin" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
@@ -473,7 +473,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
       context "by user on `ui_only` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           post :create, params: { name: "test-key", index_rubygems: "true" }, format: "text"
         end
 
@@ -492,7 +492,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_gem_signin` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           post :create, params: { name: "test-key", index_rubygems: "true" }, format: "text"
         end
 
@@ -505,7 +505,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_api` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           post :create, params: { name: "test-key", index_rubygems: "true" }, format: "text"
         end
 
@@ -579,7 +579,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
     context "when user has enabled MFA for UI and API" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 
@@ -588,7 +588,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
 
     context "when user has enabled MFA for UI and gem signin" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
         authorize_with("#{@user.email}:#{@user.password}")
       end
 

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -40,7 +40,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "when mfa for UI and API is enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "ON DELETE to create for existing gem version without OTP" do
@@ -82,7 +82,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
       context "when mfa for UI only is enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         context "api key has mfa enabled" do
@@ -110,7 +110,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "when user has mfa enabled" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
             delete :create, params: { gem_name: @rubygem.to_param, version: @v1.number }
           end
@@ -202,7 +202,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
             delete :create, params: { gem_name: @rubygem.name, version: @v1.number }
           end
 
@@ -222,7 +222,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
             delete :create, params: { gem_name: @rubygem.name, version: @v1.number }
           end
 
@@ -235,7 +235,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
             delete :create, params: { gem_name: @rubygem.name, version: @v1.number }
           end
@@ -304,7 +304,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` mfa level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "include change mfa level warning" do
@@ -327,7 +327,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` mfa level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not include mfa warnings" do
@@ -345,7 +345,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` mfa level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           end
 
           should "not include mfa warnings" do

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -113,7 +113,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
       context "when mfa for UI and API is enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "array of emails" do
@@ -174,7 +174,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
       context "when mfa for UI only is enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         context "api key has mfa enabled" do
@@ -253,7 +253,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "api user has enabled mfa" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 
@@ -376,7 +376,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "block adding the owner" do
@@ -397,7 +397,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not show error message" do
@@ -411,7 +411,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 
@@ -449,7 +449,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "include change mfa level warning" do
@@ -470,7 +470,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not include MFA warnings" do
@@ -485,7 +485,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 
@@ -542,7 +542,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
       context "when mfa for UI and API is enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "removing gem owner without OTP" do
@@ -639,7 +639,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "api user has enabled mfa" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 
@@ -742,7 +742,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "block adding the owner" do
@@ -763,7 +763,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not show error message" do
@@ -777,7 +777,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 
@@ -815,7 +815,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "include change mfa level warning" do
@@ -836,7 +836,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not include mfa warnings" do
@@ -851,7 +851,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         context "by user on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
             @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           end
 

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -112,7 +112,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
           context "when mfa is enabled" do
             context "on `ui_only` level" do
               setup do
-                @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+                @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
                 get :me, format: format
               end
 
@@ -128,7 +128,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
 
             context "on `ui_and_gem_signin` level" do
               setup do
-                @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+                @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
                 get :me, format: format
               end
 
@@ -142,7 +142,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
 
             context "on `ui_and_api` level" do
               setup do
-                @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+                @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
                 get :me, format: format
               end
 

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -216,7 +216,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "When mfa for UI and API is enabled" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
       end
 
       context "On post to create for new gem without OTP" do
@@ -254,7 +254,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "When mfa for UI and gem signin is enabled" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
       end
 
       context "Api key has mfa enabled" do
@@ -476,7 +476,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
     context "new gem with correct OTP" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
         post :create, body: gem_file("mfa-required-1.0.0.gem").read
       end
@@ -505,7 +505,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user with mfa" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           post :create, body: gem_file("mfa-required-1.0.0.gem").read
         end
@@ -539,7 +539,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user with mfa" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           post :create, body: gem_file("test-1.0.0.gem").read
         end
@@ -581,7 +581,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_only` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           post :create, body: gem_file("test-1.0.0.gem").read
         end
 
@@ -601,7 +601,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_gem_signin` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           post :create, body: gem_file("test-1.0.0.gem").read
         end
 
@@ -614,7 +614,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_api` level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           post :create, body: gem_file("test-1.0.0.gem").read
         end
@@ -651,7 +651,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_only` mfa level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           post :create, body: gem_file("test-1.0.0.gem").read
         end
 
@@ -670,7 +670,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_gem_signin` mfa level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           post :create, body: gem_file("test-1.0.0.gem").read
         end
@@ -685,7 +685,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       context "by user on `ui_and_api` mfa level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.mfa_seed).now
           post :create, body: gem_file("test-1.0.0.gem").read
         end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -344,7 +344,7 @@ path: "/profile/api_keys/1" },
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         redirect_scenarios.each do |label, request_params|
@@ -362,7 +362,7 @@ path: "/profile/api_keys/1" },
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "on DELETE to reset" do

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -130,7 +130,7 @@ class DashboardsControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           get :show
         end
 
@@ -143,7 +143,7 @@ class DashboardsControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           get :show
         end
 

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -105,7 +105,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     context "user has mfa enabled" do
       setup do
         @user = create(:user)
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
       end
 
       context "when OTP is correct" do
@@ -473,7 +473,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
         context "user has mfa set to weak level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           context "on GET to update" do
@@ -526,7 +526,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
         context "user has MFA set to strong level, expect normal behaviour" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           end
 
           context "on GET to update" do

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -12,7 +12,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
     context "when mfa enabled" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
       end
 
       context "on GET to new mfa" do
@@ -242,7 +242,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
       context "user has mfa set to weak level" do
         setup do
           @seed = ROTP::Base32.random_base32
-          @user.enable_mfa!(@seed, :ui_only)
+          @user.enable_otp!(@seed, :ui_only)
         end
 
         should "redirect user back to mfa_redirect_uri after successful mfa setup" do

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -47,7 +47,7 @@ class NotifiersControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         redirect_scenarios.each do |label, request_params|
@@ -65,7 +65,7 @@ class NotifiersControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "on GET to show" do

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -129,7 +129,7 @@ class OwnersControllerTest < ActionController::TestCase
 
           context "owner has enabled mfa" do
             setup do
-              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+              @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
               post :create, params: { handle: @new_owner.display_id, rubygem_id: @rubygem.name }
             end
 
@@ -254,7 +254,7 @@ class OwnersControllerTest < ActionController::TestCase
 
           context "owner has enabled mfa" do
             setup do
-              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+              @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
               delete :destroy, params: { handle: @second_user.display_id, rubygem_id: @rubygem.name }
             end
 

--- a/test/functional/ownership_calls_controller_test.rb
+++ b/test/functional/ownership_calls_controller_test.rb
@@ -174,7 +174,7 @@ class OwnershipCallsControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         context "on GET to index" do
@@ -213,7 +213,7 @@ class OwnershipCallsControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "on GET to index" do

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -317,7 +317,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         context "POST to create" do
@@ -365,7 +365,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
         context "POST to create" do
           setup { post :create, params: { rubygem_id: @rubygem.name, note: "small note" } }

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -75,7 +75,7 @@ class PasswordsControllerTest < ActionController::TestCase
     end
 
     context "with mfa enabled" do
-      setup { @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only) }
+      setup { @user.enable_otp!(ROTP::Base32.random_base32, :ui_only) }
 
       context "when OTP is correct" do
         setup do

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -290,7 +290,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         context "on GET to show" do
@@ -317,7 +317,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         end
 
         context "on GET to show" do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -4,7 +4,7 @@ class SessionsControllerTest < ActionController::TestCase
   context "when user has mfa enabled" do
     setup do
       @user = User.new(email_confirmed: true, handle: "test")
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     end
 
     context "on POST to create" do
@@ -226,7 +226,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           context "on `ui_only` level" do
             setup do
-              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+              @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
               post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
             end
 
@@ -244,7 +244,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           context "on `ui_and_gem_signin` level" do
             setup do
-              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+              @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
               post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
             end
 
@@ -254,7 +254,7 @@ class SessionsControllerTest < ActionController::TestCase
 
           context "on `ui_and_api` level" do
             setup do
-              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+              @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
               post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
             end
 
@@ -651,7 +651,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "user has mfa set to weak level" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
       end
 
       context "on GET to verify" do
@@ -677,7 +677,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "user has MFA set to strong level, expect normal behaviour" do
       setup do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
       end
 
       context "on GET to verify" do

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -36,7 +36,7 @@ class SettingsControllerTest < ActionController::TestCase
 
       context "user has mfa set to weak level" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           get :edit
         end
 
@@ -48,7 +48,7 @@ class SettingsControllerTest < ActionController::TestCase
 
       context "user has MFA set to strong level, expect normal behaviour" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           get :edit
         end
 

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -64,7 +64,7 @@ class EmailConfirmationTest < SystemTest
   end
 
   test "requesting confirmation mail with mfa enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     request_confirmation_mail @user.email
 
     link = last_email_link
@@ -103,7 +103,7 @@ class EmailConfirmationTest < SystemTest
   end
 
   test "requesting confirmation mail with mfa enabled, but mfa session is expired" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
     request_confirmation_mail @user.email
 
     link = last_email_link

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -102,7 +102,7 @@ class GemsSystemTest < SystemTest
   end
 
   test "shows owners without mfa when logged in as owner" do
-    @user.enable_mfa!("some-seed", "ui_and_api")
+    @user.enable_otp!("some-seed", "ui_and_api")
     user_without_mfa = create(:user, mfa_level: "disabled")
 
     create(:ownership, rubygem: @rubygem, user: @user)
@@ -115,7 +115,7 @@ class GemsSystemTest < SystemTest
   end
 
   test "show mfa enabled when logged in as owner but everyone has mfa enabled" do
-    @user.enable_mfa!("some-seed", "ui_and_api")
+    @user.enable_otp!("some-seed", "ui_and_api")
     user_with_mfa = create(:user, mfa_level: "ui_only")
 
     create(:ownership, rubygem: @rubygem, user: @user)
@@ -128,7 +128,7 @@ class GemsSystemTest < SystemTest
   end
 
   test "does not show owners without mfa when not logged in as owner" do
-    @user.enable_mfa!("some-seed", "ui_and_api")
+    @user.enable_otp!("some-seed", "ui_and_api")
     user_without_mfa = create(:user, mfa_level: "disabled")
 
     create(:ownership, rubygem: @rubygem, user: @user)

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -57,7 +57,7 @@ class OwnerTest < SystemTest
   end
 
   test "owners data is correctly represented" do
-    @other_user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    @other_user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
 
     visit_ownerships_page

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -85,7 +85,7 @@ class PasswordResetTest < SystemTest
   end
 
   test "restting password when mfa is enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     forgot_password_with @user.email
 
     visit password_reset_link
@@ -100,7 +100,7 @@ class PasswordResetTest < SystemTest
   end
 
   test "resetting a password when mfa is enabled but mfa session is expired" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
     forgot_password_with @user.email
 
     visit password_reset_link

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -158,7 +158,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
       context "ui requests" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           stay_under_exponential_limit("clearance/ip")
         end
 
@@ -194,7 +194,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
       context "api requests" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           stay_under_exponential_limit("api/ip")
 
           create(:api_key, key: "12334", add_owner: true, yank_rubygem: true, remove_owner: true, user: @user)
@@ -432,7 +432,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     context "exponential backoff" do
       setup do
         @mfa_max_period = { 1 => 300, 2 => 90_000 }
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         @api_key = "12345"
         create(:api_key, key: @api_key, user: @user)
       end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -206,20 +206,20 @@ class ApiKeyTest < ActiveSupport::TestCase
     end
 
     should "return true if mfa not enabled for api key" do
-      @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+      @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
 
       assert @api_key.mfa_authorized?(nil)
     end
 
     context "with totp" do
       should "return true when correct and mfa enabled" do
-        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
         assert @api_key.mfa_authorized?(ROTP::TOTP.new(@api_key.user.mfa_seed).now)
       end
 
       should "return false when incorrect and mfa enabled" do
-        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
         refute @api_key.mfa_authorized?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
       end
@@ -227,14 +227,14 @@ class ApiKeyTest < ActiveSupport::TestCase
 
     context "with webauthn otp" do
       should "return true when correct and mfa enabled" do
-        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         webauthn_verification = create(:webauthn_verification, user: @api_key.user)
 
         assert @api_key.mfa_authorized?(webauthn_verification.otp)
       end
 
       should "return false when incorrect and mfa enabled" do
-        @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
         create(:webauthn_verification, user: @api_key.user, otp: "jiEm2mm2sJtRqAVx7U1i")
         incorrect_otp = "Yxf57d1wEUSWyXrrLMRv"
 
@@ -257,7 +257,7 @@ class ApiKeyTest < ActiveSupport::TestCase
     end
 
     should "return mfa with MFA UI enabled user" do
-      @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
       refute_predicate @api_key, :mfa_enabled?
 
@@ -267,7 +267,7 @@ class ApiKeyTest < ActiveSupport::TestCase
     end
 
     should "return true with MFA UI and API enabled user" do
-      @api_key.user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+      @api_key.user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
       assert_predicate @api_key, :mfa_enabled?
 

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -15,7 +15,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     end
 
     should "return true if multifactor auth is disabled" do
-      @user.disable_mfa!
+      @user.disable_otp!
 
       refute_predicate @user, :mfa_enabled?
     end
@@ -143,7 +143,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     should "return false if instance owns a gem that exceeds recommended threshold and has mfa disabled" do
       create(:ownership, user: @user, rubygem: @popular_rubygem)
-      @user.disable_mfa!
+      @user.disable_otp!
 
       refute_predicate @user, :mfa_recommended_weak_level_enabled?
     end
@@ -202,7 +202,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     should "return false if instance owns a gem that exceeds required threshold and has mfa disabled" do
       create(:ownership, user: @user, rubygem: @popular_rubygem)
-      @user.disable_mfa!
+      @user.disable_otp!
 
       refute_predicate @user, :mfa_required_weak_level_enabled?
     end

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -9,7 +9,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
   context "#mfa_enabled" do
     should "return true if multifactor auth is not disabled" do
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
       assert_predicate @user, :mfa_enabled?
     end
@@ -22,7 +22,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     should "send mfa enabled email" do
       assert_emails 1 do
-        @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+        @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
       end
 
       assert_equal "Multi-factor authentication enabled on RubyGems.org", last_email.subject
@@ -37,19 +37,19 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     context "with totp" do
       should "return true when correct and if mfa is ui_and_api" do
-        @user.enable_mfa!(@seed, :ui_and_api)
+        @user.enable_otp!(@seed, :ui_and_api)
 
         assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
       end
 
       should "return true when correct and if mfa is ui_and_gem_signin" do
-        @user.enable_mfa!(@seed, :ui_and_gem_signin)
+        @user.enable_otp!(@seed, :ui_and_gem_signin)
 
         assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
       end
 
       should "return false when incorrect" do
-        @user.enable_mfa!(@seed, :ui_and_gem_signin)
+        @user.enable_otp!(@seed, :ui_and_gem_signin)
 
         refute @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
       end
@@ -57,14 +57,14 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     context "with webauthn otp" do
       should "return true when correct and if mfa is ui_and_api" do
-        @user.enable_mfa!(@seed, :ui_and_api)
+        @user.enable_otp!(@seed, :ui_and_api)
         webauthn_verification = create(:webauthn_verification, user: @user)
 
         assert @user.mfa_gem_signin_authorized?(webauthn_verification.otp)
       end
 
       should "return true when correct and if mfa is ui_and_gem_signin" do
-        @user.enable_mfa!(@seed, :ui_and_gem_signin)
+        @user.enable_otp!(@seed, :ui_and_gem_signin)
         webauthn_verification = create(:webauthn_verification, user: @user)
 
         assert @user.mfa_gem_signin_authorized?(webauthn_verification.otp)
@@ -77,7 +77,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
       end
 
       should "return false when incorrect" do
-        @user.enable_mfa!(@seed, :ui_and_gem_signin)
+        @user.enable_otp!(@seed, :ui_and_gem_signin)
         create(:webauthn_verification, user: @user, otp: "jiEm2mm2sJtRqAVx7U1i")
         incorrect_otp = "Yxf57d1wEUSWyXrrLMRv"
 
@@ -90,7 +90,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     end
 
     should "return true if mfa is ui_only" do
-      @user.enable_mfa!(@seed, :ui_only)
+      @user.enable_otp!(@seed, :ui_only)
 
       assert @user.mfa_gem_signin_authorized?(ROTP::TOTP.new(@seed).now)
     end
@@ -113,7 +113,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     should "return false if instance owns a gem that exceeds recommended threshold and has mfa enabled" do
       create(:ownership, user: @user, rubygem: @popular_rubygem)
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
       refute_predicate @user, :mfa_recommended_not_yet_enabled?
     end
@@ -132,7 +132,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
         rubygem_id: @popular_rubygem.id
       )
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     end
 
     should "return true if instance owns a gem that exceeds recommended threshold and has mfa ui_only" do
@@ -172,7 +172,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
     should "return false if instance owns a gem that exceeds required threshold and has mfa enabled" do
       create(:ownership, user: @user, rubygem: @popular_rubygem)
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
       refute_predicate @user, :mfa_required_not_yet_enabled?
     end
@@ -191,7 +191,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         Rubygem::MFA_REQUIRED_THRESHOLD + 1,
         rubygem_id: @popular_rubygem.id
       )
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
     end
 
     should "return true if instance owns a gem that exceeds required threshold and has mfa ui_only" do
@@ -216,7 +216,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
   context "#ui_otp_verified?" do
     setup do
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     end
 
     context "with totp" do
@@ -265,7 +265,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
   context "#api_otp_verified?" do
     setup do
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     end
 
     context "with totp" do

--- a/test/models/concerns/user_otp_methods_test.rb
+++ b/test/models/concerns/user_otp_methods_test.rb
@@ -9,7 +9,7 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
 
   context "#disable_otp!" do
     setup do
-      @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+      @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
         @user.disable_otp!
@@ -74,11 +74,11 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
     end
   end
 
-  context "#enable_mfa!" do
+  context "#enable_otp!" do
     setup do
       @seed = ROTP::Base32.random_base32
       @level = :ui_and_api
-      @user.enable_mfa!(@seed, @level)
+      @user.enable_otp!(@seed, @level)
     end
 
     should "enable mfa" do

--- a/test/models/concerns/user_otp_methods_test.rb
+++ b/test/models/concerns/user_otp_methods_test.rb
@@ -7,12 +7,12 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
-  context "#disable_mfa!" do
+  context "#disable_otp!" do
     setup do
       @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-        @user.disable_mfa!
+        @user.disable_otp!
       end
     end
 

--- a/test/models/concerns/user_otp_methods_test.rb
+++ b/test/models/concerns/user_otp_methods_test.rb
@@ -30,14 +30,14 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
     end
   end
 
-  context "#verify_and_enable_mfa!" do
+  context "#verify_and_enable_otp!" do
     setup do
       @seed = ROTP::Base32.random_base32
       @expiry = 30.minutes.from_now
     end
 
     should "enable mfa" do
-      @user.verify_and_enable_mfa!(
+      @user.verify_and_enable_otp!(
         @seed,
         :ui_and_api,
         ROTP::TOTP.new(@seed).now,
@@ -48,7 +48,7 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
     end
 
     should "add error if qr code expired" do
-      @user.verify_and_enable_mfa!(
+      @user.verify_and_enable_otp!(
         @seed,
         :ui_and_api,
         ROTP::TOTP.new(@seed).now,
@@ -62,7 +62,7 @@ class UserOtpMethodsTest < ActiveSupport::TestCase
     end
 
     should "add error if otp code is incorrect" do
-      @user.verify_and_enable_mfa!(
+      @user.verify_and_enable_otp!(
         @seed,
         :ui_and_api,
         ROTP::TOTP.new(ROTP::Base32.random_base32).now,

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -992,7 +992,7 @@ class RubygemTest < ActiveSupport::TestCase
       end
 
       should "be satisfied if owner has enabled mfa" do
-        @owner.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+        @owner.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
         assert @rubygem.mfa_requirement_satisfied_for?(@owner)
       end

--- a/test/models/user/with_private_fields_test.rb
+++ b/test/models/user/with_private_fields_test.rb
@@ -25,7 +25,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
       context "when mfa is enabled" do
         context "on `ui_only` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
           end
 
           should "include warning in user json" do
@@ -40,7 +40,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
         context "on `ui_and_gem_signin` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
           end
 
           should "not include warning in user json" do
@@ -53,7 +53,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
 
         context "on `ui_and_api` level" do
           setup do
-            @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+            @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
           end
 
           should "not include warning in user json" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -410,7 +410,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when disabled" do
         setup do
-          @user.disable_mfa!
+          @user.disable_otp!
         end
 
         should "return false for verifying OTP" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -354,7 +354,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when enabled" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
         end
 
         should "be able to use a recovery code only once" do
@@ -493,7 +493,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when mfa `ui_only` user owns a gem with more downloads than the recommended threshold but less than the required threshold" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
           GemDownload.increment(
             Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
@@ -516,7 +516,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when mfa `ui_only` user owns a gem with more downloads than the required threshold" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
           GemDownload.increment(
             Rubygem::MFA_REQUIRED_THRESHOLD + 1,
@@ -535,7 +535,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when strong user owns a gem with more downloads than the recommended threshold but less than the required threshold" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
           GemDownload.increment(
             Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
@@ -558,7 +558,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when strong user owns a gem with more downloads than the required threshold" do
         setup do
-          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
           GemDownload.increment(
             Rubygem::MFA_REQUIRED_THRESHOLD + 1,

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -105,7 +105,7 @@ class ApiKeysTest < ApplicationSystemTestCase
   end
 
   test "creating new api key with MFA UI enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
     visit_profile_api_keys_path
 
@@ -119,7 +119,7 @@ class ApiKeysTest < ApplicationSystemTestCase
   end
 
   test "creating new api key with MFA UI and API enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
     visit_profile_api_keys_path
 
@@ -216,7 +216,7 @@ class ApiKeysTest < ApplicationSystemTestCase
   end
 
   test "update api key with MFA UI enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_only)
 
     api_key = create(:api_key, user: @user)
 
@@ -233,7 +233,7 @@ class ApiKeysTest < ApplicationSystemTestCase
   end
 
   test "update api key with MFA UI and API enabled" do
-    @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    @user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
 
     api_key = create(:api_key, user: @user)
 

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -29,7 +29,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     sign_in_as admin_user
 
     user = create(:user)
-    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     user_attributes = user.attributes.with_indifferent_access
 
     visit avo.resources_user_path(user)
@@ -97,7 +97,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     sign_in_as admin_user
 
     user = create(:user)
-    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     user_attributes = user.attributes.with_indifferent_access
 
     visit avo.resources_user_path(user)
@@ -247,7 +247,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     rubygem = ownership.rubygem
     version = create(:version, rubygem: rubygem)
 
-    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     version_attributes = version.attributes.with_indifferent_access
 
     visit avo.resources_user_path(user)
@@ -332,7 +332,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     security_user = create(:user, email: "security@rubygems.org")
 
     user = create(:user)
-    user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+    user.enable_otp!(ROTP::Base32.random_base32, :ui_and_api)
     user_attributes = user.attributes.with_indifferent_access
 
     rubygem = create(:rubygem)

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -104,7 +104,7 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
 
   def redirect_test_mfa_weak_level(path)
     sign_in
-    @user.enable_mfa!(@seed, :ui_only)
+    @user.enable_otp!(@seed, :ui_only)
     visit path
 
     assert page.has_content? "Edit settings"

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -14,7 +14,7 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
   end
 
   teardown do
-    @user.disable_mfa!
+    @user.disable_otp!
   end
 
   test "user with mfa disabled gets redirected back to adoptions after setting up mfa" do

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -14,7 +14,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   def enable_mfa
     key = ROTP::Base32.random_base32
-    @user.enable_mfa!(key, :ui_only)
+    @user.enable_otp!(key, :ui_only)
   end
 
   def change_auth_level(type)


### PR DESCRIPTION
Follow up to https://github.com/rubygems/rubygems.org/pull/3806

## What problem are you solving?

This PR is based off of a larger PR https://github.com/rubygems/rubygems.org/pull/3805

As part of #3800, there are methods in `UserOtpMethods` that use `mfa` in the name though they only relate to TOTP devices

## What approach did you choose and why?
Renamed these methods to reference `otp` instead of `mfa`

## What should reviewers focus on?
- Are there better names for these methods?