### PR TITLE
Reference UserWebauthnMethods into UserMultifactorMethods [3/4]

### DIFF
--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -3,6 +3,7 @@ module UserMultifactorMethods
 
   included do
     include UserTotpMethods
+    include UserWebauthnMethods
 
     enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2, ui_and_gem_signin: 3 }, _prefix: :mfa
 

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -63,10 +63,6 @@ module UserMultifactorMethods
 
       rubygems.mfa_required.any?
     end
-
-    def verify_webauthn_otp(otp)
-      webauthn_verification&.verify_otp(otp)
-    end
   end
 
   class_methods do

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -35,4 +35,10 @@ module UserWebauthnMethods
       user_id: id
     )
   end
+
+  private
+
+  def verify_webauthn_otp(otp)
+    webauthn_verification&.verify_otp(otp)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   include UserMultifactorMethods
-  include UserWebauthnMethods
   include Clearance::User
   include Gravtastic
   is_gravtastic default: "retro"


### PR DESCRIPTION
## What problem are you solving?
This PR is based off of a larger PR https://github.com/rubygems/rubygems.org/pull/3805

As part of #3800, there are methods in `UserMultifactorMethods` that are specific to Webauthn. 

## What approach did you choose and why?
This PR moves `verify_webauthn_otp` method to UserWebauthnMethods. I also moved the inclusion of `UserWebauthnMethods` into `UserMultifactorMethods` as methods in `UserMultifactorMethods` relies on the methods in `UserWebauthnMethods`.