### PR TITLE
Higher Level MFA and Recovery

### DIFF
--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -10,18 +10,6 @@
     error.text(message);
   };
 
-  var handleJsonResponse = function(submit, responseError, response) {
-    if (response.redirected) {
-      window.location.href = response.url;
-    } else {
-      response.json().then(function (json) {
-        setError(submit, responseError, json.message);
-      }).catch(function (error) {
-        setError(submit, responseError, error);
-      });
-    }
-  };
-
   var handleHtmlResponse = function(submit, responseError, response) {
     if (response.redirected) {
       window.location.href = response.url;
@@ -95,7 +83,15 @@
           })
         });
       }).then(function (response) {
-        handleJsonResponse(credentialSubmit, credentialError, response);
+        response.json().then(function (json) {
+          if (json.redirect_url) {
+            window.location.href = json.redirect_url;
+          } else {
+            setError(credentialSubmit, credentialError, json.message);
+          }
+        }).catch(function (error) {
+          setError(credentialSubmit, credentialError, error);
+        });
       }).catch(function (error) {
         setError(credentialSubmit, credentialError, error);
       });

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -101,7 +101,7 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def setup_mfa_authentication
-    return if @user.mfa_disabled?
+    return if @user.totp_disabled?
     @form_mfa_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
   end
 

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -27,8 +27,14 @@ class MultifactorAuthsController < ApplicationController
     else
       flash.now[:success] = t(".success")
       @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
-      session.delete("mfa_redirect_uri")
-      render :recovery
+
+      if current_user.webauthn_disabled?
+        session[:show_recovery_codes] = true
+        redirect_to recovery_multifactor_auth_path
+      else
+        redirect_to @continue_path
+        session.delete("mfa_redirect_uri")
+      end
     end
   end
 

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -78,6 +78,18 @@ class MultifactorAuthsController < ApplicationController
     end
   end
 
+  def recovery
+    if session[:show_recovery_codes].nil?
+      redirect_to edit_settings_path
+      flash[:error] = t(".already_generated")
+      return
+    end
+    @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
+    session.delete("mfa_redirect_uri")
+  ensure
+    session.delete(:show_recovery_codes)
+  end
+
   private
 
   def otp_param

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -28,7 +28,7 @@ class MultifactorAuthsController < ApplicationController
       flash.now[:success] = t(".success")
       @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
 
-      if current_user.webauthn_disabled?
+      if current_user.mfa_device_count_one?
         session[:show_recovery_codes] = true
         redirect_to recovery_multifactor_auth_path
       else

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -3,7 +3,7 @@ class MultifactorAuthsController < ApplicationController
   include WebauthnVerifiable
 
   before_action :redirect_to_signin, unless: :signed_in?
-  before_action :require_mfa_disabled, only: %i[new create]
+  before_action :require_totp_disabled, only: %i[new create]
   before_action :require_mfa_enabled, only: :update
   before_action :require_totp_enabled, only: %i[mfa_update]
   before_action :seed_and_expire, only: :create
@@ -80,9 +80,9 @@ class MultifactorAuthsController < ApplicationController
     request.host || "rubygems.org"
   end
 
-  def require_mfa_disabled
-    return unless current_user.mfa_enabled?
-    flash[:error] = t("multifactor_auths.require_mfa_disabled")
+  def require_totp_disabled
+    return if current_user.totp_disabled?
+    flash[:error] = t("multifactor_auths.require_totp_disabled")
     redirect_to edit_settings_path
   end
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -74,7 +74,7 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def setup_mfa_authentication
-    return if @user.mfa_disabled?
+    return if @user.totp_disabled?
     @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -138,7 +138,7 @@ class SessionsController < Clearance::SessionsController
   end
 
   def setup_mfa_authentication
-    return if @user.mfa_disabled?
+    return if @user.totp_disabled?
     session[:mfa_user] = @user.id
   end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -8,8 +8,7 @@ class SettingsController < ApplicationController
     @webauthn_credential = WebauthnCredential.new(user: @user)
     @mfa_options = [
       [t(".mfa.level.ui_and_api"), "ui_and_api"],
-      [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
-      [t(".mfa.level.disabled"), "disabled"]
+      [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"]
     ]
     @mfa_options.insert(2, [t(".mfa.level.ui_only"), "ui_only"]) if @user.mfa_ui_only?
   end

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -28,6 +28,7 @@ class WebauthnCredentialsController < ApplicationController
   def destroy
     webauthn_credential = current_user.webauthn_credentials.find(params[:id])
     if webauthn_credential.destroy
+      set_recovery_codes_destroy
       flash[:notice] = t(".webauthn_credential.confirm_delete")
     else
       flash[:error] = webauthn_credential.errors.full_messages.to_sentence
@@ -65,5 +66,12 @@ class WebauthnCredentialsController < ApplicationController
     else
       render json: { redirect_url: edit_settings_url }
     end
+  end
+
+  def set_recovery_codes_destroy
+    return unless current_user.count_webauthn_credentials == 1 && current_user.totp_disabled?
+
+    current_user.mfa_recovery_codes = []
+    current_user.save!(validate: false)
   end
 end

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -56,7 +56,7 @@ class WebauthnCredentialsController < ApplicationController
   end
 
   def render_callback_redirect
-    if current_user.totp_disabled? && current_user.count_webauthn_credentials == 1
+    if current_user.mfa_device_count_one?
       session[:show_recovery_codes] = true
       render json: { redirect_url: recovery_multifactor_auth_url }
     else

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -28,7 +28,6 @@ class WebauthnCredentialsController < ApplicationController
   def destroy
     webauthn_credential = current_user.webauthn_credentials.find(params[:id])
     if webauthn_credential.destroy
-      set_recovery_codes_destroy
       flash[:notice] = t(".webauthn_credential.confirm_delete")
     else
       flash[:error] = webauthn_credential.errors.full_messages.to_sentence
@@ -58,20 +57,10 @@ class WebauthnCredentialsController < ApplicationController
 
   def render_callback_redirect
     if current_user.totp_disabled? && current_user.count_webauthn_credentials == 1
-      current_user.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-      current_user.save!(validate: false)
-
       session[:show_recovery_codes] = true
       render json: { redirect_url: recovery_multifactor_auth_url }
     else
       render json: { redirect_url: edit_settings_url }
     end
-  end
-
-  def set_recovery_codes_destroy
-    return unless current_user.count_webauthn_credentials == 1 && current_user.totp_disabled?
-
-    current_user.mfa_recovery_codes = []
-    current_user.save!(validate: false)
   end
 end

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -13,7 +13,8 @@ class WebauthnCredentialsController < ApplicationController
     webauthn_credential = build_webauthn_credential
 
     if webauthn_credential.save
-      redirect_to edit_settings_path
+      flash[:notice] = t(".success")
+      render_callback_redirect
     else
       message = webauthn_credential.errors.full_messages.to_sentence
       render json: { message: message }, status: :unprocessable_entity
@@ -52,5 +53,17 @@ class WebauthnCredentialsController < ApplicationController
         sign_count: credential.sign_count
       )
     )
+  end
+
+  def render_callback_redirect
+    if current_user.totp_disabled? && current_user.count_webauthn_credentials == 1
+      current_user.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
+      current_user.save!(validate: false)
+
+      session[:show_recovery_codes] = true
+      render json: { redirect_url: recovery_multifactor_auth_url }
+    else
+      render json: { redirect_url: edit_settings_url }
+    end
   end
 end

--- a/app/jobs/mfa_usage_stats_job.rb
+++ b/app/jobs/mfa_usage_stats_job.rb
@@ -2,10 +2,10 @@ class MfaUsageStatsJob < ApplicationJob
   queue_as "stats"
 
   def perform
-    non_mfa_users = User.where(mfa_level: :disabled).where.not(id: WebauthnCredential.select(:user_id)).count
-    otp_only_users = User.where.not(mfa_level: :disabled).where.not(id: WebauthnCredential.select(:user_id)).count
-    webauthn_only_users = User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).count
-    webauthn_and_otp_users = User.where.not(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).count
+    non_mfa_users = User.where(mfa_seed: nil).where.not(id: WebauthnCredential.select(:user_id)).count
+    otp_only_users = User.where.not(mfa_seed: nil).where.not(id: WebauthnCredential.select(:user_id)).count
+    webauthn_only_users = User.where(mfa_seed: nil).where(id: WebauthnCredential.select(:user_id)).count
+    webauthn_and_otp_users = User.where.not(mfa_seed: nil).where(id: WebauthnCredential.select(:user_id)).count
 
     StatsD.gauge("mfa_usage_stats.non_mfa_users", non_mfa_users)
     StatsD.gauge("mfa_usage_stats.otp_only_users", otp_only_users)

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -9,6 +9,11 @@ module UserMultifactorMethods
   end
 
   def mfa_enabled?
+    if webauthn_credentials.present? && mfa_disabled?
+      self.mfa_level = :ui_and_gem_signin
+      save!(validate: false)
+    end
+
     !mfa_disabled?
   end
 

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -17,6 +17,14 @@ module UserMultifactorMethods
     !mfa_disabled?
   end
 
+  def mfa_device_count_one?
+    (totp_disabled? && webauthn_credentials.count == 1) || (totp_enabled? && webauthn_disabled?)
+  end
+
+  def no_mfa_devices?
+    totp_disabled? && webauthn_disabled?
+  end
+
   def mfa_gem_signin_authorized?(otp)
     return true unless strong_mfa_level? || webauthn_credentials.present?
     api_mfa_verified?(otp)

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -36,9 +36,9 @@ module UserTotpMethods
 
     if webauthn_disabled?
       self.mfa_level = level
+      self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
     end
 
-    self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
     save!(validate: false)
     Mailer.mfa_enabled(id, Time.now.utc).deliver_later
   end

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -1,6 +1,14 @@
 module UserTotpMethods
   extend ActiveSupport::Concern
 
+  def totp_enabled?
+    mfa_seed.present?
+  end
+
+  def totp_disabled?
+    mfa_seed.blank?
+  end
+
   def disable_totp!
     mfa_disabled!
     self.mfa_seed = ""

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -12,7 +12,7 @@ module UserTotpMethods
   def disable_totp!
     self.mfa_seed = ""
 
-    if webauthn_disabled?
+    if no_mfa_devices?
       self.mfa_level = "disabled"
       self.mfa_recovery_codes = []
     end
@@ -34,7 +34,7 @@ module UserTotpMethods
   def enable_totp!(seed, level)
     self.mfa_seed = seed
 
-    if webauthn_disabled?
+    if mfa_device_count_one?
       self.mfa_level = level
       self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
     end

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -28,8 +28,12 @@ module UserTotpMethods
   end
 
   def enable_totp!(seed, level)
-    self.mfa_level = level
     self.mfa_seed = seed
+
+    if webauthn_disabled?
+      self.mfa_level = level
+    end
+
     self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
     save!(validate: false)
     Mailer.mfa_enabled(id, Time.now.utc).deliver_later

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -11,10 +11,10 @@ module UserTotpMethods
 
   def disable_totp!
     self.mfa_seed = ""
-    self.mfa_recovery_codes = []
 
     if webauthn_disabled?
       self.mfa_level = "disabled"
+      self.mfa_recovery_codes = []
     end
 
     save!(validate: false)

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -10,9 +10,13 @@ module UserTotpMethods
   end
 
   def disable_totp!
-    mfa_disabled!
     self.mfa_seed = ""
     self.mfa_recovery_codes = []
+
+    if webauthn_disabled?
+      self.mfa_level = "disabled"
+    end
+
     save!(validate: false)
     Mailer.mfa_disabled(id, Time.now.utc).deliver_later
   end

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -29,10 +29,6 @@ module UserWebauthnMethods
     webauthn_credentials.none?
   end
 
-  def count_webauthn_credentials
-    webauthn_credentials.count
-  end
-
   def webauthn_options_for_get
     WebAuthn::Credential.options_for_get(
       allow: webauthn_credentials.pluck(:external_id),

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -21,6 +21,18 @@ module UserWebauthnMethods
     )
   end
 
+  def webauthn_enabled?
+    webauthn_credentials.present?
+  end
+
+  def webauthn_disabled?
+    webauthn_credentials.none?
+  end
+
+  def count_webauthn_credentials
+    webauthn_credentials.count
+  end
+
   def webauthn_options_for_get
     WebAuthn::Credential.options_for_get(
       allow: webauthn_credentials.pluck(:external_id),

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -7,9 +7,9 @@ class WebauthnCredential < ApplicationRecord
   validates :sign_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   after_create :send_creation_email
-  after_create :set_user_mfa_level_create
+  after_create :enable_user_mfa
   after_destroy :send_deletion_email
-  after_destroy :set_user_mfa_level_destroy
+  after_destroy :disable_user_mfa
 
   private
 
@@ -21,13 +21,17 @@ class WebauthnCredential < ApplicationRecord
     Mailer.webauthn_credential_removed(user_id, nickname, Time.now.utc).deliver_later
   end
 
-  def set_user_mfa_level_create
+  def enable_user_mfa
     return unless user.count_webauthn_credentials == 1 && user.totp_disabled?
-    user.update!(mfa_level: "ui_and_api")
+    user.mfa_level = :ui_and_api
+    user.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
+    user.save!(validate: false)
   end
 
-  def set_user_mfa_level_destroy
+  def disable_user_mfa
     return unless user.webauthn_credentials.empty? && user.totp_disabled?
-    user.update!(mfa_level: "disabled")
+    user.mfa_level = :disabled
+    user.mfa_recovery_codes = []
+    user.save!(validate: false)
   end
 end

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -22,14 +22,14 @@ class WebauthnCredential < ApplicationRecord
   end
 
   def enable_user_mfa
-    return unless user.count_webauthn_credentials == 1 && user.totp_disabled?
+    return unless user.mfa_device_count_one?
     user.mfa_level = :ui_and_api
     user.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
     user.save!(validate: false)
   end
 
   def disable_user_mfa
-    return unless user.webauthn_credentials.empty? && user.totp_disabled?
+    return unless user.no_mfa_devices?
     user.mfa_level = :disabled
     user.mfa_recovery_codes = []
     user.save!(validate: false)

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -25,4 +25,9 @@ class WebauthnCredential < ApplicationRecord
     return unless user.count_webauthn_credentials == 1 && user.totp_disabled?
     user.update!(mfa_level: "ui_and_api")
   end
+
+  def set_user_mfa_level_destroy
+    return unless user.webauthn_credentials.empty? && user.totp_disabled?
+    user.update!(mfa_level: "disabled")
+  end
 end

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -17,7 +17,7 @@
       </div>
   <% end %>
 
-  <% if @user.mfa_enabled? %>
+  <% if @user.totp_enabled? %>
     <%= form_tag @form_mfa_url, method: :post do %>
       <div class="text_field">
         <%= label_tag :otp, t("multifactor_auths.otp_code"), class: "form__label" %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -2,20 +2,25 @@
 
 <div class="t-body">
   <h2 class="page__subheading"><%= t ".mfa.multifactor_auth" %></h2>
-  <% if @user.mfa_enabled? %>
-    <h2><%= t(".mfa.otp")%></h2>
-    <p><%= t(".mfa.enabled_html") %></p>
+  <% if @user.totp_enabled? || @user.webauthn_enabled?%>
+    <h2><%= t(".mfa.level.title")%></h2>
+    <p><%= t(".mfa.level_html") %></p>
+
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
-      <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
-
-
       <%= select_tag :level, options_for_select(@mfa_options, @user.mfa_level), class: "form__input form__select" %>
 
+      <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+    <% end %>
+  <% end %>
+  <% if @user.totp_enabled? %>
+    <h2><%= t(".mfa.level.title")%></h2>
+    <p><%= t(".mfa.enabled") %></p>
+    <%= form_tag multifactor_auth_path, method: :delete, id: "mfa-delete" do %>
       <div class="text_field">
         <%= label_tag :otp, t(".otp_code"), class: "form__label" %>
         <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>
       </div>
-      <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+      <%= submit_tag t(".mfa.disable"), class: "form__submit" %>
     <% end %>
   <% else %>
     <div class="t-body">

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="t-body">
   <h2 class="page__subheading"><%= t ".mfa.multifactor_auth" %></h2>
-  <% if @user.totp_enabled? || @user.webauthn_enabled?%>
+  <% if @user.mfa_enabled? %>
     <h2><%= t(".mfa.level.title")%></h2>
     <p><%= t(".mfa.level_html") %></p>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -456,8 +456,10 @@ de:
         otp:
         disabled_html:
         go_settings:
-        enabled_html:
+        level_html:
+        enabled:
         update:
+        disable:
         level:
           title:
           disabled:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -347,6 +347,7 @@ de:
     require_mfa_disabled:
     require_mfa_enabled:
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -346,6 +346,7 @@ de:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -373,6 +374,7 @@ de:
     destroy:
       success:
     update:
+      invalid_level:
       success:
   notifiers:
     update:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,7 +344,7 @@ de:
     incorrect_otp:
     session_expired:
     otp_code:
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
     require_webauthn_enabled:
@@ -372,6 +372,7 @@ de:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success:
     update:
@@ -681,6 +682,8 @@ de:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -352,7 +352,6 @@ de:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,7 +340,7 @@ en:
     incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.
     otp_code: OTP code
-    require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
+    require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
     require_webauthn_enabled: You don't have any security devices enabled. You have to associate a device to your account first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,10 +453,11 @@ en:
         otp: Authentication app
         disabled_html: You have not yet enabled OTP based multi-factor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
         go_settings: Register a new device
-        enabled_html:
-          You have enabled multi-factor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
-          Refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
+        level_html: You have enabled multi-factor authentication. Please click 'Update' to change your MFA level. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
+        enabled: You have enabled multi-factor authentication. Please input your OTP from your authenticator or one of your active
+          recovery codes to disable it.
         update: Update
+        disable: Disable
         level:
           title: MFA Level
           disabled: Disabled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,7 @@ en:
       copy: "[ copy ]"
       saved: I acknowledge that I have saved my recovery codes.
       note_html: "Please <strong class='recovery__bold'>copy and save</strong> these recovery codes. You can use these codes to login and reset your MFA if your lose your authentication device. Each code can be used once."
+      already_generated: You should have already saved your recovery codes.
     destroy:
       success: You have successfully disabled multi-factor authentication.
     update:
@@ -679,6 +680,8 @@ en:
     create_req: Create ownership request
     signin_to_create_html: Please <a href="https://rubygems.org/sign_in">sign in</a> to create an ownership request.
   webauthn_credentials:
+    callback:
+      success: You have successfully registered a security device.
     recovery:
       continue: Continue
       title: You have successfully added a security device

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,7 @@ en:
     require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
+    require_webauthn_enabled: You don't have any security devices enabled. You have to associate a device to your account first.
     setup_required_html: For protection of your account and your gems, you are required to set up multi-factor authentication. Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,7 @@ en:
     otp_code: OTP code
     require_mfa_disabled: Your multi-factor authentication has been enabled. To reconfigure multi-factor authentication, you'll have to disable it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
+    require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
     setup_required_html: For protection of your account and your gems, you are required to set up multi-factor authentication. Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.
@@ -369,6 +370,7 @@ en:
     destroy:
       success: You have successfully disabled multi-factor authentication.
     update:
+      invalid_level: Invalid MFA level.
       success: You have successfully updated your multi-factor authentication level.
   notifiers:
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,6 @@ en:
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
-    ui_only_warning: Updating multi-factor authentication to "UI Only" is no longer supported. Please use "UI and gem signin" or "UI and API".
     new:
       title: Enabling multi-factor auth
       scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -365,6 +365,7 @@ es:
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -360,8 +360,7 @@ es:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired:
     otp_code: código OTP
-    require_mfa_disabled: Se ha activado la autenticación de múltiples factores. Para
-      reconfigurarla, primero tendrás que desactivarla.
+    require_totp_disabled:
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
     require_totp_enabled:
@@ -393,6 +392,7 @@ es:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success: Has desactivado exitosamente la autenticación de múltiples factores.
     update:
@@ -726,6 +726,8 @@ es:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -477,8 +477,10 @@ es:
         otp:
         disabled_html:
         go_settings: Registrar un nuevo dispositivo
-        enabled_html:
+        level_html:
+        enabled:
         update: Actualizar
+        disable:
         level:
           title: Nivel de Autenticación de Múltiples Factores
           disabled: Desactivada

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -364,6 +364,7 @@ es:
       reconfigurarla, primero tendrás que desactivarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -394,6 +395,7 @@ es:
     destroy:
       success: Has desactivado exitosamente la autenticación de múltiples factores.
     update:
+      invalid_level:
       success: Has actualizado exitosamente la autenticación de múltiples factores.
   notifiers:
     update:
@@ -495,7 +497,8 @@ es:
       enter_password: Por favor introduce tu contraseña
       hide_email: Ocultar correo electrónico en perfil público
       optional_full_name: Opcional. Será mostrado en tu perfil público
-      optional_twitter_username: Usuario de Twitter opcional. Será mostrado en tu perfil público
+      optional_twitter_username: Usuario de Twitter opcional. Será mostrado en tu
+        perfil público
       title: Editar perfil
       delete:
         delete: Eliminar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -369,7 +369,6 @@ es:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title: Activando autenticación de múltiples factores
       scan_prompt: Por favor escanea el código QR con tu aplicación de Autenticación.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -371,7 +371,6 @@ fr:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title: Activer l'authentification multifacteur
       scan_prompt: Veuillez scanner le QR code avec votre app d'authentification.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,8 +362,7 @@ fr:
     incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:
     otp_code: clé OTP
-    require_mfa_disabled: Votre authentification multi-facteur a été activée. Si vous
-      voulez la reconfigurer, vous devez d'abord la désactiver.
+    require_totp_disabled:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
     require_totp_enabled:
@@ -396,6 +395,7 @@ fr:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success: Vous avez désactivé l'authentification multifacteur.
     update:
@@ -732,6 +732,8 @@ fr:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -479,8 +479,10 @@ fr:
         otp:
         disabled_html:
         go_settings: Enregistrer un nouvel appareil
-        enabled_html:
+        level_html:
+        enabled:
         update:
+        disable:
         level:
           title:
           disabled:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -366,6 +366,7 @@ fr:
       voulez la reconfigurer, vous devez d'abord la désactiver.
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -397,6 +398,7 @@ fr:
     destroy:
       success: Vous avez désactivé l'authentification multifacteur.
     update:
+      invalid_level:
       success:
   notifiers:
     update:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -367,6 +367,7 @@ fr:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -334,6 +334,7 @@ ja:
     require_mfa_disabled:
     require_mfa_enabled:
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -441,8 +441,10 @@ ja:
         otp:
         disabled_html:
         go_settings:
-        enabled_html:
+        level_html:
+        enabled:
         update:
+        disable:
         level:
           title:
           disabled:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -339,7 +339,6 @@ ja:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -331,7 +331,7 @@ ja:
     incorrect_otp:
     session_expired:
     otp_code:
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
     require_webauthn_enabled:
@@ -359,6 +359,7 @@ ja:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success:
     update:
@@ -669,6 +670,8 @@ ja:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -333,6 +333,7 @@ ja:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -360,6 +361,7 @@ ja:
     destroy:
       success:
     update:
+      invalid_level:
       success:
   notifiers:
     update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -356,7 +356,6 @@ nl:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -351,6 +351,7 @@ nl:
     require_mfa_disabled:
     require_mfa_enabled:
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -350,6 +350,7 @@ nl:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -377,6 +378,7 @@ nl:
     destroy:
       success:
     update:
+      invalid_level:
       success:
   notifiers:
     update:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -348,7 +348,7 @@ nl:
     incorrect_otp:
     session_expired:
     otp_code:
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
     require_webauthn_enabled:
@@ -376,6 +376,7 @@ nl:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success:
     update:
@@ -684,6 +685,8 @@ nl:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -460,8 +460,10 @@ nl:
         otp:
         disabled_html:
         go_settings:
-        enabled_html:
+        level_html:
+        enabled:
         update:
+        disable:
         level:
           title:
           disabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -471,8 +471,10 @@ pt-BR:
         otp:
         disabled_html:
         go_settings:
-        enabled_html:
+        level_html:
+        enabled:
         update:
+        disable:
         level:
           title:
           disabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -361,6 +361,7 @@ pt-BR:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -388,6 +389,7 @@ pt-BR:
     destroy:
       success:
     update:
+      invalid_level:
       success:
   notifiers:
     update:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -359,7 +359,7 @@ pt-BR:
     incorrect_otp:
     session_expired:
     otp_code:
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
     require_webauthn_enabled:
@@ -387,6 +387,7 @@ pt-BR:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success:
     update:
@@ -707,6 +708,8 @@ pt-BR:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -367,7 +367,6 @@ pt-BR:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title:
       scan_prompt:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -362,6 +362,7 @@ pt-BR:
     require_mfa_disabled:
     require_mfa_enabled:
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -331,7 +331,7 @@ zh-CN:
     incorrect_otp: 你的 OTP 码 不正确。
     session_expired:
     otp_code: OTP 码
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     require_totp_enabled:
     require_webauthn_enabled:
@@ -359,6 +359,7 @@ zh-CN:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success: 你已成功停用多重要素验证。
     update:
@@ -667,6 +668,8 @@ zh-CN:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -339,7 +339,6 @@ zh-CN:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title: 启用多重要素验证
       scan_prompt: 请用你的验证装置扫描 QR-code。如果你没办法扫描，手动输入下面的资料。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -334,6 +334,7 @@ zh-CN:
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -442,8 +442,10 @@ zh-CN:
         otp:
         disabled_html:
         go_settings: 注册新装置
-        enabled_html:
+        level_html:
+        enabled:
         update: 更新
+        disable:
         level:
           title: 多重验证等级
           disabled: 停用

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -333,6 +333,7 @@ zh-CN:
     otp_code: OTP 码
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -360,6 +361,7 @@ zh-CN:
     destroy:
       success: 你已成功停用多重要素验证。
     update:
+      invalid_level:
       success: 你已成功修改多重验证等级。
   notifiers:
     update:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -334,6 +334,7 @@ zh-TW:
     otp_code: OTP 碼
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
+    require_totp_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
@@ -361,6 +362,7 @@ zh-TW:
     destroy:
       success: 你已成功停用多重要素驗證。
     update:
+      invalid_level:
       success: 你已成功修改多重驗證等級。
   notifiers:
     update:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -335,6 +335,7 @@ zh-TW:
     require_mfa_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     require_totp_enabled:
+    require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -443,8 +443,10 @@ zh-TW:
         otp:
         disabled_html:
         go_settings: 註冊新裝置
-        enabled_html:
+        level_html:
+        enabled:
         update: 更新
+        disable:
         level:
           title: 多重驗證等級
           disabled: 停用

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -332,7 +332,7 @@ zh-TW:
     incorrect_otp: 你的 OTP 碼 不正確。
     session_expired:
     otp_code: OTP 碼
-    require_mfa_disabled:
+    require_totp_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     require_totp_enabled:
     require_webauthn_enabled:
@@ -360,6 +360,7 @@ zh-TW:
       copy:
       saved:
       note_html:
+      already_generated:
     destroy:
       success: 你已成功停用多重要素驗證。
     update:
@@ -668,6 +669,8 @@ zh-TW:
     create_req:
     signin_to_create_html:
   webauthn_credentials:
+    callback:
+      success:
     recovery:
       continue:
       title:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -340,7 +340,6 @@ zh-TW:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
-    ui_only_warning:
     new:
       title: 啟用多重要素驗證
       scan_prompt: 請用你的驗證裝置掃描 QR-code。如果你沒辦法掃描，手動輸入下面的資料。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
     resources :profiles, only: :show
     resource :multifactor_auth, only: %i[new create update] do
       post 'mfa_update', to: 'multifactor_auths#mfa_update', as: :mfa_update
+      post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
     end
     resource :settings, only: :edit
     resource :profile, only: %i[edit update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,9 @@ Rails.application.routes.draw do
     end
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
-    resource :multifactor_auth, only: %i[new create update]
+    resource :multifactor_auth, only: %i[new create update] do
+      post 'mfa_update', to: 'multifactor_auths#mfa_update', as: :mfa_update
+    end
     resource :settings, only: :edit
     resource :profile, only: %i[edit update] do
       get :adoptions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,7 @@ Rails.application.routes.draw do
     end
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
-    resource :multifactor_auth, only: %i[new create update] do
+    resource :multifactor_auth, only: %i[new create update destroy] do
       post 'mfa_update', to: 'multifactor_auths#mfa_update', as: :mfa_update
       post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
     resource :multifactor_auth, only: %i[new create update destroy] do
+      get 'recovery'
       post 'mfa_update', to: 'multifactor_auths#mfa_update', as: :mfa_update
       post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
     end

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -3,4 +3,9 @@ namespace :one_time do
   task populate_totp_seed: :environment do
     User.where.not(mfa_seed: nil).update_all("totp_seed = mfa_seed")
   end
+
+  desc "Assign ui_and_gen_signin to webauthn only users"
+  task assign_ui_and_gen_signin: :environment do
+    User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).update_all(mfa_level: :ui_and_gen_signin)
+  end
 end

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -818,6 +818,34 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
       end
     end
 
+    context "on GET to recovery" do
+      context "when show_recovery_codes is true" do
+        setup do
+          @controller.session[:show_recovery_codes] = true
+          get :recovery
+        end
+
+        should respond_with :success
+
+        should "clear show_recovery_codes" do
+          assert_nil @controller.session[:show_recovery_codes]
+        end
+      end
+
+      context "when show_recovery_codes is not set" do
+        setup do
+          get :recovery
+        end
+
+        should respond_with :redirect
+        should redirect_to("the settings page") { edit_settings_path }
+
+        should "set error flash message" do
+          assert_equal "You should have already saved your recovery codes.", flash[:error]
+        end
+      end
+    end
+
     context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
       setup do
         @rubygem = create(:rubygem)

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -65,6 +65,130 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           travel_back
         end
       end
+
+      context "on POST to mfa_update" do
+        context "when updating to ui_and_api" do
+          context "when redirect url is not set" do
+            setup do
+              put :update, params: { level: "ui_and_api" }
+              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should redirect_to("the settings page") { edit_settings_path }
+
+            should "update mfa level" do
+              assert_predicate @user.reload, :mfa_ui_and_api?
+            end
+
+            should "clear session variables" do
+              assert_nil @controller.session[:mfa_expires_at]
+              assert_nil @controller.session[:level]
+            end
+          end
+
+          context "when redirect url is set" do
+            setup do
+              @controller.session["mfa_redirect_uri"] = profile_api_keys_path
+              put :update, params: { level: "ui_and_api" }
+              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should redirect_to("the api keys index") { profile_api_keys_path }
+          end
+        end
+
+        context "when updating to ui_and_gem_signin" do
+          context "when redirect url is not set" do
+            setup do
+              put :update, params: { level: "ui_and_gem_signin" }
+              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should redirect_to("the settings page") { edit_settings_path }
+
+            should "update mfa level" do
+              assert_predicate @user.reload, :mfa_ui_and_gem_signin?
+            end
+
+            should "clear session variables" do
+              assert_nil @controller.session[:mfa_expires_at]
+              assert_nil @controller.session[:level]
+            end
+          end
+
+          context "when redirect url is set" do
+            setup do
+              @controller.session["mfa_redirect_uri"] = profile_api_keys_path
+              put :update, params: { level: "ui_and_api" }
+              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should redirect_to("the api keys index") { profile_api_keys_path }
+          end
+        end
+
+        context "when otp is incorrect" do
+          setup do
+            put :update, params: { level: "ui_and_api" }
+            post :mfa_update, params: { otp: "123456" }
+          end
+
+          should redirect_to("the settings page") { edit_settings_path }
+
+          should "not update mfa level" do
+            assert_predicate @user.reload, :mfa_ui_only?
+          end
+
+          should "set flash error" do
+            assert_equal "Your OTP code is incorrect.", flash[:error]
+          end
+
+          should "clear session variables" do
+            assert_nil @controller.session[:mfa_expires_at]
+            assert_nil @controller.session[:level]
+            assert_nil @controller.session[:mfa_redirect_uri]
+          end
+        end
+
+        context "when mfa level is invalid" do
+          setup do
+            put :update, params: { level: "disabled" }
+            post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+          end
+
+          should "set flash error" do
+            assert_equal "Invalid MFA level.", flash[:error]
+          end
+
+          should redirect_to("the settings page") { edit_settings_path }
+        end
+
+        context "when session is expired" do
+          setup do
+            get :update, params: { level: "ui_and_api" }
+
+            travel 16.minutes do
+              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+          end
+
+          should redirect_to("the settings page") { edit_settings_path }
+
+          should "not update mfa level" do
+            assert_predicate @user.reload, :mfa_ui_only?
+          end
+
+          should "set flash error" do
+            assert_equal "Your login page session has expired.", flash[:error]
+          end
+
+          should "clear session variables" do
+            assert_nil @controller.session[:mfa_expires_at]
+            assert_nil @controller.session[:level]
+            assert_nil @controller.session[:mfa_redirect_uri]
+          end
+        end
+      end
     end
 
     context "when a webauthn device is enabled" do
@@ -98,6 +222,28 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         teardown do
           travel_back
+        end
+      end
+
+      context "on POST to mfa_update" do
+        setup do
+          put :update, params: { level: "ui_and_api" }
+          post :mfa_update
+        end
+
+        should redirect_to("the settings page") { edit_settings_path }
+
+        should "set flash error" do
+          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
+        end
+
+        should "not update mfa level" do
+          assert_predicate @user.reload, :mfa_ui_only?
+        end
+
+        should "clear session variables" do
+          assert_nil @controller.session[:mfa_expires_at]
+          assert_nil @controller.session[:level]
         end
       end
     end
@@ -173,6 +319,23 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
                        "You have to enable it first.", flash[:error]
         end
       end
+
+      context "on POST to mfa_update" do
+        setup do
+          post :mfa_update
+        end
+
+        should respond_with :redirect
+        should redirect_to("the settings page") { edit_settings_path }
+
+        should "keep mfa disabled" do
+          refute_predicate @user.reload, :mfa_enabled?
+        end
+
+        should "say MFA is not enabled" do
+          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
+        end
+      end
     end
 
     context "when totp and webauthn are enabled" do
@@ -192,6 +355,25 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         should "render webauthn prompt" do
           assert page.has_content?("Security Device")
+        end
+      end
+
+      context "on POST to mfa_update" do
+        setup do
+          @controller.session["mfa_redirect_uri"] = profile_api_keys_path
+          put :update, params: { level: "ui_and_api" }
+          post :mfa_update, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+        end
+
+        should redirect_to("the api keys index") { profile_api_keys_path }
+
+        should "update mfa level" do
+          assert_predicate @user.reload, :mfa_ui_and_api?
+        end
+
+        should "clear session variables" do
+          assert_nil @controller.session[:mfa_expires_at]
+          assert_nil @controller.session[:level]
         end
       end
     end

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -304,7 +304,6 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           @seed = ROTP::Base32.random_base32
           @controller.session[:mfa_seed] = @seed
           @controller.session[:mfa_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
-
           perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
             post :create, params: { otp: ROTP::TOTP.new(@seed).now }
           end
@@ -313,7 +312,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         should respond_with :success
 
         should "keep mfa enabled" do
-          assert_predicate @user.reload, :mfa_enabled?
+          assert_predicate @user.reload, :mfa_ui_only?
         end
 
         should "send totp enabled email" do

--- a/test/functional/webauthn_credentials_controller_test.rb
+++ b/test/functional/webauthn_credentials_controller_test.rb
@@ -280,7 +280,7 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
 
     should redirect_to :edit_settings
 
-    context "when the user has no other webauthn credentials" do
+    context "when the user has no other webauthn credentials and no otp" do
       setup do
         @user = create(:user)
         @credential = create(:webauthn_credential, user: @user)
@@ -294,6 +294,10 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
       should "set the users mfa_level to disabled" do
         assert_equal "disabled", @user.reload.mfa_level
       end
+
+      should "remove recovery codes" do
+        assert_empty @user.reload.mfa_recovery_codes
+      end
     end
 
     context "when the user has other webauthn credentials but no otp" do
@@ -303,6 +307,8 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential2 = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
+        @user_recovery_codes = @user.mfa_recovery_codes
+
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
           delete :destroy, params: { id: @credential1.id }
         end
@@ -310,6 +316,10 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
 
       should "not change the users mfa_level" do
         assert_equal "ui_and_api", @user.reload.mfa_level
+      end
+
+      should "not change the users recovery codes" do
+        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
       end
     end
 
@@ -321,6 +331,8 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
+        @user_recovery_codes = @user.mfa_recovery_codes
+
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
           delete :destroy, params: { id: @credential.id }
         end
@@ -328,6 +340,10 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
 
       should "not change the users mfa_level" do
         assert_equal "ui_and_api", @user.reload.mfa_level
+      end
+
+      should "not change the users recovery codes" do
+        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
       end
     end
 
@@ -340,6 +356,8 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential2 = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
+        @user_recovery_codes = @user.mfa_recovery_codes
+
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
           delete :destroy, params: { id: @credential1.id }
         end
@@ -347,6 +365,10 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
 
       should "not change the users mfa_level" do
         assert_equal "ui_and_api", @user.reload.mfa_level
+      end
+
+      should "not change the users recovery codes" do
+        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
       end
     end
   end

--- a/test/jobs/mfa_usage_stats_job_test.rb
+++ b/test/jobs/mfa_usage_stats_job_test.rb
@@ -5,9 +5,9 @@ class MfaUsageStatsJobTest < ActiveJob::TestCase
 
   setup do
     create(:user, mfa_level: :disabled) # non-mfa user
-    2.times { create(:user, mfa_level: :ui_and_api) } # otp-only users
-    3.times { create(:webauthn_credential, user: create(:user, mfa_level: :disabled)) } # webauthn-only users
-    4.times { create(:webauthn_credential, user: create(:user, mfa_level: :ui_and_api)) } # webauthn-and-otp users
+    2.times { create(:user, mfa_seed: ROTP::Base32.random_base32) } # otp-only users
+    3.times { create(:webauthn_credential, user: create(:user)) } # webauthn-only users
+    4.times { create(:webauthn_credential, user: create(:user, mfa_seed: ROTP::Base32.random_base32)) } # webauthn-and-otp users
   end
 
   test "it sends the count of non-MFA users to statsd" do

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -28,6 +28,14 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
       assert_equal "Multi-factor authentication enabled on RubyGems.org", last_email.subject
       assert_equal [@user.email], last_email.to
     end
+
+    should "update mfa level and return true with mfa disabled webauthn only users" do
+      @credential = create(:webauthn_credential, user: @user)
+      @user.update!(mfa_level: :disabled)
+
+      assert_predicate @user, :mfa_enabled?
+      assert_predicate @user, :mfa_ui_and_gem_signin?
+    end
   end
 
   context "#mfa_gem_signin_authorized?" do

--- a/test/models/concerns/user_totp_methods_test.rb
+++ b/test/models/concerns/user_totp_methods_test.rb
@@ -7,6 +7,34 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
+  context "#totp_enabled?" do
+    should "return true if totp is enabled" do
+      @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+
+      assert_predicate @user, :totp_enabled?
+    end
+
+    should "return false if totp is disabled" do
+      @user.disable_totp!
+
+      refute_predicate @user, :totp_enabled?
+    end
+  end
+
+  context "#totp_disabled?" do
+    should "return true if totp is disabled" do
+      @user.disable_totp!
+
+      assert_predicate @user, :totp_disabled?
+    end
+
+    should "return false if totp is enabled" do
+      @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+
+      refute_predicate @user, :totp_disabled?
+    end
+  end
+
   context "#disable_totp!" do
     setup do
       @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)

--- a/test/models/concerns/user_totp_methods_test.rb
+++ b/test/models/concerns/user_totp_methods_test.rb
@@ -56,6 +56,16 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
       assert_equal "Multi-factor authentication disabled on RubyGems.org", last_email.subject
       assert_equal [@user.email], last_email.to
     end
+
+    should "set mfa_level to disabled if webauthn is also disabled" do
+      assert_equal "disabled", @user.mfa_level
+    end
+
+    should "maintain the mfa_level if webauthn is enabled" do
+      @credential = create(:webauthn_credential, user: @user)
+
+      assert_equal "ui_and_api", @user.mfa_level
+    end
   end
 
   context "#verify_and_enable_totp!" do

--- a/test/models/concerns/user_webauthn_methods_test.rb
+++ b/test/models/concerns/user_webauthn_methods_test.rb
@@ -35,19 +35,6 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
     end
   end
 
-  context "#count_webauthn_credentials" do
-    should "return 0 if webauthn is disabled" do
-      assert_equal 0, @user.count_webauthn_credentials
-    end
-
-    should "return number of webauthn credentials if webauthn is enabled" do
-      create(:webauthn_credential, user: @user)
-      create(:webauthn_credential, user: @user)
-
-      assert_equal 2, @user.count_webauthn_credentials
-    end
-  end
-
   context "#webauthn_options_for_create" do
     should "returns options with id, and name" do
       user_create_options = @user.webauthn_options_for_create.user

--- a/test/models/concerns/user_webauthn_methods_test.rb
+++ b/test/models/concerns/user_webauthn_methods_test.rb
@@ -11,6 +11,43 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
     end
   end
 
+  context "#webauthn_enabled?" do
+    should "return true if webauthn is enabled" do
+      create(:webauthn_credential, user: @user)
+
+      assert_predicate @user, :webauthn_enabled?
+    end
+
+    should "return false if webauthn is disabled" do
+      refute_predicate @user, :webauthn_enabled?
+    end
+  end
+
+  context "#webauthn_disabled?" do
+    should "return true if webauthn is disabled" do
+      assert_predicate @user, :webauthn_disabled?
+    end
+
+    should "return false if webauthn is enabled" do
+      create(:webauthn_credential, user: @user)
+
+      refute_predicate @user, :webauthn_disabled?
+    end
+  end
+
+  context "#count_webauthn_credentials" do
+    should "return 0 if webauthn is disabled" do
+      assert_equal 0, @user.count_webauthn_credentials
+    end
+
+    should "return number of webauthn credentials if webauthn is enabled" do
+      create(:webauthn_credential, user: @user)
+      create(:webauthn_credential, user: @user)
+
+      assert_equal 2, @user.count_webauthn_credentials
+    end
+  end
+
   context "#webauthn_options_for_create" do
     should "returns options with id, and name" do
       user_create_options = @user.webauthn_options_for_create.user

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -109,8 +109,10 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
 
     assert page.has_content? "Edit settings"
 
-    fill_in "otp", with: @totp.now
     change_auth_level "UI and gem signin"
+    fill_in "otp", with: @totp.now
+
+    click_button "Authenticate"
 
     yield if block_given?
 

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -70,7 +70,7 @@ class SettingsTest < ApplicationSystemTestCase
     visit edit_settings_path
 
     page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
-    change_auth_level "Disabled"
+    click_button "Disable"
 
     assert page.has_content? "You have not yet enabled OTP based multi-factor authentication."
     css = %(a[href="https://guides.rubygems.org/setting-up-multifactor-authentication"])
@@ -85,7 +85,7 @@ class SettingsTest < ApplicationSystemTestCase
 
     key = ROTP::Base32.random_base32
     page.fill_in "otp", with: ROTP::TOTP.new(key).now
-    change_auth_level "Disabled"
+    click_button "Disable"
 
     assert page.has_content? "You have enabled multi-factor authentication."
   end
@@ -107,7 +107,7 @@ class SettingsTest < ApplicationSystemTestCase
     check "ack"
     click_button "Continue"
     page.fill_in "otp", with: recoveries.sample
-    change_auth_level "Disabled"
+    click_button "Disable"
 
     assert page.has_content? "You have not yet enabled OTP based multi-factor authentication."
   end
@@ -126,13 +126,13 @@ class SettingsTest < ApplicationSystemTestCase
     end
 
     assert_equal "Leave without copying recovery codes?", confirm_text
-    assert_equal page.current_path, multifactor_auth_path
+    assert_equal recovery_multifactor_auth_path, page.current_path
     page.accept_confirm do
       click_button "Continue"
     end
     page.find("h1", text: "Edit settings")
 
-    assert_equal page.current_path, edit_settings_path
+    assert_equal edit_settings_path, page.current_path
   end
 
   test "Navigating away another way without copying recovery codes creates default leave warning popup" do
@@ -150,13 +150,13 @@ class SettingsTest < ApplicationSystemTestCase
     end
 
     assert_equal("", confirm_text)
-    assert_equal page.current_path, multifactor_auth_path
+    assert_equal recovery_multifactor_auth_path, page.current_path
 
     accept_confirm do
       visit root_path
     end
 
-    assert_equal page.current_path, root_path
+    assert_equal root_path, page.current_path
   end
 
   test "shows 'ui only' if user's level is ui_only" do
@@ -164,7 +164,7 @@ class SettingsTest < ApplicationSystemTestCase
     enable_mfa
     visit edit_settings_path
 
-    assert page.has_selector?("#level > option:nth-child(4)")
+    assert page.has_selector?("#level > option:nth-child(3)")
     assert page.has_content? "UI Only"
   end
 
@@ -174,9 +174,9 @@ class SettingsTest < ApplicationSystemTestCase
     visit edit_settings_path
 
     page.fill_in "otp", with: ROTP::TOTP.new(@user.mfa_seed).now
-    change_auth_level "Disabled"
+    change_auth_level "UI and API"
 
-    refute page.has_selector?("#level > option:nth-child(4)")
+    refute page.has_selector?("#level > option:nth-child(3)")
     refute page.has_content? "UI Only"
   end
 end

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -7,7 +7,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
 
-    @authenticator = create_webauthn_authenticator
+    @authenticator = create_webauthn_credential
   end
 
   teardown do
@@ -49,28 +49,5 @@ class SignInWebauthnTest < ApplicationSystemTestCase
       assert page.has_content? "Your login page session has expired."
       assert page.has_content? "Multi-factor authentication"
     end
-  end
-
-  def create_webauthn_authenticator
-    visit sign_in_path
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
-    visit edit_settings_path
-
-    options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new
-    authenticator = page.driver.browser.add_virtual_authenticator(options)
-    WebAuthn::PublicKeyCredentialWithAttestation.any_instance.stubs(:verify).returns true
-
-    credential_nickname = "new cred"
-    fill_in "Nickname", with: credential_nickname
-    click_on "Register device"
-
-    find("div", text: credential_nickname, match: :first)
-
-    find(:css, ".header__popup-link").click
-    click_on "Sign out"
-
-    authenticator
   end
 end

--- a/test/system/webauthn_credentials_test.rb
+++ b/test/system/webauthn_credentials_test.rb
@@ -104,15 +104,21 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
       fill_in "Nickname", with: @credential_nickname
       click_on "Register device"
 
-      assert page.has_content? @credential_nickname
+      assert page.has_content? "Recovery codes"
     end
+
+    assert_equal recovery_multifactor_auth_path, current_path
+    click_on "[ copy ]"
+    check "ack"
+    click_on "Continue"
+
+    assert_equal edit_settings_path, current_path
 
     webauthn_credential_creation_email = ActionMailer::Base.deliveries.find do |email|
       email.to.include?(@user.email)
     end
 
     assert_equal "New security device added on RubyGems.org", webauthn_credential_creation_email.subject
-    assert_equal edit_settings_path, current_path
 
     # Cleanup test data
     authenticator.remove!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -145,10 +145,16 @@ class ActiveSupport::TestCase
     fill_in "Nickname", with: credential_nickname
     click_on "Register device"
 
+    click_on "[ copy ]"
+    check "ack"
+    click_on "Continue"
+
     find("div", text: credential_nickname, match: :first)
 
     find(:css, ".header__popup-link").click
     click_on "Sign out"
+
+    @authenticator
   end
 end
 


### PR DESCRIPTION
## What problem are you solving?
This PR makes MFA level independent of OTP, and applies MFA level to OTP and WebAuthN at a higher level. MFA level is now set separately for OTP, and can be done when any type of MFA is enabled. Recovery codes are also made to be higher level, applying to both OTP and authn. Recovery codes are generated on the creation of the first MFA device. Currently, recovery codes cannot yet be used with webauthn. We have decided to split this into a separate follow-up PR in order to keep this one smaller. 

Contributes to #3800 

## What approach did you choose and why?
MFA level was made to be higher level to allow webauthn to function independently from OTP. Given that recovery codes and MFA level are both somewhat interwoven on creation and deletion of devices, it was decided to make the relevant changes for those in a single PR to prevent any regression in functionality and prevent any edge cases from popping up.

## What should reviewers focus on?
A lot of the changes come in the `multifactor_auths_controller` to move it to a higher level. This would be a good place to look. 

Codecov is complaining about a decrease in coverage, but it is complaining about lines that do not exist anymore, so not sure what's happening there 🤔. 

## Tested flows

### Creation MFA Levels

- Create OTP as first device, MFA level set
- Create WebAuthN as first device, MFA level set
- Create OTP as first device, change MFA level, add webauthn device, MFA level remains as previous one
- Create webauthn as first device, change MFA level, add otp device, MFA level remains as previous one
- Create webauthn as first device, change MFA level, add second webauthn device, MFA level remains as previous one
- Create OTP as first device, change MFA level, add webauthn device, add second authn device, MFA level remains as previous one
- Create webauthn as first device, change MFA level, add second webauthn device, add otp device MFA level remains as previous one
- Create webauthn as first device, change MFA level, add OTP device, add second webauthn device, MFA level remains as previous one
 
### Creation Recovery Codes

- Create OTP as first device, recovery codes created
- Create Webauthn as first device, recovery codes created
- Create OTP as first device, then webauthn, recovery codes remain the same
- Create webauthn as first device, then OTP, recovery codes remain the same
 
### Deletion MFA Level

- Create OTP device, remove it, no MFA level
- Create authn device, remove it, no MFA level
- Create OTP device, then authn, change MFA level, remove OTP device, MFA level still set
- Create OTP device, then authn, change MFA level, remove webauthn device, MFA level still set
- Create authn device, then OTP, change MFA level, remove webauthn device, MFA level still set
- Create authn device, then OTP, change MFA level, remove OTP device, MFA level still set
- Create OTP device, then authn, change MFA level, remove OTP device, MFA level still set, remove authn device, no MFA level
- Create OTP device, then authn, change MFA level, remove webauthn device, MFA level still set, remove OTP device, no MFA level
- Create authn device, then OTP, change MFA level, remove webauthn device, MFA level still set, remove OTP device, no MFA level
- Create authn device, then OTP, change MFA level, remove OTP device, MFA level still set, remove webauthn device, no MFA level

### Deletion Recovery Codes

- Create OTP device, remove it, no recovery codes
- Create authn device, remove it, no recovery codes
- Create OTP device, then authn, remove OTP device, recovery codes still set
- Create OTP device, then authn, remove webauthn device, recovery codes
- Create authn device, then OTP, remove webauthn device, recovery codes still set
- Create authn device, then OTP, remove OTP device, recovery codes still set
- Create OTP device, then authn, remove OTP device, recovery codes still set, remove authn device, no recovery codes
- Create OTP device, then authn, remove webauthn device, recovery codes still set, remove OTP device, no recovery codes
- Create authn device, then OTP, remove webauthn device, recovery codes still set, remove OTP device, no recovery codes
- Create authn device, then OTP, remove OTP device, recovery codes still set, remove webauthn device, no recovery codes

