### PR TITLE
Add `seed` and `recovery_codes` to filter parameters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,5 +2,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %I[
-  password passw secret token _key crypt salt certificate otp ssn api_key
+  password passw secret token _key crypt salt certificate otp ssn api_key recovery_codes seed
 ]


### PR DESCRIPTION
## What problem are you solving?
The current filtering does not redact seeds (i.e., mfa_seed) or the recovery codes, meaning that these can make their way into logs, in plaintext, which posses a security risk. This PR adds these two parameters as filters.

Before:
<img width="346" alt="Screenshot 2023-06-01 at 4 49 50 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/d667b2a8-b9b9-4947-86a3-b6b361a9a971">

After:
<img width="241" alt="Screenshot 2023-06-01 at 4 49 28 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/d0d3b57a-5b06-460f-8310-999c86a756cd">

## What approach did you choose and why?
Simply added these two items to the Rails filter.

## What should reviewers focus on?
Is there any other params we should be filtering?