### PR TITLE
Fix typo in rake task to backfill mfa levels for WebAuthn-only-enabled accounts

### DIFF
--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -4,8 +4,8 @@ namespace :one_time do
     User.where.not(mfa_seed: nil).update_all("totp_seed = mfa_seed")
   end
 
-  desc "Assign ui_and_gen_signin to webauthn only users"
-  task assign_ui_and_gen_signin: :environment do
-    User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).update_all(mfa_level: :ui_and_gen_signin)
+  desc "Assign ui_and_gem_signin to webauthn only users"
+  task assign_ui_and_gem_signin: :environment do
+    User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).update_all(mfa_level: :ui_and_gem_signin)
   end
 end


### PR DESCRIPTION
## 🤔 What problem are you solving?
Contributes to https://github.com/rubygems/rubygems.org/issues/3800
Contributes to https://github.com/Shopify/ruby-dependency-security/issues/330

This addresses [the review comment](https://github.com/rubygems/rubygems.org/pull/3821#issuecomment-1588345766) noted in the [PR](https://github.com/rubygems/rubygems.org/pull/3821) where MFA levels & recovery codes were decoupled from time-based one time passwords (TOTP).

After WebAuthn had initially been introduced, users had the option of enabling MFA through TOTP or WebAuthn. If a user chose to only have WebAuthn-enabled, they did not have an MFA level associated to their accounts since MFA levels were initially designed to be tightly coupled to TOTP, when TOTP was the only second factor option.

In https://github.com/rubygems/rubygems.org/pull/3821, a task was created to backfill MFA levels for WebAuthn-only-enabled accounts so they could have an MFA level set.

However, there's a typo with the rake task. If the task is run, it'll set the MFA levels to an invalid level, `ui_and_gen_signin`. This PR fixes that typo so we don't backfill the accounts with bad/incorrect data.

## 🛠️ What approach did you choose and why?
Just renaming all references of `ui_and_gen_signin` to `ui_and_gem_signin`

## 👀 What should reviewers focus on?
N/A