### PR TITLE
Recovery code support for webauthn

### DIFF
--- a/app/assets/stylesheets/modules/form.css
+++ b/app/assets/stylesheets/modules/form.css
@@ -23,6 +23,9 @@
 .form__label__icon-container .form__label__text {
   padding-left: 33px;}
 
+.form__label--hidden {
+  display: none; }
+    
 .form__input__addon-container {
   position: relative; }
 

--- a/app/assets/stylesheets/modules/form.css
+++ b/app/assets/stylesheets/modules/form.css
@@ -23,9 +23,6 @@
 .form__label__icon-container .form__label__text {
   padding-left: 33px;}
 
-.form__label--hidden {
-  display: none; }
-    
 .form__input__addon-container {
   position: relative; }
 

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -101,7 +101,6 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def setup_mfa_authentication
-    return if @user.totp_disabled?
     @form_mfa_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
   end
 

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -25,7 +25,7 @@ class EmailConfirmationsController < ApplicationController
 
   def update
     if @user.mfa_enabled?
-      setup_mfa_authentication
+      @form_mfa_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_update_email_confirmations_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
@@ -98,10 +98,6 @@ class EmailConfirmationsController < ApplicationController
 
   def mfa_update_conditions_met?
     @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
-  end
-
-  def setup_mfa_authentication
-    @form_mfa_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
   end
 
   def login_failure(message)

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -4,8 +4,8 @@ class MultifactorAuthsController < ApplicationController
 
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :require_totp_disabled, only: %i[new create]
-  before_action :require_mfa_enabled, only: :update
-  before_action :require_totp_enabled, only: %i[mfa_update destroy]
+  before_action :require_mfa_enabled, only: %i[update mfa_update webauthn_update]
+  before_action :require_totp_enabled, only: :destroy
   before_action :seed_and_expire, only: :create
   before_action :verify_session_expiration, only: %i[mfa_update webauthn_update]
   after_action :delete_mfa_level_update_session_variables, only: %i[mfa_update webauthn_update]

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -42,7 +42,7 @@ class MultifactorAuthsController < ApplicationController
     session[:level] = level_param
     @user = current_user
 
-    setup_mfa_authentication
+    @form_mfa_url = mfa_update_multifactor_auth_url(token: current_user.confirmation_token)
     setup_webauthn_authentication
 
     create_new_mfa_expiry
@@ -136,11 +136,6 @@ class MultifactorAuthsController < ApplicationController
     %i[mfa_seed mfa_seed_expire].each do |key|
       session.delete(key)
     end
-  end
-
-  def setup_mfa_authentication
-    return if current_user.totp_disabled?
-    @form_mfa_url = mfa_update_multifactor_auth_url(token: current_user.confirmation_token)
   end
 
   def setup_webauthn_authentication

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -4,7 +4,7 @@ class MultifactorAuthsController < ApplicationController
 
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :require_totp_disabled, only: %i[new create]
-  before_action :require_mfa_enabled, only: %i[update mfa_update webauthn_update]
+  before_action :require_mfa_enabled, only: %i[update mfa_update]
   before_action :require_totp_enabled, only: :destroy
   before_action :seed_and_expire, only: :create
   before_action :verify_session_expiration, only: %i[mfa_update webauthn_update]

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -74,7 +74,6 @@ class PasswordsController < Clearance::PasswordsController
   end
 
   def setup_mfa_authentication
-    return if @user.totp_disabled?
     @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
   end
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,7 +7,7 @@ class PasswordsController < Clearance::PasswordsController
 
   def edit
     if @user.mfa_enabled?
-      setup_mfa_authentication
+      @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
@@ -71,10 +71,6 @@ class PasswordsController < Clearance::PasswordsController
 
   def deliver_email(user)
     ::ClearanceMailer.change_password(user).deliver_later
-  end
-
-  def setup_mfa_authentication
-    @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
   end
 
   def mfa_edit_conditions_met?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,7 @@ class SessionsController < Clearance::SessionsController
 
     if @user&.mfa_enabled?
       setup_webauthn_authentication(form_url: webauthn_create_session_path, session_options: { "user" => @user.id })
-      setup_mfa_authentication
+      session[:mfa_user] = @user.id
 
       session[:mfa_login_started_at] = Time.now.utc.to_s
       create_new_mfa_expiry
@@ -135,11 +135,6 @@ class SessionsController < Clearance::SessionsController
 
     flash.now.alert = t(".account_blocked")
     render template: "sessions/new", status: :unauthorized
-  end
-
-  def setup_mfa_authentication
-    return if @user.totp_disabled?
-    session[:mfa_user] = @user.id
   end
 
   def login_conditions_met?

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -29,6 +29,10 @@ module UserWebauthnMethods
     webauthn_credentials.none?
   end
 
+  def webauthn_only_with_recovery?
+    webauthn_enabled? && totp_disabled? && mfa_recovery_codes.present?
+  end
+
   def webauthn_options_for_get
     WebAuthn::Credential.options_for_get(
       allow: webauthn_credentials.pluck(:external_id),

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -17,15 +17,30 @@
       </div>
   <% end %>
 
-  <% if @user.totp_enabled? %>
-    <%= form_tag @form_mfa_url, method: :post do %>
-      <div class="text_field">
-        <%= label_tag :otp, t("multifactor_auths.otp_code"), class: "form__label" %>
-        <%= text_field_tag :otp, "", class: "form__input", autofocus: true, autocomplete: :off %>
+  <% if @user.totp_enabled? || @user.webauthn_only_with_recovery? %>
+    <div class="mfa__option">
+      <% if @user.totp_enabled? %>
+        <h2 class="page__subheading--block"> <%= t("multifactor_auths.otp_code") %></h2>
+      <% elsif @user.webauthn_only_with_recovery? %>
+        <h2 class="page__subheading--block"> <%= t("multifactor_auths.recovery_code") %></h2>
+      <% end %>
+      <div class="t-body">
+        <p><%= t("multifactor_auths.recovery_code_html") %></p>
       </div>
-      <div class="form_bottom">
-        <%= submit_tag t("authenticate"), data: {disable_with: t("form_disable_with")}, class: "form__submit" %>
-      </div>
-    <% end %>
+      <%= form_tag @form_mfa_url, method: :post do %>
+        <div class="text_field">
+          <% if @user.totp_enabled? %>
+            <%= label_tag :otp, t('multifactor_auths.otp_or_recovery'), class: 'form__label' %>
+            <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+          <% elsif @user.webauthn_only_with_recovery? %>
+            <%= label_tag :otp, t('multifactor_auths.recovery_code'), class: 'form__label' %>
+            <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+          <% end %>
+        </div>
+        <div class="form_bottom">
+          <%= submit_tag t("authenticate"), data: { disable_with: t("form_disable_with")}, class: "form__submit" %>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -33,8 +33,13 @@
             <%= label_tag :otp, t('multifactor_auths.otp_or_recovery'), class: 'form__label' %>
             <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
           <% elsif @user.webauthn_only_with_recovery? %>
-            <%= label_tag :otp, t('multifactor_auths.recovery_code'), class: 'form__label' %>
-            <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+            <%= text_field_tag :otp,
+              '',
+              class: 'form__input',
+              autofocus: true,
+              autocomplete: :off,
+              aria: { label: t("multifactor_auths.recovery_code") }
+            %>
           <% end %>
         </div>
         <div class="form_bottom">

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -35,8 +35,13 @@
           <%= label_tag :otp, t('.otp_or_recovery'), class: 'form__label' %>
           <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
         <% elsif @user.webauthn_only_with_recovery? %>
-          <%= label_tag :otp, t('.recovery_code'), class: 'form__label' %>
-          <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+          <%= text_field_tag :otp,
+            '',
+            class: 'form__input',
+            autofocus: true,
+            autocomplete: :off,
+            aria: { label: t(".recovery_code") }
+          %>
         <% end %>
         </div>
         <div class="form_bottom">

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -44,5 +44,5 @@
         </div>
       <% end %>
     </div>
-    <% end %>
+  <% end %>
 </div>

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -18,22 +18,31 @@
     </div>
   <% end %>
 
-  <% if @user.mfa_enabled? %>
+  <% if @user.totp_enabled? || @user.webauthn_only_with_recovery? %>
     <div class="mfa__option">
-      <h2 class="page__subheading--block"> <%= t(".otp_code") %></h2>
+      <% if @user.totp_enabled? %>
+        <h2 class="page__subheading--block"> <%= t(".otp_code") %></h2>
+      <% elsif @user.webauthn_only_with_recovery? %>
+        <h2 class="page__subheading--block"> <%= t(".recovery_code") %></h2>
+      <% end %>
       <div class="t-body">
         <p><%= t("multifactor_auths.recovery_code_html") %></p>
       </div>
 
       <%= form_tag mfa_create_session_path, method: :post, class: "mfa-form" do %>
         <div class="text_field">
+        <% if @user.totp_enabled? %>
           <%= label_tag :otp, t('.otp_or_recovery'), class: 'form__label' %>
           <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+        <% elsif @user.webauthn_only_with_recovery? %>
+          <%= label_tag :otp, t('.recovery_code'), class: 'form__label' %>
+          <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: :off %>
+        <% end %>
         </div>
         <div class="form_bottom">
           <%= submit_tag t('.verify_code'), data: { disable_with: t('form_disable_with') }, class: 'form__submit' %>
         </div>
       <% end %>
     </div>
-  <% end %>
+    <% end %>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,7 +344,6 @@ de:
     incorrect_otp:
     session_expired:
     otp_code:
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
@@ -604,6 +603,7 @@ de:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,6 +344,8 @@ de:
     incorrect_otp:
     session_expired:
     otp_code:
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,6 +344,7 @@ de:
     incorrect_otp:
     session_expired:
     otp_code:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
     incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.
     otp_code: OTP code
+    recovery_code: Recovery code
     require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,7 +340,6 @@ en:
     incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.
     otp_code: OTP code
-    recovery_code: Recovery code
     require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
@@ -602,6 +601,7 @@ en:
       sign_in_with_webauthn_credential: Authenticate with security device
       otp_code: One Time Passcode
       otp_or_recovery: OTP or recovery code
+      recovery_code: Recovery code
       security_device: Security Device
       verify_code: Verify code
   stats:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,8 @@ en:
     incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.
     otp_code: OTP code
+    otp_or_recovery: OTP or recovery code
+    recovery_code: Recovery code
     require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
     require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -360,6 +360,8 @@ es:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired:
     otp_code: código OTP
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -360,6 +360,7 @@ es:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired:
     otp_code: código OTP
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -360,7 +360,6 @@ es:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired:
     otp_code: código OTP
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
@@ -648,6 +647,7 @@ es:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,6 +362,7 @@ fr:
     incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:
     otp_code: clé OTP
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,7 +362,6 @@ fr:
     incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:
     otp_code: clé OTP
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
@@ -654,6 +653,7 @@ fr:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -362,6 +362,8 @@ fr:
     incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:
     otp_code: clé OTP
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -331,6 +331,8 @@ ja:
     incorrect_otp:
     session_expired:
     otp_code:
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -331,6 +331,7 @@ ja:
     incorrect_otp:
     session_expired:
     otp_code:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -331,7 +331,6 @@ ja:
     incorrect_otp:
     session_expired:
     otp_code:
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
@@ -593,6 +592,7 @@ ja:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -348,6 +348,7 @@ nl:
     incorrect_otp:
     session_expired:
     otp_code:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -348,6 +348,8 @@ nl:
     incorrect_otp:
     session_expired:
     otp_code:
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -348,7 +348,6 @@ nl:
     incorrect_otp:
     session_expired:
     otp_code:
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
@@ -608,6 +607,7 @@ nl:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -359,6 +359,7 @@ pt-BR:
     incorrect_otp:
     session_expired:
     otp_code:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -359,6 +359,8 @@ pt-BR:
     incorrect_otp:
     session_expired:
     otp_code:
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -359,7 +359,6 @@ pt-BR:
     incorrect_otp:
     session_expired:
     otp_code:
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled:
     require_totp_enabled:
@@ -631,6 +630,7 @@ pt-BR:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -331,7 +331,6 @@ zh-CN:
     incorrect_otp: 你的 OTP 码 不正确。
     session_expired:
     otp_code: OTP 码
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     require_totp_enabled:
@@ -590,6 +589,7 @@ zh-CN:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -331,6 +331,7 @@ zh-CN:
     incorrect_otp: 你的 OTP 码 不正确。
     session_expired:
     otp_code: OTP 码
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     require_totp_enabled:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -331,6 +331,8 @@ zh-CN:
     incorrect_otp: 你的 OTP 码 不正确。
     session_expired:
     otp_code: OTP 码
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
     require_totp_enabled:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -332,6 +332,7 @@ zh-TW:
     incorrect_otp: 你的 OTP 碼 不正確。
     session_expired:
     otp_code: OTP 碼
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     require_totp_enabled:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -332,7 +332,6 @@ zh-TW:
     incorrect_otp: 你的 OTP 碼 不正確。
     session_expired:
     otp_code: OTP 碼
-    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     require_totp_enabled:
@@ -591,6 +590,7 @@ zh-TW:
       sign_in_with_webauthn_credential:
       otp_code:
       otp_or_recovery:
+      recovery_code:
       security_device:
       verify_code:
   stats:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -332,6 +332,8 @@ zh-TW:
     incorrect_otp: 你的 OTP 碼 不正確。
     session_expired:
     otp_code: OTP 碼
+    otp_or_recovery:
+    recovery_code:
     require_totp_disabled:
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
     require_totp_enabled:

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -87,9 +87,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       end
     end
 
-    context "user has mfa enabled" do
+    context "user has totp enabled" do
       setup do
-        @user.mfa_ui_only!
+        @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
         get :update, params: { token: @user.confirmation_token }
       end
 
@@ -97,6 +97,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       should "display otp form" do
         assert page.has_content?("Multi-factor authentication")
+        assert page.has_content?("OTP or recovery code")
       end
     end
 
@@ -135,6 +136,24 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       should "display recovery code prompt" do
         assert page.has_content?("Recovery code")
+      end
+    end
+
+    context "when user has webauthn and totp" do
+      setup do
+        @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+        create(:webauthn_credential, user: @user)
+        get :update, params: { token: @user.confirmation_token }
+      end
+
+      should respond_with :success
+
+      should "display webauthn prompt" do
+        assert page.has_button?("Authenticate with security device")
+      end
+
+      should "display otp prompt" do
+        assert page.has_content?("OTP or recovery code")
       end
     end
   end

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -99,6 +99,44 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         assert page.has_content?("Multi-factor authentication")
       end
     end
+
+    context "user has webauthn enabled but no recovery codes" do
+      setup do
+        create(:webauthn_credential, user: @user)
+        @user.mfa_recovery_codes = []
+        @user.save!
+        get :update, params: { token: @user.confirmation_token }
+      end
+
+      should respond_with :success
+
+      should "display webauthn form" do
+        assert page.has_content?("Multi-factor authentication")
+        assert page.has_button?("Authenticate with security device")
+      end
+
+      should "not display recovery code prompt" do
+        refute page.has_content?("Recovery code")
+      end
+    end
+
+    context "user has webauthn enabled and recovery codes" do
+      setup do
+        create(:webauthn_credential, user: @user)
+        get :update, params: { token: @user.confirmation_token }
+      end
+
+      should respond_with :success
+
+      should "display webauthn form" do
+        assert page.has_content?("Multi-factor authentication")
+        assert page.has_button?("Authenticate with security device")
+      end
+
+      should "display recovery code prompt" do
+        assert page.has_content?("Recovery code")
+      end
+    end
   end
 
   context "on POST to mfa_update" do

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -330,6 +330,10 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           assert page.has_content?("Security Device")
         end
 
+        should "render recovery code prompt" do
+          assert page.has_content?("Recovery code")
+        end
+
         should "not update mfa level" do
           assert_predicate @user.reload, :mfa_ui_only?
         end

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -731,7 +731,8 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         should redirect_to("the settings page") { edit_settings_path }
 
         should "set flash error" do
-          assert_equal "Your multi-factor authentication has not been enabled. You have to enable it first.", flash[:error]
+          assert_equal "You don't have any security devices enabled. " \
+                       "You have to associate a device to your account first.", flash[:error]
         end
       end
 

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -85,7 +85,7 @@ class PasswordsControllerTest < ActionController::TestCase
       end
 
       should "not display recovery code prompt" do
-        refute page.has_content?("Recovery Code")
+        refute page.has_content?("Recovery code")
       end
     end
 
@@ -104,7 +104,7 @@ class PasswordsControllerTest < ActionController::TestCase
       end
 
       should "display recovery code prompt" do
-        assert page.has_button?("Authenticate")
+        assert page.has_content?("Recovery code")
       end
     end
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -85,11 +85,27 @@ class PasswordsControllerTest < ActionController::TestCase
       end
 
       should "not display recovery code prompt" do
-        assert page.has_button?("Authenticate")
+        refute page.has_content?("Recovery Code")
       end
     end
 
     context "when user has webauthn credentials and recovery codes" do
+      setup do
+        create(:webauthn_credential, user: @user)
+        @user.save!
+        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
+      end
+
+      should respond_with :success
+
+      should "display webauthn prompt" do
+        assert page.has_button?("Authenticate with security device")
+      end
+
+      should "display recovery code prompt" do
+        assert page.has_button?("Authenticate")
+      end
     end
   end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -347,8 +347,44 @@ class SessionsControllerTest < ActionController::TestCase
         assert_not_nil session[:webauthn_authentication]["challenge"]
       end
 
-      should "not set mfa_user" do
-        assert_nil session[:mfa_user]
+      should "set mfa_user" do
+        assert_equal @user.id, session[:mfa_user]
+      end
+
+      should "have recovery code form if user has recovery codes" do
+        assert page.has_content?("Multi-factor authentication")
+        assert page.has_field?("Recovery code")
+        assert page.has_button?("Verify code")
+      end
+
+      should "not have mfa forms and have webauthn credentials form" do
+        assert page.has_content?("Multi-factor authentication")
+        assert_not page.has_field?("OTP code")
+        assert page.has_button?("Authenticate with security device")
+      end
+    end
+
+    context "when user has webauthn credentials but no recovery code" do
+      setup do
+        @user = create(:user)
+        create(:webauthn_credential, user: @user)
+        @user.mfa_recovery_codes = []
+        @user.save!
+        post(
+          :create,
+          params: { session: { who: @user.handle, password: @user.password } }
+        )
+      end
+
+      should respond_with :ok
+
+      should "set webauthn authentication" do
+        assert_equal @user.id, session[:webauthn_authentication]["user"]
+        assert_not_nil session[:webauthn_authentication]["challenge"]
+      end
+
+      should "set mfa_user" do
+        assert_equal @user.id, session[:mfa_user]
       end
 
       should "not have mfa forms and have webauthn credentials form" do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -353,7 +353,7 @@ class SessionsControllerTest < ActionController::TestCase
 
       should "have recovery code form if user has recovery codes" do
         assert page.has_content?("Multi-factor authentication")
-        assert page.has_field?("Recovery code")
+        assert page.has_content?("Recovery code")
         assert page.has_button?("Verify code")
       end
 
@@ -390,7 +390,7 @@ class SessionsControllerTest < ActionController::TestCase
       should "not have mfa forms and have webauthn credentials form" do
         assert page.has_content?("Multi-factor authentication")
         assert_not page.has_field?("OTP code")
-        assert_not page.has_field?("Recovery code")
+        assert_not page.has_content?("Recovery code")
         assert page.has_button?("Authenticate with security device")
       end
     end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -100,7 +100,7 @@ class EmailConfirmationTest < SystemTest
     assert page.has_content?("SIGN OUT")
   end
 
-  test "reqeuesting confirmation mail with webauthn enabled using recovery codes" do
+  test "requesting confirmation mail with webauthn enabled using recovery codes" do
     create_webauthn_credential
 
     request_confirmation_mail @user.email
@@ -139,7 +139,7 @@ class EmailConfirmationTest < SystemTest
   end
 
   teardown do
-    @authenticator.remove! if @authenticator
+    @authenticator&.remove!
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -98,8 +98,27 @@ class EmailConfirmationTest < SystemTest
     find(:css, ".header__popup-link").click
 
     assert page.has_content?("SIGN OUT")
+  end
 
-    @authenticator.remove!
+  test "reqeuesting confirmation mail with webauthn enabled using recovery codes" do
+    create_webauthn_credential
+
+    request_confirmation_mail @user.email
+
+    link = last_email_link
+
+    assert_not_nil link
+    visit link
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+
+    fill_in "otp", with: @user.mfa_recovery_codes.first
+    click_button "Authenticate"
+
+    find(:css, ".header__popup-link").click
+
+    assert page.has_content?("SIGN OUT")
   end
 
   test "requesting confirmation mail with mfa enabled, but mfa session is expired" do
@@ -120,6 +139,7 @@ class EmailConfirmationTest < SystemTest
   end
 
   teardown do
+    @authenticator.remove! if @authenticator
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -134,8 +134,29 @@ class PasswordResetTest < SystemTest
     find(:css, ".header__popup-link").click
 
     assert page.has_content?("SIGN OUT")
+  end
 
-    @authenticator.remove!
+  test "resetting password when webauthn is enabled using recovery codes" do
+    create_webauthn_credential
+
+    forgot_password_with @user.email
+
+    visit password_reset_link
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+    assert page.has_content? "Recovery code"
+    assert_not_nil page.find(".js-webauthn-session--form")[:action]
+
+    fill_in "otp", with: @user.mfa_recovery_codes.first
+    click_button "Authenticate"
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Save this password"
+
+    find(:css, ".header__popup-link").click
+
+    assert page.has_content?("SIGN OUT")
   end
 
   test "resetting password with pending email change" do
@@ -171,6 +192,7 @@ class PasswordResetTest < SystemTest
   end
 
   teardown do
+    @authenticator.remove! if @authenticator
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -192,7 +192,7 @@ class PasswordResetTest < SystemTest
   end
 
   teardown do
-    @authenticator.remove! if @authenticator
+    @authenticator&.remove!
     Capybara.reset_sessions!
     Capybara.use_default_driver
   end

--- a/test/models/concerns/user_webauthn_methods_test.rb
+++ b/test/models/concerns/user_webauthn_methods_test.rb
@@ -35,6 +35,31 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
     end
   end
 
+  context "#webauthn_only_with_recovery?" do
+    should "return true if webauthn is enabled, totp is disabled, and recovery codes are present" do
+      create(:webauthn_credential, user: @user)
+
+      assert_predicate @user, :webauthn_only_with_recovery?
+    end
+
+    should "return false if webauthn is disabled" do
+      refute_predicate @user, :webauthn_only_with_recovery?
+    end
+
+    should "return false if totp is enabled" do
+      @user.enable_totp!(ROTP::Base32.random_base32, "ui_and_api")
+
+      refute_predicate @user, :webauthn_only_with_recovery?
+    end
+
+    should "return false if recovery codes are not present" do
+      create(:webauthn_credential, user: @user)
+      @user.mfa_recovery_codes = []
+
+      refute_predicate @user, :webauthn_only_with_recovery?
+    end
+  end
+
   context "#webauthn_options_for_create" do
     should "returns options with id, and name" do
       user_create_options = @user.webauthn_options_for_create.user

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -50,4 +50,20 @@ class SignInWebauthnTest < ApplicationSystemTestCase
       assert page.has_content? "Multi-factor authentication"
     end
   end
+
+  test "sign in with webauthn using recovery codes" do
+    visit sign_in_path
+
+    fill_in "Email or Username", with: @user.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+
+    assert page.has_content? "Multi-factor authentication"
+    assert page.has_content? "Security Device"
+
+    fill_in "otp", with: @user.mfa_recovery_codes.first
+    click_button "Verify code"
+
+    assert page.has_content? "Dashboard"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,6 +155,7 @@ class ActiveSupport::TestCase
     find(:css, ".header__popup-link").click
     click_on "Sign out"
 
+    @user.reload
     @authenticator
   end
 end


### PR DESCRIPTION
## What problem are you solving?
This PR allows recovery codes to be used with webauthn. If a user generates webauthn credentials after #3821 was merged, or has OTP enabled, they will have recovery codes which can be used. On both prompts, this functionality is now supported.

If a user has webauthn only enabled, and has recovery codes, this is what they will see:
<img width="1151" alt="Screenshot 2023-06-08 at 1 49 20 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/298fa211-7f63-4a11-9f42-3b0d3343d67b">


Contributes to #3800 

## What approach did you choose and why?
There is a case where a webauthn user wouldn't have recovery codes. That is, if they had webauthn only enabled before #3821 was merged. So, there is protection in rendering, in order to not render the recovery code prompt if a user does not have these recovery codes. The recovery code field simply uses the existing OTP field. 


