### PR TITLE
Update enable and disable messages to be more specific

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -25,7 +25,7 @@ class MultifactorAuthsController < ApplicationController
       flash[:error] = current_user.errors[:base].join
       redirect_to edit_settings_url
     else
-      flash.now[:success] = t(".success")
+      flash[:success] = t(".success")
       @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
 
       if current_user.mfa_device_count_one?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,7 +359,7 @@ en:
       time_based: "Time based: Yes"
     create:
       qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
-      success: You have successfully enabled multi-factor authentication.
+      success: You have successfully enabled OTP based multi-factor authentication.
     recovery:
       copied: "[ copied ]"
       continue: Continue
@@ -369,7 +369,7 @@ en:
       note_html: "Please <strong class='recovery__bold'>copy and save</strong> these recovery codes. You can use these codes to login and reset your MFA if your lose your authentication device. Each code can be used once."
       already_generated: You should have already saved your recovery codes.
     destroy:
-      success: You have successfully disabled multi-factor authentication.
+      success: You have successfully disabled OTP based multi-factor authentication.
     update:
       invalid_level: Invalid MFA level.
       success: You have successfully updated your multi-factor authentication level.

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -253,7 +253,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           end
 
           should "flash success" do
-            assert_equal "You have successfully disabled multi-factor authentication.", flash[:success]
+            assert_equal "You have successfully disabled OTP based multi-factor authentication.", flash[:success]
           end
 
           should "delete mfa_redirect_uri from session" do

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -642,6 +642,10 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             assert_equal "Multi-factor authentication enabled on RubyGems.org", last_email.subject
             assert_equal [@user.email], last_email.to
           end
+
+          should "flash success" do
+            assert_equal "You have successfully enabled OTP based multi-factor authentication.", flash[:success]
+          end
         end
 
         context "when qr-code is expired" do


### PR DESCRIPTION
## What problem are you solving?
The messaging on update and deletion of a OTP device was too generic, saying they enabled or disabled multi-factor authentication.

Contributes to #3800 

## What approach did you choose and why?
Changed the messaging to be OTP specific.


