### PR TITLE
Switch webauthn_credentials.any? and .present? to be webauthn_enabled?

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::ApiKeysController < Api::BaseController
       return render_mfa_strong_level_required_error if user.mfa_required_weak_level_enabled?
 
       yield
-    elsif user&.mfa_enabled? || user&.webauthn_credentials.present?
+    elsif user&.mfa_enabled?
       prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)
       render plain: prompt_text, status: :unauthorized
     else

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
   before_action :authenticate_with_credentials
 
   def create
-    if @user.webauthn_credentials.present?
+    if @user.webauthn_enabled?
       verification = @user.refresh_webauthn_verification
       webauthn_path = webauthn_verification_url(verification.path_token)
       respond_to do |format|

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -24,7 +24,7 @@ class EmailConfirmationsController < ApplicationController
   end
 
   def update
-    if @user.mfa_enabled? || @user.webauthn_credentials.any?
+    if @user.mfa_enabled?
       setup_mfa_authentication
       setup_webauthn_authentication(form_url: webauthn_update_email_confirmations_url(token: @user.confirmation_token))
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,7 +6,7 @@ class PasswordsController < Clearance::PasswordsController
   after_action :delete_mfa_expiry_session, only: %i[mfa_edit webauthn_edit]
 
   def edit
-    if @user.mfa_enabled? || @user.webauthn_credentials.any?
+    if @user.mfa_enabled?
       setup_mfa_authentication
       setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < Clearance::SessionsController
   def create
     @user = find_user
 
-    if @user && (@user.mfa_enabled? || @user.webauthn_credentials.any?)
+    if @user&.mfa_enabled?
       setup_webauthn_authentication(form_url: webauthn_create_session_path, session_options: { "user" => @user.id })
       setup_mfa_authentication
 

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -9,7 +9,7 @@ module UserMultifactorMethods
   end
 
   def mfa_enabled?
-    if webauthn_credentials.present? && mfa_disabled?
+    if webauthn_enabled? && mfa_disabled?
       self.mfa_level = :ui_and_gem_signin
       save!(validate: false)
     end
@@ -26,7 +26,7 @@ module UserMultifactorMethods
   end
 
   def mfa_gem_signin_authorized?(otp)
-    return true unless strong_mfa_level? || webauthn_credentials.present?
+    return true unless strong_mfa_level? || webauthn_enabled?
     api_mfa_verified?(otp)
   end
 

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -1,7 +1,7 @@
 <% @title = t("multifactor_authentication") %>
 
 <div class="mfa__container">
-  <% if @user.webauthn_credentials.any?%>
+  <% if @user.webauthn_enabled?%>
     <div class="mfa__option">
         <h2 class="page__subheading--block"> <%= t("sessions.prompt.security_device") %></h2>
         <div class="t-body">

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -1,7 +1,7 @@
 <% @title = t('multifactor_authentication') %>
 
 <div class="mfa__container">
-  <% if @user.webauthn_credentials.any? %>
+  <% if @user.webauthn_enabled? %>
     <div class="mfa__option">
       <h2 class="page__subheading--block"> <%= t(".security_device") %></h2>
       <div class="t-body">

--- a/app/views/webauthn_verifications/prompt.html.erb
+++ b/app/views/webauthn_verifications/prompt.html.erb
@@ -1,6 +1,6 @@
 <% @title = t(".title")%>
 
-<% if @user.webauthn_credentials.any? %>
+<% if @user.webauthn_enabled? %>
   <div class="t-body">
     <% if browser.safari? %>
       <p class="l-text-red-600" ><%= t(".safari_note_html") %></p>


### PR DESCRIPTION
## What problem are you solving?
`user.webauthn_credentials.any?` and `user.webauthn_credentials.present?` were used to detect if any webauthn credentials are present. But, there is a method, `webauthn_enabled?` that we can now use. The different patterns used to detect if there are webauthn credentials is inconsistent. 

Further, prior to decoupling, we used `@user.mfa_enabled? || @user.webauthn_credentials.any?` (or `present?`) to represent if MFA is enabled. Now that `@user.mfa_enabled?` encompasses both totp and webauthn devices, the ` || @user.webauthn_credentials.any?` should be removed.

Contributes to #3800 

## What approach did you choose and why?
Removes instances of `.present?` and `.any?` and replaces with `webauthn_enabled?` where needed. Also remove the now unnecessary or-ing to check if mfa is enabled.


