### PR TITLE
Add polling fallback to Safari browsers

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -17,6 +17,19 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
     end
   end
 
+  def status
+    verification = @user.webauthn_verification
+    if verification.path_token != params[:webauthn_token]
+      render json: { status: :not_found, message: t(:not_found) }
+    elsif verification.otp_expired?
+      render json: { status: :expired, message: t("webauthn_verifications.expired_or_already_used") }
+    elsif verification.otp.nil?
+      render json: { status: :pending, message: t("webauthn_verifications.pending") }
+    else
+      render json: { status: :success, code: verification.otp }
+    end
+  end
+
   private
 
   def authenticate_with_credentials

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -162,4 +162,8 @@ class ApplicationController < ActionController::Base
       user_email: current_user.email
     )
   end
+
+  def browser
+    Browser.new(request.user_agent)
+  end
 end

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -24,6 +24,7 @@ class WebauthnVerificationsController < ApplicationController
     @verification.generate_otp
     @verification.expire_path_token
 
+    return render plain: "success" if browser.safari?
     redirect_to(URI.parse("http://localhost:#{port}?code=#{@verification.otp}").to_s, allow_other_host: true)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,8 +70,4 @@ module ApplicationHelper
     return sanitize(msg) if name.end_with? "html"
     msg
   end
-
-  def browser
-    Browser.new(request.user_agent)
-  end
 end

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -25,14 +25,15 @@ class WebauthnVerification < ApplicationRecord
     expire_otp
   end
 
+  def otp_expired?
+    return false if otp_expires_at.nil?
+    otp_expires_at < Time.now.utc
+  end
+
   private
 
   def expire_otp
     self.otp_expires_at = 1.second.ago
     save!
-  end
-
-  def otp_expired?
-    otp_expires_at < Time.now.utc
   end
 end

--- a/app/views/webauthn_verifications/prompt.html.erb
+++ b/app/views/webauthn_verifications/prompt.html.erb
@@ -2,9 +2,6 @@
 
 <% if @user.webauthn_enabled? %>
   <div class="t-body">
-    <% if browser.safari? %>
-      <p class="l-text-red-600" ><%= t(".safari_note_html") %></p>
-    <% end %>
     <h2><%= t(".authenticating_as") %> <%= @user.name %></h2>
     <p><%= t("settings.edit.webauthn_credential_note") %></p>
   </div>
@@ -13,7 +10,7 @@
     <div class="form_bottom">
       <p hidden class="l-text-red-600 js-webauthn-session-cli--error"></p>
 
-      <%= submit_tag t(".authenticate"), class: 'js-webauthn-session-cli--submit form__submit form__submit--no-hover', disabled: browser.safari? %>
+      <%= submit_tag t(".authenticate"), class: 'js-webauthn-session-cli--submit form__submit form__submit--no-hover' %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -395,6 +395,7 @@ de:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -400,7 +400,6 @@ de:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,7 @@ en:
   webauthn_verifications:
     expired_or_already_used: The token in the link you used has either expired or been used already.
     no_port: No port provided. Please try again.
+    pending: Security device authentication is still pending.
     prompt:
       title: Authenticate with Security Device
       authenticating_as: Authenticating as

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -399,7 +399,6 @@ en:
       authenticating_as: Authenticating as
       authenticate: Authenticate
       no_webauthn_devices: You don't have any security devices enabled
-      safari_note_html: It looks like you are using Safari. Due to limitations within Safari, you will be unable to authenticate using this browser. Please use a different browser. Refer to the <a target="_blank" href="https://guides.rubygems.org/using-webauthn-mfa-in-command-line">WebAuthn MFA CLI guide</a> for more information on this limitation.
     successful_verification:
       title: Success!
       close_browser: Please close this browser.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -421,7 +421,6 @@ es:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -416,6 +416,7 @@ es:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -418,6 +418,7 @@ fr:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -423,7 +423,6 @@ fr:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -382,6 +382,7 @@ ja:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -387,7 +387,6 @@ ja:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -399,6 +399,7 @@ nl:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -404,7 +404,6 @@ nl:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -410,6 +410,7 @@ pt-BR:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -415,7 +415,6 @@ pt-BR:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -382,6 +382,7 @@ zh-CN:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -387,7 +387,6 @@ zh-CN:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -383,6 +383,7 @@ zh-TW:
   webauthn_verifications:
     expired_or_already_used:
     no_port:
+    pending:
     prompt:
       title:
       authenticating_as:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -388,7 +388,6 @@ zh-TW:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
-      safari_note_html:
     successful_verification:
       title:
       close_browser:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
       end
       resource :multifactor_auth, only: :show
       resource :webauthn_verification, only: :create do
-        get ':webauthn_token/status', action: :status, constraints: { format: :json }
+        get ':webauthn_token/status', action: :status, as: :status, constraints: { format: :json }
       end
       resources :profiles, only: :show
       get "profile/me", to: "profiles#me"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
         end
       end
       resource :multifactor_auth, only: :show
-      resource :webauthn_verification, only: :create
+      resource :webauthn_verification, only: :create do
+        get ':webauthn_token/status', action: :status, constraints: { format: :json }
+      end
       resources :profiles, only: :show
       get "profile/me", to: "profiles#me"
       resources :downloads, only: :index do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,10 +6,4 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   # TODO: remove once https://github.com/rails/rails/pull/47117 is released
   Selenium::WebDriver.logger.ignore(:capabilities)
-
-  Capybara.register_driver :fake_safari do |app|
-    Capybara::RackTest::Driver.new(app,
-      headers: { "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_3) AppleWebKit/605.1.15 (KHTML, like Gecko)
-         Version/16.4 Safari/605.1.15" })
-  end
 end

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -131,6 +131,25 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
     end
 
+    context "when verifying the challenge with safari" do
+      setup do
+        @challenge = session[:webauthn_authentication]["challenge"]
+        @origin = "http://localhost:3000"
+        @rp_id = URI.parse(@origin).host
+        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
+        WebauthnHelpers.create_credential(
+          webauthn_credential: @webauthn_credential,
+          client: @client
+        )
+        Browser::Unknown.any_instance.stubs(:safari?).returns true
+        authenticate_request
+      end
+
+      should "render success" do
+        assert_equal "success", response.body
+      end
+    end
+
     context "when not providing credentials" do
       setup do
         travel_to Time.utc(2023, 1, 1, 0, 0, 3) do

--- a/test/models/concerns/user_webauthn_methods_test.rb
+++ b/test/models/concerns/user_webauthn_methods_test.rb
@@ -119,5 +119,17 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
 
       refute_equal token_before, @user.webauthn_verification.path_token
     end
+
+    should "reset the otp each time the method is called" do
+      @webauthn_verification.generate_otp
+
+      assert_not_nil @user.webauthn_verification.otp
+      assert_not_nil @user.webauthn_verification.otp_expires_at
+
+      @user.refresh_webauthn_verification
+
+      assert_nil @user.webauthn_verification.otp
+      assert_nil @user.webauthn_verification.otp_expires_at
+    end
   end
 end

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -24,29 +24,6 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     assert_link_is_expired
   end
 
-  test "when verifying webauthn and not using safari" do
-    visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
-    WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true
-
-    refute_match "It looks like you are using Safari. Due to limitations within Safari, " \
-                 "you will be unable to authenticate using this browser. Please use a different browser. " \
-                 'Refer to the <a target="_blank" href="https://guides.rubygems.org/using-webauthn-mfa-in-command-line">' \
-                 "WebAuthn MFA CLI guide</a> for more information on this limitation.",
-      page.html
-  end
-
-  test "when verifying webauthn and using safari" do
-    Capybara.current_driver = :fake_safari
-    visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
-    WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true
-
-    assert_match "It looks like you are using Safari. Due to limitations within Safari, " \
-                 "you will be unable to authenticate using this browser. Please use a different browser. " \
-                 'Refer to the <a target="_blank" href="https://guides.rubygems.org/using-webauthn-mfa-in-command-line">' \
-                 "WebAuthn MFA CLI guide</a> for more information on this limitation.",
-      page.html
-  end
-
   test "when client closes connection during verification" do
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
     WebAuthn::AuthenticatorAssertionResponse.any_instance.stubs(:verify).returns true

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -159,6 +159,40 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
       end
     end
 
+    context "#otp_expired?" do
+      context "when otp is expired" do
+        setup do
+          @expires_at = @current_time - 1.minute
+          @verification = create(:webauthn_verification, user: @user, otp_expires_at: @expires_at)
+        end
+
+        should "return true" do
+          assert_predicate @verification, :otp_expired?
+        end
+      end
+
+      context "when otp is not expired" do
+        setup do
+          @expires_at = @current_time + 1.minute
+          @verification = create(:webauthn_verification, user: @user, otp_expires_at: @expires_at)
+        end
+
+        should "return false" do
+          refute_predicate @verification, :otp_expired?
+        end
+      end
+
+      context "when otp has not been generated" do
+        setup do
+          @verification = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+        end
+
+        should "return false" do
+          refute_predicate @verification, :otp_expired?
+        end
+      end
+    end
+
     teardown do
       travel_back
     end


### PR DESCRIPTION
## What problem are you solving?
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->

Fixes: https://github.com/rubygems/rubygems.org/issues/3826
Discussed in the issue, we decided to rely on a polling solution for Safari users

RubyGems PR: https://github.com/rubygems/rubygems/pull/6774

## What approach did you choose and why?
<!--  If you've explored different options, list them, and share your rationale for the approach you took. -->

A new JSON API endpoint is added to poll the otp `/api/v1/webauthn_verification/<token>/status`. It requires the webauthn token to be known as well as the user credentials (whether that is api key or email/password combo).

Example responses
```
{
  status: "pending"
  message: "Security device authentication is still pending."
}

{
  status: "success"
  code: "i1273ti13gei"
}

{
  status: "expired"
  message: "The token in the link you used has either expired or been used already."
}
```

If the user is using Safari, instead of redirecting the user to localhost after successful webauthn verification in the browser, [we'll show the success page](https://github.com/shopify/rubygems.org/blob/5cc347e37c8fcee61d9f463cba4f4c62fde46a6c/app/controllers/webauthn_verifications_controller.rb#L27) (since the auth on the browser was successful).

On the CLI, since we can't be sure which browser the user will be using (finding the default browser won't be fool proof since a user can paste the link into any browser), so we'll have a socket and poller open. Whichever thread terminates successfully with the otp will be used.

## What should reviewers focus on?
<!-- If there are any risks in shipping this, list them here too. -->
- Is the naming and format good with this endpoint (url and fields)?

## Testing
<!-- aka tophatting instructions. -->
- Use this CLI branch https://github.com/rubygems/rubygems/pull/6774
- Have a Webauthn credential associated with your user.
- Run `RUBYGEMS_HOST=http://localhost:3000 ruby -Ilib exe/gem signin` and webauthn verify using Safari