### PR TITLE
Add admin action to reserve a gem namespace

### DIFF
--- a/app/avo/actions/reserve_namespace.rb
+++ b/app/avo/actions/reserve_namespace.rb
@@ -1,0 +1,47 @@
+class ReserveNamespace < BaseAction
+  self.name = "Reserve Namespace"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :index
+  }
+  self.standalone = true
+  self.confirm_button_label = "Reserve Namespace"
+
+  field :name, name: "Name", as: :text, required: true
+  field :version, name: "Version", as: :text, required: true, default: "0.0.0.reserved"
+
+  class ActionHandler < ActionHandler
+    def handle_standalone
+      if (rubygem = Rubygem.find_by(name: fields["name"])) && rubygem.indexed_versions?
+        raise "This gem has indexed versions. To reserve the namespace, first yank all indexed versions."
+      end
+
+      user = User.find_by!(email: "security@rubygems.org")
+      gemcutter = Pusher.new(user, gem_body)
+      raise("Failed to push gem: #{gemcutter.message}") unless gemcutter.process
+      succeed("Namespace reserved: #{gemcutter.message}")
+      gemcutter.version
+    end
+
+    private
+
+    def gem_body
+      io = StringIO.new
+      package = Gem::Package.new(io, nil)
+      package.spec = Gem::Specification.new do |s|
+        s.name = fields["name"]
+        s.version = fields["version"]
+        s.authors = ["RubyGems.org"]
+        s.summary = "This gem namespace is reserved by RubyGems.org"
+      end
+
+      # TODO: delete once https://github.com/rubygems/rubygems/pull/6769 is released
+      source = package.gem
+      def source.path
+        "reserved.gem"
+      end
+
+      package.build
+      io.tap(&:rewind)
+    end
+  end
+end

--- a/app/avo/resources/rubygem_resource.rb
+++ b/app/avo/resources/rubygem_resource.rb
@@ -17,6 +17,7 @@ class RubygemResource < Avo::BaseResource
   action ReleaseReservedNamespace
   action AddOwner
   action YankRubygem
+  action ReserveNamespace
 
   class IndexedFilter < ScopeBooleanFilter; end
   filter IndexedFilter, arguments: { default: { with_versions: true, without_versions: true } }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -159,7 +159,7 @@ Admin::GitHubUser.create_with(
 ).find_or_create_by!(github_id: "FAKE-not_an_admin")
 
 puts <<~MESSAGE # rubocop:disable Rails/Output
-  Three users  were created, you can login with following combinations:
+  Four users were created, you can login with following combinations:
     - email: #{author.email}, password: #{password} -> gem author owning few example gems
     - email: #{maintainer.email}, password: #{password} -> gem maintainer having push access to one author's example gem
     - email: #{user.email}, password: #{password} -> user with no gems


### PR DESCRIPTION
<img width="754" alt="image" src="https://github.com/rubygems/rubygems.org/assets/1946610/a0eeaafa-1d52-4825-b73c-ccfa7a77228d">

So the rubygems.org security team can actively prevent squatters from re-taking a namespace after yanking all versions