### PR TITLE
Increase font size of MFA text

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -66,7 +66,6 @@
     opacity: .5; }
 
 .gem__users__mfa-text {
-  font-size: 14px;
   color: #e9573f;
 }
 .gem__downloads-wrap {

--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -66,7 +66,7 @@
     opacity: .5; }
 
 .gem__users__mfa-text {
-  font-size: 9px;
+  font-size: 14px;
   color: #e9573f;
 }
 .gem__downloads-wrap {


### PR DESCRIPTION
The font size for the MFA reminder text is very small at 9px. I've increased it to 14px.

Before:
<img width="1552" alt="Screenshot 2023-06-25 at 11 32 03 AM" src="https://github.com/rubygems/rubygems.org/assets/4227/f19588e4-192b-47d9-bdba-43da08290f2c">


After:
<img width="1552" alt="Screenshot 2023-06-25 at 11 32 20 AM" src="https://github.com/rubygems/rubygems.org/assets/4227/c2dd1e4b-42b9-445a-8327-1817bef14b55">
