### PR TITLE
Adding page title to adoptions#index page.

### DIFF
--- a/app/views/adoptions/index.html.erb
+++ b/app/views/adoptions/index.html.erb
@@ -1,3 +1,5 @@
+<% @title_for_header_only = t('.title') %>
+
 <% content_for :title do %>
   <h1 class="t-display page__heading page__heading--small">
     <%= t('.title') %>


### PR DESCRIPTION
This change adds the title to the tab/window. It doesn't change the body of the page.

Before:
<img width="1547" alt="Screenshot 2023-06-26 at 1 02 00 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/62574aa1-ad42-453c-a36f-e1d77db2c6ae">


After:
<img width="1547" alt="Screenshot 2023-06-26 at 1 01 43 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/cd58bdcb-b032-4e6b-aa39-3ecbf37243ab">
