### PR TITLE
Fix class name and font size for for markdown supported text

### DIFF
--- a/app/views/ownership_calls/_form.html.erb
+++ b/app/views/ownership_calls/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag rubygem_ownership_calls_path, method: :post, class: "ownership_call_form", id: "new_ownership_call" do %>
     <div class="text_field">
       <%= label_tag :note, t("ownership_calls.note_for_applicants"),  class: "form__label" %>
-      <span class="gem__users__mfa-text"><%= t("ownership_calls.markup_supported_html") %></span>
+      <%= t("ownership_calls.markup_supported_html") %>
       <%= text_area_tag :note, nil, placeholder: t("ownership_calls.share_requirements"), class: "form__input form__textarea", required: true %>
     </div>
     <div class="submit_field">

--- a/app/views/ownership_requests/_form.html.erb
+++ b/app/views/ownership_requests/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag rubygem_ownership_requests_path(@rubygem), method: :post, class: "ownership_request_form", id: "new_ownership_request" do %>
     <div class="text_field push--top-s">
       <%= label_tag :note, t("ownership_requests.note_for_owners"), class: "form__label" %>
-      <span class="gem__users__mfa-text"><%= t("ownership_calls.markup_supported_html") %></span>
+      <%= t("ownership_calls.markup_supported_html") %>
       <%= text_area_tag :note, nil, placeholder: "Please share why are you requesting ownership of #{@rubygem.name}", class: "form__input form__textarea", required: true %>
     </div>
     <div class="submit_field">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -659,7 +659,7 @@ en:
     details: Details
     apply: Apply
     close: Close
-    markup_supported_html: <a class="adoption__rdoc__link" href="https://ruby.github.io/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-RDoc+Markup+Reference">Rdoc markup</a> supported
+    markup_supported_html: <a class="adoption__rdoc__link" href="https://ruby.github.io/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-RDoc+Markup+Reference">Rdoc markup supported</a>
     create_call: Create ownership call
   ownership_requests:
     create:


### PR DESCRIPTION
I'm looking to change the class `gem__users__mfa-text` in pull #3876. This class is randomly used in two other places, the ownership call and ownership requests forms (both the same line of code, just different forms).

https://github.com/rubygems/rubygems.org/blob/c1e3c0b057d1453ffaef41fb7475f64063cbedad/app/views/ownership_requests/_form.html.erb#L5

https://github.com/rubygems/rubygems.org/blob/c1e3c0b057d1453ffaef41fb7475f64063cbedad/app/views/ownership_calls/_form.html.erb#L5

There is a class `adoption__rdoc__link` already on the link, but the word `supported` is outside the link so it isn't getting the proper styling. My suggestion is to just make supported part of the link. Otherwise we can replace the `gem__users__mfa-text` classes in those forms to something like `adoption__markup-supported` and define the styles there.

Additionally, the `gem__users__mfa-text` class was making the text very small at 9px. I did not add a size to the `adoption__rdoc__link` class so it is now using the default body text size of 15px. If that is too big for the context I can change it to 12 or 13px.


Before:
<img width="1547" alt="Screenshot 2023-06-25 at 9 36 09 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/f507af57-27d2-4541-b623-5188fe9c03b5">

After:
<img width="1547" alt="Screenshot 2023-06-25 at 9 35 30 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/2dbc9be4-a13e-41fb-9336-88afa352aa63">
