### PR TITLE
Removing Firefox specific styles for buttons.

### DIFF
--- a/app/assets/stylesheets/modules/button.css
+++ b/app/assets/stylesheets/modules/button.css
@@ -12,18 +12,11 @@
   outline: none;
   transition-duration: 0.25s;
   transition-property: border-color, background-color; }
-@-moz-document url-prefix() {
-  .home__join, .form__submit {
-    padding-top: 12px;
-    padding-bottom: 8px; } }
 
 .home__join:before {
   position: absolute;
   right: 18px;
   line-height: 22px; }
-@-moz-document url-prefix() {
-  .home__join:before {
-    line-height: 16px; } }
 .home__join:focus:before, .home__join:hover:before {
   animation: arrow .75s infinite; }
 @-ms-keyframes arrow {


### PR DESCRIPTION
I noticed the text in buttons in Firefox was not centered. I found some Firefox specific styles from 2014 that once removed fixed the issue.

Before:
<img width="1552" alt="Screenshot 2023-06-25 at 9 55 05 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/965b395d-04cf-4c3b-be7c-bf530b4a1e24">
<img width="1552" alt="Screenshot 2023-06-25 at 9 50 43 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/1b465d50-64c6-47c8-882f-e0c7c784d003">
<img width="1552" alt="Screenshot 2023-06-25 at 9 49 53 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/a91986f6-cfb8-4320-8a86-a6f402dde6a0">


After:
<img width="1552" alt="Screenshot 2023-06-25 at 9 48 42 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/4503ae1b-dd05-4fc9-ac78-a5ea130d0d66">
<img width="1552" alt="Screenshot 2023-06-25 at 9 50 53 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/e9ecb5f4-d022-4a84-8edf-735edd616d6a">
<img width="1552" alt="Screenshot 2023-06-25 at 9 50 13 PM" src="https://github.com/rubygems/rubygems.org/assets/4227/54faf599-ce40-4480-acb2-44664cfba7ef">
