### PR TITLE
Also serve /info/* files from S3

### DIFF
--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -10,7 +10,7 @@ class UploadInfoFileJob < ApplicationJob
     # it makes no sense to enqueue more than one at a time
     enqueue_limit: good_job_concurrency_enqueue_limit(default: 1),
     perform_limit: good_job_concurrency_perform_limit(default: 1),
-    key: -> { "#{name}/#{rubygem_name_arg}" }
+    key: -> { "#{self.class.name}:#{rubygem_name_arg}" }
   )
 
   def perform(rubygem_name:)

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -1,0 +1,48 @@
+class UploadInfoFileJob < ApplicationJob
+  queue_with_priority PRIORITIES.fetch(:push)
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+  good_job_control_concurrency_with(
+    # Maximum number of jobs with the concurrency key to be
+    # concurrently enqueued (excludes performing jobs)
+    #
+    # Because the job only uses current state at time of perform,
+    # it makes no sense to enqueue more than one at a time
+    enqueue_limit: good_job_concurrency_enqueue_limit(default: 1),
+    perform_limit: good_job_concurrency_perform_limit(default: 1),
+    key: -> { "#{name}/#{rubygem_name_arg}" }
+  )
+
+  def perform(rubygem_name:)
+    compact_index_info = GemInfo.new(rubygem_name).compact_index_info
+    response_body = CompactIndex.info(compact_index_info)
+
+    content_md5 = Digest::MD5.base64digest(response_body)
+    checksum_sha256 = Digest::SHA256.base64digest(response_body)
+
+    response = RubygemFs.compact_index.store(
+      "info/#{rubygem_name}", response_body,
+      public_acl: false, # the compact-index bucket does not have ACLs enabled
+      metadata: {
+        "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
+        "surrogate-key" => "info/* info/#{rubygem_name} gem/#{rubygem_name} s3-compact-index s3-info/* s3-info/#{rubygem_name}",
+        "sha256" => checksum_sha256,
+        "md5" => content_md5
+      },
+      cache_control: "max-age=60, public",
+      content_type: "text/plain; charset=utf-8",
+      checksum_sha256:,
+      content_md5:
+    )
+
+    logger.info(message: "Uploading info file for #{rubygem_name} succeeded", response:)
+
+    FastlyPurgeJob.perform_later(key: "s3-info/#{rubygem_name}", soft: true)
+  end
+
+  private
+
+  def rubygem_name_arg
+    arguments.first.fetch(:rubygem_name)
+  end
+end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,6 +129,7 @@ class Pusher
     end
     Indexer.perform_later
     UploadVersionsFileJob.perform_later
+    UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
     ReindexRubygemJob.perform_later(rubygem:)
     GemCachePurger.call(rubygem.name)
     StoreVersionContentsJob.perform_later(version:) if ld_variation(key: "gemcutter.pusher.store_version_contents", default: false)

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class UploadInfoFileJobTest < ActiveJob::TestCase
+  make_my_diffs_pretty!
+
+  test "uploads the info file" do
+    version = create(:version, number: "0.0.1", required_ruby_version: ">= 2.0.0", required_rubygems_version: ">= 2.6.3")
+
+    perform_enqueued_jobs only: [UploadInfoFileJob] do
+      UploadInfoFileJob.perform_now(rubygem_name: version.rubygem.name)
+    end
+
+    content = <<~INFO
+      ---
+      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+    INFO
+
+    assert_equal content, RubygemFs.compact_index.get("info/#{version.rubygem.name}")
+
+    assert_equal(
+      {
+        metadata: {
+          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
+          "surrogate-key" =>
+            "info/* info/#{version.rubygem.name} gem/#{version.rubygem.name} s3-compact-index s3-info/* s3-info/#{version.rubygem.name}",
+          "sha256" => Digest::SHA256.base64digest(content),
+          "md5" => Digest::MD5.base64digest(content)
+        },
+        cache_control: "max-age=60, public",
+        content_type: "text/plain; charset=utf-8",
+        checksum_sha256: Digest::SHA256.base64digest(content),
+        content_md5: Digest::MD5.base64digest(content),
+        key: "info/#{version.rubygem.name}"
+      }, RubygemFs.compact_index.head("info/#{version.rubygem.name}")
+    )
+
+    assert_enqueued_with(job: FastlyPurgeJob, args: [{ key: "s3-info/#{version.rubygem.name}", soft: true }])
+  end
+end

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -36,4 +36,10 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
 
     assert_enqueued_with(job: FastlyPurgeJob, args: [{ key: "s3-info/#{version.rubygem.name}", soft: true }])
   end
+
+  test "#good_job_concurrency_key" do
+    job = UploadInfoFileJob.new(rubygem_name: "foo")
+
+    assert_equal "UploadInfoFileJob:foo", job.good_job_concurrency_key
+  end
 end


### PR DESCRIPTION
Same way we do now for /versions

Fastly will preferentially serve the S3 files, falling back to the rails app when the S3 files do not exist