### PR TITLE
Remove temporary webauthn only logic

### DIFF
--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -9,11 +9,6 @@ module UserMultifactorMethods
   end
 
   def mfa_enabled?
-    if webauthn_enabled? && mfa_disabled?
-      self.mfa_level = :ui_and_gem_signin
-      save!(validate: false)
-    end
-
     !mfa_disabled?
   end
 
@@ -26,7 +21,7 @@ module UserMultifactorMethods
   end
 
   def mfa_gem_signin_authorized?(otp)
-    return true unless strong_mfa_level? || webauthn_enabled?
+    return true unless strong_mfa_level?
     api_mfa_verified?(otp)
   end
 


### PR DESCRIPTION
## What problem are you solving?
After the decoupling, a rake task was needed to set all webauthn only users to have an MFA level. This is because previously these users did not have one. Until the rake task could be ran, we had to add some additional logic to the `user_multifactor_methods` file to simulate the user having this level already set.

Contributes to #3800 

## What approach did you choose and why?
Removed the webauthn only bypass logic now that the rake task was run and added some tests. 

## Testing
Can validate that all users that have webauthn only enabled have an MFA level set, and that the relevant methods (`mfa_enabled?` and `mfa_gem_signin_authorized?`) work properly without the bypass logic. 