### PR TITLE
Direct MFA Required users to edit settings page

### DIFF
--- a/app/controllers/concerns/application_multifactor_methods.rb
+++ b/app/controllers/concerns/application_multifactor_methods.rb
@@ -4,8 +4,14 @@ module ApplicationMultifactorMethods
   included do
     def redirect_to_new_mfa
       message = t("multifactor_auths.setup_required_html")
+
+      if request.path_info == edit_settings_path
+        flash.now[:notice_html] = message
+        return
+      end
+
       session["mfa_redirect_uri"] = request.path_info
-      redirect_to new_multifactor_auth_path, notice_html: message
+      redirect_to edit_settings_path, notice_html: message
     end
 
     def mfa_required_not_yet_enabled?

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -333,7 +333,7 @@ path: "/profile/api_keys/1" },
           context "on #{label}" do
             setup { process(request_params[:action], **request_params[:request]) }
 
-            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should redirect_to("the edit settings page") { edit_settings_path }
 
             should "set mfa_redirect_uri" do
               assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -121,7 +121,7 @@ class DashboardsControllerTest < ActionController::TestCase
 
       context "user has mfa disabled" do
         setup { get :show }
-        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should redirect_to("the edit settings page") { edit_settings_path }
 
         should "set mfa_redirect_uri" do
           assert_equal dashboard_path, session[:mfa_redirect_uri]

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -500,7 +500,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
           context "on PATCH to unconfirmed" do
             setup { patch :unconfirmed }
-            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should redirect_to("the edit settings page") { edit_settings_path }
 
             should "set mfa_redirect_uri" do
               assert_equal unconfirmed_email_confirmations_path, session[:mfa_redirect_uri]

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -36,7 +36,7 @@ class NotifiersControllerTest < ActionController::TestCase
           context "on #{label}" do
             setup { process(request_params[:action], **request_params[:request]) }
 
-            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should redirect_to("the edit settings page") { edit_settings_path }
 
             should "set mfa_redirect_uri" do
               assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]

--- a/test/functional/ownership_calls_controller_test.rb
+++ b/test/functional/ownership_calls_controller_test.rb
@@ -153,7 +153,7 @@ class OwnershipCallsControllerTest < ActionController::TestCase
           setup do
             patch :close, params: { rubygem_id: @rubygem.name }
           end
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal close_rubygem_ownership_calls_path, session[:mfa_redirect_uri]
@@ -164,7 +164,7 @@ class OwnershipCallsControllerTest < ActionController::TestCase
           setup do
             post :create, params: { rubygem_id: @rubygem.name, note: "short note" }
           end
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal rubygem_ownership_calls_path, session[:mfa_redirect_uri]

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -277,7 +277,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
         context "POST to create" do
           setup { post :create, params: { rubygem_id: @rubygem.name, note: "small note" } }
 
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal rubygem_ownership_requests_path, session[:mfa_redirect_uri]
@@ -287,7 +287,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
         context "PATCH to close_all" do
           setup { patch :close_all, params: { rubygem_id: @rubygem.name } }
 
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal close_all_rubygem_ownership_requests_path, session[:mfa_redirect_uri]
@@ -297,7 +297,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
         context "PATCH to update" do
           setup { patch :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]
@@ -307,7 +307,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
         context "PUT to update" do
           setup { put :update, params: { rubygem_id: @rubygem.name, id: @ownership_request.id, status: "closed" } }
 
-          should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+          should redirect_to("the edit settings page") { edit_settings_path }
 
           should "set mfa_redirect_uri" do
             assert_equal rubygem_ownership_request_path, session[:mfa_redirect_uri]

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -279,7 +279,7 @@ class ProfilesControllerTest < ActionController::TestCase
           context "on #{label}" do
             setup { process(request_params[:action], **request_params[:request]) }
 
-            should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+            should redirect_to("the edit settings page") { edit_settings_path }
 
             should "set mfa_redirect_uri" do
               assert_equal request_params[:path], @controller.session[:mfa_redirect_uri]

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -667,7 +667,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "on GET to verify" do
         setup { get :verify, params: { user_id: @user.id } }
 
-        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should redirect_to("the edit settings page") { edit_settings_path }
 
         should "set mfa_redirect_uri" do
           assert_equal verify_session_path, session[:mfa_redirect_uri]
@@ -677,7 +677,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "on POST to authenticate" do
         setup { post :authenticate, params: { user_id: @user.id, verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD } } }
 
-        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
+        should redirect_to("the edit settings page") { edit_settings_path }
 
         should "set mfa_redirect_uri" do
           assert_equal authenticate_session_path, session[:mfa_redirect_uri]

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -27,7 +27,7 @@ class SettingsControllerTest < ActionController::TestCase
 
       context "user has mfa disabled" do
         setup { get :edit }
-        should "flash setup_required_html warning message" do
+        should "flash a warning message" do
           assert_response :success
           assert page.has_content? "For protection of your account and your gems, you are required to set up multi-factor authentication."
         end

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -27,10 +27,9 @@ class SettingsControllerTest < ActionController::TestCase
 
       context "user has mfa disabled" do
         setup { get :edit }
-        should redirect_to("the setup mfa page") { new_multifactor_auth_path }
-
-        should "set mfa_redirect_uri" do
-          assert_equal edit_settings_path, session[:mfa_redirect_uri]
+        should "flash setup_required_html warning message" do
+          assert_response :success
+          assert page.has_content? "For protection of your account and your gems, you are required to set up multi-factor authentication."
         end
       end
 

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -87,8 +87,9 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     sign_in
     visit path
 
-    assert(page.has_content?("Enabling multi-factor auth"), "#{path} was not redirected to mfa setup page")
+    assert(page.has_content?("you are required to set up multi-factor authentication"))
 
+    click_button "Register a new device"
     totp = ROTP::TOTP.new(otp_key)
     fill_in "otp", with: totp.now
     click_button "Enable"

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -88,6 +88,7 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     visit path
 
     assert(page.has_content?("you are required to set up multi-factor authentication"))
+    assert_current_path(edit_settings_path)
 
     click_button "Register a new device"
     totp = ROTP::TOTP.new(otp_key)


### PR DESCRIPTION
Contributes to #3800 

## What problem are you solving?
Currently, on an MFA Required user, they are directed to the TOTP setup page:  
<img width="1094" alt="Screenshot 2023-07-04 at 5 16 38 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/cd6f46e3-cad9-4639-b798-9b15799cedeb">
Given that TOTP or webauthn can both be used, it makes more sense to redirect them to the edit settings page where they can choose TOTP or webauthn. 

## What approach did you choose and why?
Where a user would previously have hit to TOTP setup page as shown above, they will now instead be redirected to the edit settings page, and will be given the relevant flash warning. 
<img width="1109" alt="Screenshot 2023-07-04 at 5 18 47 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/a7cc657a-79b5-4f2e-ae19-a10844c37f2b">


## Testing
Set up a user that has a gem with over 180M downloads. You can do this by creating a gem, and running something along the lines of the below in your Rails Console.
```bash
my_gem = GemDownload.last
my_gem.count = 180000123
my_gem.save!
```
After this, you can log in to the web app, and validate that the correct functionality is occuring.

## Future Considerations
I noticed that we lack test suites for a few of our concerns, including the one I touched in this PR, `ApplicationMultifactorMethods`. These are somewhat funky to set up, but it would perhaps be beneficial to backfill these tests in the future. 