### PR TITLE
User Validation on MFA Level

### DIFF
--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -11,5 +11,29 @@ FactoryBot.define do
       mfa_level { User.mfa_levels["ui_and_api"] }
       mfa_recovery_codes { %w[aaa bbb ccc] }
     end
+
+    trait :disabled do
+      totp_seed { "" }
+      mfa_level { User.mfa_levels["disabled"] }
+      mfa_recovery_codes { [] }
+    end
+
+    trait :ui_only do
+      totp_seed { "123abc" }
+      mfa_level { User.mfa_levels["ui_only"] }
+      mfa_recovery_codes { %w[aaa bbb ccc] }
+    end
+
+    trait :ui_and_api do
+      totp_seed { "123abc" }
+      mfa_level { User.mfa_levels["ui_and_api"] }
+      mfa_recovery_codes { %w[aaa bbb ccc] }
+    end
+
+    trait :ui_and_gem_signin do
+      totp_seed { "123abc" }
+      mfa_level { User.mfa_levels["ui_and_gem_signin"] }
+      mfa_recovery_codes { %w[aaa bbb ccc] }
+    end
   end
 end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -103,7 +103,7 @@ class GemsSystemTest < SystemTest
 
   test "shows owners without mfa when logged in as owner" do
     @user.enable_totp!("some-seed", "ui_and_api")
-    user_without_mfa = create(:user, mfa_level: "disabled")
+    user_without_mfa = create(:user)
 
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_without_mfa)
@@ -116,7 +116,8 @@ class GemsSystemTest < SystemTest
 
   test "show mfa enabled when logged in as owner but everyone has mfa enabled" do
     @user.enable_totp!("some-seed", "ui_and_api")
-    user_with_mfa = create(:user, mfa_level: "ui_only")
+    user_with_mfa = create(:user)
+    user_with_mfa.enable_totp!("some-seed", "ui_and_api")
 
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_with_mfa)
@@ -129,7 +130,7 @@ class GemsSystemTest < SystemTest
 
   test "does not show owners without mfa when not logged in as owner" do
     @user.enable_totp!("some-seed", "ui_and_api")
-    user_without_mfa = create(:user, mfa_level: "disabled")
+    user_without_mfa = create(:user)
 
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_without_mfa)

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -7,6 +7,98 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
+  context "validation" do
+    context "#mfa_level_for_enabled_devices" do
+      context "when mfa_level is disabled" do
+        should "be valid if there no mfa devices" do
+          assert_predicate @user, :valid?
+        end
+
+        should "be invalid if totp is enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.mfa_level = :disabled
+
+          refute_predicate @user, :valid?
+        end
+
+        should "be invalid if webauthn is enabled" do
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :disabled
+
+          refute_predicate @user, :valid?
+        end
+
+        should "be invalid if both totp and webauthn are enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :disabled
+
+          refute_predicate @user, :valid?
+        end
+      end
+
+      context "when mfa_level is ui_and_gem_signin" do
+        should "be invalid if there no mfa devices" do
+          @user.mfa_level = :ui_and_gem_signin
+
+          refute_predicate @user, :valid?
+        end
+
+        should "be valid if totp is enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.mfa_level = :ui_and_gem_signin
+
+          assert_predicate @user, :valid?
+        end
+
+        should "be valid if webauthn is enabled" do
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :ui_and_gem_signin
+
+          assert_predicate @user, :valid?
+        end
+
+        should "be valid if both totp and webauthn are enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :ui_and_gem_signin
+
+          assert_predicate @user, :valid?
+        end
+      end
+
+      context "when mfa_level is ui_and_api" do
+        should "be invalid if there no mfa devices" do
+          @user.mfa_level = :ui_and_api
+
+          refute_predicate @user, :valid?
+        end
+
+        should "be valid if totp is enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          @user.mfa_level = :ui_and_api
+
+          assert_predicate @user, :valid?
+        end
+
+        should "be valid if webauthn is enabled" do
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :ui_and_api
+
+          assert_predicate @user, :valid?
+        end
+
+        should "be valid if both totp and webauthn are enabled" do
+          @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+          create(:webauthn_credential, user: @user)
+          @user.mfa_level = :ui_and_api
+
+          assert_predicate @user, :valid?
+        end
+      end
+    end
+  end
+
   context "#mfa_enabled" do
     should "return true if multifactor auth is not disabled using totp" do
       @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
@@ -310,8 +402,8 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         refute @user.ui_mfa_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
       end
 
-      should "return false if the totp_seed is blank" do
-        @user.update!(totp_seed: nil)
+      should "return false if the mfa_seed is blank" do
+        @user.disable_totp!
 
         refute @user.ui_mfa_verified?(ROTP::TOTP.new(ROTP::Base32.random_base32).now)
       end
@@ -405,7 +497,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
 
   context ".without_mfa" do
     setup do
-      create(:user, mfa_level: :ui_and_api)
+      create(:user).enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
     end
 
     should "return instances without mfa" do

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -12,6 +12,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
       context "when mfa_level is disabled" do
         should "be valid if there no mfa devices" do
           assert_predicate @user, :valid?
+          assert_predicate @user, :no_mfa_devices?
         end
 
         should "be invalid if totp is enabled" do
@@ -41,6 +42,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         should "be invalid if there no mfa devices" do
           @user.mfa_level = :ui_and_gem_signin
 
+          assert_predicate @user, :no_mfa_devices?
           refute_predicate @user, :valid?
         end
 
@@ -71,6 +73,7 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
         should "be invalid if there no mfa devices" do
           @user.mfa_level = :ui_and_api
 
+          assert_predicate @user, :no_mfa_devices?
           refute_predicate @user, :valid?
         end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -579,8 +579,8 @@ class UserTest < ActiveSupport::TestCase
 
   context ".without_mfa" do
     setup do
-      create(:user, handle: "has_mfa", mfa_level: "ui_and_api")
-      create(:user, handle: "no_mfa", mfa_level: "disabled")
+      create(:user, handle: "has_mfa").enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+      create(:user, handle: "no_mfa")
     end
 
     should "return only users without mfa" do

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -125,8 +125,9 @@ class RubygemsHelperTest < ActionView::TestCase
     end
 
     should "create links to gem owners without mfa" do
-      with_mfa = create(:user, mfa_level: "ui_and_api")
-      without_mfa = create_list(:user, 2, mfa_level: "disabled")
+      with_mfa = create(:user)
+      with_mfa.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+      without_mfa = create_list(:user, 2)
       rubygem = create(:rubygem, owners: [*without_mfa, with_mfa])
 
       expected_links = without_mfa.sort_by(&:id).map do |u|

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -46,7 +46,9 @@ class MailerTest < ActionMailer::TestCase
     end
 
     should "send mail to users with with more than 180M+ downloads and have weak MFA" do
-      user = create(:user, mfa_level: "ui_only")
+      user = create(:user)
+      user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -64,7 +66,8 @@ class MailerTest < ActionMailer::TestCase
     end
 
     should "not send mail to users with with more than 180M+ downloads and have strong MFA" do
-      user = create(:user, mfa_level: "ui_and_api")
+      user = create(:user)
+      user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -108,7 +111,8 @@ class MailerTest < ActionMailer::TestCase
     end
 
     should "send mail to users with more than 180M+ downloads and have weak MFA enabled" do
-      user = create(:user, mfa_level: "ui_only")
+      user = create(:user)
+      user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -126,7 +130,8 @@ class MailerTest < ActionMailer::TestCase
     end
 
     should "not send mail to users with more than 180M+ downloads and have strong MFA enabled" do
-      user = create(:user, mfa_level: "ui_and_api")
+      user = create(:user)
+      user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
       create(:rubygem, owners: [user], downloads: MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY)
 
       perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do


### PR DESCRIPTION
Contributes to #3800 

## What problem are you solving?
MFA Level could be set without having any MFA device, such as not having a  `mfa_seed` (-> `totp_seed`) set, nor webauthn credentials. Users could also have MFA disabled while still having devices. This could lead to data inconsistencies. 

## What approach did you choose and why?
Adds a validation on a user to ensure that `mfa_level` can only be set if there is a MFA device present and can only be disabled if there is no MFA device. 

## What should reviewers focus on?
The approach to validating that MFA level is set in the correct scenarios. 

## Testing
Can attempt to set MFA impromperly, for example by doing `create(:user, mfa_level: :ui_and_api)` and observing it fails validation. 

## ⚠️ Pre-merging considerations ⚠️
We should validate if this is somehow present in production. Specifically, we should check if there exists any user that has `mfa_level` somehow set while not having any MFA devices. We should also check that there isn't any user that has `mfa_level` set to disabled, but has an MFA device present. It's possible that merging this would cause some funky behaviour for users if they somehow got into a weird state like this. I don't have the ability to check production in this way, so will have to **defer to other maintainers to validate this before merging**. 