### PR TITLE
Use correct heading for TOTP setting section

### DIFF
--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -12,8 +12,9 @@
       <%= submit_tag t(".mfa.update"), class: "form__submit" %>
     <% end %>
   <% end %>
+
+  <h2><%= t(".mfa.otp")%></h2>
   <% if @user.totp_enabled? %>
-    <h2><%= t(".mfa.level.title")%></h2>
     <p><%= t(".mfa.enabled") %></p>
     <%= form_tag multifactor_auth_path, method: :delete, id: "mfa-delete" do %>
       <div class="text_field">
@@ -24,8 +25,6 @@
     <% end %>
   <% else %>
     <div class="t-body">
-      <h2><%= t(".mfa.otp")%></h2>
-
       <p>
       <%= t(".mfa.disabled_html") %>
       <%= button_to t(".mfa.go_settings"), new_multifactor_auth_path, method: "get", class: "form__submit" %>


### PR DESCRIPTION
Currently, when totp is enabled, the heading used was `MFA Level` which is incorrect.

<img width="746" alt="Screenshot 2023-07-06 at 1 52 22 PM" src="https://github.com/rubygems/rubygems.org/assets/42748004/4916617e-f3da-4441-b90f-d2c7bdcb1c1e">


## What approach did you choose and why?
Moved the heading to a level higher and removed the MFA level translation
<img width="834" alt="Screenshot 2023-07-06 at 1 52 03 PM" src="https://github.com/rubygems/rubygems.org/assets/42748004/c0ed7ef7-0121-433b-b634-a0fbaf5b519d">

cc: @ericherscovich 