### PR TITLE
Renames certain `mfa` references to `otp` references

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -6,8 +6,8 @@ class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: :unconfirmed
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: :unconfirmed
-  before_action :validate_confirmation_token, only: %i[update mfa_update webauthn_update]
-  after_action :delete_mfa_expiry_session, only: %i[mfa_update webauthn_update]
+  before_action :validate_confirmation_token, only: %i[update otp_update webauthn_update]
+  after_action :delete_mfa_expiry_session, only: %i[otp_update webauthn_update]
 
   def new
   end
@@ -25,7 +25,7 @@ class EmailConfirmationsController < ApplicationController
 
   def update
     if @user.mfa_enabled?
-      @form_mfa_url = mfa_update_email_confirmations_url(token: @user.confirmation_token)
+      @form_mfa_url = otp_update_email_confirmations_url(token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_update_email_confirmations_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
@@ -36,8 +36,8 @@ class EmailConfirmationsController < ApplicationController
     end
   end
 
-  def mfa_update
-    if mfa_update_conditions_met?
+  def otp_update
+    if otp_update_conditions_met?
       confirm_email
     elsif !session_active?
       login_failure(t("multifactor_auths.session_expired"))
@@ -96,7 +96,7 @@ class EmailConfirmationsController < ApplicationController
     params.permit(:token).require(:token)
   end
 
-  def mfa_update_conditions_met?
+  def otp_update_conditions_met?
     @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
   end
 

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -4,11 +4,11 @@ class MultifactorAuthsController < ApplicationController
 
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :require_totp_disabled, only: %i[new create]
-  before_action :require_mfa_enabled, only: %i[update mfa_update]
+  before_action :require_mfa_enabled, only: %i[update otp_update]
   before_action :require_totp_enabled, only: :destroy
   before_action :seed_and_expire, only: :create
-  before_action :verify_session_expiration, only: %i[mfa_update webauthn_update]
-  after_action :delete_mfa_level_update_session_variables, only: %i[mfa_update webauthn_update]
+  before_action :verify_session_expiration, only: %i[otp_update webauthn_update]
+  after_action :delete_mfa_level_update_session_variables, only: %i[otp_update webauthn_update]
   helper_method :issuer
 
   def new
@@ -42,7 +42,7 @@ class MultifactorAuthsController < ApplicationController
     session[:level] = level_param
     @user = current_user
 
-    @form_mfa_url = mfa_update_multifactor_auth_url(token: current_user.confirmation_token)
+    @form_mfa_url = otp_update_multifactor_auth_url(token: current_user.confirmation_token)
     setup_webauthn_authentication
 
     create_new_mfa_expiry
@@ -50,7 +50,7 @@ class MultifactorAuthsController < ApplicationController
     render template: "multifactor_auths/mfa_prompt"
   end
 
-  def mfa_update
+  def otp_update
     if current_user.ui_mfa_verified?(params[:otp])
       update_level_and_redirect
     else

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -2,12 +2,12 @@ class PasswordsController < Clearance::PasswordsController
   include MfaExpiryMethods
   include WebauthnVerifiable
 
-  before_action :validate_confirmation_token, only: %i[edit mfa_edit webauthn_edit]
-  after_action :delete_mfa_expiry_session, only: %i[mfa_edit webauthn_edit]
+  before_action :validate_confirmation_token, only: %i[edit otp_edit webauthn_edit]
+  after_action :delete_mfa_expiry_session, only: %i[otp_edit webauthn_edit]
 
   def edit
     if @user.mfa_enabled?
-      @form_mfa_url = mfa_edit_user_password_url(@user, token: @user.confirmation_token)
+      @form_mfa_url = otp_edit_user_password_url(@user, token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
@@ -33,8 +33,8 @@ class PasswordsController < Clearance::PasswordsController
     end
   end
 
-  def mfa_edit
-    if mfa_edit_conditions_met?
+  def otp_edit
+    if otp_edit_conditions_met?
       render template: "passwords/edit"
     elsif !session_active?
       login_failure(t("multifactor_auths.session_expired"))
@@ -73,7 +73,7 @@ class PasswordsController < Clearance::PasswordsController
     ::ClearanceMailer.change_password(user).deliver_later
   end
 
-  def mfa_edit_conditions_met?
+  def otp_edit_conditions_met?
     @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < Clearance::SessionsController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: %i[verify authenticate]
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: %i[verify authenticate]
   before_action :ensure_not_blocked, only: :create
-  after_action :delete_mfa_expiry_session, only: %i[webauthn_create mfa_create]
+  after_action :delete_mfa_expiry_session, only: %i[webauthn_create otp_create]
 
   def create
     @user = find_user
@@ -40,7 +40,7 @@ class SessionsController < Clearance::SessionsController
     session.delete(:mfa_login_started_at)
   end
 
-  def mfa_create
+  def otp_create
     @user = User.find(session[:mfa_user])
     session.delete(:mfa_user)
 

--- a/app/views/sessions/prompt.html.erb
+++ b/app/views/sessions/prompt.html.erb
@@ -29,7 +29,7 @@
         <p><%= t("multifactor_auths.recovery_code_html") %></p>
       </div>
 
-      <%= form_tag mfa_create_session_path, method: :post, class: "mfa-form" do %>
+      <%= form_tag otp_create_session_path, method: :post, class: "mfa-form" do %>
         <div class="text_field">
         <% if @user.totp_enabled? %>
           <%= label_tag :otp, t('.otp_or_recovery'), class: 'form__label' %>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,7 +39,7 @@ class Rack::Attack
   ]
 
   mfa_create_action        = { controller: "sessions", action: "mfa_create" }
-  mfa_password_edit_action = { controller: "passwords", action: "mfa_edit" }
+  mfa_password_edit_action = { controller: "passwords", action: "otp_edit" }
 
   protected_ui_mfa_actions = [
     mfa_create_action,
@@ -117,7 +117,7 @@ class Rack::Attack
         # mfa_create doesn't have remember_token set. use session[:mfa_user]
         if protected_route?([mfa_create_action], req.path, req.request_method)
           action_dispatch_req.session.fetch("mfa_user", "").presence
-        # password#mfa_edit has unique confirmation token
+        # password#otp_edit has unique confirmation token
         elsif protected_route?([mfa_password_edit_action], req.path, req.request_method)
           req.params.fetch("token", "").presence
         else

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -38,11 +38,11 @@ class Rack::Attack
     { controller: "reverse_dependencies", action: "index" }
   ]
 
-  mfa_create_action        = { controller: "sessions", action: "mfa_create" }
+  otp_create_action        = { controller: "sessions", action: "otp_create" }
   mfa_password_edit_action = { controller: "passwords", action: "otp_edit" }
 
   protected_ui_mfa_actions = [
-    mfa_create_action,
+    otp_create_action,
     mfa_password_edit_action,
     { controller: "multifactor_auths",   action: "create" },
     { controller: "multifactor_auths",   action: "update" }
@@ -114,8 +114,8 @@ class Rack::Attack
       if protected_route?(protected_ui_mfa_actions, req.path, req.request_method)
         action_dispatch_req = ActionDispatch::Request.new(req.env)
 
-        # mfa_create doesn't have remember_token set. use session[:mfa_user]
-        if protected_route?([mfa_create_action], req.path, req.request_method)
+        # otp_create doesn't have remember_token set. use session[:mfa_user]
+        if protected_route?([otp_create_action], req.path, req.request_method)
           action_dispatch_req.session.fetch("mfa_user", "").presence
         # password#otp_edit has unique confirmation token
         elsif protected_route?([mfa_password_edit_action], req.path, req.request_method)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,7 +207,7 @@ Rails.application.routes.draw do
     resources :passwords, only: %i[new create]
 
     resource :session, only: %i[create destroy] do
-      post 'mfa_create', to: 'sessions#mfa_create', as: :mfa_create
+      post 'otp_create', to: 'sessions#otp_create', as: :otp_create
       post 'webauthn_create', to: 'sessions#webauthn_create', as: :webauthn_create
       get 'verify', to: 'sessions#verify', as: :verify
       post 'authenticate', to: 'sessions#authenticate', as: :authenticate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,7 @@ Rails.application.routes.draw do
     resources :profiles, only: :show
     resource :multifactor_auth, only: %i[new create update destroy] do
       get 'recovery'
-      post 'mfa_update', to: 'multifactor_auths#mfa_update', as: :mfa_update
+      post 'otp_update', to: 'multifactor_auths#otp_update', as: :otp_update
       post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
     end
     resource :settings, only: :edit
@@ -199,7 +199,7 @@ Rails.application.routes.draw do
 
     resource :email_confirmations, only: %i[new create] do
       get 'confirm', to: 'email_confirmations#update', as: :update
-      post 'mfa_update', to: 'email_confirmations#mfa_update', as: :mfa_update
+      post 'otp_update', to: 'email_confirmations#otp_update', as: :otp_update
       post 'webauthn_update', to: 'email_confirmations#webauthn_update', as: :webauthn_update
       patch 'unconfirmed'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,7 +215,7 @@ Rails.application.routes.draw do
 
     resources :users, only: %i[new create] do
       resource :password, only: %i[create edit update] do
-        post 'mfa_edit', to: 'passwords#mfa_edit', as: :mfa_edit
+        post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
         post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
       end
     end

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -158,7 +158,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     end
   end
 
-  context "on POST to mfa_update" do
+  context "on POST to otp_update" do
     context "user has mfa enabled" do
       setup do
         @user = create(:user)
@@ -168,7 +168,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       context "when OTP is correct" do
         setup do
           get :update, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :mfa_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+          post :otp_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
         should redirect_to("the homepage") { root_url }
@@ -184,7 +184,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       context "when OTP is incorrect" do
         setup do
           get :update, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+          post :otp_update, params: { token: @user.confirmation_token, otp: "incorrect" }
         end
 
         should respond_with :unauthorized
@@ -198,7 +198,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         setup do
           get :update, params: { token: @user.confirmation_token, user_id: @user.id }
           travel 16.minutes do
-            post :mfa_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post :otp_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
         end
 
@@ -490,9 +490,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
             end
           end
 
-          context "on POST to mfa_update" do
+          context "on POST to otp_update" do
             setup do
-              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+              post :otp_update, params: { token: @user.confirmation_token, otp: "incorrect" }
             end
 
             should respond_with :unauthorized
@@ -543,9 +543,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
             end
           end
 
-          context "on POST to mfa_update" do
+          context "on POST to otp_update" do
             setup do
-              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+              post :otp_update, params: { token: @user.confirmation_token, otp: "incorrect" }
             end
 
             should respond_with :unauthorized
@@ -596,9 +596,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
             end
           end
 
-          context "on POST to mfa_update" do
+          context "on POST to otp_update" do
             setup do
-              post :mfa_update, params: { token: @user.confirmation_token, otp: "incorrect" }
+              post :otp_update, params: { token: @user.confirmation_token, otp: "incorrect" }
             end
 
             should respond_with :unauthorized

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -79,12 +79,12 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
       end
 
-      context "on POST to mfa_update" do
+      context "on POST to otp_update" do
         context "when updating to ui_and_api" do
           context "when redirect url is not set" do
             setup do
               put :update, params: { level: "ui_and_api" }
-              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should redirect_to("the settings page") { edit_settings_path }
@@ -103,7 +103,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             setup do
               @controller.session["mfa_redirect_uri"] = profile_api_keys_path
               put :update, params: { level: "ui_and_api" }
-              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should redirect_to("the api keys index") { profile_api_keys_path }
@@ -114,7 +114,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           context "when redirect url is not set" do
             setup do
               put :update, params: { level: "ui_and_gem_signin" }
-              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should redirect_to("the settings page") { edit_settings_path }
@@ -133,7 +133,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             setup do
               @controller.session["mfa_redirect_uri"] = profile_api_keys_path
               put :update, params: { level: "ui_and_api" }
-              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should redirect_to("the api keys index") { profile_api_keys_path }
@@ -143,7 +143,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         context "when otp is incorrect" do
           setup do
             put :update, params: { level: "ui_and_api" }
-            post :mfa_update, params: { otp: "123456" }
+            post :otp_update, params: { otp: "123456" }
           end
 
           should redirect_to("the settings page") { edit_settings_path }
@@ -166,7 +166,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         context "when mfa level is invalid" do
           setup do
             put :update, params: { level: "disabled" }
-            post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
 
           should "set flash error" do
@@ -181,7 +181,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
             get :update, params: { level: "ui_and_api" }
 
             travel 16.minutes do
-              post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
           end
 
@@ -369,10 +369,10 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
       end
 
-      context "on POST to mfa_update with correct recovery codes" do
+      context "on POST to otp_update with correct recovery codes" do
         setup do
           put :update, params: { level: "ui_and_api" }
-          post :mfa_update, params: { otp: @user.mfa_recovery_codes.first }
+          post :otp_update, params: { otp: @user.mfa_recovery_codes.first }
         end
 
         should redirect_to("the settings page") { edit_settings_path }
@@ -388,10 +388,10 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
       end
 
-      context "on POST to mfa_update with incorrect recovery codes" do
+      context "on POST to otp_update with incorrect recovery codes" do
         setup do
           put :update, params: { level: "ui_and_api" }
-          post :mfa_update, params: { otp: "blah" }
+          post :otp_update, params: { otp: "blah" }
         end
 
         should redirect_to("the settings page") { edit_settings_path }
@@ -724,9 +724,9 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
       end
 
-      context "on POST to mfa_update" do
+      context "on POST to otp_update" do
         setup do
-          post :mfa_update
+          post :otp_update
         end
 
         should respond_with :redirect
@@ -796,11 +796,11 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         end
       end
 
-      context "on POST to mfa_update" do
+      context "on POST to otp_update" do
         setup do
           @controller.session["mfa_redirect_uri"] = profile_api_keys_path
           put :update, params: { level: "ui_and_api" }
-          post :mfa_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+          post :otp_update, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
         should redirect_to("the api keys index") { profile_api_keys_path }
@@ -907,7 +907,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           @redirect_paths.each do |path|
             session[:mfa_redirect_uri] = path
             put :update, params: { level: "ui_and_api" }
-            put :mfa_update, params: { otp: ROTP::TOTP.new(@seed).now }
+            put :otp_update, params: { otp: ROTP::TOTP.new(@seed).now }
 
             assert_redirected_to path
             assert_nil session[:mfa_redirect_uri]
@@ -918,7 +918,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           @redirect_paths.each do |path|
             session[:mfa_redirect_uri] = path
             put :update, params: { level: "ui_and_api" }
-            put :mfa_update, params: { otp: "12345" }
+            put :otp_update, params: { otp: "12345" }
 
             assert_redirected_to edit_settings_path
             assert_equal path, session[:mfa_redirect_uri]
@@ -929,11 +929,11 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           @redirect_paths.each do |path|
             session[:mfa_redirect_uri] = path
             put :update, params: { level: "ui_and_api" }
-            put :mfa_update, params: { otp: "12345" }
+            put :otp_update, params: { otp: "12345" }
 
             assert_redirected_to edit_settings_path
             put :update, params: { level: "ui_and_api" }
-            put :mfa_update, params: { otp: ROTP::TOTP.new(@seed).now }
+            put :otp_update, params: { otp: ROTP::TOTP.new(@seed).now }
 
             assert_redirected_to path
             assert_nil session[:mfa_redirect_uri]

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -123,7 +123,7 @@ class PasswordsControllerTest < ActionController::TestCase
     end
   end
 
-  context "on POST to mfa_edit" do
+  context "on POST to otp_edit" do
     setup do
       @user = create(:user)
       @user.forgot_password!
@@ -135,7 +135,7 @@ class PasswordsControllerTest < ActionController::TestCase
       context "when OTP is correct" do
         setup do
           get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :mfa_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+          post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
         should respond_with :success
@@ -151,7 +151,7 @@ class PasswordsControllerTest < ActionController::TestCase
       context "when OTP is incorrect" do
         setup do
           get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :mfa_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: "eatthis" }
+          post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: "eatthis" }
         end
 
         should respond_with :unauthorized
@@ -165,7 +165,7 @@ class PasswordsControllerTest < ActionController::TestCase
         setup do
           get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
           travel 16.minutes do
-            post :mfa_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
         end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -32,7 +32,7 @@ class SessionsControllerTest < ActionController::TestCase
       end
     end
 
-    context "on POST to mfa_create" do
+    context "on POST to otp_create" do
       setup do
         @current_time = Time.utc(2023, 1, 1, 0, 0, 0)
         travel_to @current_time
@@ -45,7 +45,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "when OTP is correct" do
         setup do
           @controller.session[:mfa_user] = @user.id
-          post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+          post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
         should respond_with :redirect
@@ -63,7 +63,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "when OTP is recovery code" do
         setup do
           @controller.session[:mfa_user] = @user.id
-          post :mfa_create, params: { otp: @user.mfa_recovery_codes.first }
+          post :otp_create, params: { otp: @user.mfa_recovery_codes.first }
         end
 
         should respond_with :redirect
@@ -82,7 +82,7 @@ class SessionsControllerTest < ActionController::TestCase
         setup do
           @controller.session[:mfa_user] = @user.id
           wrong_otp = (ROTP::TOTP.new(@user.totp_seed).now.to_i.succ % 1_000_000).to_s
-          post :mfa_create, params: { otp: wrong_otp }
+          post :otp_create, params: { otp: wrong_otp }
         end
 
         should set_flash.now[:notice]
@@ -113,7 +113,7 @@ class SessionsControllerTest < ActionController::TestCase
           StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
 
           travel_to @end_time do
-            post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
         end
 
@@ -121,7 +121,7 @@ class SessionsControllerTest < ActionController::TestCase
           StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
 
           travel_to @end_time do
-            post :mfa_create, params: { otp: @user.mfa_recovery_codes.first }
+            post :otp_create, params: { otp: @user.mfa_recovery_codes.first }
           end
         end
       end
@@ -137,7 +137,7 @@ class SessionsControllerTest < ActionController::TestCase
         @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
         travel 30.minutes
 
-        post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+        post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
       end
 
       should set_flash.now[:notice]
@@ -164,7 +164,7 @@ class SessionsControllerTest < ActionController::TestCase
       setup do
         @controller.session[:mfa_user] = @user.id
         travel 30.minutes do
-          post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+          post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
       end
 
@@ -227,7 +227,7 @@ class SessionsControllerTest < ActionController::TestCase
           context "on `ui_only` level" do
             setup do
               @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
-              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should respond_with :redirect
@@ -245,7 +245,7 @@ class SessionsControllerTest < ActionController::TestCase
           context "on `ui_and_gem_signin` level" do
             setup do
               @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_gem_signin)
-              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should respond_with :redirect
@@ -255,7 +255,7 @@ class SessionsControllerTest < ActionController::TestCase
           context "on `ui_and_api` level" do
             setup do
               @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
-              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+              post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
             end
 
             should respond_with :redirect

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -176,7 +176,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
           @user.forgot_password!
           get "/users/#{@user.id}/password/edit",
             params: { token: @user.confirmation_token, user_id: @user.id }
-          post "/users/#{@user.id}/password/mfa_edit",
+          post "/users/#{@user.id}/password/otp_edit",
             params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now },
             headers: { REMOTE_ADDR: @ip_address }
 
@@ -547,7 +547,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         should "throttle mfa forgot password at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
-            post "/users/#{@user.id}/password/mfa_edit", headers: { REMOTE_ADDR: @ip_address }
+            post "/users/#{@user.id}/password/otp_edit", headers: { REMOTE_ADDR: @ip_address }
 
             assert_throttle_at(level)
           end
@@ -558,7 +558,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
             @user.forgot_password!
             exceed_exponential_user_limit_for("clearance/user/#{level}", @user.confirmation_token, level)
 
-            post "/users/#{@user.id}/password/mfa_edit",
+            post "/users/#{@user.id}/password/otp_edit",
               params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
 
             assert_throttle_at(level)

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -165,7 +165,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         should "allow for mfa sign in" do
           post "/session", params: { session: { who: @user.handle, password: @user.password } } # sets session[:mfa_user]
 
-          post "/session/mfa_create",
+          post "/session/otp_create",
             params: { otp: ROTP::TOTP.new(@user.totp_seed).now },
             headers: { REMOTE_ADDR: @ip_address }
 
@@ -441,7 +441,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         should "throttle for mfa sign in at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
-            post "/session/mfa_create", headers: { REMOTE_ADDR: @ip_address }
+            post "/session/otp_create", headers: { REMOTE_ADDR: @ip_address }
 
             assert_throttle_at(level)
           end
@@ -452,7 +452,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
             # sign page sets mfa_user in session
             post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
             exceed_exponential_user_limit_for("clearance/user/#{level}", @user.id, level)
-            post "/session/mfa_create"
+            post "/session/otp_create"
 
             assert_throttle_at(level)
           end
@@ -699,7 +699,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
   def sign_in_as(user)
     post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
-    post "/session/mfa_create", params: { otp: ROTP::TOTP.new(@user.totp_seed).now } if user.mfa_enabled?
+    post "/session/otp_create", params: { otp: ROTP::TOTP.new(@user.totp_seed).now } if user.mfa_enabled?
   end
 
   def set_owners_session(_rubygem, user)


### PR DESCRIPTION
## Background

Following on behind the good work in #3821 , there [was a comment](https://github.com/rubygems/rubygems.org/pull/3821#discussion_r1205545337) about clarifying `mfa` references to be more specifically around `otp`.

This PR aims to do that. 

## For Reviewers

`totp` or `otp`? I went with otp because technically `totp` *is* `otp`. Also @jenshenny pointed out that it also accepts recovery codes.

This is my first every rubgems.org pr! 🎉  Is there anything I'm missing or need to ensure that I'm doing here to be a good contributor? 🙇‍♂️