### PR TITLE
Fix to pass required keyword argument to Rails.error.report

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   config.good_job.preserve_job_records = true
   config.good_job.retry_on_unhandled_error = false
-  config.good_job.on_thread_error = ->(exception) { Rails.error.report(exception) }
+  config.good_job.on_thread_error = ->(exception) { Rails.error.report(exception, handled: false) }
   config.good_job.queues = '*'
   config.good_job.shutdown_timeout = 25 # seconds
   config.good_job.logger = SemanticLogger[GoodJob]


### PR DESCRIPTION
See https://api.rubyonrails.org/classes/ActiveSupport/ErrorReporter.html#method-i-report.