### PR TITLE
Rename method names with `mfa` to `otp`

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -25,7 +25,7 @@ class EmailConfirmationsController < ApplicationController
 
   def update
     if @user.mfa_enabled?
-      @form_mfa_url = otp_update_email_confirmations_url(token: @user.confirmation_token)
+      @otp_verification_url = otp_update_email_confirmations_url(token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_update_email_confirmations_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry

--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -42,7 +42,7 @@ class MultifactorAuthsController < ApplicationController
     session[:level] = level_param
     @user = current_user
 
-    @form_mfa_url = otp_update_multifactor_auth_url(token: current_user.confirmation_token)
+    @otp_verification_url = otp_update_multifactor_auth_url(token: current_user.confirmation_token)
     setup_webauthn_authentication
 
     create_new_mfa_expiry

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,7 +7,7 @@ class PasswordsController < Clearance::PasswordsController
 
   def edit
     if @user.mfa_enabled?
-      @form_mfa_url = otp_edit_user_password_url(@user, token: @user.confirmation_token)
+      @otp_verification_url = otp_edit_user_password_url(@user, token: @user.confirmation_token)
       setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry

--- a/app/views/multifactor_auths/mfa_prompt.html.erb
+++ b/app/views/multifactor_auths/mfa_prompt.html.erb
@@ -27,7 +27,7 @@
       <div class="t-body">
         <p><%= t("multifactor_auths.recovery_code_html") %></p>
       </div>
-      <%= form_tag @form_mfa_url, method: :post do %>
+      <%= form_tag @otp_verification_url, method: :post do %>
         <div class="text_field">
           <% if @user.totp_enabled? %>
             <%= label_tag :otp, t('multifactor_auths.otp_or_recovery'), class: 'form__label' %>

--- a/app/views/multifactor_auths/new.html.erb
+++ b/app/views/multifactor_auths/new.html.erb
@@ -7,9 +7,9 @@
   <div>
     <p><%= t('.scan_prompt') %></p>
     <p>
-      <span id="mfa-account"><%= t('.account', account: "#{issuer}:#{current_user.email}") %></span><br>
-      <span id="mfa-key"><%= t('.key', key: @seed.chars.each_slice(4).map(&:join).join(' ')) %></span><br>
-      <span id="mfa-type"><%= t('.time_based') %></span>
+      <span><%= t('.account', account: "#{issuer}:#{current_user.email}") %></span><br>
+      <span id="otp-key"><%= t('.key', key: @seed.chars.each_slice(4).map(&:join).join(' ')) %></span><br>
+      <span><%= t('.time_based') %></span>
     </p>
   </div>
 </div>

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -242,6 +242,7 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
           should "disable mfa and clear recovery codes" do
             assert_predicate @user.reload, :totp_disabled?
+            assert_predicate @user.reload, :mfa_disabled?
             assert_empty @user.mfa_recovery_codes
           end
 

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -89,7 +89,7 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
 
     assert(page.has_content?("Enabling multi-factor auth"), "#{path} was not redirected to mfa setup page")
 
-    totp = ROTP::TOTP.new(mfa_key)
+    totp = ROTP::TOTP.new(otp_key)
     fill_in "otp", with: totp.now
     click_button "Enable"
 
@@ -126,9 +126,9 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     click_button "Sign in"
   end
 
-  def mfa_key
+  def otp_key
     key_regex = /( (\w{4})){8}/
-    page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
+    page.find_by_id("otp-key").text.match(key_regex)[0].delete("\s")
   end
 
   def verify_password

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -12,7 +12,7 @@ class SettingsTest < ApplicationSystemTestCase
     click_button "Sign in"
   end
 
-  def enable_mfa
+  def enable_otp
     key = ROTP::Base32.random_base32
     @user.enable_totp!(key, :ui_only)
   end
@@ -22,9 +22,9 @@ class SettingsTest < ApplicationSystemTestCase
     find("#mfa-edit input[type=submit]").click
   end
 
-  def mfa_key
+  def otp_key
     key_regex = /( (\w{4})){8}/
-    page.find_by_id("mfa-key").text.match(key_regex)[0].delete("\s")
+    page.find_by_id("otp-key").text.match(key_regex)[0].delete("\s")
   end
 
   test "enabling multi-factor authentication with valid otp" do
@@ -34,7 +34,7 @@ class SettingsTest < ApplicationSystemTestCase
 
     assert page.has_content? "Enabling multi-factor auth"
 
-    totp = ROTP::TOTP.new(mfa_key)
+    totp = ROTP::TOTP.new(otp_key)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
@@ -66,7 +66,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   test "disabling multi-factor authentication with valid otp" do
     sign_in
-    enable_mfa
+    enable_otp
     visit edit_settings_path
 
     page.fill_in "otp", with: ROTP::TOTP.new(@user.totp_seed).now
@@ -80,7 +80,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   test "disabling multi-factor authentication with invalid otp" do
     sign_in
-    enable_mfa
+    enable_otp
     visit edit_settings_path
 
     key = ROTP::Base32.random_base32
@@ -95,7 +95,7 @@ class SettingsTest < ApplicationSystemTestCase
     visit edit_settings_path
     click_button "Register a new device"
 
-    totp = ROTP::TOTP.new(mfa_key)
+    totp = ROTP::TOTP.new(otp_key)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
@@ -117,7 +117,7 @@ class SettingsTest < ApplicationSystemTestCase
     visit edit_settings_path
     click_button "Register a new device"
 
-    totp = ROTP::TOTP.new(mfa_key)
+    totp = ROTP::TOTP.new(otp_key)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
     check "ack"
@@ -140,7 +140,7 @@ class SettingsTest < ApplicationSystemTestCase
     visit edit_settings_path
     click_button "Register a new device"
 
-    totp = ROTP::TOTP.new(mfa_key)
+    totp = ROTP::TOTP.new(otp_key)
     page.fill_in "otp", with: totp.now
     click_button "Enable"
 
@@ -161,7 +161,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   test "shows 'ui only' if user's level is ui_only" do
     sign_in
-    enable_mfa
+    enable_otp
     visit edit_settings_path
 
     assert page.has_selector?("#level > option:nth-child(3)")
@@ -170,7 +170,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   test "does not shows 'ui only' if user's level is not ui_only" do
     sign_in
-    enable_mfa
+    enable_otp
     visit edit_settings_path
 
     page.fill_in "otp", with: ROTP::TOTP.new(@user.totp_seed).now


### PR DESCRIPTION
## What problem are you solving?
Follow up to https://github.com/rubygems/rubygems.org/pull/3821 and https://github.com/rubygems/rubygems.org/pull/3918.
Just some remaining refactoring of `mfa` to `otp`

cc: @jenshenny let me know if this looks good and i'll squash!