### PR TITLE
Add autocomplete attribute to password fields

### DIFF
--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -6,7 +6,7 @@
   <%= error_messages_for @user %>
   <div class="password_field">
     <%= form.label :password, "Password", :class => 'form__label' %>
-    <%= form.password_field :password, :class => 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'new-password', class: 'form__input' %>
   </div>
   <div class="form__checkbox">
     <%= form.check_box :reset_api_key, { :class => 'form__checkbox__input' } , 'true', 'false' %>

--- a/app/views/profiles/delete.html.erb
+++ b/app/views/profiles/delete.html.erb
@@ -31,7 +31,7 @@
   <%= form_for current_user, url: destroy_profile_path, method: :delete do |form| %>
     <div class="password_field">
       <%= form.label :password, "Password", class: 'form__label' %>
-      <%= form.password_field :password, placeholder: 'password', class: 'form__input' %>
+      <%= form.password_field :password, placeholder: 'password', autocomplete: 'current-password', class: 'form__input' %>
     </div>
     <%= form.submit t('.confirm'), data: { confirm: "This action can't be UNDONE! Are you sure?" }, class: 'form__submit' %>
   <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -62,7 +62,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, :class => 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
   </div>
 
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -14,7 +14,7 @@
   </div>
   <div class="password_field">
     <%= form.label :password, t('activerecord.attributes.session.password'), :class => 'form__label' %>
-    <%= form.password_field :password, :class => 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
   </div>
   <div class="form_bottom">
     <%= form.submit t('sign_in'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>

--- a/app/views/sessions/verify.html.erb
+++ b/app/views/sessions/verify.html.erb
@@ -7,7 +7,7 @@
 <%= form_for :verify_password, url: authenticate_session_path, method: :post do |form| %>
   <div class="password_field">
     <%= form.label :password, t("activerecord.attributes.session.password"), class: "form__label" %>
-    <%= form.password_field :password, class: "form__input" %>
+    <%= form.password_field :password, autocomplete: "current-password", class: "form__input" %>
   </div>
   <div class="form_bottom">
     <%= form.submit t(".confirm"), data: {disable_with: t("form_disable_with")}, class: "form__submit" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -18,5 +18,5 @@
 </div>
 <div class="password_field">
   <%= form.label :password, t('activerecord.attributes.user.password'), :class => 'form__label' %>
-  <%= form.password_field :password, :class => 'form__input' %>
+  <%= form.password_field :password, autocomplete: "new-password", class: 'form__input' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,8 +220,8 @@ Rails.application.routes.draw do
       end
     end
 
-    get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
-    delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
+    get '/sign_in' => 'sessions#new', as: 'sign_in'
+    delete '/sign_out' => 'sessions#destroy', as: 'sign_out'
 
     get '/sign_up' => 'users#new', as: 'sign_up' if Clearance.configuration.allow_sign_up?
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -37,6 +37,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should "display edit form" do
         page.assert_text("Reset password")
+        page.assert_selector("input[type=password][autocomplete=new-password]")
       end
     end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -75,6 +75,19 @@ class ProfilesControllerTest < ActionController::TestCase
       end
     end
 
+    context "on GET to delete" do
+      setup do
+        get :delete
+      end
+
+      should respond_with :success
+
+      should "render user delete page" do
+        page.assert_text "Delete profile"
+        page.assert_selector "input[type=password][autocomplete=current-password]"
+      end
+    end
+
     context "on GET to edit" do
       setup { get :edit }
 
@@ -82,6 +95,7 @@ class ProfilesControllerTest < ActionController::TestCase
 
       should "render user edit page" do
         assert page.has_content? "Edit profile"
+        assert page.has_css? "input[type=password][autocomplete=current-password]"
       end
     end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -438,6 +438,16 @@ class SessionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to new" do
+    setup do
+      get :new
+    end
+
+    should "render sign-in form" do
+      page.assert_text("Sign in")
+    end
+  end
+
   context "on GET to verify" do
     setup do
       rubygem = create(:rubygem)

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -445,6 +445,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     should "render sign-in form" do
       page.assert_text("Sign in")
+      page.assert_selector("input[type=password][autocomplete=current-password]")
     end
   end
 
@@ -464,6 +465,7 @@ class SessionsControllerTest < ActionController::TestCase
 
       should "render password verification form" do
         assert page.has_css? "#verify_password_password"
+        assert page.has_css? "input[type=password][autocomplete=current-password]"
       end
     end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -9,6 +9,11 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     render_template(:new)
+
+    should "render the new user form" do
+      page.assert_text "Sign up"
+      page.assert_selector "input[type=password][autocomplete=new-password]"
+    end
   end
 
   context "on POST to create" do


### PR DESCRIPTION
I was checking my settings on my phone, and when I checked the API keys section, Safari iOS offered a suggestion for a new password instead of offering my current password.

This PR fixes the issue by adding an autocomplete attribute for the password field in `sessions#verify`. While I was there, I went through all the password fields I found.

The values for the `autocomplete` attribute are documented in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#specifications) and the [reference](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete).

For a couple of forms, I couldn't find any tests so I added tests for them: `profiles#delete` and `sessions#new`, let me know if I simply missed the test somewhere else.

I used the surrounding style for simple vs. double quotes, but I always used the new hash syntax.