### PR TITLE
Make recovery code text clickable

### DIFF
--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -11,7 +11,7 @@
 
   <p><%= link_to t(".copy"), "#/", class: "t-link--bold recovery__copy__icon", data: { "clipboard-target": "#recovery-code-list" } %></p>
   <div class = "form__checkbox__item">
-    <%= check_box_tag "ack", "ack", false, class: "form__checkbox__input" %>
+    <%= check_box_tag "checked", "ack", false, class: "form__checkbox__input" %>
     <%= label_tag "checked", t(".saved"), class: "form__checkbox__label" %>
   </div>
   <%= button_to t(".continue"), @continue_path, method: "get", class: "form__submit form__submit--no-hover", disabled: true %>


### PR DESCRIPTION
Closes: https://github.com/Shopify/ruby-dependency-security/issues/335

As described:
"As a user, I want to be able to click on the label "I have saved my recovery codes" to select the checkbox, so that I have a larger hotspot making the form more accessible and also friendly to screen readers"

This PR adds this functionality

![2023-07-12 14 31 11](https://github.com/rubygems/rubygems.org/assets/20158582/5a12a623-6de8-484f-8730-d6a4c2f810bd)

Co-authored-by: Scott Yang <scott.yang@shopify.com>