### PR TITLE
Remove one time rake task

### DIFF
--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -1,6 +1,0 @@
-namespace :one_time do
-  desc "Assign ui_and_gem_signin to webauthn only users"
-  task assign_ui_and_gem_signin: :environment do
-    User.where(mfa_level: :disabled).where(id: WebauthnCredential.select(:user_id)).update_all(mfa_level: :ui_and_gem_signin)
-  end
-end


### PR DESCRIPTION
## 🤔 What problem are you solving?
Contributes to https://github.com/rubygems/rubygems.org/issues/3800

Cleaning up codebase since the `assign_ui_and_gem_signin` task was successfully run. It's meant to be only run once (hence, "one time" task). 

<p align="center">
  <kbd>
    <img src="https://github.com/rubygems/rubygems.org/assets/4270287/5d4d287c-4989-4277-845d-2174f8e0b062" alt="In Bundler Slack, #rubygems-org channel, Samuel confirmed he ran the `one_time:assign_ui_and_gem_signin` task" width=400 />
  </kbd>
</p>

## 🛠️ What approach did you choose and why?
Just removing code 🗑️ 🔥 👋. 

## 👀 What should reviewers focus on?
I considered the value of keeping the file and the `one_time` namespace, so it'd be easier for folks to create one-time tasks in the future. However, I decided to remove the file entirely since we can easily recreate it when needed. If anyone disagrees and prefers to keep the file with the `one_time` namespace, I'm open to adjusting and only removing the `assign_ui_and_gem_signin` task itself.