### PR TITLE
Stop reading & writing from User#mfa_recovery_codes

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -29,7 +29,7 @@ class MultifactorAuthsController < ApplicationController
       @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
 
       if current_user.mfa_device_count_one?
-        session[:show_recovery_codes] = true
+        session[:show_recovery_codes] = current_user.new_mfa_recovery_codes
         redirect_to recovery_multifactor_auth_path
       else
         redirect_to @continue_path
@@ -85,10 +85,14 @@ class MultifactorAuthsController < ApplicationController
   end
 
   def recovery
-    if session[:show_recovery_codes].nil?
+    @mfa_recovery_codes = session[:show_recovery_codes]
+    if @mfa_recovery_codes.nil?
       redirect_to edit_settings_path
       flash[:error] = t(".already_generated")
       return
+    elsif @mfa_recovery_codes == true
+      # redirected in between deploys
+      @mfa_recovery_codes = current_user.mfa_recovery_codes
     end
     @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
     session.delete("mfa_redirect_uri")

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -57,7 +57,7 @@ class WebauthnCredentialsController < ApplicationController
 
   def render_callback_redirect
     if current_user.mfa_device_count_one?
-      session[:show_recovery_codes] = true
+      session[:show_recovery_codes] = current_user.new_mfa_recovery_codes
       render json: { redirect_url: recovery_multifactor_auth_url }
     else
       render json: { redirect_url: edit_settings_url }

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -34,11 +34,7 @@ module UserTotpMethods
   def enable_totp!(seed, level)
     self.totp_seed = seed
 
-    if mfa_device_count_one?
-      self.mfa_level = level
-      self.new_mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-      self.mfa_hashed_recovery_codes = new_mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
-    end
+    mfa_method_added(level)
 
     save!(validate: false)
     Mailer.totp_enabled(id, Time.now.utc).deliver_later

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -14,7 +14,6 @@ module UserTotpMethods
 
     if no_mfa_devices?
       self.mfa_level = "disabled"
-      self.mfa_recovery_codes = []
       self.mfa_hashed_recovery_codes = []
     end
 
@@ -37,8 +36,8 @@ module UserTotpMethods
 
     if mfa_device_count_one?
       self.mfa_level = level
-      self.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-      self.mfa_hashed_recovery_codes = mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
+      self.new_mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
+      self.mfa_hashed_recovery_codes = new_mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
     end
 
     save!(validate: false)

--- a/app/models/concerns/user_webauthn_methods.rb
+++ b/app/models/concerns/user_webauthn_methods.rb
@@ -30,7 +30,7 @@ module UserWebauthnMethods
   end
 
   def webauthn_only_with_recovery?
-    webauthn_enabled? && totp_disabled? && (mfa_recovery_codes.present? || mfa_hashed_recovery_codes.present?)
+    webauthn_enabled? && totp_disabled? && mfa_hashed_recovery_codes.present?
   end
 
   def webauthn_options_for_get

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -22,10 +22,7 @@ class WebauthnCredential < ApplicationRecord
   end
 
   def enable_user_mfa
-    return unless user.mfa_device_count_one?
-    user.mfa_level = :ui_and_api
-    user.new_mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-    user.mfa_hashed_recovery_codes = user.new_mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
+    user.mfa_method_added(:ui_and_api)
     user.save!(validate: false)
   end
 

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -24,15 +24,15 @@ class WebauthnCredential < ApplicationRecord
   def enable_user_mfa
     return unless user.mfa_device_count_one?
     user.mfa_level = :ui_and_api
-    user.mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
-    user.mfa_hashed_recovery_codes = user.mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
+    user.new_mfa_recovery_codes = Array.new(10).map { SecureRandom.hex(6) }
+    user.mfa_hashed_recovery_codes = user.new_mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
     user.save!(validate: false)
   end
 
   def disable_user_mfa
     return unless user.no_mfa_devices?
     user.mfa_level = :disabled
-    user.mfa_recovery_codes = []
+    user.new_mfa_recovery_codes = nil
     user.mfa_hashed_recovery_codes = []
     user.save!(validate: false)
   end

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -4,7 +4,7 @@
   <p><%= t ".note_html" %></p>
 
   <ul id="recovery-code-list">
-    <% current_user.mfa_recovery_codes.each do |code| %>
+    <% @mfa_recovery_codes.each do |code| %>
       <li class="recovery-code-list__item"><%= code %></li>
     <% end %>
   </ul>

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -6,11 +6,15 @@ FactoryBot.define do
     api_key { "secret123" }
     email_confirmed { true }
 
+    transient do
+      mfa_recovery_codes { [] }
+    end
+    mfa_hashed_recovery_codes { mfa_recovery_codes.map { |code| BCrypt::Password.create(code) } }
+
     trait :mfa_enabled do
       totp_seed { "123abc" }
       mfa_level { User.mfa_levels["ui_and_api"] }
-      mfa_recovery_codes { %w[aaa bbb ccc] } # TODO: make transient once the column is dropped
-      mfa_hashed_recovery_codes { mfa_recovery_codes.map { |code| BCrypt::Password.create(code) } }
+      mfa_recovery_codes { %w[aaa bbb ccc] }
     end
 
     trait :disabled do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -104,7 +104,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     context "user has webauthn enabled but no recovery codes" do
       setup do
         create(:webauthn_credential, user: @user)
-        @user.mfa_recovery_codes = []
+        @user.new_mfa_recovery_codes = nil
         @user.mfa_hashed_recovery_codes = []
         @user.save!
         get :update, params: { token: @user.confirmation_token }

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -71,7 +71,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "when user has webauthn credentials but no recovery codes" do
       setup do
         create(:webauthn_credential, user: @user)
-        @user.mfa_recovery_codes = []
+        @user.new_mfa_recovery_codes = nil
         @user.mfa_hashed_recovery_codes = []
         @user.save!
         get :edit, params: { token: @user.confirmation_token, user_id: @user.id }

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -63,7 +63,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "when OTP is recovery code" do
         setup do
           @controller.session[:mfa_user] = @user.id
-          post :otp_create, params: { otp: @user.mfa_recovery_codes.first }
+          post :otp_create, params: { otp: @user.new_mfa_recovery_codes.first }
         end
 
         should respond_with :redirect
@@ -121,7 +121,7 @@ class SessionsControllerTest < ActionController::TestCase
           StatsD.expects(:distribution).with("login.mfa.otp.duration", @duration)
 
           travel_to @end_time do
-            post :otp_create, params: { otp: @user.mfa_recovery_codes.first }
+            post :otp_create, params: { otp: @user.new_mfa_recovery_codes.first }
           end
         end
       end
@@ -368,7 +368,7 @@ class SessionsControllerTest < ActionController::TestCase
       setup do
         @user = create(:user)
         create(:webauthn_credential, user: @user)
-        @user.mfa_recovery_codes = []
+        @user.new_mfa_recovery_codes = nil
         @user.mfa_hashed_recovery_codes = []
         @user.save!
         post(

--- a/test/functional/webauthn_credentials_controller_test.rb
+++ b/test/functional/webauthn_credentials_controller_test.rb
@@ -127,7 +127,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         end
 
         should "generate recovery codes" do
-          assert_equal 10, @user.reload.mfa_recovery_codes.count
           assert_equal 10, @user.reload.mfa_hashed_recovery_codes.count
         end
 
@@ -203,7 +202,7 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         end
 
         should "not change the users mfa_level or recovery codes" do
-          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_recovery_codes.count, @user.reload.mfa_hashed_recovery_codes.count] } do
+          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_hashed_recovery_codes.count] } do
             post(
               :callback,
               params: {
@@ -258,7 +257,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
       end
 
       should "remove recovery codes" do
-        assert_empty @user.reload.mfa_recovery_codes
         assert_empty @user.reload.mfa_hashed_recovery_codes
       end
 
@@ -299,7 +297,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential2 = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
-        @user_recovery_codes = @user.mfa_recovery_codes
         @user_hashed_recovery_codes = @user.mfa_hashed_recovery_codes
 
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -312,7 +309,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
       end
 
       should "not change the users recovery codes" do
-        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
         assert_equal @user_hashed_recovery_codes, @user.reload.mfa_hashed_recovery_codes
       end
     end
@@ -325,7 +321,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
-        @user_recovery_codes = @user.mfa_recovery_codes
         @user_hashed_recovery_codes = @user.mfa_hashed_recovery_codes
 
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -338,7 +333,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
       end
 
       should "not change the users recovery codes" do
-        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
         assert_equal @user_hashed_recovery_codes, @user.reload.mfa_hashed_recovery_codes
       end
     end
@@ -352,7 +346,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
         @credential2 = create(:webauthn_credential, user: @user)
         sign_in_as @user
 
-        @user_recovery_codes = @user.mfa_recovery_codes
         @user_hashed_recovery_codes = @user.mfa_hashed_recovery_codes
 
         perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -365,7 +358,6 @@ class WebauthnCredentialsControllerTest < ActionController::TestCase
       end
 
       should "not change the users recovery codes" do
-        assert_equal @user_recovery_codes, @user.reload.mfa_recovery_codes
         assert_equal @user_hashed_recovery_codes, @user.reload.mfa_hashed_recovery_codes
       end
     end

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -113,7 +113,7 @@ class EmailConfirmationTest < SystemTest
     assert page.has_content? "Multi-factor authentication"
     assert page.has_content? "Security Device"
 
-    fill_in "otp", with: @user.mfa_recovery_codes.first
+    fill_in "otp", with: @mfa_recovery_codes.first
     click_button "Authenticate"
 
     find(:css, ".header__popup-link").click

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -148,7 +148,7 @@ class PasswordResetTest < SystemTest
     assert page.has_content? "Recovery code"
     assert_not_nil page.find(".js-webauthn-session--form")[:action]
 
-    fill_in "otp", with: @user.mfa_recovery_codes.first
+    fill_in "otp", with: @mfa_recovery_codes.first
     click_button "Authenticate"
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD

--- a/test/models/concerns/user_multifactor_methods_test.rb
+++ b/test/models/concerns/user_multifactor_methods_test.rb
@@ -421,11 +421,10 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     end
 
     should "return true if recovery code is correct" do
-      recovery_code = @user.mfa_recovery_codes.first
+      recovery_code = @user.new_mfa_recovery_codes.first
 
       assert @user.ui_mfa_verified?(recovery_code)
-      refute_includes @user.mfa_recovery_codes, recovery_code
-      refute_includes @user.mfa_hashed_recovery_codes, BCrypt::Password.create(recovery_code)
+      refute(@user.mfa_hashed_recovery_codes.any? { |code| BCrypt::Password.new(code) == recovery_code })
     end
   end
 
@@ -492,11 +491,10 @@ class UserMultifactorMethodsTest < ActiveSupport::TestCase
     end
 
     should "return true if recovery code is correct" do
-      recovery_code = @user.mfa_recovery_codes.first
+      recovery_code = @user.new_mfa_recovery_codes.first
 
       assert @user.api_mfa_verified?(recovery_code)
-      refute_includes @user.mfa_recovery_codes, recovery_code
-      refute_includes @user.mfa_hashed_recovery_codes, BCrypt::Password.create(recovery_code)
+      refute(@user.mfa_hashed_recovery_codes.any? { |code| BCrypt::Password.new(code) == recovery_code })
     end
   end
 

--- a/test/models/concerns/user_totp_methods_test.rb
+++ b/test/models/concerns/user_totp_methods_test.rb
@@ -71,7 +71,6 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
     should "delete recovery codes if webauthn is disabled" do
       perform_disable_totp_job
 
-      assert_empty @user.mfa_recovery_codes
       assert_empty @user.mfa_hashed_recovery_codes
     end
 
@@ -81,7 +80,7 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
       end
 
       should "not delete recovery codes" do
-        assert_no_changes ["@user.mfa_recovery_codes", "@user.mfa_hashed_recovery_codes"] do
+        assert_no_changes ["@user.mfa_hashed_recovery_codes"] do
           perform_disable_totp_job
         end
       end
@@ -150,12 +149,6 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
         end
       end
 
-      should "generate recovery codes" do
-        assert_changes "@user.mfa_recovery_codes.length", 10 do
-          @user.enable_totp!(@seed, "ui_and_api")
-        end
-      end
-
       should "generate hashed recovery codes" do
         assert_changes "@user.mfa_hashed_recovery_codes.length", 10 do
           @user.enable_totp!(@seed, "ui_and_api")
@@ -169,7 +162,7 @@ class UserTotpMethodsTest < ActiveSupport::TestCase
       end
 
       should "not reset mfa level and recovery codes" do
-        assert_no_changes ["@user.mfa_level", "@user.mfa_recovery_codes", "@user.mfa_hashed_recovery_codes"] do
+        assert_no_changes ["@user.mfa_level", "@user.mfa_hashed_recovery_codes"] do
           @user.enable_totp!(@seed, "ui_and_gem_signin")
         end
       end

--- a/test/models/concerns/user_webauthn_methods_test.rb
+++ b/test/models/concerns/user_webauthn_methods_test.rb
@@ -54,7 +54,7 @@ class UserWebauthnMethodsTest < ActiveSupport::TestCase
 
     should "return false if recovery codes are not present" do
       create(:webauthn_credential, user: @user)
-      @user.mfa_recovery_codes = []
+      @user.new_mfa_recovery_codes = nil
       @user.mfa_hashed_recovery_codes = []
 
       refute_predicate @user, :webauthn_only_with_recovery?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -358,10 +358,18 @@ class UserTest < ActiveSupport::TestCase
         end
 
         should "be able to use a recovery code only once" do
-          code = @user.mfa_recovery_codes.first
+          code = @user.new_mfa_recovery_codes.first
 
           assert @user.ui_mfa_verified?(code)
           refute @user.ui_mfa_verified?(code)
+        end
+
+        should "be able to use mfa recovery codes out of order" do
+          @user.new_mfa_recovery_codes.reverse_each do |code|
+            assert @user.ui_mfa_verified?(code)
+          end
+
+          assert_empty @user.reload.mfa_hashed_recovery_codes
         end
 
         should "be able to verify correct OTP" do
@@ -395,7 +403,6 @@ class UserTest < ActiveSupport::TestCase
 
             assert @user.email.start_with?("security+locked-")
             assert @user.email.end_with?("@rubygems.org")
-            assert_empty @user.mfa_recovery_codes
             assert_empty @user.mfa_hashed_recovery_codes
             assert_predicate @user, :mfa_disabled?
           end

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -51,7 +51,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     page.assert_no_text user.encrypted_password
     page.assert_no_text user_attributes[:encrypted_password]
     page.assert_no_text user_attributes[:totp_seed]
-    page.assert_no_text user_attributes[:mfa_recovery_codes].first
     page.assert_no_text user_attributes[:mfa_hashed_recovery_codes].first
 
     user.reload
@@ -59,7 +58,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     assert_equal "disabled", user.mfa_level
     assert_not_equal user_attributes[:encrypted_password], user.encrypted_password
     assert_nil user.totp_seed
-    assert_empty user.mfa_recovery_codes
     assert_empty user.mfa_hashed_recovery_codes
 
     audit = user.audits.sole
@@ -75,12 +73,11 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
               "mfa_level" => %w[ui_and_api disabled],
               "updated_at" => [user_attributes[:updated_at].as_json, user.updated_at.as_json],
               "totp_seed" => [user_attributes[:totp_seed], nil],
-              "mfa_recovery_codes" => [user_attributes[:mfa_recovery_codes], []],
               "mfa_hashed_recovery_codes" => [user_attributes[:mfa_hashed_recovery_codes], []],
               "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password]
             },
             "unchanged" => user.attributes
-              .except("mfa_level", "updated_at", "totp_seed", "mfa_recovery_codes", "mfa_hashed_recovery_codes", "encrypted_password")
+              .except("mfa_level", "updated_at", "totp_seed", "mfa_hashed_recovery_codes", "encrypted_password")
               .transform_values(&:as_json)
           }
         },
@@ -122,7 +119,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     page.assert_no_text user.encrypted_password
     page.assert_no_text user_attributes[:encrypted_password]
     page.assert_no_text user_attributes[:totp_seed]
-    page.assert_no_text user_attributes[:mfa_recovery_codes].first
     page.assert_no_text user_attributes[:mfa_hashed_recovery_codes].first
 
     user.reload
@@ -130,7 +126,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     assert_equal "disabled", user.mfa_level
     assert_not_equal user_attributes[:encrypted_password], user.encrypted_password
     assert_nil user.totp_seed
-    assert_empty user.mfa_recovery_codes
     assert_empty user.mfa_hashed_recovery_codes
 
     audit = user.audits.sole
@@ -148,7 +143,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
               "confirmation_token" => [user_attributes[:confirmation_token], nil],
               "mfa_level" => %w[ui_and_api disabled],
               "totp_seed" => [user_attributes[:totp_seed], nil],
-              "mfa_recovery_codes" => [user_attributes[:mfa_recovery_codes], []],
               "mfa_hashed_recovery_codes" => [user_attributes[:mfa_hashed_recovery_codes], []],
               "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password],
               "api_key" => ["secret123", nil],
@@ -163,7 +157,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
                 "email",
                 "encrypted_password",
                 "mfa_level",
-                "mfa_recovery_codes",
                 "mfa_hashed_recovery_codes",
                 "totp_seed",
                 "remember_token",
@@ -366,7 +359,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     page.assert_no_text user.encrypted_password
     page.assert_no_text user_attributes[:encrypted_password]
     page.assert_no_text user_attributes[:totp_seed]
-    page.assert_no_text user_attributes[:mfa_recovery_codes].first
     page.assert_no_text user_attributes[:mfa_hashed_recovery_codes].first
 
     user.reload
@@ -425,7 +417,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
               "confirmation_token" => [user_attributes[:confirmation_token], nil],
               "mfa_level" => %w[ui_and_api disabled],
               "totp_seed" => [user_attributes[:totp_seed], nil],
-              "mfa_recovery_codes" => [user_attributes[:mfa_recovery_codes], []],
               "mfa_hashed_recovery_codes" => [user_attributes[:mfa_hashed_recovery_codes], []],
               "encrypted_password" => [user_attributes[:encrypted_password], user.encrypted_password],
               "api_key" => ["secret123", nil],
@@ -440,7 +431,6 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
                 "email",
                 "encrypted_password",
                 "mfa_level",
-                "mfa_recovery_codes",
                 "mfa_hashed_recovery_codes",
                 "totp_seed",
                 "remember_token",

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -3,9 +3,10 @@ require "application_system_test_case"
 class SignInWebauthnTest < ApplicationSystemTestCase
   setup do
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @mfa_recovery_codes = %w[0123456789ab ba9876543210]
     @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, totp_seed: "thisisonetotpseed",
-                  mfa_recovery_codes: %w[0123456789ab ba9876543210])
+                  mfa_recovery_codes: @mfa_recovery_codes)
 
     @authenticator = create_webauthn_credential
   end
@@ -61,7 +62,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     assert page.has_content? "Multi-factor authentication"
     assert page.has_content? "Security Device"
 
-    fill_in "otp", with: @user.mfa_recovery_codes.first
+    fill_in "otp", with: @mfa_recovery_codes.first
     click_button "Verify code"
 
     assert page.has_content? "Dashboard"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,6 +147,7 @@ class ActiveSupport::TestCase
     click_on "Register device"
 
     click_on "[ copy ]"
+    @mfa_recovery_codes = find_all(:css, ".recovery-code-list__item").map(&:text)
     check "ack"
     click_on "Continue"
 


### PR DESCRIPTION
Will follow up removing the column in a migration and also removing the fallback path in #recovery (needed to avoid split-brained errors): https://github.com/rubygems/rubygems.org/pull/3933