### PR TITLE
Limit the HTTP methods that nginx will allow

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -78,6 +78,14 @@ data:
 
         client_max_body_size 500M;
 
+        # Stop unsupported methods from getting to Puma,
+        # respond with a 405.
+        # (Puma responds with a 501 to unknown methods, which leads to us getting paged
+        # for what are essentially bad requests, not server errors)
+        limit_except GET HEAD POST PUT DELETE OPTIONS PATCH {
+          deny all;
+        }
+
         location /api/v1/dependencies {
           limit_req zone=dependencyapi burst=10 nodelay;
           proxy_pass http://127.0.0.1:3000;


### PR DESCRIPTION
Stop unsupported methods from getting to Puma,
respond with a 405.
(Puma responds with a 501 to unknown methods, which leads to us getting paged for what are essentially bad requests, not server errors)