### PR TITLE
Add missing closing paren to nginx config

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -84,7 +84,7 @@ data:
         # for what are essentially bad requests, not server errors)
         # Can't use limit_except here because it doesn't work in server context,
         # only location context, and we want this to apply to all locations.
-        if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH)$ {
+        if ( $request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH)$ ) {
           return 405;
         }
 


### PR DESCRIPTION
Otherwise we fail with `nginx: [emerg] invalid condition "^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH)$" in /etc/nginx/sites-enabled/staging.ruybgems.conf:49`