### PR TITLE
Add webauthn Banner, Move webauthn above TOTP

### DIFF
--- a/app/assets/stylesheets/modules/home.css
+++ b/app/assets/stylesheets/modules/home.css
@@ -152,3 +152,24 @@
     font-size: 16px; }
   .home__link:focus {
     outline: none; }
+
+/* Banner */
+
+.banner {
+  background-color: #141c22;
+  text-align: center;
+  padding: 15px;
+  color: white;
+}
+
+@media (max-width: 899px) {
+  .banner {
+    font-size: 12px;
+  }
+}
+
+.banner a {
+  color: #e9573f;
+  text-decoration: underline;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -1,18 +1,19 @@
 /* Flash Intercoms */
 
 .flash {
-  border-bottom: 1px solid #e9573f;
-  background-color: white; }
+  border-bottom: 1px solid #dcd3b1;
+  background-color: white;
+}
 
 .flash-wrap {
-  padding-top: 5px;
-  padding-bottom: 5px;
-  background-image: linear-gradient(to right, rgba(233, 87, 63, 0.3), #e9573f); }
+  padding: 10px 0;
+  background-color: #fff6d2;
+}
 
 .flash-wrap span {
   font-size: 13px;
-  font-style: italic;
-  color: #141c22; }
+  color: #141c22;
+}
 
 .flash a {
   color: #141c22;
@@ -265,20 +266,3 @@
     float: right; }
   .about__assets__download:focus:before, .about__assets__download:hover:before {
     animation: arrow .75s infinite; }
-
-/* Banner */
-
-#banner {
-  background-color: #141c22;
-  text-align: center;
-  padding: 12px 0;
-  font-weight: 500;
-  font-size: 16px;
-  color: white;
-}
-
-#banner a {
-  color: #e9573f;
-  text-decoration: underline;
-  font-weight: bold;
-}

--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -265,3 +265,20 @@
     float: right; }
   .about__assets__download:focus:before, .about__assets__download:hover:before {
     animation: arrow .75s infinite; }
+
+/* Banner */
+
+#banner {
+  background-color: #141c22;
+  text-align: center;
+  padding: 12px 0;
+  font-weight: 500;
+  font-size: 16px;
+  color: white;
+}
+
+#banner a {
+  color: #e9573f;
+  text-decoration: underline;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -266,3 +266,20 @@
     float: right; }
   .about__assets__download:focus:before, .about__assets__download:hover:before {
     animation: arrow .75s infinite; }
+
+/* Banner */
+
+#banner {
+  background-color: #141c22;
+  text-align: center;
+  padding: 12px 0;
+  font-weight: 500;
+  font-size: 16px;
+  color: white;
+}
+
+#banner a {
+  color: #e9573f;
+  text-decoration: underline;
+  font-weight: bold;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -80,7 +80,7 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
-        flash[:notice_html] = t("layouts.application.mfa_banner_html")
+        flash[:notice_html] = t("multifactor_auths.setup_webauthn_html")
         redirect_back_or(url_after_create)
       else
         login_failure(status.failure_message)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -80,6 +80,7 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
+        flash[:notice_html] = t("home.index.mfa_banner_html")
         redirect_back_or(url_after_create)
       else
         login_failure(status.failure_message)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -80,7 +80,7 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
-        flash[:notice_html] = t("home.index.mfa_banner_html")
+        flash[:notice_html] = t("layouts.application.mfa_banner_html")
         redirect_back_or(url_after_create)
       else
         login_failure(status.failure_message)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,7 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
+<div id="banner">🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.</div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
-<div id="banner">🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.</div>
+<div id="banner"><%=t('.mfa_banner_html')%></div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,6 +5,7 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
+<div id="banner">🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.</div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
-<div id="banner"><%=t('.mfa_banner_html')%></div>
+<div class="banner"><%=t('.mfa_banner_html')%></div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,6 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
-<div id="banner"><%=t('.mfa_banner_html')%></div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :banner do %>
+  <%= t('multifactor_auths.setup_webauthn_html') %>
+<% end %>
+
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,6 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
-<div class="banner"><%=t('.mfa_banner_html')%></div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
 <div class="home__image-wrap">
   <div class="home__image"></div>
 </div>
-<div id="banner">🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.</div>
+<div id="banner"><%=t('.mfa_banner_html')%></div>
 <h1 class="home__heading"><%= t '.find_blurb' %></h1>
 <div class="home__search-wrap">
   <%= form_tag search_path, :method => :get do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,9 @@
   </head>
 
   <body class="<%= 'body--index' if request.path_info == '/' %>">
+    <%if request.path == '/'%>
+      <div class="banner"><%=t('.mfa_banner_html')%></div>
+    <% end %>
     <header class="header <%= 'header--interior' if request.path_info != '/' %>">
       <div class="l-wrap--header">
         <%= link_to(root_path, title: 'RubyGems', class: 'header__logo-wrap') do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,7 +93,7 @@
     <% flash.each do |name, msg| %>
       <div id="flash-border" class="flash">
         <div class="flash-wrap">
-          <div id="flash_<%= name %>" class="l-wrap--b"><span><b><%= flash_message(name, msg) %></b></span></div>
+          <div id="flash_<%= name %>" class="l-wrap--b"><span><%= flash_message(name, msg) %></span></div>
         </div>
       </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,8 +23,10 @@
   </head>
 
   <body class="<%= 'body--index' if request.path_info == '/' %>">
-    <%if request.path == '/'%>
-      <div class="banner"><%=t('.mfa_banner_html')%></div>
+    <% if content_for?(:banner) %>
+      <div class="banner">
+        <%= yield :banner %>
+      </div>
     <% end %>
     <header class="header <%= 'header--interior' if request.path_info != '/' %>">
       <div class="l-wrap--header">

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -15,6 +15,20 @@
     <% end %>
   <% end %>
 
+  <h2 id="security-device"><%= t(".webauthn_credentials") %></h2>
+
+  <p><%= t(".webauthn_credential_note")%></p>
+
+  <% if @user.webauthn_credentials.none? %>
+    <p><i><%= t(".no_webauthn_credentials") %></i></p>
+  <% else %>
+    <div class="l-mb-8">
+      <%= render @user.webauthn_credentials %>
+    </div>
+  <% end %>
+
+  <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
+
   <% if @user.totp_enabled? %>
     <div class="mfa__header-wrapper">
       <h2 class="mfa__header mfa__header--compact"><%= t(".mfa.otp") %></h2>
@@ -38,26 +52,6 @@
       <%= button_to t(".mfa.go_settings"), new_multifactor_auth_path, method: "get", class: "form__submit" %>
     </p>
   <% end %>
-
-  <div class="mfa__header-wrapper">
-    <h2 class="mfa__header mfa__header--compact"><%= t(".webauthn_credentials") %></h2>
-    <% if @user.webauthn_enabled? %>
-      <span class="badge badge--success"><%= t(".mfa.enabled") %></span>
-    <% else %>
-      <span class="badge badge--warning"><%= t(".mfa.disabled") %></span>
-    <% end %>
-  </div>
-  <p><%= t(".webauthn_credential_note")%></p>
-
-  <% if @user.webauthn_credentials.none? %>
-    <p><i><%= t(".no_webauthn_credentials") %></i></p>
-  <% else %>
-    <div class="l-mb-8">
-      <%= render @user.webauthn_credentials %>
-    </div>
-  <% end %>
-
-  <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
 </div>
 
 <div class="t-body">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -176,7 +176,6 @@ de:
         sign_in: Anmelden
         sign_out: Abmelden
         sign_up: Registrieren
-      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:
@@ -355,6 +354,7 @@ de:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title:
       scan_prompt:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -140,7 +140,6 @@ de:
       find_blurb: Finde, installiere und veröffentliche RubyGems.
       learn:
         install_rubygems: Installiere RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -177,6 +176,7 @@ de:
         sign_in: Anmelden
         sign_out: Abmelden
         sign_up: Registrieren
+      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -140,6 +140,7 @@ de:
       find_blurb: Finde, installiere und veröffentliche RubyGems.
       learn:
         install_rubygems: Installiere RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,6 @@ en:
       find_blurb: Find, install, and publish RubyGems.
       learn:
         install_rubygems: Install RubyGems
-      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.
   layouts:
     application:
       footer:
@@ -184,6 +183,7 @@ en:
         sign_in: Sign in
         sign_out: Sign out
         sign_up: Sign up
+      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. [Learn more](link to blog post)!
   mailer:
     confirm_your_email: Please confirm your email address with the link sent to your email.
     confirmation_subject: Please confirm your email address with RubyGems.org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en:
         sign_in: Sign in
         sign_out: Sign out
         sign_up: Sign up
-      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. [Learn more](link to blog post)!
+      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="#link-to-blog-post">Learn more</a>!
   mailer:
     confirm_your_email: Please confirm your email address with the link sent to your email.
     confirmation_subject: Please confirm your email address with RubyGems.org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,9 +349,9 @@ en:
     require_webauthn_enabled: You don't have any security devices enabled. You have to associate a device to your account first.
     setup_required_html: For protection of your account and your gems, you are required to set up multi-factor authentication. Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
-    strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.
+    strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
-    setup_webauthn_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="#link-to-blog-post">Learn more</a>!
+    setup_webauthn_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html">Learn more</a>!
     new:
       title: Enabling multi-factor auth
       scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
       find_blurb: Find, install, and publish RubyGems.
       learn:
         install_rubygems: Install RubyGems
+      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device.
   layouts:
     application:
       footer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,6 @@ en:
         sign_in: Sign in
         sign_out: Sign out
         sign_up: Sign up
-      mfa_banner_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="#link-to-blog-post">Learn more</a>!
   mailer:
     confirm_your_email: Please confirm your email address with the link sent to your email.
     confirmation_subject: Please confirm your email address with RubyGems.org
@@ -351,6 +350,7 @@ en:
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">blog post</a> for more details.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
+    setup_webauthn_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="#link-to-blog-post">Learn more</a>!
     new:
       title: Enabling multi-factor auth
       scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,7 +153,6 @@ es:
       find_blurb: Encuentra, instala, y publica RubyGems.
       learn:
         install_rubygems: Instala RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -190,6 +189,7 @@ es:
         sign_in: Ingresar
         sign_out: Salir
         sign_up: Registrarte
+      mfa_banner_html:
   mailer:
     confirm_your_email: Por favor confirma tu dirección de correo con el enlace enviado.
     confirmation_subject: Por favor confirma tu dirección de correo con RubyGems.org

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -153,6 +153,7 @@ es:
       find_blurb: Encuentra, instala, y publica RubyGems.
       learn:
         install_rubygems: Instala RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -189,7 +189,6 @@ es:
         sign_in: Ingresar
         sign_out: Salir
         sign_up: Registrarte
-      mfa_banner_html:
   mailer:
     confirm_your_email: Por favor confirma tu dirección de correo con el enlace enviado.
     confirmation_subject: Por favor confirma tu dirección de correo con RubyGems.org
@@ -372,6 +371,7 @@ es:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title: Activando autenticación de múltiples factores
       scan_prompt: Por favor escanea el código QR con tu aplicación de Autenticación.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -189,7 +189,6 @@ fr:
         sign_in: Connexion
         sign_out: Déconnexion
         sign_up: Inscription
-      mfa_banner_html:
   mailer:
     confirm_your_email: Veuillez confirmer votre adresse email avec le lien qui vous
       a été envoyé par email.
@@ -374,6 +373,7 @@ fr:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title: Activer l'authentification multifacteur
       scan_prompt: Veuillez scanner le QR code avec votre app d'authentification.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,7 +153,6 @@ fr:
       find_blurb: Trouvez, installez et publiez des RubyGems.
       learn:
         install_rubygems: Installez RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -190,6 +189,7 @@ fr:
         sign_in: Connexion
         sign_out: Déconnexion
         sign_up: Inscription
+      mfa_banner_html:
   mailer:
     confirm_your_email: Veuillez confirmer votre adresse email avec le lien qui vous
       a été envoyé par email.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,6 +153,7 @@ fr:
       find_blurb: Trouvez, installez et publiez des RubyGems.
       learn:
         install_rubygems: Installez RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,7 +142,6 @@ ja:
       find_blurb:
       learn:
         install_rubygems: RubyGemsをインストール
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -179,6 +178,7 @@ ja:
         sign_in: ログイン
         sign_out: ログアウト
         sign_up: 新規登録
+      mfa_banner_html:
   mailer:
     confirm_your_email: あなたのメールアドレスに送信されたURLを確認してください。
     confirmation_subject: RubyGems.orgに登録されたあなたのメールアドレスを確認してください

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -178,7 +178,6 @@ ja:
         sign_in: ログイン
         sign_out: ログアウト
         sign_up: 新規登録
-      mfa_banner_html:
   mailer:
     confirm_your_email: あなたのメールアドレスに送信されたURLを確認してください。
     confirmation_subject: RubyGems.orgに登録されたあなたのメールアドレスを確認してください
@@ -342,6 +341,7 @@ ja:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title:
       scan_prompt:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,6 +142,7 @@ ja:
       find_blurb:
       learn:
         install_rubygems: RubyGemsをインストール
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,7 +145,6 @@ nl:
       find_blurb: Vind je gems makkelijker en publiceer ze sneller.
       learn:
         install_rubygems: Installeer RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -182,6 +181,7 @@ nl:
         sign_in: Inloggen
         sign_out: Uitloggen
         sign_up: Registreren
+      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -181,7 +181,6 @@ nl:
         sign_in: Inloggen
         sign_out: Uitloggen
         sign_up: Registreren
-      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:
@@ -359,6 +358,7 @@ nl:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title:
       scan_prompt:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,6 +145,7 @@ nl:
       find_blurb: Vind je gems makkelijker en publiceer ze sneller.
       learn:
         install_rubygems: Installeer RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -186,7 +186,6 @@ pt-BR:
         sign_in: Fazer Login
         sign_out: Sair
         sign_up: Cadastrar
-      mfa_banner_html:
   mailer:
     confirm_your_email: Por favor, confirme seu endereço de email através do link
       que enviamos para o seu endereço de email.
@@ -370,6 +369,7 @@ pt-BR:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title:
       scan_prompt:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -150,7 +150,6 @@ pt-BR:
       find_blurb: Encontre, instale e publique RubyGems.
       learn:
         install_rubygems: Instalar o RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -187,6 +186,7 @@ pt-BR:
         sign_in: Fazer Login
         sign_out: Sair
         sign_up: Cadastrar
+      mfa_banner_html:
   mailer:
     confirm_your_email: Por favor, confirme seu endereço de email através do link
       que enviamos para o seu endereço de email.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -150,6 +150,7 @@ pt-BR:
       find_blurb: Encontre, instale e publique RubyGems.
       learn:
         install_rubygems: Instalar o RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -148,6 +148,7 @@ zh-CN:
       find_blurb: 查找、安装以及发布 Gem
       learn:
         install_rubygems: 安装 RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -184,7 +184,6 @@ zh-CN:
         sign_in: 登录
         sign_out: 退出
         sign_up: 注册
-      mfa_banner_html:
   mailer:
     confirm_your_email: 请在发送到您的邮件中点击链接，确认您的邮箱地址。
     confirmation_subject: 请确认您的邮箱地址
@@ -352,6 +351,7 @@ zh-CN:
     setup_recommended: 为了保护您的帐户和您的 Gem，我们鼓励您设置多因素验证。在将来，您的帐户将被要求启用多因素验证。
     strong_mfa_level_required_html: 为了保护您的帐户和您的 Gem，您需要将您的多因素验证级别更改为 "UI and gem signin" 或 "UI and API"。请阅读我们的<a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html"">博客文章</a>了解详情。
     strong_mfa_level_recommended: 为了保护您的帐户和您的 Gem，我们建议您将您的多因素验证级别更改为 "UI and gem signin" 或 "UI and API"。在将来，您的帐户将被要求在其中某一个级别上启用多因素验证。
+    setup_webauthn_html:
     new:
       title: 启用多因素验证
       scan_prompt: 请用您的身份验证程序扫描二维码。如果您没办法扫描，请在您的程序中手动输入下面的内容。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -148,7 +148,6 @@ zh-CN:
       find_blurb: 查找、安装以及发布 Gem
       learn:
         install_rubygems: 安装 RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -185,6 +184,7 @@ zh-CN:
         sign_in: 登录
         sign_out: 退出
         sign_up: 注册
+      mfa_banner_html:
   mailer:
     confirm_your_email: 请在发送到您的邮件中点击链接，确认您的邮箱地址。
     confirmation_subject: 请确认您的邮箱地址

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -139,6 +139,7 @@ zh-TW:
       find_blurb: 搜尋、安裝以及發佈 RubyGems
       learn:
         install_rubygems: 安裝 RubyGems
+      mfa_banner_html:
   layouts:
     application:
       footer:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -139,7 +139,6 @@ zh-TW:
       find_blurb: 搜尋、安裝以及發佈 RubyGems
       learn:
         install_rubygems: 安裝 RubyGems
-      mfa_banner_html:
   layouts:
     application:
       footer:
@@ -176,6 +175,7 @@ zh-TW:
         sign_in: 登入
         sign_out: 登出
         sign_up: 註冊
+      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -175,7 +175,6 @@ zh-TW:
         sign_in: 登入
         sign_out: 登出
         sign_up: 註冊
-      mfa_banner_html:
   mailer:
     confirm_your_email:
     confirmation_subject:
@@ -343,6 +342,7 @@ zh-TW:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
+    setup_webauthn_html:
     new:
       title: 啟用多重要素驗證
       scan_prompt: 請用你的驗證裝置掃描 QR-code。如果你沒辦法掃描，手動輸入下面的資料。

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -12,6 +12,10 @@ class HomeControllerTest < ActionController::TestCase
     should "display counts" do
       assert page.has_content?("11,000,000")
     end
+
+    should "display mfa banner" do
+      assert page.has_content? "We now support security devices!"
+    end
   end
 
   should "on GET to index with non html accept header" do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -201,7 +201,7 @@ class SessionsControllerTest < ActionController::TestCase
         should "set security device notice" do
           expected_notice = "🎉 We now support security devices! Improve your account security by " \
                             "<a href=\"/settings/edit#security-device\">setting up</a> a new device. " \
-                            "<a href=\"#link-to-blog-post\">Learn more</a>!"
+                            "<a href=\"https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html\">Learn more</a>!"
 
           assert_equal expected_notice, flash[:notice_html]
           assert_nil flash[:notice]

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -181,22 +181,35 @@ class SessionsControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when login and password are correct" do
       setup do
-        user = User.new(email_confirmed: true)
-        User.expects(:authenticate).with("login", "pass").returns user
-        post :create, params: { session: { who: "login", password: "pass" } }
+        @user = User.new(email_confirmed: true)
         @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
       end
 
-      should respond_with :redirect
-      should redirect_to("the dashboard") { dashboard_path }
+      context "when mfa is not recommended" do
+        setup do
+          User.expects(:authenticate).with("login", "pass").returns @user
+          post :create, params: { session: { who: "login", password: "pass" } }
+        end
 
-      should "sign in the user" do
-        assert_predicate @controller.request.env[:clearance], :signed_in?
+        should respond_with :redirect
+        should redirect_to("the dashboard") { dashboard_path }
+
+        should "sign in the user" do
+          assert_predicate @controller.request.env[:clearance], :signed_in?
+        end
+
+        should "set security device notice" do
+          expected_notice = "🎉 We now support security devices! Improve your account security by " \
+                            "<a href=\"/settings/edit#security-device\">setting up</a> a new device. " \
+                            "<a href=\"#link-to-blog-post\">Learn more</a>!"
+
+          assert_equal expected_notice, flash[:notice_html]
+          assert_nil flash[:notice]
+        end
       end
 
       context "when mfa is recommended" do
         setup do
-          @user = User.new(email_confirmed: true, handle: "test")
           @user.stubs(:mfa_recommended?).returns true
         end
 
@@ -214,6 +227,7 @@ class SessionsControllerTest < ActionController::TestCase
                               "Your account will be required to have MFA enabled in the future."
 
             assert_equal expected_notice, flash[:notice]
+            assert_nil flash[:notice_html]
           end
         end
 
@@ -239,6 +253,7 @@ class SessionsControllerTest < ActionController::TestCase
                                 "on one of these levels in the future."
 
               assert_equal expected_notice, flash[:notice]
+              assert_nil flash[:notice_html]
             end
           end
 
@@ -360,6 +375,10 @@ class SessionsControllerTest < ActionController::TestCase
         assert page.has_content?("Multi-factor authentication")
         assert_not page.has_field?("OTP code")
         assert page.has_button?("Authenticate with security device")
+      end
+
+      should "not set security device notice" do
+        assert_nil flash[:notice_html]
       end
     end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -15,6 +15,7 @@ class SignInTest < SystemTest
     click_button "Sign in"
 
     assert page.has_content? "Sign out"
+    assert page.has_content? "We now support security devices!"
   end
 
   test "signing in with uppercase email" do
@@ -79,6 +80,7 @@ class SignInTest < SystemTest
     end
 
     assert page.has_content? "Sign out"
+    assert page.has_content? "We now support security devices!"
   end
 
   test "signing in with current valid otp when mfa enabled but 30 minutes has passed" do

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -30,6 +30,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     click_on "Authenticate with security device"
 
     assert page.has_content? "Dashboard"
+    refute page.has_content? "We now support security devices!"
   end
 
   test "sign in with webauthn but it expired" do


### PR DESCRIPTION
Contributes to #3800 

## What problem are you solving?
We would like to better publicize webauthn now that it is fully supported. After discussing in the Slack, we have determined that a banner would be a good approach, as well as a flash notification after signin. Further, webauthn is the prefered MFA solution. So, it should be moved higher up in the settings edit page.

## What approach did you choose and why?
Adds a banner to publicize webauthn, links directly to the section to add a device on the settings edit page. Also, moves webauthn content above TOTP in the settings edit page.
<img width="1893" alt="Screenshot 2023-07-17 at 2 21 53 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/ca9f8eb8-d307-42de-91c6-86d47389db30">

When a user signs in using no MFA, or with TOTP, they are also given a flash warning telling them about security devices. Further, the flash warning CSS is getting an update to be sleeker and more readable (after 9 years!). In the image below, you can see the new flash warning.
<img width="1123" alt="Screenshot 2023-07-18 at 3 25 54 PM" src="https://github.com/rubygems/rubygems.org/assets/71022385/8488c884-837b-48df-b2c5-c75f72942147">


## What should reviewers focus on?
Content of the banner, styling of the new flash warning. 

## Blockers ⚠️ 
1. This PR should only be merged after the Safari PRs are shipped. https://github.com/rubygems/rubygems.org/pull/3873
https://github.com/rubygems/rubygems/pull/6774
2. This PR should only be merged after the new blog post is live https://github.com/rubygems/rubygems.github.io/pull/164