### PR TITLE
Allow disabling specific links for specific gems via feature flag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,7 @@ Metrics/BlockLength:
     - config/environments/development.rb
 
 Metrics/ClassLength:
-  Max: 356 # TODO: Lower to 100
+  Max: 359 # TODO: Lower to 100
   Exclude:
     - test/**/*
 

--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -26,7 +26,13 @@ class Links
   end
 
   def links
-    version.indexed ? LINKS : NON_INDEXED_LINKS
+    links = version.indexed ? LINKS : NON_INDEXED_LINKS
+
+    links.select do |_, long|
+      Rails.configuration.launch_darkly_client.variation(
+        "links.show.#{long}", rubygem.ld_context, true
+      )
+    end.to_h
   end
 
   delegate :keys, to: :links

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -383,6 +383,10 @@ class Rubygem < ApplicationRecord
     end
   end
 
+  def ld_context
+    LaunchDarkly::LDContext.with_key(name, "rubygem")
+  end
+
   private
 
   # a gem namespace is not protected if it is

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -66,6 +66,7 @@
 
   <h3 class="t-list__heading"><%= t '.links.header' %>:</h3>
   <div class="t-list__items">
+    <code><%= @versioned_links.each.to_a.to_json %></code>
     <%- @versioned_links.each do |name, link| %>
       <%= link_to_page name, link %>
     <%- end %>


### PR DESCRIPTION
Done so that we can disable the gem download link for metasploit, so the metasploit gem payes are not marked as malicious for linking to "malicious" content

Closes https://github.com/rubygems/rubygems.org/issues/3883