### PR TITLE
Fix shoulda matchers not exercised

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem "capybara", "~> 3.38"
   gem "launchy", "~> 2.5"
   gem "rack-test", "~> 2.1", require: "rack/test"
+  gem "rails-controller-testing", "~> 1.0"
   gem "mocha", "~> 2.0", require: false
   gem "shoulda", "~> 4.0"
   gem "selenium-webdriver", "~> 4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,10 @@ GEM
       activesupport (= 7.0.6)
       bundler (>= 1.15.0)
       railties (= 7.0.6)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.1.1)
       activesupport (>= 5.0.0)
       minitest
@@ -666,6 +670,7 @@ DEPENDENCIES
   rack-test (~> 2.1)
   rack-utf8_sanitizer (~> 1.8)
   rails (~> 7.0.0)
+  rails-controller-testing (~> 1.0)
   rails-erd (~> 1.7)
   rails-i18n (~> 7.0)
   rails_semantic_logger (~> 4.11)

--- a/test/functional/reverse_dependencies_controller_test.rb
+++ b/test/functional/reverse_dependencies_controller_test.rb
@@ -23,10 +23,13 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
         rubygem: @rubygem_two)
     end
 
-    should "render template" do
-      get :index, params: { rubygem_id: @rubygem_one.to_param }
-      respond_with :success
-      render_template :index
+    context "render template" do
+      setup do
+        get :index, params: { rubygem_id: @rubygem_one.to_param }
+      end
+
+      should respond_with :success
+      should render_template :index
     end
 
     should "show reverse dependencies" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -8,7 +8,7 @@ class UsersControllerTest < ActionController::TestCase
       get :new
     end
 
-    render_template(:new)
+    should render_template(:new)
 
     should "render the new user form" do
       page.assert_text "Sign up"


### PR DESCRIPTION
Saw this while writing tests for #3924, there were a couple of places where shoulda matchers were allocated but not asserted.

Calling `respond_with` or `render_template` in a test only initializes a matcher, but it's not asserted unless called with `should`.

Using the `render_template` matcher requires adding `rails-controller-testing` to the Gemfile.