### PR TITLE
Remove webdrivers gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,6 @@ group :test do
   gem "mocha", "~> 2.0", require: false
   gem "shoulda", "~> 4.0"
   gem "selenium-webdriver", "~> 4.8"
-  gem "webdrivers", "~> 5.2"
   gem "webmock", "~> 3.18"
   gem "simplecov", "~> 0.22", require: false
   gem "simplecov-cobertura", "~> 2.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,10 +594,6 @@ GEM
       openssl (>= 2.2)
       safety_net_attestation (~> 0.4.0)
       tpm-key_attestation (~> 0.12.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -700,7 +696,6 @@ DEPENDENCIES
   validates_formatting_of (~> 0.9)
   view_component (~> 2.0)
   webauthn (~> 3.0)
-  webdrivers (~> 5.2)
   webmock (~> 3.18)
   xml-simple (~> 1.1)
 


### PR DESCRIPTION
- it is not needed anymore since selenium-webdriver gem manages drivers
- should fix unstable CI https://github.com/titusfortner/webdrivers/issues/247