### PR TITLE
Redirect user to signin after webauthn error has occurred

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < Clearance::SessionsController
     @user = find_user
 
     if @user&.mfa_enabled?
-      setup_webauthn_authentication(form_url: webauthn_create_session_path, session_options: { "user" => @user.id })
+      setup_webauthn_authentication(form_url: webauthn_create_session_path)
       session[:mfa_user] = @user.id
 
       session[:mfa_login_started_at] = Time.now.utc.to_s
@@ -25,7 +25,7 @@ class SessionsController < Clearance::SessionsController
   end
 
   def webauthn_create
-    @user = User.find(session.dig(:webauthn_authentication, "user"))
+    @user = User.find(session[:mfa_user])
 
     unless session_active?
       webauthn_verification_failure(t("multifactor_auths.session_expired"))

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -343,7 +343,6 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :ok
 
       should "set webauthn authentication" do
-        assert_equal @user.id, session[:webauthn_authentication]["user"]
         assert_not_nil session[:webauthn_authentication]["challenge"]
       end
 
@@ -380,7 +379,6 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :ok
 
       should "set webauthn authentication" do
-        assert_equal @user.id, session[:webauthn_authentication]["user"]
         assert_not_nil session[:webauthn_authentication]["challenge"]
       end
 
@@ -409,7 +407,6 @@ class SessionsControllerTest < ActionController::TestCase
       should respond_with :ok
 
       should "set webauthn authentication" do
-        assert_equal @user.id, session[:webauthn_authentication]["user"]
         assert_not_nil session[:webauthn_authentication]["challenge"]
       end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -518,14 +518,14 @@ class SessionsControllerTest < ActionController::TestCase
     end
   end
 
-  context "#webauthn_create" do
-    context "when providing correct credentials" do
-      setup do
-        @user = create(:user)
-        @webauthn_credential = create(:webauthn_credential, user: @user)
-        login_to_session_with_webauthn
-      end
+  context "on POST to webauthn_create" do
+    setup do
+      @user = create(:user)
+      @webauthn_credential = create(:webauthn_credential, user: @user)
+      login_to_session_with_webauthn
+    end
 
+    context "when providing correct credentials" do
       context "redirect to dashboard" do
         setup do
           verify_challenge
@@ -559,12 +559,6 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when not providing credentials" do
       setup do
-        @user = create(:user)
-        @webauthn_credential = create(:webauthn_credential, user: @user)
-        post(
-          :create,
-          params: { session: { who: @user.handle, password: @user.password } }
-        )
         post(
           :webauthn_create,
           format: :html
@@ -580,20 +574,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when providing wrong credentials" do
       setup do
-        @user = create(:user)
-        @webauthn_credential = create(:webauthn_credential, user: @user)
-        post(
-          :create,
-          params: { session: { who: @user.handle, password: @user.password } }
-        )
         @wrong_challenge = SecureRandom.hex
-        @origin = "http://localhost:3000"
-        @rp_id = URI.parse(@origin).host
-        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
-        WebauthnHelpers.create_credential(
-          webauthn_credential: @webauthn_credential,
-          client: @client
-        )
         post(
           :webauthn_create,
           params: {
@@ -616,20 +597,6 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when providing credentials but the session expired" do
       setup do
-        @user = create(:user)
-        @webauthn_credential = create(:webauthn_credential, user: @user)
-        post(
-          :create,
-          params: { session: { who: @user.handle, password: @user.password } }
-        )
-        @challenge = session[:webauthn_authentication]["challenge"]
-        @origin = "http://localhost:3000"
-        @rp_id = URI.parse(@origin).host
-        @client = WebAuthn::FakeClient.new(@origin, encoding: false)
-        WebauthnHelpers.create_credential(
-          webauthn_credential: @webauthn_credential,
-          client: @client
-        )
         travel 30.minutes
         post(
           :webauthn_create,

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -555,6 +555,15 @@ class SessionsControllerTest < ActionController::TestCase
           verify_challenge
         end
       end
+
+      should "clear session" do
+        verify_challenge
+
+        assert_nil @controller.session[:mfa_expires_at]
+        assert_nil @controller.session[:mfa_login_started_at]
+        assert_nil @controller.session[:mfa_user]
+        assert_nil @controller.session[:webauthn_authentication]
+      end
     end
 
     context "when not providing credentials" do
@@ -569,6 +578,17 @@ class SessionsControllerTest < ActionController::TestCase
 
       should "set flash notice" do
         assert_equal "Credentials required", flash[:notice]
+      end
+
+      should "render sign in page" do
+        assert_template "sessions/new"
+      end
+
+      should "clear session" do
+        assert_nil @controller.session[:mfa_expires_at]
+        assert_nil @controller.session[:mfa_login_started_at]
+        assert_nil @controller.session[:mfa_user]
+        assert_nil @controller.session[:webauthn_authentication]
       end
     end
 
@@ -593,6 +613,17 @@ class SessionsControllerTest < ActionController::TestCase
       should "set flash notice" do
         assert_equal "WebAuthn::ChallengeVerificationError", flash[:notice]
       end
+
+      should "render sign in page" do
+        assert_template "sessions/new"
+      end
+
+      should "clear session" do
+        assert_nil @controller.session[:mfa_expires_at]
+        assert_nil @controller.session[:mfa_login_started_at]
+        assert_nil @controller.session[:mfa_user]
+        assert_nil @controller.session[:webauthn_authentication]
+      end
     end
 
     context "when providing credentials but the session expired" do
@@ -613,8 +644,11 @@ class SessionsControllerTest < ActionController::TestCase
 
       should respond_with :unauthorized
 
-      should "clear mfa_expires_at" do
+      should "clear session" do
         assert_nil @controller.session[:mfa_expires_at]
+        assert_nil @controller.session[:mfa_login_started_at]
+        assert_nil @controller.session[:mfa_user]
+        assert_nil @controller.session[:webauthn_authentication]
       end
 
       should "not sign in the user" do
@@ -623,6 +657,10 @@ class SessionsControllerTest < ActionController::TestCase
 
       should "set flash notice" do
         assert_equal "Your login page session has expired.", flash[:notice]
+      end
+
+      should "render sign in page" do
+        assert_template "sessions/new"
       end
     end
   end

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -48,7 +48,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
       click_on "Authenticate with security device"
 
       assert page.has_content? "Your login page session has expired."
-      assert page.has_content? "Multi-factor authentication"
+      assert page.has_content? "Sign in"
     end
   end
 


### PR DESCRIPTION
## What problem are you solving?

Part of: https://github.com/rubygems/rubygems.org/issues/3335

> When an error does get hit in `sessions#webauthn_create` eg. `login_failure("Credentials required")`, the ensure block is run which deletes `session[:webauthn_authentication]`. 

> When the user tries to authenticate again, `@user = User.find(session.dig(:webauthn_authentication, "user"))` will blow up with an ActiveRecord record not found error and will fail to authenticate or fail to display any error.

## What approach did you choose and why?
Currently, if a user enters the wrong totp code during mfa verification, they'll be redirected back to the sign in page. This PR would do the same with webauthn.

This would solve https://github.com/rubygems/rubygems.org/issues/3335 as the sign in flow would be reset and the correct session variables will be set when the user is prompted again. A reason I decided to redirect back to sign in instead of re-rendering the prompt page is that another error that could occur is that their login session is expired. It wouldn't make sense to re-render the prompt page as auth would always fail (the login session is expired). 

<img width="1202" alt="Screenshot 2023-07-26 at 4 38 15 PM" src="https://github.com/rubygems/rubygems.org/assets/42748004/24ef7f76-0cd5-4efc-9057-7abe338d47fd">

## Next steps
Will need to revisit the same for email confirmations, multifactor auth level update and password reset.
