### PR TITLE
Lock avo < 2.36, It requires to fix test failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "browser", "~> 5.3", ">= 5.3.1"
 gem "bcrypt", "~> 3.1", ">= 3.1.18"
 
 # Admin dashboard
-gem "avo", "~> 2.28"
+gem "avo", "~> 2.28", "< 2.36" # 2.36+ requires to fix test failures
 gem "view_component", "~> 2.0"
 gem "pundit", "~> 2.3"
 gem "chartkick", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,7 @@ PLATFORMS
 DEPENDENCIES
   amazing_print (~> 1.4)
   autoprefixer-rails (~> 10.4)
-  avo (~> 2.28)
+  avo (~> 2.28, < 2.36)
   aws-sdk-s3 (~> 1.119)
   aws-sdk-sqs (~> 1.53)
   bcrypt (~> 3.1, >= 3.1.18)


### PR DESCRIPTION
Suppress to dependabot update like https://github.com/rubygems/rubygems.org/pull/3961 until fixing test failures.