### PR TITLE
 Avo actions to enqueue compact index file upload jobs

### DIFF
--- a/app/avo/actions/upload_info_file.rb
+++ b/app/avo/actions/upload_info_file.rb
@@ -1,0 +1,15 @@
+class UploadInfoFile < BaseAction
+  self.name = "Upload Info File"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+  self.confirm_button_label = "Upload"
+
+  class ActionHandler < ActionHandler
+    def handle_model(rubygem)
+      UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
+
+      succeed("Upload job scheduled")
+    end
+  end
+end

--- a/app/avo/actions/upload_versions_file.rb
+++ b/app/avo/actions/upload_versions_file.rb
@@ -1,0 +1,18 @@
+class UploadVersionsFile < BaseAction
+  self.name = "Upload Versions File"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :index
+  }
+  self.standalone = true
+  self.confirm_button_label = "Upload"
+
+  class ActionHandler < ActionHandler
+    def handle_standalone
+      UploadVersionsFileJob.perform_later
+
+      succeed("Upload job scheduled")
+
+      Version.last
+    end
+  end
+end

--- a/app/avo/resources/rubygem_resource.rb
+++ b/app/avo/resources/rubygem_resource.rb
@@ -18,6 +18,8 @@ class RubygemResource < Avo::BaseResource
   action AddOwner
   action YankRubygem
   action ReserveNamespace
+  action UploadInfoFile
+  action UploadVersionsFile
 
   class IndexedFilter < ScopeBooleanFilter; end
   filter IndexedFilter, arguments: { default: { with_versions: true, without_versions: true } }

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -5,4 +5,5 @@ class Audit < ApplicationRecord
   serialize :audited_changes, JSON
 
   validates :action, presence: true
+  validates :auditable, presence: false
 end


### PR DESCRIPTION
So we can manually trigger the jobs if needed (e.g. https://rubygems.org/info/aws-sdk-snowball is missing the latest version, I think we need to wrap the gemcutter stuff in a transaction, will do that separately).

Either way, being able to trigger the jobs seems helpful.