### PR TITLE
Re-upload compact index files on yank/restore

### DIFF
--- a/test/factories/version.rb
+++ b/test/factories/version.rb
@@ -25,5 +25,12 @@ FactoryBot.define do
     trait :mfa_required do
       metadata { { "rubygems_mfa_required" => "true" } }
     end
+
+    after(:create) do |version|
+      if version.info_checksum.blank?
+        checksum = GemInfo.new(version.rubygem.name).info_checksum
+        version.update_attribute :info_checksum, checksum
+      end
+    end
   end
 end

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -394,6 +394,11 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         should "have enqueued a webhook" do
           assert_enqueued_jobs 1, only: NotifyWebHookJob
         end
+        should "have enqueued reindexing job" do
+          assert_enqueued_jobs 1, only: Indexer
+          assert_enqueued_jobs 1, only: UploadVersionsFileJob
+          assert_enqueued_jobs 1, only: UploadInfoFileJob, with: { rubygem_name: @rubygem.name }
+        end
       end
 
       context "and a version 0.1.1" do

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -186,6 +186,17 @@ class DeletionTest < ActiveSupport::TestCase
         @deletion.restore!
       end
     end
+
+    should "enqueue indexing jobs" do
+      @deletion = delete_gem
+      assert_enqueued_jobs 1, only: Indexer do
+        assert_enqueued_jobs 1, only: UploadVersionsFileJob do
+          assert_enqueued_jobs 1, only: UploadInfoFileJob, with: { rubygem_name: @rubygem.name } do
+            @deletion.restore!
+          end
+        end
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Fixes issues like:

> We are using a gem that has a dependency on the gem dry-configurable, specified like this: gem 'dry-configurable', '~> 1.0.1'.
> However, instead of pulling version 1.0.1, it attempts to fetch version 1.0.2 and errors out, because it has been yanked on RubyGems (see the version history of that gem here: https://rubygems.org/gems/dry-configurable/versions).
> I was able to recreate the issue by creating a Gemfile with the following content on my machine:
> ```ruby
> source "https://rubygems.org/"
> gem 'dry-configurable', '~> 1.0.1'
> ```
> Despite removing the cache using rm -rf ~/.bundle/, the problem persists. Strangely, the correct gem is downloaded when I use bundle install --full-index.
> So I suspect that the info on the versions available for this gem is stored somewhere on my computer, but I have no idea where.