### PR TITLE
Enable OpenSearch instrumentation in datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -45,6 +45,7 @@ Datadog.configure do |c|
   c.tracing.instrument :dalli
   c.tracing.instrument :faraday, split_by_domain: true, service_name: c.service
   c.tracing.instrument :http, split_by_domain: true, service_name: c.service
+  c.tracing.instrument :opensearch, service_name: c.service
   c.tracing.instrument :pg
   c.tracing.instrument :rails, request_queuing: true
   c.tracing.instrument :shoryuken


### PR DESCRIPTION
Now that we have updated to dd-trace-rb 1.13

[0]: https://github.com/DataDog/dd-trace-rb/blob/master/CHANGELOG.md#1130---2023-07-31