### PR TITLE
Fix finding magic.mgc in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,6 @@ RUN echo "${REVISION}" > REVISION
 # Stop bootsnap from writing to the filesystem, we precompiled it in the build stage
 ENV BOOTSNAP_READONLY=true
 
-# Needed since we install the gem and then move it to a new location
-ENV MAGIC="$(find /app/vendor/ruby/*/gems/ruby-magic-*/ -name magic.mgc | head -n1)"
-
 EXPOSE 3000
 
 # Ensures ruby commands are run with bundler

--- a/config/initializers/magic.rb
+++ b/config/initializers/magic.rb
@@ -1,0 +1,13 @@
+if ENV["MAGIC"].nil?
+  # Be resilient to the gem being moved after installation, as is done in the docker image
+  ENV["MAGIC"] = Dir.glob(File.join(
+                            Gem.loaded_specs.fetch("ruby-magic").full_gem_path,
+                            "ports",
+                            "*",
+                            "libmagic",
+                            Magic.version_string,
+                            "share",
+                            "misc",
+                            "magic.mgc"
+                          )).sole
+end

--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -24,6 +24,14 @@ docker buildx build --cache-from=type=local,src=/tmp/.buildx-cache \
   --build-arg REVISION="$GITHUB_SHA" \
   .
 
+# This is a ruby script we run to ensure that all dependencies are configured properly in
+# the docker container, even if they are not used in the the few requests made to the application.
+docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
+  --net host "$DOCKER_TAG" \
+  -- bin/rails runner - <<-EOS
+Magic.buffer('')
+EOS
+
 docker run -e RAILS_ENV=production -e SECRET_KEY_BASE=1234 -e DATABASE_URL=postgresql://localhost \
   --net host "$DOCKER_TAG" \
   -- bin/rails db:create db:migrate


### PR DESCRIPTION
Again

Broke because you cannot run commands to set an env var in a dockerfile

As a reminder, this is needed because we move the ruby-magic gem after the initial installation

Also adds a test to ensure the built image is able to load magic, because this has broken multiple times now