### PR TITLE
Add back webauthn badge

### DIFF
--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -15,7 +15,14 @@
     <% end %>
   <% end %>
 
-  <h2 id="security-device"><%= t(".webauthn_credentials") %></h2>
+  <div class="mfa__header-wrapper">
+    <h2 class="mfa__header mfa__header--compact"><%= t(".webauthn_credentials") %></h2>
+    <% if @user.webauthn_enabled? %>
+      <span class="badge badge--success"><%= t(".mfa.enabled") %></span>
+    <% else %>
+      <span class="badge badge--warning"><%= t(".mfa.disabled") %></span>
+    <% end %>
+  </div>
 
   <p><%= t(".webauthn_credential_note")%></p>
 


### PR DESCRIPTION
## Problem

We think a bad rebase removed the badge for webauthn, this PR adds it back

<p align="center">
  <kbd>
    <img src="https://github.com/rubygems/rubygems.org/assets/20158582/0689f8e4-6538-4fa5-a7c5-413639f41ae1" width=300>
    <img src="https://github.com/rubygems/rubygems.org/assets/20158582/75de4796-9c07-4e38-9874-86cab5d10fb2" width=300>
  </kbd>
</p>

