### PR TITLE
Upload capybara test screenshots on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,15 @@ jobs:
           cp config/database.yml.sample config/database.yml
           bundle exec rake db:setup
       - name: Tests
+        id: test-all
         run: bin/rails test:all
+      - name: Save capybara screenshots
+        if: steps.test-all.outcome == 'failure'
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: capybara-screenshots
+          path: tmp/capybara
+          if-no-files-found: ignore
       - name: Upload coverage to Codecov
         if: matrix.rubygems.name == 'locked' && (success() || failure())
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4


### PR DESCRIPTION
Makes diagnosing test failures in the system tests easier