### PR TITLE
Silence capybara in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ Capybara.default_max_wait_time = 2
 Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
 Capybara.always_include_port = true
 Capybara.server_port = 31_337
-Capybara.server = :puma
+Capybara.server = :puma, { Silent: true }
 
 GoodJob::Execution.delete_all
 


### PR DESCRIPTION
The "starting puma" message is just noise (and happens at indeterminite points) when test progress is printed out with dots