### PR TITLE
Clarify Version#rely_on_built_at? protects against other incongruent gem dates

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -186,6 +186,8 @@ class Version < ApplicationRecord
     created_at
   end
 
+  # Originally used to prevent showing misidentified dates for gems predating RubyGems,
+  # this method also covers cases where a Gem::Specification date is obviously invalid due to build-time considerations.
   def rely_on_built_at?
     return false if created_at.to_date != RUBYGEMS_IMPORT_DATE
 


### PR DESCRIPTION
In discussing invalid dates appearing on some `Gem::Specification` in [rubygems PR #6859][rubygems-discussion], it was uncovered that this helper method has been inadvertently protecting `RubyGems.org` from displaying incorrect build dates in other contexts.

Originally used to handle importing gems into the service back in 2003, we discovered that some maintainers utilizing Nix ran into a case where default values for `SOURCE_DATE_EPOCH` were provided as the build date for the gem. `rely_on_built_at?` protected users on the website, or accessing gem details via the API, from seeing these incorrect dates.

@duckinator [wisely suggested][duckinator-suggestion] to add a comment here, surfacing the inadvertent benefit the method has been carrying. That comment also suggests more documentation around gem builds, and setting `SOURCE_DATE_EPOCH` which I'll leave for separate PR's (and link to, from here, if possible!)

[rubygems-discussion]: https://github.com/rubygems/rubygems/pull/6859
[duckinator-suggestion]: https://github.com/rubygems/rubygems/pull/6859#issuecomment-1672155632