### PR TITLE
Add Avo to sponsors page

### DIFF
--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -6,7 +6,6 @@
   </p>
 
   <h2><a href="https://rubycentral.org">Ruby Central</a></h2>
-
   <p>
     Ruby Central, Inc. is a nonprofit 501(c)3 organization dedicated to the support and advocacy of the worldwide Ruby community. They organize the annual RubyConf and RailsConf as opportunities for Rubyists to collaborate and network. As part of those conferences, Ruby Central also operates the Opportunity Scholarship program to consistently bring new people into the tech community and to provide them with a comfortable, welcoming environment to explore our community and its events.
     <br><br>
@@ -16,7 +15,6 @@
   </p>
 
   <h2><a href="https://fastly.com">Fastly</a></h2>
-
   <p>
     Fastly is the future of content delivery, giving businesses complete control over how they serve content, unprecedented access to real-time performance analytics, and the ability to cache frequently changing content at the edge.
   <br><br>
@@ -26,6 +24,13 @@
   <hr>
 
   <h3><a href="https://1password.com">1Password</a></h3>
-
   <p>A password manager, digital vault, form filler and secure digital wallet. 1Password remembers all your passwords for you to help keep account information safe.</p>
+
+  <hr>
+
+  <h3><a href="https://avohq.io">Avo</a></h3>
+  <p>
+    Avo is a custom Content Management System for Ruby on Rails that saves developers and teams months of development time. It's built on modern technologies and provides all the necessary hooks to ensure developers ship the best experiences to their customers.<br><br>
+    Avo enables the RubyGems.org team to quickly build internal tools with limited resources.
+  </p>
 </div>


### PR DESCRIPTION
They provide a free license for Avo for RubyGems to use while building
internal and admin tooling.