### PR TITLE
Remove legacy search fallback for RubyGems search.

### DIFF
--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -2,6 +2,9 @@ class Api::V1::SearchesController < Api::BaseController
   before_action :set_page, only: %i[show autocomplete]
   before_action :verify_query_string, only: %i[show autocomplete]
 
+  rescue_from ElasticSearcher::SearchNotAvailableError, with: :search_not_available_error
+  rescue_from ElasticSearcher::InvalidQueryError, with: :invalid_query_error
+
   def show
     @rubygems = ElasticSearcher.new(query_params, page: @page).api_search
     respond_to do |format|
@@ -19,6 +22,14 @@ class Api::V1::SearchesController < Api::BaseController
 
   def verify_query_string
     render plain: "bad request", status: :bad_request unless query_params.is_a?(String)
+  end
+
+  def search_not_available_error
+    render plain: "search not available, please try again later", status: :service_unavailable
+  end
+
+  def invalid_query_error
+    render plain: "invalid query", status: :bad_request
   end
 
   def query_params

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -24,12 +24,12 @@ class Api::V1::SearchesController < Api::BaseController
     render plain: "bad request", status: :bad_request unless query_params.is_a?(String)
   end
 
-  def search_not_available_error
-    render plain: "search not available, please try again later", status: :service_unavailable
+  def search_not_available_error(error)
+    render plain: error.message, status: :service_unavailable
   end
 
-  def invalid_query_error
-    render plain: "invalid query", status: :bad_request
+  def invalid_query_error(error)
+    render plain: error.message, status: :bad_request
   end
 
   def query_params

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,6 +5,7 @@ class SearchesController < ApplicationController
     return unless params[:query].is_a?(String)
     @error_msg, @gems = ElasticSearcher.new(params[:query], page: @page).search
 
+    return unless @gems
     set_total_pages if @gems.total_count > Gemcutter::SEARCH_MAX_PAGES * Rubygem.default_per_page
     exact_match = Rubygem.name_is(params[:query]).first
     @yanked_gem = exact_match unless exact_match&.indexed_versions?

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -33,17 +33,18 @@ class ElasticSearcher
     result = Rubygem.searchkick_search(body: search_definition(for_api: true).to_hash, page: @page, per_page: Kaminari.config.default_per_page,
 load: false)
     result.response["hits"]["hits"].pluck("_source")
-  rescue Searchkick::InvalidQueryError
-    raise InvalidQueryError
-  rescue *CONNECTION_ERRORS
-    raise SearchNotAvailableError
+  rescue Searchkick::InvalidQueryError => e
+    raise InvalidQueryError, error_msg(e)
+  rescue *CONNECTION_ERRORS => e
+    raise SearchNotAvailableError, error_msg(e)
   end
 
   def suggestions
     result = Rubygem.searchkick_search(body: suggestions_definition.to_hash, page: @page, per_page: Kaminari.config.default_per_page, load: false)
     result = result.response["suggest"]["completion_suggestion"][0]["options"]
     result.map { |gem| gem["_source"]["name"] }
-  rescue *CONNECTION_ERRORS
+  rescue *CONNECTION_ERRORS => e
+    Rails.error.report(e, handled: true)
     Array(nil)
   end
 

--- a/lib/elastic_searcher.rb
+++ b/lib/elastic_searcher.rb
@@ -1,4 +1,16 @@
 class ElasticSearcher
+  CONNECTION_ERRORS = [
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError,
+    Searchkick::Error,
+    OpenSearch::Transport::Transport::Error,
+    Errno::ECONNRESET,
+    HTTPClient::KeepAliveDisconnected
+  ].freeze
+
+  SearchNotAvailableError = Class.new(StandardError)
+  InvalidQueryError = Class.new(StandardError)
+
   def initialize(query, page: 1)
     @query  = query
     @page   = page
@@ -13,24 +25,25 @@ class ElasticSearcher
     )
     result.response # ES query is triggered here to allow fallback. avoids lazy loading done in the view
     [nil, result]
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Searchkick::Error, OpenSearch::Transport::Transport::Error => e
-    result = Rubygem.legacy_search(@query).page(@page)
-    [error_msg(e), result]
+  rescue StandardError => e
+    [error_msg(e), nil]
   end
 
   def api_search
     result = Rubygem.searchkick_search(body: search_definition(for_api: true).to_hash, page: @page, per_page: Kaminari.config.default_per_page,
 load: false)
     result.response["hits"]["hits"].pluck("_source")
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Searchkick::Error, OpenSearch::Transport::Transport::Error
-    Rubygem.legacy_search(@query).page(@page)
+  rescue Searchkick::InvalidQueryError
+    raise InvalidQueryError
+  rescue *CONNECTION_ERRORS
+    raise SearchNotAvailableError
   end
 
   def suggestions
     result = Rubygem.searchkick_search(body: suggestions_definition.to_hash, page: @page, per_page: Kaminari.config.default_per_page, load: false)
     result = result.response["suggest"]["completion_suggestion"][0]["options"]
     result.map { |gem| gem["_source"]["name"] }
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Searchkick::Error, OpenSearch::Transport::Transport::Error
+  rescue *CONNECTION_ERRORS
     Array(nil)
   end
 
@@ -104,10 +117,10 @@ load: false)
 
   def error_msg(error)
     if error.is_a? Searchkick::InvalidQueryError
-      "Failed to parse: '#{@query}'. Falling back to legacy search."
+      "Failed to parse search term: '#{@query}'."
     else
       Rails.error.report(error, handled: true)
-      "Advanced search is currently unavailable. Falling back to legacy search."
+      "Search is currently unavailable. Please try again later."
     end
   end
 

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -59,7 +59,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
           get :show, params: { query: "other" }, format: :json
 
           assert_response :service_unavailable
-          assert_equal "search not available, please try again later", @response.body
+          assert_equal "Search is currently unavailable. Please try again later.", @response.body
         end
       end
     end
@@ -69,7 +69,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
         get :show, params: { query: "AND other" }, format: :json
 
         assert_response :bad_request
-        assert_equal "invalid query", @response.body
+        assert_equal "Failed to parse search term: 'AND other'.", @response.body
       end
     end
   end

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -53,14 +53,23 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
     end
 
     context "with elasticsearch down" do
-      should "fallback to legacy search" do
+      should "returns friendly error message" do
         requires_toxiproxy
         Toxiproxy[:elasticsearch].down do
           get :show, params: { query: "other" }, format: :json
 
-          assert_response :success
-          assert_equal "other", JSON.parse(@response.body).first["name"]
+          assert_response :service_unavailable
+          assert_equal "search not available, please try again later", @response.body
         end
+      end
+    end
+
+    context "invalid query" do
+      should "returns friendly error message" do
+        get :show, params: { query: "AND other" }, format: :json
+
+        assert_response :bad_request
+        assert_equal "invalid query", @response.body
       end
     end
   end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -155,14 +155,13 @@ class SearchesControllerTest < ActionController::TestCase
       create(:version, rubygem: @sinatra)
       create(:version, rubygem: @sinatra_redux)
     end
-    should "fallback to legacy search" do
+    should "error with friendly error message" do
       requires_toxiproxy
       Toxiproxy[:elasticsearch].down do
         get :show, params: { query: "sinatra" }
 
         assert_response :success
-        assert page.has_content?("Advanced search is currently unavailable. Falling back to legacy search.")
-        assert page.has_content?("Displaying")
+        assert page.has_content?("Search is currently unavailable. Please try again later.")
       end
     end
   end


### PR DESCRIPTION
OpenSearch deploy is stable enough to cover search functionality with no fallback need.

## wrong search term

![image](https://github.com/rubygems/rubygems.org/assets/193936/dbc79b19-fbd3-49c4-b715-39e6369572d5)

## OpenSearch unavailable

![image](https://github.com/rubygems/rubygems.org/assets/193936/f6af0093-37b3-4ed5-ad85-9354b874481e)
