### PR TITLE
Validate no dashes in version number

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -40,6 +40,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :authors_format, on: :create
   validate :metadata_links_format
   validate :metadata_attribute_length
+  validate :no_dashes_in_version_number, on: :create
 
   class AuthorType < ActiveModel::Type::String
     def cast_value(value)
@@ -468,5 +469,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def unique_canonical_number
     version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
+  end
+
+  def no_dashes_in_version_number
+    return unless number&.include?("-")
+    errors.add(:number, "cannot contain a dash (it will be uninstallable)")
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -409,6 +409,7 @@ class VersionTest < ActiveSupport::TestCase
     should_not allow_value("1.2.3-\"[javalol]\"").for(:number)
     should_not allow_value("0.8.45::Gem::PLATFORM::FAILBOAT").for(:number)
     should_not allow_value("1.2.3\n<bad>").for(:number)
+    should_not allow_value("1.2.3-bad").for(:number)
 
     should allow_value("ruby").for(:platform)
     should allow_value("mswin32").for(:platform)
@@ -973,7 +974,7 @@ class VersionTest < ActiveSupport::TestCase
     v2 = Version.new(authors: %w[arthurnn dwradcliffe], number: "733.t-0.0.1", platform: "ruby", gem_platform: "ruby", rubygem: g2)
 
     refute_predicate v2, :valid?
-    assert_equal %i[full_name gem_full_name], v2.errors.attribute_names
+    assert_equal %i[full_name gem_full_name number], v2.errors.attribute_names
   end
 
   context "checksums" do


### PR DESCRIPTION
While technically allowed by Gem::Version::VERSION_PATTERN, it would be uninstallable using the compact index, as we `version.split(",", 2)` the version number, leading to anything after the dash being treated as part of the platform, vs the version number

So disallow that going forward