### PR TITLE
Moves sha256 file to /api/v2/rubygems/gem/versions/1.0.0/contents.sha256

### DIFF
--- a/app/controllers/api/v2/contents_controller.rb
+++ b/app/controllers/api/v2/contents_controller.rb
@@ -1,0 +1,35 @@
+class Api::V2::ContentsController < Api::BaseController
+  before_action :find_rubygem_by_name, only: [:index]
+
+  def index
+    return unless stale?(@rubygem)
+    cache_expiry_headers
+    set_surrogate_key "gem/#{@rubygem.name}"
+
+    find_version
+    return unless @version
+
+    checksums_file = @version.manifest.checksums_file
+    return render plain: "Content is unavailable for this version.", status: :not_found unless checksums_file
+
+    respond_to do |format|
+      format.json { render json: checksums_payload(checksums_file) }
+      format.yaml { render yaml: checksums_payload(checksums_file) }
+      format.sha256 { render plain: checksums_file }
+    end
+  end
+
+  protected
+
+  def find_version
+    version_params = params.permit(:version_number, :platform)
+    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform])
+    render plain: "This version could not be found.", status: :not_found unless @version
+  end
+
+  def checksums_payload(checksums_file)
+    ShasumFormat.parse(checksums_file).transform_values do |checksum|
+      { VersionManifest::DEFAULT_DIGEST => checksum }
+    end
+  end
+end

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -11,14 +11,6 @@ class Api::V2::VersionsController < Api::BaseController
       respond_to do |format|
         format.json { render json: version }
         format.yaml { render yaml: version }
-        format.sha256 do
-          hashes = @rubygem.version_manifest(version_params[:number], version_params[:platform]).checksums_file
-          if hashes
-            render plain: hashes
-          else
-            render plain: "SHA256 format unavailable for this version.", status: :not_found
-          end
-        end
       end
     else
       render plain: "This version could not be found.", status: :not_found

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -130,13 +130,18 @@ class Rubygem < ApplicationRecord # rubocop:disable Metrics/ClassLength
     versions.uniq.sort_by(&:position)
   end
 
+  # NB: this intentionally does not default the platform to ruby.
+  # Without platform, finds the most recent version by (position, created_at) ignoring platform.
+  def find_public_version(number, platform = nil)
+    if platform
+      public_versions.find_by(number:, platform:)
+    else
+      public_versions.find_by(number:)
+    end
+  end
+
   def public_version_payload(number, platform = nil)
-    version =
-      if platform
-        public_versions.find_by(number: number, platform: platform)
-      else
-        public_versions.find_by(number: number)
-      end
+    version = find_public_version(number, platform)
     payload(version).merge!(version.as_json) if version
   end
 

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class VersionManifest
+  DEFAULT_DIGEST = "sha256"
+
   attr_reader :version, :contents
 
   delegate :gem, :fs, to: :contents
@@ -139,7 +141,7 @@ class VersionManifest
     format RubygemContents::CHECKSUMS_ROOT_FORMAT, gem: gem
   end
 
-  def checksums_key(format: :sha256)
+  def checksums_key(format: DEFAULT_DIGEST)
     format RubygemContents::CHECKSUMS_KEY_FORMAT, gem: gem, version: version, format:
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,12 @@ Rails.application.routes.draw do
       resources :rubygems, param: :name, only: [], constraints: { name: Patterns::ROUTE_PATTERN } do
         resources :versions, param: :number, only: :show, constraints: {
           number: /#{Gem::Version::VERSION_PATTERN}(?=\.(json|yaml|sha256)\z)|#{Gem::Version::VERSION_PATTERN}/o
-        }
+        } do
+          resources :contents, only: :index, constraints: {
+            version_number: /#{Gem::Version::VERSION_PATTERN}/o,
+            format: /json|yaml|sha256/
+          }
+        end
       end
     end
 

--- a/test/functional/api/v2/contents_controller_test.rb
+++ b/test/functional/api/v2/contents_controller_test.rb
@@ -1,0 +1,239 @@
+require "test_helper"
+
+class Api::V2::ContentsControllerTest < ActionController::TestCase
+  def get_index(rubygem, version_number, platform = nil, format: :sha256)
+    get :index, params: { rubygem_name: rubygem.name, version_number:, platform:, format: }.compact
+  end
+
+  def set_cache_header
+    @request.if_modified_since = @response.headers["Last-Modified"]
+    @request.if_none_match = @response.etag
+  end
+
+  context "routing to index" do
+    should "route to index" do
+      expected = { controller: "api/v2/contents", action: "index", rubygem_name: "foo", version_number: "1.0.0" }
+
+      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0/contents"
+    end
+
+    should "route to index with .json" do
+      expected = { controller: "api/v2/contents", action: "index", rubygem_name: "foo", version_number: "1.0.0", format: "json" }
+
+      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0/contents.json"
+    end
+
+    should "route to index with .yaml" do
+      expected = { controller: "api/v2/contents", action: "index", rubygem_name: "foo", version_number: "1.0.0", format: "yaml" }
+
+      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0/contents.yaml"
+    end
+
+    should "route to index with .sha256" do
+      expected = { controller: "api/v2/contents", action: "index", rubygem_name: "foo", version_number: "1.0.0", format: "sha256" }
+
+      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0/contents.sha256"
+    end
+
+    should "not be confused by prerelease versions" do
+      expected = { controller: "api/v2/contents", action: "index", rubygem_name: "foo", version_number: "1.0.0-a.pre" }
+
+      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0-a.pre/contents"
+    end
+
+    should "not route when disallowed characters are used" do
+      assert_raises(ActionController::UrlGenerationError) do
+        get :index, params: { rumgem_name: "foo", version_number: "bad%20version", format: "json" }
+      end
+    end
+  end
+
+  context "on GET to index" do
+    setup do
+      @rubygem = create(:rubygem)
+      @jruby_version = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "jruby")
+      @version = create(:version, rubygem: @rubygem, number: "2.0.0")
+      create(:version, rubygem: @rubygem, number: "1.0.0.pre", prerelease: true)
+      create(:version, rubygem: @rubygem, number: "3.0.0", indexed: false)
+
+      @rubygem2 = create(:rubygem)
+      create(:version, rubygem: @rubygem2, number: "3.0.0")
+      create(:version, rubygem: @rubygem2, number: "2.0.0")
+      create(:version, rubygem: @rubygem2, number: "1.0.0")
+
+      @checksums = { "file.rb" => "abc12345", "file2.rb" => "def67890" }
+      @version.manifest.store_checksums(@checksums)
+
+      @jruby_checksums = { "file.rb" => "c0ffee11", "file2.rb" => "c0ffee22" }
+      @jruby_version.manifest.store_checksums(@jruby_checksums)
+    end
+
+    context "with .json format" do
+      should "return checksums for the gem" do
+        get_index(@rubygem, "2.0.0", format: :json)
+
+        assert_response :success
+
+        data = JSON.parse(@response.body)
+        expected_data = @checksums.transform_values { |checksum| { "sha256" => checksum } }
+
+        assert_equal expected_data, data
+      end
+    end
+
+    context "with .yaml format" do
+      should "return checksums for the gem" do
+        get_index(@rubygem, "2.0.0", format: :yaml)
+
+        assert_response :success
+
+        data = YAML.safe_load(@response.body)
+        expected_data = @checksums.transform_values { |checksum| { "sha256" => checksum } }
+
+        assert_equal expected_data, data
+      end
+    end
+
+    context "with .sha256 format" do
+      should "return not found when the hashed files are not available" do
+        get_index(@rubygem, "1.0.0.pre")
+
+        assert_response :not_found
+        assert_equal "Content is unavailable for this version.", @response.body
+      end
+
+      should "return not found when the gem is not indexed" do
+        get_index(@rubygem, "3.0.0")
+
+        assert_response :not_found
+        assert_equal "This version could not be found.", @response.body
+      end
+
+      should "return a list of contents for the first gem" do
+        get_index(@rubygem, "2.0.0")
+
+        assert_response :success
+        assert_equal <<~CHECKSUMS, @response.body
+          abc12345  file.rb
+          def67890  file2.rb
+        CHECKSUMS
+      end
+
+      should "not be confused by ruby platform" do
+        get :index, params: { rubygem_name: @rubygem.name, version_number: "2.0.0", platform: "ruby", format: :sha256 }
+
+        assert_response :success
+        assert_equal <<~CHECKSUMS, @response.body
+          abc12345  file.rb
+          def67890  file2.rb
+        CHECKSUMS
+      end
+
+      should "return jruby version with platform param" do
+        get_index @rubygem, "2.0.0", "jruby"
+
+        assert_response :success
+        assert_equal <<~CHECKSUMS, @response.body
+          c0ffee11  file.rb
+          c0ffee22  file2.rb
+        CHECKSUMS
+      end
+    end
+
+    should "return a platformed gem even without platform param if it was created more recently" do
+      darwin_version = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "universal-darwin-20")
+      darwin_checksums = { "file.rb" => "file.rb-darwin", "file2.rb" => "file2.rb-darwin" }
+      darwin_version.manifest.store_checksums(darwin_checksums)
+
+      get_index @rubygem, "2.0.0", format: :json
+
+      assert_response :success
+      data = JSON.parse(@response.body)
+      expected_data = darwin_checksums.transform_values { |checksum| { "sha256" => checksum } }
+
+      assert_equal expected_data, data
+    end
+
+    should "return Last-Modified header" do
+      get_index(@rubygem, "2.0.0")
+
+      assert_equal @response.headers["Last-Modified"], @rubygem.updated_at.httpdate
+    end
+
+    should "return 304 when If-Modified-Since header is satisfied" do
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :success
+      set_cache_header
+
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :not_modified
+    end
+
+    should "return 200 when If-Modified-Since header is not satisfied" do
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :success
+      set_cache_header
+
+      @rubygem.update(updated_at: Time.zone.now + 1)
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :success
+    end
+
+    should "return 404 if all versions yanked" do
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :success
+      set_cache_header
+
+      travel_to(Time.zone.now + 1) do
+        @rubygem.public_versions.each { |v| v.update!(indexed: false) }
+      end
+
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :not_found
+    end
+  end
+
+  context "on GET to index for an unknown gem" do
+    setup do
+      get_index(Rubygem.new(name: "nonexistent_gem"), "1.2.3")
+    end
+
+    should "return a 404" do
+      assert_response :not_found
+    end
+
+    should "say gem could not be found" do
+      assert_equal "This gem could not be found", @response.body
+    end
+  end
+
+  context "on GET to index for a yanked gem" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:version, rubygem: @rubygem, indexed: false, number: "1.0.0")
+      get_index(@rubygem, "2.0.0")
+    end
+
+    should "return a 404" do
+      assert_response :not_found
+    end
+
+    should "say gem could not be found" do
+      assert_equal "This version could not be found.", @response.body
+    end
+
+    should "should cache the 404" do
+      set_cache_header
+
+      get_index(@rubygem, "2.0.0")
+
+      assert_response :not_modified
+    end
+  end
+end

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -14,7 +14,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
     context "with #{format.to_s.upcase}" do
       should "have a list of versions for the first gem" do
         get_show(@rubygem, "2.0.0", format)
-        @response.body
+        yield @response.body
 
         assert_response :success
       end
@@ -38,12 +38,6 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       expected = { controller: "api/v2/versions", action: "show", rubygem_name: "foo", number: "1.0.0", format: "yaml" }
 
       assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0.yaml"
-    end
-
-    should "route to show with .sha256" do
-      expected = { controller: "api/v2/versions", action: "show", rubygem_name: "foo", number: "1.0.0", format: "sha256" }
-
-      assert_recognizes expected, "/api/v2/rubygems/foo/versions/1.0.0.sha256"
     end
 
     should "not be confused by prerelease versions" do
@@ -78,40 +72,6 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
 
     should_respond_to(:yaml) do |body|
       YAML.safe_load(body)
-    end
-
-    context "with .sha256 format" do
-      setup do
-        @checksums = { "file" => "hash", "file2" => "hash2" }
-        manifest = VersionManifest.new(gem: @rubygem.name, number: "2.0.0")
-        manifest.store_checksums(@checksums)
-      end
-
-      should "return not found when the hashed files are not available" do
-        get_show(@rubygem, "1.0.0.pre", :sha256)
-
-        assert_response :not_found
-      end
-
-      should "return not found when the gem is not indexed" do
-        get_show(@rubygem, "3.0.0", :sha256)
-
-        assert_response :not_found
-      end
-
-      should "have a list of versions for the first gem" do
-        get_show(@rubygem, "2.0.0", :sha256)
-
-        assert_response :success
-        assert_equal ShasumFormat.generate(@checksums), @response.body
-      end
-
-      should "not be confused by ruby platform" do
-        get :show, params: { rubygem_name: @rubygem.name, number: "2.0.0", platform: "ruby", format: :sha256 }
-
-        assert_response :success
-        assert_equal ShasumFormat.generate(@checksums), @response.body
-      end
     end
 
     should "return Last-Modified header" do
@@ -170,6 +130,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
         response = JSON.load(@response.body)
 
         assert_equal "jruby", response["platform"]
+        assert_equal "2.0.0", response["version"]
       end
 
       should "return platform version with platform param" do
@@ -179,6 +140,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
         response = JSON.load(@response.body)
 
         assert_equal "ruby", response["platform"]
+        assert_equal "2.0.0", response["version"]
       end
     end
   end
@@ -251,5 +213,18 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
     should("have dependencies") { assert @response["dependencies"] }
     should("have development dependencies") { assert @response["dependencies"]["development"] }
     should("have runtime dependencies") { assert @response["dependencies"]["runtime"] }
+    should "have expected keys" do
+      assert_equal(
+        %w[
+          name downloads version version_created_at version_downloads platform
+          authors info licenses metadata yanked sha project_uri gem_uri
+          homepage_uri wiki_uri documentation_uri mailing_list_uri
+          source_code_uri bug_tracker_uri changelog_uri funding_uri dependencies
+          built_at created_at description downloads_count number summary
+          rubygems_version ruby_version prerelease requirements
+        ],
+        @response.keys
+      )
+    end
   end
 end


### PR DESCRIPTION
Removes the API format .sha256 from /api/v2/rubygems/gem/versions/1.0.0

This URI make more sense for what the API returns and leaves open a space for returning something specific to the gem version at the previous location.

This also adds a json and yaml representation of the contents. I'm returning them as hashes at each file name so that attributes could be added to each file in the future (like size or any of the other attributes we store when we parse contents).
```json
{
  "file.rb": {
    "sha256": "449ca93acc517a90b35e13c3b652e27b5a24f585800be5dab1f49338e9242314"
  },
  "file2.rb": {
    "sha256": "884b12dee993217795bb5f58acc89c0121c88bdc99df4d1636c0505dca352b36"
  }
}
```

I added YAML as well, but I'm not sure it will be used so we could remove it.
```yaml
file.rb:
  sha256: file.rb-hash
file2.rb:
  sha256: file2.rb-hash
```