### PR TITLE
Add avo filters for sendgrid event type

### DIFF
--- a/app/avo/resources/sendgrid_event_resource.rb
+++ b/app/avo/resources/sendgrid_event_resource.rb
@@ -8,6 +8,9 @@ class SendgridEventResource < Avo::BaseResource
   class StatusFilter < ScopeBooleanFilter; end
   filter StatusFilter, arguments: { default: SendgridEvent.statuses.transform_values { true } }
 
+  class EventTypeFilter < ScopeBooleanFilter; end
+  filter EventTypeFilter, arguments: { default: SendgridEvent.event_types.transform_values { true } }
+
   filter EmailFilter
 
   field :id, as: :id, hide_on: :index

--- a/app/models/sendgrid_event.rb
+++ b/app/models/sendgrid_event.rb
@@ -2,6 +2,7 @@
 
 class SendgridEvent < ApplicationRecord
   enum :status, %i[pending processed].index_with(&:to_s)
+  enum :event_type, %i[delivered dropped bounce].index_with(&:to_s)
 
   # To make allowances for occasional inbox down time, this counts a maximum of one fail per day,
   # e.g.:


### PR DESCRIPTION
Pretty straightforward, adding since we've been getting email delivery-related support questions