### PR TITLE
Backfill linkset links to version metadata

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -115,9 +115,9 @@ class Rubygem < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def all_errors(version = nil)
-    [self, linkset, version].compact.map do |ar|
+    [self, linkset, version].compact.flat_map do |ar|
       ar.errors.full_messages
-    end.flatten.join(", ")
+    end.join(", ")
   end
 
   def public_versions(limit = nil)

--- a/app/tasks/maintenance/backfill_linkset_links_to_version_metadata_task.rb
+++ b/app/tasks/maintenance/backfill_linkset_links_to_version_metadata_task.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Maintenance::BackfillLinksetLinksToVersionMetadataTask < MaintenanceTasks::Task
+  def collection
+    Version.all.includes(:rubygem, rubygem: [:linkset])
+  end
+
+  def process(version)
+    return unless (linkset = version.rubygem.linkset)
+
+    if version.metadata_uri_set?
+      # only the homepage does not respect #metadata_uri_set?
+      backfill_links(version, linkset, Links::LINKS.slice("home"))
+    else
+      backfill_links(version, linkset, Links::LINKS)
+    end
+  end
+
+  private
+
+  def backfill_links(version, linkset, links)
+    # would need a transaction since we're updating multiple attributes and
+    # metadata_uri_set? needs to be updated atomically to keep the backfill idempotent,
+    # but there is only a single update being issued here
+
+    changes = false
+    links.each do |short, long|
+      next if version.metadata[long].present?
+
+      next unless (value = linkset[short.to_sym])
+
+      version.metadata[long] = value
+      changes = true
+    end
+    version.save! if changes
+  end
+end

--- a/test/tasks/maintenance/backfill_linkset_links_to_version_metadata_task_test.rb
+++ b/test/tasks/maintenance/backfill_linkset_links_to_version_metadata_task_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Maintenance::BackfillLinksetLinksToVersionMetadataTaskTest < ActiveSupport::TestCase
+  context "#collection" do
+    should "return all versions" do
+      assert_equal Version.count, Maintenance::BackfillLinksetLinksToVersionMetadataTask.collection.count
+    end
+  end
+
+  context "#process" do
+    context "without a linkset" do
+      setup do
+        @version = create(:version)
+        @rubygem = @version.rubygem
+        @rubygem.update!(linkset: nil)
+      end
+
+      should "not change version metadata" do
+        assert_no_changes "@version.reload.metadata" do
+          Maintenance::BackfillLinksetLinksToVersionMetadataTask.process(@version)
+        end
+      end
+    end
+
+    context "with a linkset and version metadata uris" do
+      setup do
+        @version = create(
+          :version,
+          metadata: {
+            "source_code_uri" => "https://example.com/source",
+            "documentation_uri" => "https://example.com/docs",
+            "foo" => "bar"
+          }
+        )
+        @rubygem = @version.rubygem
+        @rubygem.linkset.update!("home" => "https://example.com/home",
+                                 "wiki" => "https://example.com/wiki")
+      end
+
+      should "only update the home uri" do
+        Maintenance::BackfillLinksetLinksToVersionMetadataTask.process(@version)
+
+        assert_equal({
+                       "source_code_uri" => "https://example.com/source",
+                       "documentation_uri" => "https://example.com/docs",
+                       "foo" => "bar",
+                       "homepage_uri" => "https://example.com/home"
+                     }, @version.reload.metadata)
+      end
+
+      should "not update the home uri when present in metadata" do
+        @version.metadata["homepage_uri"] = "https://example.com/home/custom"
+        @version.save!
+
+        Maintenance::BackfillLinksetLinksToVersionMetadataTask.process(@version)
+
+        assert_equal({
+                       "source_code_uri" => "https://example.com/source",
+                       "documentation_uri" => "https://example.com/docs",
+                       "foo" => "bar",
+                       "homepage_uri" => "https://example.com/home/custom"
+                     }, @version.reload.metadata)
+      end
+    end
+
+    context "with a linkset and no version metadata uris" do
+      setup do
+        @version = create(:version, metadata: { "foo" => "bar" })
+        @rubygem = @version.rubygem
+        @rubygem.linkset.update!("home" => "https://example.com/home",
+                                 "wiki" => "https://example.com/wiki")
+      end
+
+      should "update the version metadata" do
+        Maintenance::BackfillLinksetLinksToVersionMetadataTask.process(@version)
+
+        assert_equal({
+                       "wiki_uri" => "https://example.com/wiki",
+                       "foo" => "bar",
+                       "homepage_uri" => "https://example.com/home",
+                       "bug_tracker_uri" => "http://example.com",
+                       "source_code_uri" => "http://example.com",
+                       "mailing_list_uri" => "http://example.com",
+                       "documentation_uri" => "http://example.com"
+                     }, @version.reload.metadata)
+      end
+    end
+  end
+end


### PR DESCRIPTION
So we can complete the migration off of linkset entirely

Next step after this merges & the backfill is run is to completely stop reading/writing linksets

See https://github.com/rubygems/rubygems.org/pull/1815 for context