### PR TITLE
Precompile assets on CI before running tests.

### DIFF
--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -36,5 +36,5 @@ runs:
       shell: bash
       run: |
         cp config/database.yml.sample config/database.yml
-        bundle exec rake db:setup
+        bundle exec rake db:setup assets:precompile
 


### PR DESCRIPTION
- trying to fix https://github.com/rubygems/rubygems.org/actions/runs/6123118617/job/16620328677?pr=4055, not sure if that's related, but maybe it timeouts on precompiling assets during system tests (I wasn't able to reproduce locally)