### PR TITLE
Parallel CI

### DIFF
--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -1,0 +1,40 @@
+name: 'Setup rubygems.org'
+description: 'Setup steps for rubygems.org'
+inputs:
+  ruby-version:
+    description: 'Ruby version to use'
+    required: true
+  rubygems-version:
+    description: 'RubyGems version to use'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install and start services
+      shell: bash
+      run: |
+        docker-compose up -d
+    - name: Wait for ES to boot
+      shell: bash
+      run: |
+        timeout 300 bash -c "until curl --silent --output /dev/null http://localhost:9200/_cat/health?h=st; do printf '.'; sleep 5; done; printf '\n'"
+    - uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.149.0
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: true
+    - name: set rubygems version
+      shell: bash
+      run: |
+        if [ "${{ inputs.rubygems-version }}" != "latest" ]; then
+          gem update --system ${{ inputs.rubygems-version }};
+        else
+          gem update --system
+        fi
+        gem --version
+        bundle --version
+    - name: Prepare environment
+      shell: bash
+      run: |
+        cp config/database.yml.sample config/database.yml
+        bundle exec rake db:setup
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,17 @@ permissions:
   contents: read
 
 jobs:
+  # This is umbrella job for all tests needed to pass to make it simpler
+  # to maintain GitHub Actions status required checks since job names and
+  # amount change over the time and it is easier to maintian having just
+  # this umbrella check set as required.
+  status_check:
+    name: All required tests passing check
+    needs: [rails]
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "All required tests passed!"
+
   rails:
     strategy:
       fail-fast: false
@@ -27,6 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RUBYGEMS_VERSION: ${{ matrix.rubygems.version }}
+      # Fail hard when Toxiproxy is not running to ensure all tests (even Toxiproxy optional ones) are passing
       REQUIRE_TOXIPROXY: true
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,36 +22,20 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RUBYGEMS_VERSION: ${{ matrix.rubygems.version }}
-      # Fail hard when Toxiproxy is not running to ensure all tests (even Toxiproxy optional ones) are passing
       REQUIRE_TOXIPROXY: true
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - name: Install and start services
-        run: |
-          docker-compose up -d
-      - name: Wait for ES to boot
-        run: |
-          timeout 300 bash -c "until curl --silent --output /dev/null http://localhost:9200/_cat/health?h=st; do printf '.'; sleep 5; done; printf '\n'"
-      - uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.149.0
+
+      - name: Setup rubygems.org
+        uses: ./.github/actions/setup-rubygems.org
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: set rubygems version
-        run: |
-          if [ "$RUBYGEMS_VERSION" != "latest" ]; then
-            gem update --system $RUBYGEMS_VERSION;
-          else
-            gem update --system
-          fi
-          gem --version
-          bundle --version
-      - name: Prepare environment
-        run: |
-          cp config/database.yml.sample config/database.yml
-          bundle exec rake db:setup
+          rubygems-version: ${{ matrix.rubygems.version }}
+
       - name: Tests
         id: test-all
         run: bin/rails test:all
+
       - name: Save capybara screenshots
         if: steps.test-all.outcome == 'failure'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
@@ -59,6 +43,7 @@ jobs:
           name: capybara-screenshots
           path: tmp/capybara
           if-no-files-found: ignore
+
       - name: Upload coverage to Codecov
         if: matrix.rubygems.name == 'locked' && (success() || failure())
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,12 @@ jobs:
           - name: latest
             version: latest
         ruby_version: ["3.2.2"]
-    name: Rails tests (RubyGems ${{ matrix.rubygems.name }})
+        tests:
+          - name: general
+            command: test
+          - name: system
+            command: test:system
+    name: Rails tests ${{ matrix.tests.name }} (RubyGems ${{ matrix.rubygems.name }})
     runs-on: ubuntu-22.04
     env:
       RUBYGEMS_VERSION: ${{ matrix.rubygems.version }}
@@ -32,9 +37,9 @@ jobs:
           ruby-version: ${{ matrix.ruby_version }}
           rubygems-version: ${{ matrix.rubygems.version }}
 
-      - name: Tests
+      - name: Tests ${{ matrix.tests.name }}
         id: test-all
-        run: bin/rails test:all
+        run: bin/rails ${{ matrix.tests.command }}
 
       - name: Save capybara screenshots
         if: steps.test-all.outcome == 'failure'


### PR DESCRIPTION
This is first step to make CI faster. Currently it shrinks time from 11/12 minutes to 8/9 minutes. General tests could be run in parallel using https://github.com/grosser/parallel_tests (plan to follow if this is merged). My target is ~5 minutes in the end.

@segiddins do you think this is worth it? I'll update checks after if merged.