### PR TITLE
Disable prepared statements.

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   encoding: utf8
   username: postgres
+  prepared_statements: false
 
 development:
   <<: *default

--- a/config/deploy/oidc-api-token/secrets.ejson
+++ b/config/deploy/oidc-api-token/secrets.ejson
@@ -5,7 +5,7 @@
       "_type": "Opaque",
       "data": {
         "secret_key_base": "EJ[1:5AM/k5a98sQgd+E/Fn/GmEitKrpsVTmycCUGwrQg5mA=:iHOo47qmHmfaK1SRLjrT52aQBSTgMi8X:WN4+I63pe4rXZIueVP7i9ZGn7EhL/42haxLpxFyRk3PDEBnAAD0ov8BqRcr/HERGfkrKIRDq9GyWOQxSU150rVjlzsCQShGwba/i/Utc/teRDC6ahgT9oTzWOvJ5Ee0lRvBiw8jnptZHqaSNutIbV9WW20a+SfK01WXdyeDEN/uC5w3M3JQmyG1r6KXGMdyO]",
-        "database_url": "EJ[1:5AM/k5a98sQgd+E/Fn/GmEitKrpsVTmycCUGwrQg5mA=:33z/QZnU/Et7a9co6QLB6riG8erSFjiQ:D/bT+DQ3ZY104fpRCBha8sXZHXx3IEsXwKTzewQsIKwiPS0VPUwG4u0GXO6D2rj8BzeGJRGM8cA+h3X71MI7+B2VMolanI5c1ZFkJbV2+EELDFQC+PvtjKFmizyYO84vGw3TVi1/ydxWyepXtuCLzHkXUFBqi1GXmbFJ+c7gyboJmzjYKWVpL7oC8a//oYGn4bs6oNGSycr9X7YjGVEJeWJXKRYYBwWsP1Su]",
+        "database_url": "EJ[1:rK8I8E1zjuUOxCIAKai92TLItT+lwhKRG4wb7PVLMGQ=:H0exHbNjhOTPGtk85DGMUvqgRYHOa2RC:b7475RJ3qbf0nl+mfWj1+1/JHslbkUHqxVDSxs8e3amTk1CJS8ImBHoy1CO17UIQXTPFmvNWL6IqvJ0o5JPFw/Tq0lgpnw6COCFwe5EjDJ0kPaSZaBGDGsHAcovso288TY3APeQNU9aJlZJ1yu8wILXCvRXqXHyb8k8EC4MS7KulAZqODmMe/VgVXxgbbt8H+d+FVMTryUdAJaYg76jpcPGul5aIkG9I49arVaiFjlD1VuPcI64Gscqzr92SzCMfZduomy0=]",
         "aws_access_key_id": "EJ[1:5AM/k5a98sQgd+E/Fn/GmEitKrpsVTmycCUGwrQg5mA=:GUxYoOzgAwORuMsY4cv2EaNyiNZigIvz:zgVr0Zjx4o81YpFbMkcupAh4k/OKMbeYNAT5Fz6gBma1FtYx]",
         "aws_secret_access_key": "EJ[1:5AM/k5a98sQgd+E/Fn/GmEitKrpsVTmycCUGwrQg5mA=:KV0VSxUGRJdQzLL9BtjKtMb6WDCqiea4:RMDXqPBegalvAtlRhMOIgFcd3VF+qcnsn+P116WPIMnv6KaRNpXdGhNgd6lxXcn7U5FD5csHhmk=]",
         "honeybadger_api_key": "EJ[1:5AM/k5a98sQgd+E/Fn/GmEitKrpsVTmycCUGwrQg5mA=:5PSnBVzcDkCK6H82yxJTKJOwuhAVRNrz:G6XwcGfrs4r+xQK5K1rcsiuvvh3XxS1E]",

--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -5,7 +5,7 @@
       "_type": "Opaque",
       "data": {
         "secret_key_base": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:i2m4ZdL6cNaw89lU8r22s403O9eEiEDl:NY18SMzycBnJwDS/hYHI3GmxqKDpLgBxGJbFhf3GgRScY2J/QEHCHv+Fl+vahDSeYEbAmgJxTUS/mpeE++FuhnWrGua9dpQpar5hr12X4CzadkQN2ef+YadRmUr97IvD10VBCUn5zjBjZOYiJQdBqwhK73Cr4jf/hWH30RJn6UCuAiPGo5H+KsjlZ7voW/Ep]",
-        "database_url": "EJ[1:vJNVfHEjq+SualZqTJEqL5rNL78Ci17DE9YSJxilp3g=:E/JNRRBkxjVGbziezvIv7P66QUKP6K1V:PkSExVrYsxtQX+IZG2myTQ7aWvxJzPXAfBP/98XccsaODu+LPDRsM5ijdT3uypPQ/tRhLldCF9rPXShA0Aw9iqxm85qsNQe00QTb4H/YOUNM3slC2IFJ5dxiwMEGn9bprTw8HWJyvmGVrkQLhpY0zhsurz7XOglRTMJhKr5vSMOuI9ocz5OEpYrDVeCYS4cTzgJCi+NLEa59CxsJ]",
+        "database_url": "EJ[1:/aLhumlos/DZXUNQ/3BYiDp1wKyxZQc+Q0KICeK+QnA=:YxFjVTCJUyg0n0jiu0b3f043LJSXT2qk:AaPrjgyz3ZA3DkYNdTwddk8ig2ofmCNj2cmim6aACkHwV14/ujHV6efOslBO4NTX68HnLFhA39PkcyqTzuza/6zw2eJ5y+uL+5BXHcbpcJxl3Sw+e6ueIhDzMyyzltN219rR6ikhy16g0exuI/IteGNfZV5VLMuaYlKHPyGSRTdTge8jZWKym8N8y9+IdqRCVzo0pvvYE/ljViPh2Pre7fTva4kz9FoAA63u4RucRfhS+iQxJ1o=]",
         "aws_access_key_id": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:KeGkWu/d8KKHzHzGpDncf6Nvp2NfVYRQ:YMhI+eSsVUJKoYJCM0zWenmcJ6CtVcLiyz6GHU2V63O6HPFx]",
         "aws_secret_access_key": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:u6fuRpUNQaSoDWTFMn/Me+9Kr1Z+93hA:1HEeKUFo2+K5xaf9fjD6VmewC60GIaYZ93JESoOCqpGhybfk3UypbFhp0yNTsHVM7PhH1n1O56M=]",
         "honeybadger_api_key": "EJ[1:PdZreInTWXI1FLrFAIe4j7eLOfbTVh6EWWwBL89TMAk=:PvoZeAX52WmcFsCSWiVhSF86SNd3j9SF:z5I4XA0St0psAfod3SCcwPMWYl2d330p]",

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -5,7 +5,7 @@
       "_type": "Opaque",
       "data": {
         "secret_key_base": "EJ[1:d8Qpc6QSyiCh7sBlZ3VzKenIldRrWaFh8nE/ThE6cio=:X57Fr3d7YC/hdbuJYu/xrbglh7C3g2eF:L0jHynvq98zSuGHlVsH2DTTxitG1enTc4T8N0qEIc+wP3cxG/dWVdo5kCRdeufJfi+B1rv38DkKWW4/Cc3QjJQzN9awHVOK9KZcSTUdUqFlm7Kk5fai4FsIPgHTyFQLyTta8iubIrDNuZgpw9t3NZ6KkRwAkFsLLy2TaoICcEEQFgesiyMWVoXhun1kJnbQp]",
-        "database_url": "EJ[1:jc6POVuZ4ZKMywMSfQKGYRf5BDx9g74OeOj7BPKK0zk=:tzwnJdAYjq4xx5O+MksI3x+n1Uhrj8Dd:wk+q/W8FDss/DiLHYaZuFkPSDbhPxGNaAp2WtsJRCsn997FJMfBGBCpUVDG6LkmAOU80KPZZVKtmRyidth+ebpsGIqE8df05epB8u309BATW4ukTs6SgtyMJppeiCee2pdw5rkUMJyq1kn7dFEirzK0DPya6rBFfU/tRtqxZmxt6mKmgl0E5uBAWQDMKtWYJ]",
+        "database_url": "EJ[1:pWdDjbKg+vvJNbzB01oQzYlmXDPVIxoPydn1NtUUPFI=:S/bKqCGClJWQeqxu2qbDKYeP7qwieuJR:L8/fR5V643iQa3LE2Z6YEmCIOELin0joj5OEWBpzSxJF1ItYO0sMlheg1BdNDDT9nxegFjsclScg8MgkM4dAoTv4A6CrnEdqT8Z3N6LPagIeDBG3Wr+GQ4QpO7GhdC1/eEwnnVbANUPjOCbcWMvP4/jg3OlsqGb8poovCnTJaRjTOMY1lPQZAHDsiMfHgHXL70Vc7rnlrpQJe38+ANqMx1HkTNR/na/nq/A=]",
         "aws_access_key_id": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:OLx6cKpU43qYM+Fsa8FeC5Bnx0jbIB68:n9U9IUwaWpnbrLIkjwP7erHefKdX1/08kSTvSmBeuq9+0YQ4]",
         "aws_secret_access_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:uMtyxPC2DC0BgsYRhOWGCdaom6OroJqI:drTaFTjJ2uhfJn+aPgYTQ4hp1GdLS3Os2PfJVn1BevaukzzcsI9xVp2xS0umzutnQbmmdISOgYg=]",
         "honeybadger_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:TD1e42m2hCnraaRigNZZZao9WKF9S9Nf:Myj5m7maDkOC2GbolUskZ2F+zmRscHE8]",


### PR DESCRIPTION
- this is needed (at least temporary) for pgbouncer needed for database major version upgrade with (almost) zero downtime
- Are there any performance concerns regarding this? We will need to decide if that's ok to merge for now or if we should merge this temporarily before and revert after.
- for now I'm just checking if CI is happy