### PR TITLE
Codecov waits until 2 reports received to notify

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
Since we now have a 2 build matrix that uploads to codecov

See https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds