### PR TITLE
Make version backfills more resilient

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -28,9 +28,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   validates :number, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Patterns::VERSION_PATTERN }
   validates :platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }
-  validates :gem_platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }, on: :create
-  validates :full_name, presence: true, uniqueness: { case_sensitive: false }
-  validates :gem_full_name, presence: true, uniqueness: { case_sensitive: false, allow_nil: true }, on: :create
+  validates :gem_platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN },
+                           on: %i[create gem_platform_changed?]
+  validates :full_name, presence: true, uniqueness: { case_sensitive: false }, on: %i[create full_name_changed?]
+  validates :gem_full_name, presence: true, uniqueness: { case_sensitive: false, allow_nil: true }, on: %i[create gem_full_name_changed?]
   validates :rubygem, presence: true
   validates :licenses, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_blank: true
   validates :required_rubygems_version, :required_ruby_version, length: { maximum: Gemcutter::MAX_FIELD_LENGTH },

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -29,9 +29,11 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :number, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Patterns::VERSION_PATTERN }
   validates :platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN }
   validates :gem_platform, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: Rubygem::NAME_PATTERN },
-                           on: %i[create gem_platform_changed?]
-  validates :full_name, presence: true, uniqueness: { case_sensitive: false }, on: %i[create full_name_changed?]
-  validates :gem_full_name, presence: true, uniqueness: { case_sensitive: false, allow_nil: true }, on: %i[create gem_full_name_changed?]
+            if: -> { validation_context == :create || gem_platform_changed? }
+  validates :full_name, presence: true, uniqueness: { case_sensitive: false },
+            if: -> { validation_context == :create || full_name_changed? }
+  validates :gem_full_name, presence: true, uniqueness: { case_sensitive: false },
+            if: -> { validation_context == :create || gem_full_name_changed? }
   validates :rubygem, presence: true
   validates :licenses, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_blank: true
   validates :required_rubygems_version, :required_ruby_version, length: { maximum: Gemcutter::MAX_FIELD_LENGTH },

--- a/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
+++ b/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Maintenance::BackfillGemPlatformToVersionsTask < MaintenanceTasks::Task
+  include SemanticLogger::Loggable
+
+  FULL_NAME_ATTRIBUTES = %i[full_name gem_full_name].freeze
+
   def collection
     Version.where(gem_platform: nil)
   end
@@ -8,5 +12,13 @@ class Maintenance::BackfillGemPlatformToVersionsTask < MaintenanceTasks::Task
   def process(element)
     platform = Gem::Platform.new(element.platform)
     element.update!(gem_platform: platform.to_s)
+  rescue ActiveRecord::RecordInvalid => e
+    if e.record.errors.errors.all? { |error| FULL_NAME_ATTRIBUTES.include?(error.attribute) && error.type == :taken }
+      element.save!(validate: false)
+      logger.warn "Version #{element.full_name} failed validation setting gem_platform to #{platform.to_s.inspect} but was saved without validation",
+                  error: e
+    else
+      logger.error "Version #{element.full_name} failed validation setting gem_platform to #{platform.to_s.inspect}", error: e
+    end
   end
 end

--- a/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
+++ b/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
@@ -9,16 +9,16 @@ class Maintenance::BackfillGemPlatformToVersionsTask < MaintenanceTasks::Task
     Version.where(gem_platform: nil)
   end
 
-  def process(element)
-    platform = Gem::Platform.new(element.platform)
-    element.update!(gem_platform: platform.to_s)
+  def process(version)
+    platform = Gem::Platform.new(version.platform)
+    version.update!(gem_platform: platform.to_s)
   rescue ActiveRecord::RecordInvalid => e
     if e.record.errors.errors.all? { |error| FULL_NAME_ATTRIBUTES.include?(error.attribute) && error.type == :taken }
-      element.save!(validate: false)
-      logger.warn "Version #{element.full_name} failed validation setting gem_platform to #{platform.to_s.inspect} but was saved without validation",
+      version.save!(validate: false)
+      logger.warn "Version #{version.full_name} failed validation setting gem_platform to #{platform.to_s.inspect} but was saved without validation",
                   error: e
     else
-      logger.error "Version #{element.full_name} failed validation setting gem_platform to #{platform.to_s.inspect}", error: e
+      logger.error "Version #{version.full_name} failed validation setting gem_platform to #{platform.to_s.inspect}", error: e
     end
   end
 end

--- a/app/tasks/maintenance/backfill_spec_sha256_task.rb
+++ b/app/tasks/maintenance/backfill_spec_sha256_task.rb
@@ -9,10 +9,12 @@ class Maintenance::BackfillSpecSha256Task < MaintenanceTasks::Task
 
   def process(version)
     logger.tagged(version_id: version.id, name: version.rubygem.name, number: version.number, platform: version.platform) do
+      logger.info "Updating spec_sha256 for #{version.full_name}"
+
       spec_path = "quick/Marshal.4.8/#{version.full_name}.gemspec.rz"
       spec_contents = RubygemFs.instance.get(spec_path)
 
-      raise "#{spec_path} is missing" if spec_contents.blank?
+      raise "#{spec_path} is missing" if spec_contents.nil?
 
       spec_sha256 = Digest::SHA2.base64digest(spec_contents)
 

--- a/config/initializers/maintenance_tasks.rb
+++ b/config/initializers/maintenance_tasks.rb
@@ -1,5 +1,15 @@
 MaintenanceTasks.error_handler = lambda { |error, task_context, errored_element|
-  Rails.error.report error, context: { task_context:, errored_element: }, handled: false
+  errored_element =
+    case errored_element
+    when ActiveRecord::Base
+      errored_element.to_gid
+    end
+
+  Rails.error.report(
+    error,
+    context: { task_context:, errored_element: },
+    handled: false
+  )
 }
 
 Rails.autoloaders.main.on_load("MaintenanceTasks::ApplicationController") do

--- a/test/tasks/maintenance/backfill_gem_platform_to_versions_task_test.rb
+++ b/test/tasks/maintenance/backfill_gem_platform_to_versions_task_test.rb
@@ -14,6 +14,8 @@ class Maintenance::BackfillGemPlatformToVersionsTaskTest < ActiveSupport::TestCa
   end
 
   context "#process" do
+    include SemanticLogger::Test::Minitest
+
     should "update the gem_platform for ruby platform" do
       v = create(:version, rubygem: build(:rubygem, name: "rubygem"), number: "1", platform: "ruby")
       v.update_attribute(:gem_platform, nil)
@@ -52,6 +54,48 @@ class Maintenance::BackfillGemPlatformToVersionsTaskTest < ActiveSupport::TestCa
 
       assert_equal "rubygem-1-x64-darwin19", v1.full_name
       assert_equal "rubygem-1-x64-darwin-19", v2.full_name
+    end
+
+    should "handle full_name casing collisions" do
+      rubygem1 = create(:rubygem, name: "rubygem")
+      rubygem2 = create(:rubygem)
+      rubygem2.update_attribute(:name, "RubyGem")
+
+      v1 = build(:version, rubygem: rubygem1, number: "1", platform: "ruby", gem_platform: nil).tap do |v|
+        v.validate
+        v.save!(validate: false)
+      end
+      v2 = build(:version, rubygem: rubygem2, number: "1", platform: "ruby", gem_platform: nil).tap do |v|
+        v.validate
+        v.save!(validate: false)
+      end
+
+      logger = SemanticLogger::Test::CaptureLogEvents.new
+      Maintenance::BackfillGemPlatformToVersionsTask.stubs(:logger).returns(logger)
+
+      Maintenance::BackfillGemPlatformToVersionsTask.process(v1)
+      Maintenance::BackfillGemPlatformToVersionsTask.process(v2)
+
+      assert_equal "ruby", v1.reload.gem_platform
+      assert_equal "ruby", v2.reload.gem_platform
+
+      assert_equal "rubygem-1", v1.gem_full_name
+      assert_equal "RubyGem-1", v2.gem_full_name
+
+      assert_equal "rubygem-1", v1.full_name
+      assert_equal "RubyGem-1", v2.full_name
+
+      assert_semantic_logger_event(
+        logger.events[0],
+        level:            :warn,
+        message_includes: "Version rubygem-1 failed validation setting gem_platform to \"ruby\""
+      )
+      assert_semantic_logger_event(
+        logger.events[1],
+        level:            :warn,
+        message_includes: "Version RubyGem-1 failed validation setting gem_platform to \"ruby\""
+      )
+      assert_equal 2, logger.events.size
     end
   end
 end

--- a/test/tasks/maintenance/backfill_spec_sha256_task_test.rb
+++ b/test/tasks/maintenance/backfill_spec_sha256_task_test.rb
@@ -33,7 +33,9 @@ class Maintenance::BackfillSpecSha256TaskTest < ActiveSupport::TestCase
 
     should "error if spec is missing" do
       v = create(:version, rubygem: @rubygem, number: "1", platform: "ruby", spec_sha256: nil)
-      assert_raise { Maintenance::BackfillSpecSha256Task.process(v) }
+      e = assert_raise { Maintenance::BackfillSpecSha256Task.process(v) }
+
+      assert_equal "quick/Marshal.4.8/rubygem-1.gemspec.rz is missing", e.message
     end
 
     should "not update the spec sha256 if it is already set" do
@@ -50,7 +52,9 @@ class Maintenance::BackfillSpecSha256TaskTest < ActiveSupport::TestCase
 
       v = create(:version, rubygem: @rubygem, number: "1", platform: "ruby", spec_sha256: "Ry6N90Xp7Or9qGoWziaaTotD1K7vOAonnRAAPjXCzic=")
       assert_no_changes "v.reload.spec_sha256" do
-        assert_raise { Maintenance::BackfillSpecSha256Task.process(v) }
+        e = assert_raise(RuntimeError) { Maintenance::BackfillSpecSha256Task.process(v) }
+
+        assert_includes e.message, "Version rubygem-1 has incorrect spec_sha256"
       end
     end
   end


### PR DESCRIPTION
- .present? doesnt work with binary data

- there are old gems with conflicting full names with different cases, handle them in backfill

- skip validating fields unless they themselves have changed (makes it easier to backfill unrelated fields without convoluted error handling)