### PR TITLE
Add Versions index on lower(gem_full_name)

### DIFF
--- a/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
+++ b/app/tasks/maintenance/backfill_gem_platform_to_versions_task.rb
@@ -6,7 +6,7 @@ class Maintenance::BackfillGemPlatformToVersionsTask < MaintenanceTasks::Task
   FULL_NAME_ATTRIBUTES = %i[full_name gem_full_name].freeze
 
   def collection
-    Version.where(gem_platform: nil)
+    Version.includes(:rubygem).where(gem_platform: nil)
   end
 
   def process(version)

--- a/db/migrate/20230926202658_index_versions_on_lower_gem_full_name.rb
+++ b/db/migrate/20230926202658_index_versions_on_lower_gem_full_name.rb
@@ -1,0 +1,7 @@
+class IndexVersionsOnLowerGemFullName < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :versions, "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_194257) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_202658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -414,6 +414,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_194257) do
     t.string "gem_full_name"
     t.string "spec_sha256", limit: 44
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
+    t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
     t.index ["created_at"], name: "index_versions_on_created_at"


### PR DESCRIPTION
So the uniqueness constraint can run significantly faster, right now each of these queries is taking 500ms

Also preload rubygems in backfill to avoid n+1