### PR TITLE
Handle missing specs in backfill

### DIFF
--- a/app/tasks/maintenance/backfill_spec_sha256_task.rb
+++ b/app/tasks/maintenance/backfill_spec_sha256_task.rb
@@ -14,7 +14,10 @@ class Maintenance::BackfillSpecSha256Task < MaintenanceTasks::Task
       spec_path = "quick/Marshal.4.8/#{version.full_name}.gemspec.rz"
       spec_contents = RubygemFs.instance.get(spec_path)
 
-      raise "#{spec_path} is missing" if spec_contents.nil?
+      if spec_contents.nil?
+        logger.error "Could not find #{spec_path}"
+        return
+      end
 
       spec_sha256 = Digest::SHA2.base64digest(spec_contents)
 


### PR DESCRIPTION
Some specs are missing, allow the backfill to continue & log errors for the missing specs

For example, `quick/Marshal.4.8/chef-api-0.1.0.gemspec.rz is missing` despite https://rubygems.org/gems/chef-api/versions/0.1.0 not being marked as yanked