### PR TITLE
Fix test fan-in job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
     name: All required tests passing check
     needs: [rails]
     runs-on: ubuntu-22.04
+    if: always()
     steps:
-      - run: echo "All required tests passed!"
+      - run: /bin/${{ (needs.rails.result == 'success' || needs.rails.result == 'skipped') }}
 
   rails:
     strategy:


### PR DESCRIPTION
If the job is skipped, branch protection will treat that as a success & allow merging

Instead, always jun the status_check job, and have the output be whether all dependent jobs passed