### PR TITLE
Subscription links in dashboard fixed

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -57,7 +57,7 @@
         <ul>
           <% current_user.subscribed_gems.each do |gem| %>
             <li>
-              <%= link_to gem, gem.slug, :title => short_info(gem.versions.most_recent), :class => 't-link' %>
+              <%= link_to gem, rubygem_path(gem.slug), :title => short_info(gem.versions.most_recent), :class => 't-link' %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Subscription links in the dashboard are broken

![image](https://github.com/rubygems/rubygems.org/assets/8846835/b8616987-bb7f-4340-be74-d5a2061e0fdc)
![image](https://github.com/rubygems/rubygems.org/assets/8846835/9623e9ef-4e41-413e-b4d2-f58ecf746868)

## Before
https://rubygems.org/aws-sdk

## After
https://rubygems.org/gems/aws-sdk
