### PR TITLE
Clarify Ownership uniqueness errors when user already invited or owner

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -55,6 +55,11 @@ de:
         unpwn:
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,11 @@ en:
         unpwn: has previously appeared in a data breach and should not be used
         blocked: "domain '%{domain}' has been blocked for spamming. Please use a valid personal email."
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed: "is already an owner of this gem"
+              already_invited: "is already invited to this gem"
         version:
           attributes:
             gem_full_name:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -66,6 +66,11 @@ es:
         unpwn:
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -66,6 +66,11 @@ fr:
         unpwn:
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -59,6 +59,11 @@ ja:
         unpwn: 過去にデータ侵害を受けたためお使いになれません
         blocked: ドメイン %{domain} はスパムのため差し止められました。正しい個人のEメールを使ってください。
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -58,6 +58,11 @@ nl:
         unpwn:
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -65,6 +65,11 @@ pt-BR:
         unpwn: já apareceu anteriormente em um vazamento de dados e não deve ser utilizada
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -60,6 +60,11 @@ zh-CN:
         unpwn: 曾出现过数据泄露，不应该再使用
         blocked: 域名 '%{domain}' 因发送垃圾邮件已被禁用。请使用另外有效的个人邮箱。
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -55,6 +55,11 @@ zh-TW:
         unpwn:
         blocked:
       models:
+        ownership:
+          attributes:
+            user_id:
+              already_confirmed:
+              already_invited:
         version:
           attributes:
             gem_full_name:

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -241,7 +241,20 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         should respond_with :unprocessable_entity
 
         should "respond with error message" do
-          assert_equal "User has already been taken", @response.body
+          assert_equal "User is already an owner of this gem", @response.body
+        end
+      end
+
+      context "owner has already been invited" do
+        setup do
+          post :create, params: { rubygem_id: @rubygem.slug, email: @second_user.email }
+          post :create, params: { rubygem_id: @rubygem.slug, email: @second_user.email }
+        end
+
+        should respond_with :unprocessable_entity
+
+        should "respond with error message" do
+          assert_equal "User is already invited to this gem", @response.body
         end
       end
 


### PR DESCRIPTION
@deivid-rodriguez had an experience adding a user to owners that wasn't ideal. I threw this together to try to make the error make more sense, since unconfirmed owners won't show up on the list of owners.