### PR TITLE
Migrate to propshaft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,18 +74,12 @@ gem "csv", "~> 3.3" # zeitwerk-2.6.12
 gem "observer", "~> 0.1.2" # launchdarkly-server-sdk-8.0.0
 
 # Assets
-gem "sprockets-rails", "~> 3.4"
+gem "propshaft", "~> 0.8.0"
 gem "importmap-rails", "~> 2.0"
 gem "stimulus-rails", "~> 1.3" # this adds stimulus-loading.js so it must be available at runtime
 
 group :assets, :development do
   gem "tailwindcss-rails", "~> 2.3"
-end
-
-group :assets do
-  gem "dartsass-sprockets", "~> 3.1"
-  gem "terser", "~> 1.2"
-  gem "autoprefixer-rails", "~> 10.4"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,8 +91,6 @@ GEM
       ffi-compiler (~> 1.0)
     ast (2.4.2)
     attr_required (1.0.2)
-    autoprefixer-rails (10.4.16.0)
-      execjs (~> 2)
     avo (2.48.0)
       actionview (>= 6.0)
       active_link_to
@@ -181,12 +179,6 @@ GEM
       addressable
     csv (3.3.0)
     dalli (3.2.8)
-    dartsass-sprockets (3.1.0)
-      railties (>= 4.0.0)
-      sassc-embedded (~> 1.69)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     datadog-ci (0.8.3)
       msgpack
     date (3.3.4)
@@ -228,7 +220,6 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.11)
       tzinfo
-    execjs (2.9.1)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -485,6 +476,11 @@ GEM
     pp (0.5.0)
       prettyprint
     prettyprint (0.2.0)
+    propshaft (0.8.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     prosopite (1.4.2)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -635,11 +631,6 @@ GEM
     rubyzip (2.3.2)
     safety_net_attestation (0.4.0)
       jwt (~> 2.0)
-    sass-embedded (1.72.0)
-      google-protobuf (>= 3.25, < 5.0)
-      rake (>= 13.0.0)
-    sassc-embedded (1.70.1)
-      sass-embedded (~> 1.70)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -673,13 +664,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     statsd-instrument (3.7.0)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
@@ -693,10 +677,7 @@ GEM
       faraday-follow_redirects
     tailwindcss-rails (2.3.0)
       railties (>= 6.0.0)
-    terser (1.2.0)
-      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
-    tilt (2.3.0)
     timeout (0.4.1)
     toxiproxy (2.0.2)
     tpm-key_attestation (0.12.0)
@@ -762,7 +743,6 @@ PLATFORMS
 DEPENDENCIES
   aggregate_assertions (~> 0.2.0)
   amazing_print (~> 1.6)
-  autoprefixer-rails (~> 10.4)
   avo (~> 2.48)
   aws-sdk-s3 (~> 1.146)
   aws-sdk-sqs (~> 1.70)
@@ -776,7 +756,6 @@ DEPENDENCIES
   compact_index (~> 0.15.0)
   csv (~> 3.3)
   dalli (~> 3.2)
-  dartsass-sprockets (~> 3.1)
   ddtrace (~> 1.21)
   derailed_benchmarks (~> 2.1)
   discard (~> 1.3)
@@ -820,6 +799,7 @@ DEPENDENCIES
   pghero (~> 3.4)
   phlex-rails (~> 1.1)
   pp (= 0.5.0)
+  propshaft (~> 0.8.0)
   prosopite (~> 1.4)
   pry-byebug (~> 3.10)
   puma (~> 6.4)
@@ -853,12 +833,10 @@ DEPENDENCIES
   shoulda-matchers (~> 6.2)
   simplecov (~> 0.22)
   simplecov-cobertura (~> 2.1)
-  sprockets-rails (~> 3.4)
   statsd-instrument (~> 3.7)
   stimulus-rails (~> 1.3)
   strong_migrations (~> 1.8)
   tailwindcss-rails (~> 2.3)
-  terser (~> 1.2)
   toxiproxy (~> 2.0)
   unpwn (~> 1.0)
   user_agent_parser (~> 2.17)
@@ -890,7 +868,6 @@ CHECKSUMS
   argon2 (2.3.0) sha256=980ef65172bf512ad37b6cbb0d61eef40b6dccab6a7db4e70557527e1dce9557
   ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
   attr_required (1.0.2) sha256=f0ebfc56b35e874f4d0ae799066dbc1f81efefe2364ca3803dc9ea6a4de6cb99
-  autoprefixer-rails (10.4.16.0) sha256=40c4b14d6f26f66026cd0d4631baf18d6c56aab425b36059c8abbda17f19a706
   avo (2.48.0) sha256=6d634367a1df91cf4bdaf8b65ed9eead6ed7d8bea19382d4e945fe71ab68499b
   awrence (1.2.1) sha256=dd1d214c12a91f449d1ef81d7ee3babc2816944e450752e7522c65521872483e
   aws-eventstream (1.3.0) sha256=f1434cc03ab2248756eb02cfa45e900e59a061d7fbdc4a9fd82a5dd23d796d3f
@@ -929,7 +906,6 @@ CHECKSUMS
   css_parser (1.16.0) sha256=f70fb492254418522ea77c01d57bf64452d6c7465001926c3620d0b50289b1a2
   csv (3.3.0) sha256=0bbd1defdc31134abefed027a639b3723c2753862150f4c3ee61cab71b20d67d
   dalli (3.2.8) sha256=2e63595084d91fae2655514a02c5d4fc0f16c0799893794abe23bf628bebaaa5
-  dartsass-sprockets (3.1.0) sha256=c238ec9f7f496489ac5a7813cd1f83d1e077a1826921acefc7e290a521b7a20a
   datadog-ci (0.8.3) sha256=6e78c03aa2524476dc99b969a7c3154195d1d84a912a21707e7f5c17783e03f9
   date (3.3.4) sha256=971f2cb66b945bcbea4ddd9c7908c9400b31a71bc316833cb42fa584b59d3291
   ddtrace (1.21.1) sha256=05b4d2bfb502a06cfbb31779381f49b219878d883f4ca867534160d5c39afad7
@@ -948,7 +924,6 @@ CHECKSUMS
   erb (4.0.4) sha256=de116e106205c46bc01918789b611aaad1328dcc6e9f12cf8cd2cc60ef619717
   erubi (1.12.0) sha256=27bedb74dfb1e04ff60674975e182d8ca787f2224f2e8143268c7696f42e4723
   et-orbi (1.2.11) sha256=d26e868cc21db88280a9ec1a50aa3da5d267eb9b2037ba7b831d6c2731f5df64
-  execjs (2.9.1) sha256=e8fd066f6df60c8e8fbebc32c6fb356b5212c77374e8416a9019ca4bb154dcfb
   factory_bot (6.4.5) sha256=d71dd29bc95f0ec2bf27e3dd9b1b4d557bd534caca744663cb7db4bacf3198be
   factory_bot_rails (6.4.3) sha256=ea73ceac1c0ff3dc11fff390bf2ea8a2604066525ed8ecd3b3bc2c267226dcc8
   faraday (2.9.0) sha256=1aa114507006eed6779a726b932d5cc12f5f6053984a19a3403539306b0e0be3
@@ -1050,6 +1025,7 @@ CHECKSUMS
   phlex-rails (1.1.1) sha256=b0e82d0ba541eca55ca39051de8be2817a7ed400f8a630e21b261239c8f812d0
   pp (0.5.0) sha256=f8f40bc2ba9e1ab351b9458151da3a89f46034f7f599a8e0a06abb9b9f4411dd
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  propshaft (0.8.0) sha256=cad3fa50f78ef59db4938e61e5edc9b6105838cd890f75b1ca4d7c9b5b662b68
   prosopite (1.4.2) sha256=b2e422e2d9dbf3ce20130ded3252fe14adb3833555eacd451f5015d8c9177e79
   pry (0.14.1) sha256=99b6df0665875dd5a39d85e0150aa5a12e2bb4fef401b6c4f64d32ee502f8454
   pry-byebug (3.10.1) sha256=c8f975c32255bfdb29e151f5532130be64ff3d0042dc858d0907e849125581f8
@@ -1106,8 +1082,6 @@ CHECKSUMS
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (2.3.2) sha256=3f57e3935dc2255c414484fbf8d673b4909d8a6a57007ed754dde39342d2373f
   safety_net_attestation (0.4.0) sha256=96be2d74e7ed26453a51894913449bea0e072f44490021545ac2d1c38b0718ce
-  sass-embedded (1.72.0) sha256=05d3e53092022a4b4eef5b76b9597c7f2af4e4efb06812e1a60e3601189a3d2e
-  sassc-embedded (1.70.1) sha256=a95172c9c6725dfc412c702a0e705fb8a5bcb3aac2a32586b18e5432987103d3
   sawyer (0.9.2) sha256=fa3a72d62a4525517b18857ddb78926aab3424de0129be6772a8e2ba240e7aca
   searchkick (5.3.1) sha256=dc1181543f6a68354e380651f235fa7f3df6a09e4cd67fc284dc293fa9860f57
   selenium-webdriver (4.18.1) sha256=abe8daa474c9fa8b94b6462a0cdbe093140218f876e58e3911bb064a60d45eab
@@ -1121,17 +1095,13 @@ CHECKSUMS
   simplecov-html (0.12.3) sha256=4b1aad33259ffba8b29c6876c12db70e5750cb9df829486e4c6e5da4fa0aa07b
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.1) sha256=1ac87ec157fcfe7a460e821e0cd48ae1e6f5e3e082ab520f03f31a9259dbdc31
-  sprockets (4.2.1) sha256=951b13dd2f2fcae840a7184722689a803e0ff9d2702d902bd844b196da773f97
-  sprockets-rails (3.4.2) sha256=36d6327757ccf7460a00d1d52b2d5ef0019a4670503046a129fa1fb1300931ad
   statsd-instrument (3.7.0) sha256=071eb94be7af7f529da45528ab4e3d96976fcdc8f4afd198ef2057b6b7987491
   stimulus-rails (1.3.3) sha256=4d1f9ab1d64e605f4c9cdd4cc530a9538b510606d32d02249d106256845c562c
   stringio (3.1.0) sha256=c1f6263ae03a15025e51194ab19b06b15e06adcaaedb7f5f6c06ab60f5d67718
   strong_migrations (1.8.0) sha256=18de155ebcddf44e60e74f9a6c0b4bfd2d1e576dfe1c67f4aafc4ec5b0442f5d
   swd (2.0.3) sha256=4cdbe2a4246c19f093fce22e967ec3ebdd4657d37673672e621bf0c7eb770655
   tailwindcss-rails (2.3.0) sha256=eb194b760eb637f01490f8ad30147d93f402346babfc6eeac04039cff8169ad9
-  terser (1.2.0) sha256=a25e6213233ad332378fd2add7d79a55bf31a383cc732d17f116450774d05303
   thor (1.3.1) sha256=fa7e3471d4f6a27138e3d9c9b0d4daac9c3d7383927667ae83e9ab42ae7401ef
-  tilt (2.3.0) sha256=82dd903d61213c63679d28e404ee8e10d1b0fdf5270f1ad0898ec314cc3e745c
   timeout (0.4.1) sha256=6f1f4edd4bca28cffa59501733a94215407c6960bd2107331f0280d4abdebb9a
   toxiproxy (2.0.2) sha256=2e3b53604fb921d40da3db8f78a52b3133fcae33e93d440725335b15974e440a
   tpm-key_attestation (0.12.0) sha256=e133d80cf24fef0e7a7dfad00fd6aeff01fc79875fbfc66cd8537bbd622b1e6d

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,6 +1,0 @@
-//= link application.css
-//= link_tree ../../../vendor/assets/images
-//= link_tree ../builds
-//= link_tree ../../javascript .js
-//= link_tree ../../javascript/src .js
-//= link_tree ../../../vendor/javascript .js

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,8 +1,26 @@
-/*
- * This is a manifest file that'll automatically include all the stylesheets available in this directory
- * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
- * the top of the compiled file, but it's generally better to create a new file per style scope.
- *= require_self
- *= require github_buttons
- *= require_tree .
-*/
+@import url("base.css");
+@import url("layout.css");
+@import url("suggest-list.css");
+@import url("type.css");
+@import url("github_buttons.css");
+
+@import url("modules/badge.css");
+@import url("modules/button.css");
+@import url("modules/dependencies.css");
+@import url("modules/error.css");
+@import url("modules/footer.css");
+@import url("modules/form.css");
+@import url("modules/gem.css");
+@import url("modules/gems.css");
+@import url("modules/header.css");
+@import url("modules/home.css");
+@import url("modules/mfa.css");
+@import url("modules/nav/nav--paginated.css");
+@import url("modules/nav/nav--v.css");
+@import url("modules/news.css");
+@import url("modules/org.css");
+@import url("modules/owners.css");
+@import url("modules/search.css");
+@import url("modules/shared.css");
+@import url("modules/stats.css");
+@import url("modules/status-icon.css");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,8 @@
     <link rel="fluid-icon" href="/fluid-icon.png"/>
     <link rel="search" type="application/opensearchdescription+xml" title="<%=t :title %>" href="/opensearch.xml">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-
-    <%= stylesheet_link_tag("application") %>
     <%= stylesheet_link_tag("tailwind", "data-turbo-track": "reload") %>
+    <%= stylesheet_link_tag("application", "preload_links_header": true) %>
     <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
     <link href='https://fonts.googleapis.com/css?family=Roboto:100&amp;subset=greek,latin,cyrillic,latin-ext' rel='stylesheet' type='text/css'>
     <%= render "layouts/feeds" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,6 @@ require "action_mailer/railtie"
 # require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/vendor/assets/stylesheets/github_buttons.css
+++ b/vendor/assets/stylesheets/github_buttons.css
@@ -63,7 +63,7 @@
   width: 14px;
   height: 14px;
   margin-right: 4px;
-  background: image-url('github_icon.png');
+  background: url('github_icon.png');
   background-size: 100% 100%;
   background-repeat: no-repeat;
 }


### PR DESCRIPTION
This time, skip all bundlers and load raw css/js files

Alternative take on https://github.com/rubygems/rubygems.org/pull/3470 that avoids the bundlers that need a procfile & node