### PR TITLE
Allow administering gem typo exceptions thru admin interface

### DIFF
--- a/app/avo/resources/gem_typo_exception_resource.rb
+++ b/app/avo/resources/gem_typo_exception_resource.rb
@@ -1,0 +1,15 @@
+class GemTypoExceptionResource < Avo::BaseResource
+  self.title = :name
+  self.includes = []
+  self.search_query = lambda {
+    scope.where("name ILIKE ?", "%#{params[:q]}%")
+  }
+
+  field :id, as: :id, hide_on: :index
+  # Fields generated from the model
+  field :name, as: :text, link_to_resource: true
+  field :info, as: :textarea
+  # add fields here
+  field :created_at, as: :date_time, sortable: true
+  field :updated_at, as: :date_time, sortable: true
+end

--- a/app/controllers/avo/gem_typo_exceptions_controller.rb
+++ b/app/controllers/avo/gem_typo_exceptions_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::GemTypoExceptionsController < Avo::ResourcesController
+end

--- a/app/policies/gem_typo_exception_policy.rb
+++ b/app/policies/gem_typo_exception_policy.rb
@@ -1,0 +1,20 @@
+class GemTypoExceptionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_index?
+    rubygems_org_admin?
+  end
+
+  def avo_show?
+    rubygems_org_admin?
+  end
+
+  def avo_create? = rubygems_org_admin?
+  def avo_update? = rubygems_org_admin?
+  def avo_destroy? = rubygems_org_admin?
+  def act_on? = rubygems_org_admin?
+end

--- a/test/policies/gem_typo_exception_policy_test.rb
+++ b/test/policies/gem_typo_exception_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class GemTypoExceptionPolicyTest < ActiveSupport::TestCase
+  setup do
+    @exception = create(:gem_typo_exception)
+
+    @admin = create(:admin_github_user, :is_admin)
+    @non_admin = create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@exception], Pundit.policy_scope!(
+      @admin,
+      GemTypoException
+    ).to_a
+  end
+
+  def test_avo_index
+    assert_predicate Pundit.policy!(@admin, GemTypoException), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, GemTypoException), :avo_index?
+  end
+
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @exception), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @exception), :avo_show?
+  end
+
+  def test_avo_create
+    assert_predicate Pundit.policy!(@admin, GemTypoException), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, GemTypoException), :avo_create?
+  end
+
+  def test_avo_update
+    assert_predicate Pundit.policy!(@admin, @exception), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @exception), :avo_update?
+  end
+
+  def test_avo_destroy
+    assert_predicate Pundit.policy!(@admin, @exception), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @exception), :avo_destroy?
+  end
+end


### PR DESCRIPTION
Removes another support action that requires using the console