### PR TITLE
Silence datadog logs in development

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -15,6 +15,7 @@ Datadog.configure do |c|
   c.tracing.enabled = enabled
   c.tracing.log_injection = enabled
   c.telemetry.enabled = enabled
+  c.remote.enabled = enabled
 
   unless enabled
     # TODO: https://github.com/DataDog/dd-trace-rb/issues/2542


### PR DESCRIPTION
Since theres no agent running, remote config constantly fails & logs about it