### PR TITLE
Add Buildkite OIDC support

### DIFF
--- a/app/models/oidc/provider.rb
+++ b/app/models/oidc/provider.rb
@@ -12,6 +12,15 @@ class OIDC::Provider < ApplicationRecord
   has_many :audits, as: :auditable, dependent: :nullify
 
   GITHUB_ACTIONS_ISSUER = "https://token.actions.githubusercontent.com".freeze
+  BUILDKITE_ISSUER = "https://agent.buildkite.com".freeze
+
+  def self.buildkite
+    find_by(issuer: BUILDKITE_ISSUER)
+  end
+
+  def buildkite?
+    issuer == BUILDKITE_ISSUER
+  end
 
   def self.github_actions
     find_by(issuer: GITHUB_ACTIONS_ISSUER)

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="form__group">
     <%= f.label :oidc_provider_id, class: "form__label" %>
     <p/>
-    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, selected: :provider_id, class: "form__input form__select" %>
+    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, selected: @api_key_role.oidc_provider_id, class: "form__input form__select" %>
   </div>
   <div class="form__group">
     <%= f.label :api_key_permissions, class: "form__label" %>


### PR DESCRIPTION
Add support for [Buildkite OIDC tokens](https://buildkite.com/docs/agent/v3/cli-oidc).

This doesn't yet add tests, but should be functional. I'm testing end-to-end using a local development copy of Buildkite.

I can see some good end-to-end tests, eg. `test/system/oidc_test.rb`, but unsure if you'd like those per issuer, or some other issuer-specific testing. Please let me know what coverage you would like :pray: