### PR TITLE
Set Avo license early in tests.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,10 @@ require "helpers/webauthn_helpers"
 require "helpers/oauth_helpers"
 require "webmock/minitest"
 
+# setup license early since some tests are testing Avo outside of requests
+# and license is set with first request
+Avo::App.license = Avo::Licensing::LicenseManager.new(Avo::Licensing::HQ.new.response).license
+
 WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: [


### PR DESCRIPTION
Some tests doesn't use full request cycle and are missing avo license, which fails hard at various places (for example running `bin/rails test test/policies/avo_policies_test.rb` as you can see at https://github.com/rubygems/rubygems.org/actions/runs/6712012824/job/18240653654).

This fixed this by calling licensing setter manually as is done at https://github.com/avo-hq/avo/blob/ec68e3a01d452d3081704246eea538a52c76d06c/lib/avo/app.rb#L53.

@adrianthedev any better idea how to fix this? :thinking: 