### PR TITLE
Return Repr-Digest header in compact index

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -28,8 +28,10 @@ class Api::CompactIndexController < Api::BaseController
   private
 
   def render_range(response_body)
-    headers["ETag"] = '"' << Digest::MD5.hexdigest(response_body) << '"'
-    headers["Digest"] = "sha-256=#{Digest::SHA256.base64digest(response_body)}"
+    headers["ETag"] = %("#{Digest::MD5.hexdigest(response_body)}")
+    digest = Digest::SHA256.base64digest(response_body)
+    headers["Digest"] = "sha-256=#{digest}"
+    headers["Repr-Digest"] = "sha-256=:#{digest}:"
     headers["Accept-Ranges"] = "bytes"
 
     ranges = Rack::Utils.byte_ranges(request.env, response_body.bytesize)


### PR DESCRIPTION
Supports rubygems/rubygems#7122 with non-deprecated (draft)[^1] header for the digest of the full file representation even if only a part of the file is returned. Converts the header to use colon boundaries for byte sequences[^2] in headers.

[^1]: RFC draft ([link to Repr-Digest example that distinguishes behavior](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers#name-server-returns-partial-repr))
[^2]: RFC 8941 Structured Fields https://www.rfc-editor.org/rfc/rfc8941.html#name-byte-sequences