### PR TITLE
Remove Clearance from UsersController.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   include Clearance::Authentication
-  include Clearance::Authorization
   include ApplicationMultifactorMethods
   include TraceTagger
 
@@ -67,6 +66,10 @@ class ApplicationController < ActionController::Base
   def redirect_to_signin
     response.headers["Cache-Control"] = "private, max-age=0"
     redirect_to sign_in_path, alert: t("please_sign_in")
+  end
+
+  def redirect_to_root
+    redirect_to root_path
   end
 
   def find_rubygem

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -111,7 +111,7 @@ class SessionsController < Clearance::SessionsController
       if status.success?
         StatsD.increment "login.success"
         set_login_flash
-        redirect_back_or(url_after_create)
+        redirect_to(url_after_create)
       else
         login_failure(status.failure_message)
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,16 @@
-class UsersController < Clearance::UsersController
+class UsersController < ApplicationController
+  before_action :redirect_to_root, if: :signed_in?
+
   def new
-    @user = user_from_params
+    @user = User.new
   end
 
   def create
-    @user = user_from_params
+    @user = User.new(user_params)
     if @user.save
       Mailer.email_confirmation(@user).deliver_later
       flash[:notice] = t(".email_sent")
-      redirect_back_or url_after_create
+      redirect_back_or_to root_path
     else
       render template: "users/new"
     end
@@ -17,6 +19,16 @@ class UsersController < Clearance::UsersController
   private
 
   def user_params
-    params.permit(user: Array(User::PERMITTED_ATTRS)).fetch(:user, {})
+    params.require(:user).permit(
+      :bio,
+      :email,
+      :handle,
+      :public_email,
+      :location,
+      :password,
+      :website,
+      :twitter_username,
+      :full_name
+    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,18 +4,6 @@ class User < ApplicationRecord
   include Gravtastic
   is_gravtastic default: "retro"
 
-  PERMITTED_ATTRS = %i[
-    bio
-    email
-    handle
-    public_email
-    location
-    password
-    website
-    twitter_username
-    full_name
-  ].freeze
-
   before_save :_generate_confirmation_token_no_reset_unconfirmed_email, if: :will_save_change_to_unconfirmed_email?
   before_create :_generate_confirmation_token_no_reset_unconfirmed_email
   before_destroy :yank_gems

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -14,6 +14,17 @@ class UsersControllerTest < ActionController::TestCase
       page.assert_text "Sign up"
       page.assert_selector "input[type=password][autocomplete=new-password]"
     end
+
+    context "when logged in" do
+      setup do
+        @user = create(:user)
+        sign_in_as(@user)
+
+        get :new
+      end
+
+      should redirect_to("root") { root_path }
+    end
   end
 
   context "on POST to create" do
@@ -26,9 +37,9 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     context "when missing a parameter" do
-      should "raises parameter missing" do
+      should "reports validation error" do
         assert_no_changes -> { User.count } do
-          post :create
+          post :create, params: { user: { password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         end
         assert_response :ok
         assert page.has_content?("Email address is not a valid email")


### PR DESCRIPTION
- it is not used, since it is overridden

---

### idea behind

Clearance seems not used as originally intended currently. It is based around email/password and provides various helpers. But some of them were already merged into Rails and some of them doesn't work anymore for RubyGems.org since MFA/OTP/WebAuthN... Considering it is sometimes blocking upgrades (https://github.com/thoughtbot/clearance/pull/995) it is IMHO good time to reconsider its usage. At various places it is already overridden and not used.

I do kick-off with off-boarding `Clearance` from `UsersController`. Is is possible to also remove `include Clearance::Authorization` from `ApplicationController` since it is useful only for `redirect_back_or` helper which is already present in Rails these days as `redirect_back_or_to`. In following PRs I would like to address other controllers and finally the `User` model.