### PR TITLE
Update installation instructions OS X

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Follow the instructions below on how to install Bundler and setup the database.
   * Setup information: `brew info postgresql`
 * Install memcached: `brew install memcached`
   * Show all memcached options: `memcached -h`
-* Install Google-Chrome: `brew cask install google-chrome`
+* Install Google-Chrome: `brew install google-chrome --cask`
 
 #### Environment (Linux - Debian/Ubuntu)
 


### PR DESCRIPTION
While installation rubygems.org on my OS X environment, I noticed that installations instructions for Google Chrome were outdated.