### PR TITLE
Add job to refresh all OIDC provider configs every 30m

### DIFF
--- a/app/jobs/refresh_oidc_providers_job.rb
+++ b/app/jobs/refresh_oidc_providers_job.rb
@@ -1,0 +1,9 @@
+class RefreshOIDCProvidersJob < ApplicationJob
+  queue_as :default
+
+  def perform(*_args)
+    OIDC::Provider.find_each do |provider|
+      RefreshOIDCProviderJob.perform_later(provider:)
+    end
+  end
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -19,6 +19,12 @@ Rails.application.configure do
       class: "MfaUsageStatsJob",
       set: { priority: 10 },
       description: "Sending MFA usage metrics to statsd every hour"
+    },
+    refresh_oidc_providers: {
+      cron: "every 30m",
+      class: "RefreshOIDCProvidersJob",
+      set: { priority: 10 },
+      description: "Refreshing all OIDC provider configurations every 30m"
     }
   }
 

--- a/test/jobs/refresh_oidc_providers_job_test.rb
+++ b/test/jobs/refresh_oidc_providers_job_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class RefreshOIDCProvidersJobTest < ActiveJob::TestCase
+  test "enqueues refresh jobs" do
+    provider1 = create(:oidc_provider)
+    provider2 = create(:oidc_provider)
+
+    assert_enqueued_jobs 2, only: RefreshOIDCProviderJob do
+      assert_enqueued_with(job: RefreshOIDCProviderJob, args: [{ provider: provider1 }]) do
+        assert_enqueued_with(job: RefreshOIDCProviderJob, args: [{ provider: provider2 }]) do
+          RefreshOIDCProvidersJob.perform_now
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
So they do not need to be manually refreshed. In effect, this makes the config and jwks columns in the table a cache with a 30min TTL with stale-while-revalidate.