### PR TITLE
Skip committing the session for API endpoints

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,6 @@
 class Api::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
+  after_action :skip_session
 
   private
 
@@ -116,5 +117,9 @@ class Api::BaseController < ApplicationController
 
   def render_soft_deleted_api_key
     render plain: "An invalid API key cannot be used. Please delete it and create a new one.", status: :forbidden
+  end
+
+  def skip_session
+    request.session_options[:skip] = true
   end
 end


### PR DESCRIPTION
This will help avoid setting the Set-Cookie header, which makes responses non-cacheable, and opens us up to someone causing a thundering herd by visiting an API endpoint in the browser and causing fastly to cache a hit-for-pass object, see https://developer.fastly.com/learning/concepts/edge-state/cache/request-collapsing/#hit-for-pass

(Nothing in the API is using the session or setting cookies, which makes sense since it's an API)