### PR TITLE
Use an uncached query to compute compact index info in jobs

### DIFF
--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -14,7 +14,7 @@ class UploadInfoFileJob < ApplicationJob
   )
 
   def perform(rubygem_name:)
-    compact_index_info = GemInfo.new(rubygem_name).compact_index_info
+    compact_index_info = GemInfo.new(rubygem_name, cached: false).compact_index_info
     response_body = CompactIndex.info(compact_index_info)
 
     content_md5 = Digest::MD5.base64digest(response_body)

--- a/app/jobs/upload_names_file_job.rb
+++ b/app/jobs/upload_names_file_job.rb
@@ -14,7 +14,7 @@ class UploadNamesFileJob < ApplicationJob
   )
 
   def perform
-    names = GemInfo.ordered_names
+    names = GemInfo.ordered_names(cached: false)
     response_body = CompactIndex.names(names)
 
     content_md5 = Digest::MD5.base64digest(response_body)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -1,11 +1,11 @@
 class GemInfo
-  def initialize(rubygem_name)
+  def initialize(rubygem_name, cached: true)
     @rubygem_name = rubygem_name
+    @cached = cached
   end
 
   def compact_index_info
-    info = Rails.cache.read("info/#{@rubygem_name}")
-    if info
+    if @cached && (info = Rails.cache.read("info/#{@rubygem_name}"))
       StatsD.increment "compact_index.memcached.info.hit"
       info
     else
@@ -21,9 +21,8 @@ class GemInfo
     Digest::MD5.hexdigest(compact_index_info)
   end
 
-  def self.ordered_names
-    names = Rails.cache.read("names")
-    if names
+  def self.ordered_names(cached: true)
+    if cached && (names = Rails.cache.read("names"))
       StatsD.increment "compact_index.memcached.names.hit"
     else
       StatsD.increment "compact_index.memcached.names.miss"


### PR DESCRIPTION
This way, there is no race with purging the cache & computing the new files