### PR TITLE
Fix api_key_created email when api key belongs to an oidc id token

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -8,7 +8,7 @@ class ApiKey < ApplicationRecord
   has_one :api_key_rubygem_scope, dependent: :destroy
   has_one :ownership, through: :api_key_rubygem_scope
   has_one :oidc_id_token, class_name: "OIDC::IdToken", dependent: :restrict_with_error
-  has_one :oidc_api_key_role, through: :oidc_id_token, inverse_of: :api_key
+  has_one :oidc_api_key_role, through: :oidc_id_token, source: :api_key_role, inverse_of: :api_keys
   has_many :pushed_versions, class_name: "Version", inverse_of: :pusher_api_key, foreign_key: :pusher_api_key_id, dependent: :nullify
 
   before_validation :set_owner_from_user

--- a/app/models/oidc/id_token.rb
+++ b/app/models/oidc/id_token.rb
@@ -1,5 +1,5 @@
 class OIDC::IdToken < ApplicationRecord
-  belongs_to :api_key_role, class_name: "OIDC::ApiKeyRole", foreign_key: "oidc_api_key_role_id", inverse_of: :id_tokens
+  belongs_to :api_key_role, class_name: "OIDC::ApiKeyRole", foreign_key: :oidc_api_key_role_id, inverse_of: :id_tokens
   belongs_to :api_key, inverse_of: :oidc_id_token
   has_one :provider, through: :api_key_role, inverse_of: :id_tokens
   has_one :user, through: :api_key_role, inverse_of: :oidc_id_tokens

--- a/app/views/mailer/api_key_created.html.erb
+++ b/app/views/mailer/api_key_created.html.erb
@@ -20,7 +20,7 @@
           Created at: <strong><%= @api_key.created_at.to_formatted_s(:rfc822) %></strong>
           <% if @api_key.oidc_id_token.present? %>
             <br>
-            <%= ApiKey.human_attribute_name(:oidc_api_key_role) %>: <strong><%= link_to(@api_key.oidc_api_key_role.name, profile_oidc_api_key_role_path(@api_key.oidc_api_key_role.token), target: :_blank) %></strong>
+            <%= ApiKey.human_attribute_name(:oidc_api_key_role) %>: <strong><%= link_to(@api_key.oidc_api_key_role.name, profile_oidc_api_key_role_url(@api_key.oidc_api_key_role.token), target: :_blank) %></strong>
           <% end %>
           <br>
         </p>

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -88,6 +88,11 @@ class MailerPreview < ActionMailer::Preview
     Mailer.api_key_created(api_key.id)
   end
 
+  def api_key_created_oidc_api_key_role
+    api_key = OIDC::IdToken.last.api_key
+    Mailer.api_key_created(api_key.id)
+  end
+
   def api_key_revoked
     api_key = ApiKey.last
     Mailer.api_key_revoked(api_key.user.id, api_key.name, api_key.enabled_scopes.join(", "), "https://example.com")


### PR DESCRIPTION
Fixing ApiKey association & use url helper instead of path in mailer view

Fixes https://app.datadoghq.com/logs?query=%40traceid%3A511637059039611422&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1700692471686&to_ts=1700778871686&live=true

See also: https://rubygems.team/admin/good_job/jobs/a5efdbaf-5ed1-4a9e-9383-9dc77e94cb26?locale=en