### PR TITLE
Add trusted publishers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,7 +70,7 @@ Metrics/BlockLength:
     - config/environments/development.rb
 
 Metrics/ClassLength:
-  Max: 356 # TODO: Lower to 100
+  Max: 357 # TODO: Lower to 100
   Exclude:
     - test/**/*
 

--- a/app/avo/resources/api_key_resource.rb
+++ b/app/avo/resources/api_key_resource.rb
@@ -12,7 +12,7 @@ class ApiKeyResource < Avo::BaseResource
   field :user, as: :belongs_to, visible: ->(_) { false }
   field :owner, as: :belongs_to,
     polymorphic_as: :owner,
-    types: [::User]
+    types: [::User, ::OIDC::TrustedPublisher::GitHubAction]
   field :last_accessed_at, as: :date_time
   field :soft_deleted_at, as: :date_time
   field :soft_deleted_rubygem_name, as: :text

--- a/app/avo/resources/oidc_pending_trusted_publisher_resource.rb
+++ b/app/avo/resources/oidc_pending_trusted_publisher_resource.rb
@@ -1,0 +1,16 @@
+class OIDCPendingTrustedPublisherResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  self.model_class = ::OIDC::PendingTrustedPublisher
+
+  class ExpiredFilter < ScopeBooleanFilter; end
+  filter ExpiredFilter, arguments: { default: { expired: false, unexpired: true } }
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :rubygem_name, as: :text
+  field :user, as: :belongs_to
+  field :trusted_publisher, as: :belongs_to, polymorphic_as: :trusted_publisher
+  field :expires_at, as: :date_time
+  # add fields here
+end

--- a/app/avo/resources/oidc_provider_resource.rb
+++ b/app/avo/resources/oidc_provider_resource.rb
@@ -2,9 +2,6 @@ class OIDCProviderResource < Avo::BaseResource
   self.title = :issuer
   self.includes = []
   self.model_class = ::OIDC::Provider
-  # self.search_query = -> do
-  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
-  # end
 
   action RefreshOIDCProvider
 

--- a/app/avo/resources/oidc_rubygem_trusted_publisher_resource.rb
+++ b/app/avo/resources/oidc_rubygem_trusted_publisher_resource.rb
@@ -1,0 +1,11 @@
+class OIDCRubygemTrustedPublisherResource < Avo::BaseResource
+  self.title = :id
+  self.includes = [:trusted_publisher]
+  self.model_class = ::OIDC::RubygemTrustedPublisher
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :rubygem, as: :belongs_to
+  field :trusted_publisher, as: :belongs_to, polymorphic_as: :trusted_publisher
+  # add fields here
+end

--- a/app/avo/resources/oidc_trusted_publisher_github_action_resource.rb
+++ b/app/avo/resources/oidc_trusted_publisher_github_action_resource.rb
@@ -1,0 +1,19 @@
+class OIDCTrustedPublisherGitHubActionResource < Avo::BaseResource
+  self.title = :name
+  self.includes = []
+  self.model_class = ::OIDC::TrustedPublisher::GitHubAction
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :repository_owner, as: :text
+  field :repository_name, as: :text
+  field :repository_owner_id, as: :text
+  field :workflow_filename, as: :text
+  field :environment, as: :text
+  # add fields here
+  #
+  field :rubygem_trusted_publishers, as: :has_many
+  field :pending_trusted_publishers, as: :has_many
+  field :rubygems, as: :has_many, through: :rubygem_trusted_publishers
+  field :api_keys, as: :has_many, inverse_of: :owner
+end

--- a/app/avo/resources/rubygem_resource.rb
+++ b/app/avo/resources/rubygem_resource.rb
@@ -38,6 +38,9 @@ class RubygemResource < Avo::BaseResource
     field :linkset, as: :has_one
     field :gem_download, as: :has_one
 
+    field :link_verifications, as: :has_many
+    field :oidc_rubygem_trusted_publishers, as: :has_many
+
     field :audits, as: :has_many
   end
 end

--- a/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
+++ b/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
@@ -1,0 +1,71 @@
+class Api::V1::OIDC::TrustedPublisherController < Api::BaseController
+  include ApiKeyable
+
+  before_action :decode_jwt
+  before_action :find_provider
+  before_action :verify_signature
+  before_action :find_trusted_publisher
+  before_action :validate_claims
+
+  class UnsupportedIssuer < StandardError; end
+  class UnverifiedJWT < StandardError; end
+
+  rescue_from(
+    UnsupportedIssuer, UnverifiedJWT,
+    JSON::JWT::VerificationFailed, JSON::JWK::Set::KidNotFound,
+    OIDC::AccessPolicy::AccessError,
+    with: :render_not_found
+  )
+
+  def exchange_token
+    key = generate_unique_rubygems_key
+    iat = Time.at(@jwt[:iat].to_i, in: "UTC")
+    api_key = @trusted_publisher.api_keys.create!(
+      hashed_key: hashed_key(key),
+      name: "#{@trusted_publisher.name} #{iat.iso8601}",
+      push_rubygem: true,
+      expires_at: 15.minutes.from_now
+    )
+
+    render json: {
+      rubygems_api_key: key,
+      name: api_key.name,
+      scopes: api_key.enabled_scopes,
+      gem: api_key.rubygem,
+      expires_at: api_key.expires_at
+    }.compact, status: :created
+  end
+
+  private
+
+  def decode_jwt
+    @jwt = JSON::JWT.decode_compact_serialized(params.require(:jwt), :skip_verification)
+  rescue JSON::JWT::InvalidFormat, JSON::ParserError, ArgumentError
+    # invalid base64 raises ArgumentError
+    render_bad_request
+  end
+
+  def find_provider
+    @provider = OIDC::Provider.find_by!(issuer: @jwt[:iss])
+  end
+
+  def verify_signature
+    raise UnverifiedJWT, "Invalid time" unless (@jwt["nbf"]..@jwt["exp"]).cover?(Time.now.to_i)
+    @jwt.verify!(@provider.jwks)
+  end
+
+  def find_trusted_publisher
+    unless (trusted_publisher_class = @provider.trusted_publisher_class)
+      raise UnsupportedIssuer, "Unsuported issuer for trusted publishing"
+    end
+    @trusted_publisher = trusted_publisher_class.for_claims(@jwt)
+  end
+
+  def validate_claims
+    @trusted_publisher.to_access_policy(@jwt).verify_access!(@jwt)
+  end
+
+  def render_bad_request
+    render json: { error: "Bad Request" }, status: :bad_request
+  end
+end

--- a/app/controllers/avo/oidc_pending_trusted_publishers_controller.rb
+++ b/app/controllers/avo/oidc_pending_trusted_publishers_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::OIDCPendingTrustedPublishersController < Avo::ResourcesController
+end

--- a/app/controllers/avo/oidc_rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/avo/oidc_rubygem_trusted_publishers_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::OIDCRubygemTrustedPublishersController < Avo::ResourcesController
+end

--- a/app/controllers/avo/oidc_trusted_publisher_github_actions_controller.rb
+++ b/app/controllers/avo/oidc_trusted_publisher_github_actions_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::OIDCTrustedPublisherGitHubActionsController < Avo::ResourcesController
+end

--- a/app/controllers/oidc/concerns/trusted_publisher_creation.rb
+++ b/app/controllers/oidc/concerns/trusted_publisher_creation.rb
@@ -1,0 +1,21 @@
+module OIDC::Concerns::TrustedPublisherCreation
+  extend ActiveSupport::Concern
+
+  included do
+    include SessionVerifiable
+    verify_session_before
+
+    before_action :set_trusted_publisher_type, only: %i[create]
+    before_action :create_params, only: %i[create]
+    before_action :set_page, only: :index
+  end
+
+  def set_trusted_publisher_type
+    trusted_publisher_type = params.permit(create_params_key => :trusted_publisher_type).require(create_params_key).require(:trusted_publisher_type)
+
+    @trusted_publisher_type = OIDC::TrustedPublisher.all.find { |type| type.polymorphic_name == trusted_publisher_type }
+
+    return if @trusted_publisher_type
+    redirect_back fallback_location: root_path, flash: { error: t("oidc.trusted_publisher.unsupported_type") }
+  end
+end

--- a/app/controllers/oidc/pending_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/pending_trusted_publishers_controller.rb
@@ -1,0 +1,65 @@
+class OIDC::PendingTrustedPublishersController < ApplicationController
+  include OIDC::Concerns::TrustedPublisherCreation
+
+  before_action :find_pending_trusted_publisher, only: %i[destroy]
+
+  def index
+    trusted_publishers = current_user
+      .oidc_pending_trusted_publishers.unexpired.includes(:trusted_publisher)
+      .order(:rubygem_name, :created_at).page(@page).strict_loading
+    render OIDC::PendingTrustedPublishers::IndexView.new(
+      trusted_publishers:
+    )
+  end
+
+  def new
+    pending_trusted_publisher = current_user.oidc_pending_trusted_publishers.new(trusted_publisher: OIDC::TrustedPublisher::GitHubAction.new)
+    render OIDC::PendingTrustedPublishers::NewView.new(
+      pending_trusted_publisher:
+    )
+  end
+
+  def create
+    trusted_publisher = current_user.oidc_pending_trusted_publishers.new(
+      create_params.merge(
+        expires_at: 12.hours.from_now
+      )
+    )
+
+    if trusted_publisher.save
+      redirect_to profile_oidc_pending_trusted_publishers_path, flash: { notice: t(".success") }
+    else
+      flash.now[:error] = trusted_publisher.errors.full_messages.to_sentence
+      render OIDC::PendingTrustedPublishers::NewView.new(
+        pending_trusted_publisher: trusted_publisher
+      ), status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @pending_trusted_publisher.destroy
+      redirect_to profile_oidc_pending_trusted_publishers_path, flash: { notice: t(".success") }
+    else
+      redirect_back fallback_location: profile_oidc_pending_trusted_publishers_path,
+                    flash: { error: @pending_trusted_publisher.errors.full_messages.to_sentence }
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(
+      create_params_key => [
+        :rubygem_name,
+        :trusted_publisher_type,
+        { trusted_publisher_attributes: @trusted_publisher_type.permitted_attributes }
+      ]
+    ).require(create_params_key)
+  end
+
+  def create_params_key = :oidc_pending_trusted_publisher
+
+  def find_pending_trusted_publisher
+    @pending_trusted_publisher = current_user.oidc_pending_trusted_publishers.find(params.require(:id))
+  end
+end

--- a/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
@@ -1,0 +1,80 @@
+class OIDC::RubygemTrustedPublishersController < ApplicationController
+  include OIDC::Concerns::TrustedPublisherCreation
+
+  before_action :find_rubygem
+  before_action :render_forbidden, unless: :owner?
+  before_action :find_rubygem_trusted_publisher, except: %i[index new create]
+
+  def index
+    render OIDC::RubygemTrustedPublishers::IndexView.new(
+      rubygem: @rubygem,
+      trusted_publishers: @rubygem.oidc_rubygem_trusted_publishers.includes(:trusted_publisher).page(@page).strict_loading
+    )
+  end
+
+  def new
+    render OIDC::RubygemTrustedPublishers::NewView.new(
+      rubygem_trusted_publisher: @rubygem.oidc_rubygem_trusted_publishers.new(trusted_publisher: gh_actions_trusted_publisher)
+    )
+  end
+
+  def create
+    trusted_publisher = @rubygem.oidc_rubygem_trusted_publishers.new(
+      create_params
+    )
+
+    if trusted_publisher.save
+      redirect_to rubygem_trusted_publishers_path(@rubygem.slug), flash: { notice: t(".success") }
+    else
+      flash.now[:error] = trusted_publisher.errors.full_messages.to_sentence
+      render OIDC::RubygemTrustedPublishers::NewView.new(
+        rubygem_trusted_publisher: trusted_publisher
+      ), status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @rubygem_trusted_publisher.destroy
+      redirect_to rubygem_trusted_publishers_path(@rubygem.slug), flash: { notice: t(".success") }
+    else
+      redirect_back fallback_location: rubygem_trusted_publishers_path(@rubygem.slug),
+                    flash: { error: @rubygem_trusted_publisher.errors.full_messages.to_sentence }
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(
+      create_params_key => [
+        :trusted_publisher_type,
+        { trusted_publisher_attributes: @trusted_publisher_type.permitted_attributes }
+      ]
+    ).require(create_params_key)
+  end
+
+  def create_params_key = :oidc_rubygem_trusted_publisher
+
+  def find_rubygem_trusted_publisher
+    @rubygem_trusted_publisher = @rubygem.oidc_rubygem_trusted_publishers.find(params.require(:id))
+  end
+
+  def gh_actions_trusted_publisher
+    github_params = helpers.github_params(@rubygem)
+
+    publisher = OIDC::TrustedPublisher::GitHubAction.new
+    if github_params
+      publisher.repository_owner = github_params[:user]
+      publisher.repository_name = github_params[:repo]
+      publisher.workflow_filename = workflow_filename(publisher.repository)
+    end
+    publisher
+  end
+
+  def workflow_filename(repo)
+    paths = Octokit.contents(repo, path: ".github/workflows").lazy.select { _1.type == "file" }.map(&:name).grep(/\.ya?ml\z/)
+    paths.max_by { |path| [path.include?("release"), path.include?("push")].map! { (_1 && 1) || 0 } }
+  rescue Octokit::NotFound
+    nil
+  end
+end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -93,6 +93,10 @@ module RubygemsHelper
     link_to I18n.t("rubygems.aside.links.ownership"), rubygem_owners_path(rubygem.slug), class: "gem__link t-list__item"
   end
 
+  def rubygem_trusted_publishers_link(rubygem)
+    link_to t("rubygems.aside.links.trusted_publishers"), rubygem_trusted_publishers_path(rubygem.slug), class: "gem__link t-list__item"
+  end
+
   def oidc_api_key_role_links(rubygem)
     roles = current_user.oidc_api_key_roles.for_rubygem(rubygem)
 
@@ -133,6 +137,15 @@ module RubygemsHelper
   def link_to_user(user)
     link_to avatar(48, "gravatar-#{user.id}", user), profile_path(user.display_id),
       alt: user.display_handle, title: user.display_handle
+  end
+
+  def link_to_pusher(api_key_owner)
+    case api_key_owner
+    when OIDC::TrustedPublisher::GitHubAction
+      image_tag "github_icon.png", width: 48, height: 48, theme: :light, alt: "GitHub", title: api_key_owner.name
+    else
+      raise ArgumentError, "unknown api_key_owner type #{api_key_owner.class}"
+    end
   end
 
   def nice_date_for(time)

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -67,6 +67,18 @@ class Mailer < ApplicationMailer
                       default: "Gem %{gem} pushed to RubyGems.org")
   end
 
+  def gem_trusted_publisher_added(rubygem_trusted_publisher, created_by_user, notified_user)
+    @rubygem_trusted_publisher = rubygem_trusted_publisher
+    @created_by_user = created_by_user
+    @notified_user = notified_user
+
+    mail to: notified_user.email,
+      subject: I18n.t("mailer.gem_trusted_publisher_added.subject",
+        gem: @rubygem_trusted_publisher.rubygem.name,
+        host: Gemcutter::HOST_DISPLAY,
+        default: "Trusted publisher added to %{gem} on RubyGems.org")
+  end
+
   def mfa_notification(user_id)
     @user = User.find(user_id)
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -9,7 +9,7 @@ class ApiKey < ApplicationRecord
   has_one :api_key_rubygem_scope, dependent: :destroy
   has_one :ownership, through: :api_key_rubygem_scope
   has_one :oidc_id_token, class_name: "OIDC::IdToken", dependent: :restrict_with_error
-  has_one :oidc_api_key_role, through: :oidc_id_token, source: :api_key_role, inverse_of: :api_keys
+  has_one :oidc_api_key_role, class_name: "OIDC::ApiKeyRole", through: :oidc_id_token, source: :api_key_role, inverse_of: :api_keys
   has_many :pushed_versions, class_name: "Version", inverse_of: :pusher_api_key, foreign_key: :pusher_api_key_id, dependent: :nullify
 
   before_validation :set_owner_from_user

--- a/app/models/oidc/pending_trusted_publisher.rb
+++ b/app/models/oidc/pending_trusted_publisher.rb
@@ -1,0 +1,38 @@
+class OIDC::PendingTrustedPublisher < ApplicationRecord
+  belongs_to :user
+  belongs_to :trusted_publisher, polymorphic: true, optional: false
+
+  accepts_nested_attributes_for :trusted_publisher
+
+  validates :rubygem_name,
+    length: { maximum: Gemcutter::MAX_FIELD_LENGTH },
+    presence: true,
+    name_format: true,
+    uniqueness: { case_sensitive: false, scope: %i[trusted_publisher_id trusted_publisher_type], conditions: -> { unexpired } }
+
+  validate :available_rubygem_name, on: :create
+
+  scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(Time.now.utc))) }
+  scope :expired, -> { where(arel_table[:expires_at].lteq(Time.now.utc)) }
+
+  scope :rubygem_name_is, lambda { |name|
+    sensitive = where(rubygem_name: name.strip).limit(1)
+    return sensitive unless sensitive.empty?
+
+    where("UPPER(rubygem_name) = UPPER(?)", name.strip).limit(1)
+  }
+
+  def build_trusted_publisher(params)
+    self.trusted_publisher = trusted_publisher_type.constantize.build_trusted_publisher(params)
+  end
+
+  private
+
+  def available_rubygem_name
+    return if rubygem_name.blank?
+    rubygem = Rubygem.name_is(rubygem_name).first
+    return if rubygem.nil? || rubygem.pushable?
+
+    errors.add(:rubygem_name, :unavailable)
+  end
+end

--- a/app/models/oidc/provider.rb
+++ b/app/models/oidc/provider.rb
@@ -39,6 +39,13 @@ class OIDC::Provider < ApplicationRecord
 
   attribute :jwks, Types::JsonDeserializable.new(JSON::JWK::Set)
 
+  def trusted_publisher_class
+    case issuer
+    when GITHUB_ACTIONS_ISSUER
+      OIDC::TrustedPublisher::GitHubAction
+    end
+  end
+
   private
 
   def issuer_match

--- a/app/models/oidc/rubygem_trusted_publisher.rb
+++ b/app/models/oidc/rubygem_trusted_publisher.rb
@@ -1,0 +1,12 @@
+class OIDC::RubygemTrustedPublisher < ApplicationRecord
+  belongs_to :rubygem
+  belongs_to :trusted_publisher, polymorphic: true, optional: false
+
+  accepts_nested_attributes_for :trusted_publisher
+
+  validates :rubygem, uniqueness: { scope: %i[trusted_publisher_id trusted_publisher_type] }
+
+  def build_trusted_publisher(params)
+    self.trusted_publisher = trusted_publisher_type.constantize.build_trusted_publisher(params)
+  end
+end

--- a/app/models/oidc/trusted_publisher.rb
+++ b/app/models/oidc/trusted_publisher.rb
@@ -1,0 +1,9 @@
+module OIDC::TrustedPublisher
+  def self.table_name_prefix
+    "oidc_trusted_publisher_"
+  end
+
+  def self.all
+    [GitHubAction]
+  end
+end

--- a/app/models/oidc/trusted_publisher/github_action.rb
+++ b/app/models/oidc/trusted_publisher/github_action.rb
@@ -1,0 +1,162 @@
+class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
+  has_many :rubygem_trusted_publishers, class_name: "OIDC::RubygemTrustedPublisher", as: :trusted_publisher, dependent: :destroy,
+    inverse_of: :trusted_publisher
+  has_many :pending_trusted_publishers, class_name: "OIDC::PendingTrustedPublisher", as: :trusted_publisher, dependent: :destroy,
+    inverse_of: :trusted_publisher
+  has_many :rubygems, through: :rubygem_trusted_publishers
+  has_many :api_keys, dependent: :destroy, inverse_of: :owner, as: :owner
+
+  before_validation :find_github_repository_owner_id
+
+  validates :repository_owner, presence: true
+  validates :repository_name, presence: true
+  validates :workflow_filename, presence: true
+  validates :environment, presence: true, allow_nil: true
+  validates :repository_owner_id, presence: true
+
+  validate :unique_publisher
+  validate :workflow_filename_format
+
+  def self.for_claims(claims)
+    repository = claims.fetch(:repository)
+    repository_owner, repository_name = repository.split("/", 2)
+    workflow_prefix = "#{repository}/.github/workflows/"
+    workflow_ref = claims.fetch(:job_workflow_ref).delete_prefix(workflow_prefix)
+    workflow_filename = workflow_ref.sub(/@[^@]+\z/, "")
+
+    required = {
+      repository_owner:, repository_name:, workflow_filename:,
+      repository_owner_id: claims.fetch(:repository_owner_id)
+    }
+
+    base = where(required)
+    if (env = claims[:environment])
+      base.where(environment: env).or(base.where(environment: nil)).order(environment: :asc) # NULLS LAST by default for asc
+    else
+      base.where(environment: nil)
+    end.first!
+  end
+
+  def self.permitted_attributes
+    %i[repository_owner repository_name workflow_filename environment]
+  end
+
+  def self.build_trusted_publisher(params)
+    params.delete(:environment) if params[:environment].blank?
+    params = params.reverse_merge(repository_owner_id: nil, repository_name: nil, workflow_filename: nil, environment: nil)
+    find_or_initialize_by(params)
+  end
+
+  def self.publisher_name = "GitHub Actions"
+
+  def repository_condition
+    OIDC::AccessPolicy::Statement::Condition.new(
+      operator: "string_equals",
+      claim: "repository",
+      value: [repository_owner, repository_name].join("/")
+    )
+  end
+
+  def environment_condition
+    return if environment.blank?
+    OIDC::AccessPolicy::Statement::Condition.new(
+      operator: "string_equals",
+      claim: "environment",
+      value: environment
+    )
+  end
+
+  def repository_owner_id_condition
+    OIDC::AccessPolicy::Statement::Condition.new(
+      operator: "string_equals",
+      claim: "repository_owner_id",
+      value: repository_owner_id
+    )
+  end
+
+  def audience_condition
+    OIDC::AccessPolicy::Statement::Condition.new(
+      operator: "string_equals",
+      claim: "aud",
+      value: Gemcutter::HOST
+    )
+  end
+
+  def job_workflow_ref_condition(ref)
+    OIDC::AccessPolicy::Statement::Condition.new(
+      operator: "string_equals",
+      claim: "job_workflow_ref",
+      value: "#{repository}/#{workflow_slug}@#{ref}"
+    )
+  end
+
+  def to_access_policy(jwt)
+    common_conditions = [repository_condition, environment_condition, repository_owner_id_condition, audience_condition].compact
+    refs = [jwt.fetch(:ref), jwt.fetch(:sha)].compact_blank
+    raise OIDC::AccessPolicy::AccessError, "ref and sha are both missing" if refs.empty?
+    OIDC::AccessPolicy.new(
+      statements: refs.map do |ref|
+        OIDC::AccessPolicy::Statement.new(
+          effect: "allow",
+          principal: OIDC::AccessPolicy::Statement::Principal.new(
+            oidc: OIDC::Provider::GITHUB_ACTIONS_ISSUER
+          ),
+          conditions: common_conditions + [job_workflow_ref_condition(ref)]
+        )
+      end
+    )
+  end
+
+  def name
+    name = "#{self.class.publisher_name} #{repository_owner}/#{repository_name} @ #{workflow_slug}"
+    name << " (#{environment})" if environment?
+    name
+  end
+
+  def repository = "#{repository_owner}/#{repository_name}"
+
+  def workflow_slug = ".github/workflows/#{workflow_filename}"
+
+  def owns_gem?(rubygem) = rubygem_trusted_publishers.exists?(rubygem: rubygem)
+
+  def ld_context
+    LaunchDarkly::LDContext.create(
+      key: "#{model_name.singular}-key-#{id}",
+      kind: "trusted_publisher",
+      name: name
+    )
+  end
+
+  private
+
+  def find_github_repository_owner_id
+    return if repository_owner.blank?
+    return if repository_owner_id.present?
+
+    self.repository_owner_id =
+      begin
+        Octokit::Client.new.user(repository_owner).id
+      rescue Octokit::NotFound
+        nil
+      end
+  end
+
+  def unique_publisher
+    return unless self.class.exists?(
+      repository_owner: repository_owner,
+      repository_name: repository_name,
+      repository_owner_id: repository_owner_id,
+      workflow_filename: workflow_filename,
+      environment: environment
+    )
+
+    errors.add(:base, "publisher already exists")
+  end
+
+  def workflow_filename_format
+    return if workflow_filename.blank?
+
+    errors.add(:workflow_filename, "must end with .yml or .yaml") unless /\.ya?ml\z/.match?(workflow_filename)
+    errors.add(:workflow_filename, "must be a filename only, without directories") if workflow_filename.include?("/")
+  end
+end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -20,6 +20,7 @@ class Rubygem < ApplicationRecord
   has_many :ownership_requests, -> { opened }, dependent: :destroy, inverse_of: :rubygem
   has_many :audits, as: :auditable, inverse_of: :auditable
   has_many :link_verifications, as: :linkable, inverse_of: :linkable, dependent: :destroy
+  has_many :oidc_rubygem_trusted_publishers, class_name: "OIDC::RubygemTrustedPublisher", inverse_of: :rubygem, dependent: :destroy
 
   validates :name,
     length: { maximum: Gemcutter::MAX_FIELD_LENGTH },
@@ -315,8 +316,11 @@ class Rubygem < ApplicationRecord
   end
 
   def disown
-    ownerships_including_unconfirmed.each(&:delete)
+    ownerships_including_unconfirmed.find_each(&:delete)
     ownerships_including_unconfirmed.clear
+
+    oidc_rubygem_trusted_publishers.find_each(&:delete)
+    oidc_rubygem_trusted_publishers.clear
   end
 
   def find_version_from_spec(spec)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,9 @@ class User < ApplicationRecord
 
   has_many :oidc_api_key_roles, dependent: :nullify, class_name: "OIDC::ApiKeyRole", inverse_of: :user
   has_many :oidc_id_tokens, through: :oidc_api_key_roles, class_name: "OIDC::IdToken", inverse_of: :user, source: :id_tokens
-  has_many :oidc_providers, through: :oidc_api_key_roles, class_name: "OIDC::Provider", inverse_of: :users, source: :providers
+  has_many :oidc_providers, through: :oidc_api_key_roles, class_name: "OIDC::Provider", inverse_of: :users, source: :provider
+  has_many :oidc_pending_trusted_publishers, class_name: "OIDC::PendingTrustedPublisher", inverse_of: :user, dependent: :destroy
+  has_many :oidc_rubygem_trusted_publishers, through: :rubygems, class_name: "OIDC::RubygemTrustedPublisher"
 
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true
   validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true

--- a/app/policies/oidc/pending_trusted_publisher_policy.rb
+++ b/app/policies/oidc/pending_trusted_publisher_policy.rb
@@ -1,0 +1,13 @@
+class OIDC::PendingTrustedPublisherPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
+
+  has_association :rubygem
+  has_association :trusted_publisher
+end

--- a/app/policies/oidc/rubygem_trusted_publisher_policy.rb
+++ b/app/policies/oidc/rubygem_trusted_publisher_policy.rb
@@ -1,0 +1,13 @@
+class OIDC::RubygemTrustedPublisherPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
+
+  has_association :rubygem
+  has_association :trusted_publisher
+end

--- a/app/policies/oidc/trusted_publisher/github_action_policy.rb
+++ b/app/policies/oidc/trusted_publisher/github_action_policy.rb
@@ -1,0 +1,16 @@
+class OIDC::TrustedPublisher::GitHubActionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
+
+  has_association :trusted_publishers
+  has_association :rubygem_trusted_publishers
+  has_association :pending_trusted_publishers
+  has_association :rubygems
+  has_association :api_keys
+end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -33,4 +33,7 @@ class RubygemPolicy < ApplicationPolicy
   has_association :linkset
   has_association :gem_download
   has_association :audits
+  has_association :link_verifications
+
+  has_association :oidc_rubygem_trusted_publishers
 end

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -10,4 +10,8 @@ class ApplicationView < ApplicationComponent
   def title=(title)
     @_view_context.instance_variable_set :@title, title
   end
+
+  def title_for_header_only=(title)
+    @_view_context.instance_variable_set :@title_for_header_only, title
+  end
 end

--- a/app/views/components/application_component.rb
+++ b/app/views/components/application_component.rb
@@ -2,7 +2,28 @@
 
 class ApplicationComponent < Phlex::HTML
   include Phlex::Rails::Helpers::Routes
-  include ActionView::Helpers::TranslationHelper
+
+  class TranslationHelper
+    include ActionView::Helpers::TranslationHelper
+
+    def initialize(translation_path:)
+      @translation_path = translation_path
+    end
+
+    private
+
+    def scope_key_by_partial(key)
+      return key unless key&.start_with?(".")
+
+      "#{@translation_path}#{key}"
+    end
+  end
+
+  delegate :t, to: "self.class.translation_helper"
+
+  def self.translation_helper
+    @translation_helper ||= TranslationHelper.new(translation_path: translation_path)
+  end
 
   def self.translation_path
     @translation_path ||= name&.dup.tap do |n|
@@ -11,13 +32,5 @@ class ApplicationComponent < Phlex::HTML
       n.gsub!(/([a-z])([A-Z])/, '\1_\2')
       n.downcase!
     end
-  end
-
-  private
-
-  def scope_key_by_partial(key)
-    return key unless key&.start_with?(".")
-
-    "#{self.class.translation_path}#{key}"
   end
 end

--- a/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class OIDC::TrustedPublisher::GitHubAction::FormComponent < ApplicationComponent
+  extend Dry::Initializer
+
+  option :github_action_form
+
+  def template
+    github_action_form.fields_for :trusted_publisher do |trusted_publisher_form|
+      field trusted_publisher_form, :text_field, :repository_owner, autocomplete: :off
+      field trusted_publisher_form, :text_field, :repository_name, autocomplete: :off
+      field trusted_publisher_form, :text_field, :workflow_filename, autocomplete: :off
+      field trusted_publisher_form, :text_field, :environment, autocomplete: :off, optional: true
+    end
+  end
+
+  private
+
+  def field(form, type, name, optional: false, **opts)
+    form.label name, class: "form__label" do
+      plain form.object.class.human_attribute_name(name)
+      span(class: "t-text--s") { " (#{t('form.optional')})" } if optional
+    end
+    form.send type, name, class: helpers.class_names("form__input", "tw-border tw-border-red-500" => form.object.errors.include?(name)), **opts
+    p(class: "form__field__instructions") { t("oidc.trusted_publisher.github_actions.#{name}_help_html") }
+  end
+end

--- a/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
@@ -1,0 +1,20 @@
+class OIDC::TrustedPublisher::GitHubAction::TableComponent < ApplicationComponent
+  extend Dry::Initializer
+
+  option :github_action
+
+  def template
+    dl(class: "tw-flex tw-flex-col sm:tw-grid sm:tw-grid-cols-2 tw-items-baseline tw-gap-4 full-width overflow-wrap") do
+      dt(class: "adoption__heading ") { "GitHub Repository" }
+      dd { code { github_action.repository } }
+
+      dt(class: "adoption__heading ") { "Workflow Filename" }
+      dd { code { github_action.workflow_filename } }
+
+      if github_action.environment?
+        dt(class: "adoption__heading") { "Environment" }
+        dd { code { github_action.environment } }
+      end
+    end
+  end
+end

--- a/app/views/mailer/gem_pushed.html.erb
+++ b/app/views/mailer/gem_pushed.html.erb
@@ -15,10 +15,17 @@
         <p>
           Gem: <strong><%= link_to @version.to_title, rubygem_version_url(@version.rubygem.slug, @version.slug), target: "_blank" %></strong>
           <br/>
+          <% if @pushed_by_user.is_a?(User) %>
           Pushed by user:
           <strong>
             <%= link_to @pushed_by_user.handle, profile_url(@pushed_by_user.display_id), target: "_blank" %> <%= mail_to(@pushed_by_user.email) if @pushed_by_user.public_email? %>
           </strong>
+          <% else %>
+          Pushed by trusted publisher:
+          <strong>
+            <%= link_to @pushed_by_user.name, rubygem_trusted_publishers_url(@version.rubygem.slug), target: "_blank" %>
+          </strong>
+          <% end %>
           <br/>
           Pushed at: <strong><%= @version.created_at.to_formatted_s(:rfc822) %></strong>
         </p>

--- a/app/views/mailer/gem_trusted_publisher_added.html.erb
+++ b/app/views/mailer/gem_trusted_publisher_added.html.erb
@@ -1,0 +1,53 @@
+<% @title = t(".title") %>
+<% @sub_title = @rubygem_trusted_publisher.rubygem.name %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          A gem you have push access to has recently added a new trusted publisher.
+        </p>
+        <p>
+          Gem: <strong><%= link_to @rubygem_trusted_publisher.rubygem.name, rubygem_url(@rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
+          <br/>
+          Trusted publisher: <strong><%= link_to @rubygem_trusted_publisher.trusted_publisher.name, rubygem_trusted_publishers_url(@rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
+          <br/>
+          Added by:
+          <strong>
+            <%= link_to @created_by_user.display_handle, profile_url(@created_by_user.display_id), target: "_blank" %> <%= mail_to(@created_by_user.email) if @created_by_user.public_email? %>
+          </strong>
+          <br/>
+          Added at: <strong><%= @rubygem_trusted_publisher.created_at.to_formatted_s(:rfc822) %></strong>
+        </p>
+        <br/>
+        <p>If this new trusted publisher is expected, you do not need to take further action.</p>
+        <p>
+          <strong>Only if this change is unexpected</strong>
+          please take immediate steps to secure your account and gems:
+        </p>
+
+        <%= render "compromised_instructions" do %>
+          <li>Remove the trusted publisher reported in this email</li>
+        <% end %>
+
+        <p>
+          <em>
+            To stop receiving these messages, update your <%= link_to("email notification settings", notifier_url) %>.
+          </em>
+        </p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
+  include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::DistanceOfTimeInWordsToNow
+  include Phlex::Rails::Helpers::LinkTo
+  extend Dry::Initializer
+
+  option :trusted_publishers
+
+  def template
+    title_content
+
+    div(class: "tw-space-y-2 t-body") do
+      p do
+        t(".description_html")
+      end
+
+      p do
+        button_to t(".create"), new_profile_oidc_pending_trusted_publisher_path, class: "form__submit", method: :get
+      end
+
+      header(class: "gems__header push--s") do
+        p(class: "gems__meter l-mb-0") { plain helpers.page_entries_info(trusted_publishers) }
+      end
+
+      div(class: "tw-divide-y") do
+        trusted_publishers.each do |pending_trusted_publisher|
+          trusted_publisher_section(pending_trusted_publisher)
+        end
+      end
+
+      plain helpers.paginate(trusted_publishers)
+    end
+  end
+
+  def title_content
+    self.title_for_header_only = t(".title")
+    content_for :title do
+      h1(class: "t-display page__heading page__heading-small") do
+        plain t(".title")
+      end
+    end
+  end
+
+  def trusted_publisher_section(pending_trusted_publisher)
+    div(class: "tw-border-solid tw-my-4 tw-space-y-2 tw-flex tw-flex-col") do
+      div(class: "sm:tw-flex sm:tw-flex-row tw-gap-4 tw-mt-2") do
+        h3(class: "!tw-mb-0") { pending_trusted_publisher.rubygem_name }
+        button_to(t(".delete"), profile_oidc_pending_trusted_publisher_path(pending_trusted_publisher),
+          method: :delete, class: "form__submit form__submit--small")
+      end
+
+      div(class: "sm:tw-flex sm:tw-flex-row tw-gap-4") do
+        p(class: "!tw-mb-0") { pending_trusted_publisher.trusted_publisher.class.publisher_name }
+        p(class: "!tw-mb-0") do
+          t(".valid_for_html",
+            time_html: helpers.time_tag(pending_trusted_publisher.expires_at,
+distance_of_time_in_words_to_now(pending_trusted_publisher.expires_at)))
+        end
+      end
+
+      render pending_trusted_publisher.trusted_publisher
+    end
+  end
+end

--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class OIDC::PendingTrustedPublishers::NewView < ApplicationView
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::SelectTag
+  include Phlex::Rails::Helpers::OptionsForSelect
+  include Phlex::Rails::Helpers::FormWith
+
+  extend Dry::Initializer
+
+  option :pending_trusted_publisher
+
+  def template
+    self.title = t(".title")
+
+    div(class: "t-body") do
+      form_with(
+        model: pending_trusted_publisher,
+        url: profile_oidc_pending_trusted_publishers_path
+      ) do |f|
+        f.label :rubygem_name, class: "form__label"
+        f.text_field :rubygem_name, class: "form__input", autocomplete: :off
+        p(class: "form__field__instructions") { t("oidc.trusted_publisher.pending.rubygem_name_help_html") }
+
+        f.label :trusted_publisher_type, class: "form__label"
+        f.select :trusted_publisher_type, OIDC::TrustedPublisher.all.map { |type|
+                                            [type.publisher_name, type.polymorphic_name]
+                                          }, {}, class: "form__input form__select"
+
+        render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
+          github_action_form: f
+        )
+        f.submit class: "form__submit"
+      end
+    end
+  end
+end

--- a/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
@@ -1,0 +1,18 @@
+module OIDC::RubygemTrustedPublishers::Concerns::Title
+  extend ActiveSupport::Concern
+
+  included do
+    def title_content
+      self.title_for_header_only = t(".title")
+      content_for :title do
+        h1(class: "t-display page__heading page__heading-small") do
+          plain t(".title")
+
+          i(class: "page__subheading page__subheading--block") do
+            t(".subtitle_owner_html", gem_html: helpers.link_to(rubygem.name, rubygem_path(rubygem.slug), class: "t-link t-underline"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/oidc/rubygem_trusted_publishers/index_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/index_view.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class OIDC::RubygemTrustedPublishers::IndexView < ApplicationView
+  include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ContentFor
+  include OIDC::RubygemTrustedPublishers::Concerns::Title
+  extend Dry::Initializer
+
+  option :rubygem
+  option :trusted_publishers
+
+  def template
+    title_content
+
+    div(class: "tw-space-y-2 t-body") do
+      p do
+        t(".description_html")
+      end
+
+      p do
+        button_to t(".create"), new_rubygem_trusted_publisher_path(rubygem.slug), class: "form__submit", method: :get
+      end
+
+      header(class: "gems__header push--s") do
+        p(class: "gems__meter l-mb-0") { plain helpers.page_entries_info(trusted_publishers) }
+      end
+
+      div(class: "tw-divide-y") do
+        trusted_publishers.each do |rubygem_trusted_publisher|
+          div(class: "tw-border-solid tw-my-4 tw-space-y-4 tw-flex tw-flex-col") do
+            div(class: "sm:tw-flex sm:tw-items-baseline tw-mt-4 tw-gap-2") do
+              h4 { rubygem_trusted_publisher.trusted_publisher.class.publisher_name }
+              button_to(t(".delete"), rubygem_trusted_publisher_path(rubygem.slug, rubygem_trusted_publisher),
+                        method: :delete, class: "form__submit form__submit--small")
+            end
+            render rubygem_trusted_publisher.trusted_publisher
+          end
+        end
+      end
+
+      plain helpers.paginate(trusted_publishers)
+    end
+  end
+end

--- a/app/views/oidc/rubygem_trusted_publishers/new_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/new_view.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
+  include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::FormWith
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::OptionsForSelect
+  include Phlex::Rails::Helpers::SelectTag
+  include OIDC::RubygemTrustedPublishers::Concerns::Title
+
+  extend Dry::Initializer
+
+  option :rubygem_trusted_publisher
+
+  def template
+    title_content
+
+    div(class: "t-body") do
+      form_with(
+        model: rubygem_trusted_publisher,
+        url: rubygem_trusted_publishers_path(rubygem_trusted_publisher.rubygem.slug)
+      ) do |f|
+        f.label :trusted_publisher_type, class: "form__label"
+        f.select :trusted_publisher_type, OIDC::TrustedPublisher.all.map { |type|
+                                            [type.publisher_name, type.polymorphic_name]
+                                          }, {}, class: "form__input form__select"
+
+        render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
+          github_action_form: f
+        )
+        f.submit class: "form__submit"
+      end
+    end
+  end
+
+  delegate :rubygem, to: :rubygem_trusted_publisher
+end

--- a/app/views/oidc/trusted_publisher/github_actions/_github_action.html.erb
+++ b/app/views/oidc/trusted_publisher/github_actions/_github_action.html.erb
@@ -1,0 +1,1 @@
+<%= render OIDC::TrustedPublisher::GitHubAction::TableComponent.new(github_action:) %>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -67,6 +67,7 @@
     <%= report_abuse_link(@rubygem) %>
     <%= reverse_dependencies_link(@rubygem) %>
     <%= ownership_link(@rubygem) if @rubygem.owned_by?(current_user) %>
+    <%= rubygem_trusted_publishers_link(@rubygem) if @rubygem.owned_by?(current_user) %>
     <%= oidc_api_key_role_links(@rubygem) if @rubygem.owned_by?(current_user) %>
     <%= resend_owner_confirmation_link(@rubygem) if @rubygem.unconfirmed_ownership?(current_user) %>
     <%= rubygem_adoptions_link(@rubygem) if @rubygem.owned_by?(current_user) || @rubygem.ownership_requestable?%>

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -32,6 +32,11 @@
     <div class="gem__users">
       <%= link_to_user(latest_version.pusher) %>
     </div>
+  <% elsif latest_version.pusher_api_key&.owner.present? %>
+    <h3 class="t-list__heading"><%= t '.pushed_by' %>:</h3>
+    <div class="gem__users">
+      <%= link_to_pusher(latest_version.pusher_api_key.owner) %>
+    </div>
   <% end %>
 
   <% if latest_version.yanker.present? %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -69,6 +69,13 @@
   <h2><%= link_to t('api_keys.index.api_keys'), profile_api_keys_path %></h2>
 </div>
 
+<% if @user.oidc_pending_trusted_publishers.any? %>
+  <div class="t-body">
+    <h2><%= link_to t('oidc.pending_trusted_publishers.index.title'), profile_oidc_pending_trusted_publishers_path %></h2>
+    <span>Pending trusted publishers allow you to configure trusted publishing before you have pushed the first version of a gem. For more information about how to set up trusted publishing, see <a href="https://guides.rubygems.org/trusted-publishing/pushing-a-new-gem/">the trusted publishing documentation</a>.</span>
+  </div>
+<% end %>
+
 <% if @user.oidc_api_key_roles.any? %>
   <div class="t-body">
     <h2><%= link_to t('oidc.api_key_roles.index.api_key_roles'), profile_oidc_api_key_roles_path %></h2>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/oidc/id_tokens_controller.rb",
-      "line": 17,
+      "line": 16,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => OIDC::IdTokens::IndexView.new(:id_tokens => current_user.oidc_id_tokens.includes(:api_key, :api_key_role, :provider).page(params[:page].to_i).strict_loading), {})",
       "render_path": null,
@@ -30,7 +30,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/oidc/api_key_roles/show.html.erb",
-      "line": 20,
+      "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => current_user.oidc_api_key_roles.includes(:provider).find_by!(:token => params.require(:token)).access_policy, {})",
       "render_path": [
@@ -51,6 +51,29 @@
         "template": "oidc/api_key_roles/show"
       },
       "user_input": "params.require(:token)",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "175ed1fa3ddae92efe03e70a1fea7df153ac9bd53edf617e0c70f420f4ac6781",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/oidc/rubygem_trusted_publishers_controller.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => OIDC::RubygemTrustedPublishers::IndexView.new(:rubygem => Rubygem.find_by_name((params[:rubygem_id] or params[:id])), :trusted_publishers => Rubygem.find_by_name((params[:rubygem_id] or params[:id])).oidc_rubygem_trusted_publishers.includes(:trusted_publisher).page(params[:page].to_i).strict_loading), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OIDC::RubygemTrustedPublishersController",
+        "method": "index"
+      },
+      "user_input": "params[:page]",
       "confidence": "Weak",
       "cwe_id": [
         22
@@ -110,7 +133,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/oidc/providers_controller.rb",
-      "line": 13,
+      "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => OIDC::Providers::IndexView.new(:providers => OIDC::Provider.all.strict_loading.page(params[:page].to_i)), {})",
       "render_path": null,
@@ -129,11 +152,34 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
+      "fingerprint": "c120032e149023b5d6bb95739c27f2d47bfdb64f78b9bccb2e92c7707bd92a78",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/oidc/pending_trusted_publishers_controller.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => OIDC::PendingTrustedPublishers::IndexView.new(:trusted_publishers => current_user.oidc_pending_trusted_publishers.unexpired.includes(:trusted_publisher).order(:rubygem_name, :created_at).page(params[:page].to_i).strict_loading), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OIDC::PendingTrustedPublishersController",
+        "method": "index"
+      },
+      "user_input": "params[:page]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
       "fingerprint": "f23085c93323ec923578bed895c153b25b5bc2e9b64687c05ce426da16e6c755",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/oidc/api_key_roles/show.html.erb",
-      "line": 16,
+      "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => current_user.oidc_api_key_roles.includes(:provider).find_by!(:token => params.require(:token)).api_key_permissions, {})",
       "render_path": [
@@ -167,7 +213,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/oidc/providers_controller.rb",
-      "line": 17,
+      "line": 16,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => OIDC::Providers::ShowView.new(:provider => OIDC::Provider.find(params.require(:id))), {})",
       "render_path": null,
@@ -184,6 +230,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-10-17 10:36:55 -0700",
+  "updated": "2023-11-24 13:29:48 -0600",
   "brakeman_version": "6.0.1"
 }

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -9,7 +9,7 @@ Datadog.configure do |c|
 
   # Enabling datadog functionality
 
-  enabled = (Rails.env.production? || Rails.env.staging?) && ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
+  enabled = !(Rails.env.development? || Rails.env.test?) && ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
   c.runtime_metrics.enabled = enabled
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -57,6 +57,10 @@ de:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn:
@@ -73,6 +77,14 @@ de:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user:
   activemodel:
@@ -317,6 +329,8 @@ de:
       global_html:
       gem_text:
       gem_html:
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title:
@@ -580,6 +594,7 @@ de:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace:
     dependencies:
@@ -783,6 +798,42 @@ de:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -796,3 +847,5 @@ de:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,10 @@ en:
         api_key_role: API Key Role
       oidc/api_key_role:
         api_key_permissions: API Key Permissions
+      oidc/trusted_publisher/github_action:
+        repository_owner_id: GitHub Repository Owner ID
+      oidc/pending_trusted_publisher:
+        rubygem_name: RubyGem name
     errors:
       messages:
         unpwn: has previously appeared in a data breach and should not be used
@@ -83,6 +87,14 @@ en:
               taken: "%{value} already exists"
             full_name:
               taken: "%{value} already exists"
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken: "has already been configured with this trusted publisher"
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable: "is already in use"
     models:
       user: User
   activemodel:
@@ -331,6 +343,8 @@ en:
       global_html: This webhook was previously called when <em>any</em> gem was pushed.
       gem_text: This webhook was previously called when %{gem} was pushed.
       gem_html: This webhook was previously called when <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> was pushed.
+    gem_trusted_publisher_added:
+      title: TRUSTED PUBLISHER ADDED
   news:
     show:
       title: New Releases — All Gems
@@ -580,6 +594,7 @@ en:
           api_key_role:
             name: "OIDC: %{name}"
             new: "OIDC: Create"
+        trusted_publishers: Trusted publishers
     reserved:
       reserved_namespace: This namespace is reserved by rubygems.org.
     dependencies:
@@ -784,6 +799,49 @@ en:
         title: "OIDC ID Tokens"
       show:
         title: "OIDC ID Token"
+    rubygem_trusted_publishers:
+      index:
+        title: Trusted Publishers
+        subtitle_owner_html: "Trusted publishers for %{gem_html}"
+        delete: Delete
+        create: Create
+        description_html: |
+          Trusted publishers allow you to push gems from CI without storing any long-lived sensitive credentials.
+          For more information about how to set up trusted publishing, see the <a href="https://guides.rubygems.org/trusted-publishing/adding-a-publisher/" class="t-link">trusted publishing documentation</a>.
+      destroy:
+        success: "Trusted Publisher deleted"
+      create:
+        success: "Trusted Publisher created"
+      new:
+        title: "New Trusted Publisher"
+        subtitle_owner_html: "Add a trusted publisher for %{gem_html}"
+    pending_trusted_publishers:
+      index:
+        title: Pending Trusted Publishers
+        valid_for_html: "Valid for %{time_html}"
+        delete: Delete
+        create: Create
+        description_html: |
+          Pending trusted publishers allow you to configure trusted publishing before you have pushed the first version of a gem.
+          For more information about how to set up trusted publishing, see the <a href="https://guides.rubygems.org/trusted-publishing/pushing-a-new-gem/" class="t-link">trusted publishing documentation</a>.
+      destroy:
+        success: "Pending Trusted Publisher deleted"
+      create:
+        success: "Pending Trusted Publisher created"
+      new:
+        title: "New Pending Trusted Publisher"
+    trusted_publisher:
+      unsupported_type: "Unsupported trusted publisher type"
+      github_actions:
+        repository_owner_help_html: "The GitHub organization name or GitHub username that owns the repository"
+        repository_name_help_html: "The name of the GitHub repository that contains the publishing workflow"
+        workflow_filename_help_html: "The filename of the publishing workflow.<br>This file should exist in the <code>.github/workflows/</code> directory in the repository configured above."
+        environment_help_html: |
+          The name of the <a href="https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment">GitHub Actions environment</a> that the above workflow uses for publishing.<br>
+          This should be configured under the repository's settings.<br>
+          While not required, a dedicated publishing environment is strongly encouraged, especially if your repository has maintainers with commit access who shouldn't have RubyGems.org gem push access.
+      pending:
+        rubygem_name_help_html: "The gem (on RubyGems.org) that will be created when this publisher is used"
   duration:
     minutes:
       other: "%{count} minutes"
@@ -797,3 +855,5 @@ en:
     seconds:
       other: "%{count} seconds"
       one: "1 second"
+  form:
+    optional: optional

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -68,10 +68,16 @@ es:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
-        unpwn: ha aparecido con anterioridad en una filtración de datos y no se debería usar
-        blocked: "El dominio '%{domain}' ha sido bloqueado por spam. Por favor utiliza un email personal válido."
+        unpwn: ha aparecido con anterioridad en una filtración de datos y no se debería
+          usar
+        blocked: El dominio '%{domain}' ha sido bloqueado por spam. Por favor utiliza
+          un email personal válido.
       models:
         ownership:
           attributes:
@@ -84,6 +90,14 @@ es:
               taken: "%{value} ya existe"
             full_name:
               taken: "%{value} ya existe"
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user: Usuario
   activemodel:
@@ -96,15 +110,16 @@ es:
         oidc/api_key_permissions:
           attributes:
             valid_for:
-              inclusion: "%{value} segundos debe estar entre 5 minutos (300 segundos) y 1 día (86.400 segundos)"
+              inclusion: "%{value} segundos debe estar entre 5 minutos (300 segundos)
+                y 1 día (86.400 segundos)"
             gems:
-              too_long: "como mucho puede incluir una gema"
+              too_long: como mucho puede incluir una gema
   api_keys:
     create:
-      success: "Nueva clave de API creada"
+      success: Nueva clave de API creada
       invalid_gem: La gema seleccionada no se puede incluir en esta clave
     destroy:
-      success: "Clave de API eliminada con éxito: %{name}"
+      success: 'Clave de API eliminada con éxito: %{name}'
     index:
       api_keys: Claves de API
       name: Nombre
@@ -125,28 +140,34 @@ es:
       access_webhooks: Acceso a webhooks
       show_dashboard: Mostrar dashboard
       reset: Restablecer
-      save_key: "Ten en cuenta que no se volverá a mostrar la clave de API. Nueva clave de API:"
+      save_key: 'Ten en cuenta que no se volverá a mostrar la clave de API. Nueva
+        clave de API:'
       mfa: AMF
     new:
       new_api_key: Nueva clave de API
       multifactor_auth: Autenticación multifactor
       enable_mfa: Activar AMF
       rubygem_scope: Ámbito de aplicación
-      rubygem_scope_info: Este alcance restringe los comandos de añadir/eliminar gemas y añadir/eliminar propietarios a una gema específica.
+      rubygem_scope_info: Este alcance restringe los comandos de añadir/eliminar gemas
+        y añadir/eliminar propietarios a una gema específica.
     reset:
-      success: "Borradas todas las claves de API"
+      success: Borradas todas las claves de API
     update:
-      success: "Clave de API actualizada con éxito"
-      invalid_gem: La gema seleccionada no se puede incluir en el alcance de esta clave
+      success: Clave de API actualizada con éxito
+      invalid_gem: La gema seleccionada no se puede incluir en el alcance de esta
+        clave
     edit:
       edit_api_key: Editar clave de API
       multifactor_auth: Autenticación de múltiples factores
       enable_mfa: Activar AMF
       rubygem_scope: Ámbito de aplicación
-      rubygem_scope_info: Este alcance restringe los comandos de añadir/eliminar gemas y añadir/eliminar propietarios a una gema específica.
-      invalid_key: No se puede editar una clave de API inválida. Por favor bórrala y crea una nueva.
+      rubygem_scope_info: Este alcance restringe los comandos de añadir/eliminar gemas
+        y añadir/eliminar propietarios a una gema específica.
+      invalid_key: No se puede editar una clave de API inválida. Por favor bórrala
+        y crea una nueva.
     all_gems: Todas las gemas
-    gem_ownership_removed: Se ha eliminado la propiedad de %{rubygem_name} tras haber sido añadida a esta clave.
+    gem_ownership_removed: Se ha eliminado la propiedad de %{rubygem_name} tras haber
+      sido añadida a esta clave.
   clearance_mailer:
     change_password:
       title: CAMBIAR CONTRASEÑA
@@ -212,7 +233,7 @@ es:
         uptime: Uptime
         verified_by: Verificado por
         secured_by: Protegido por
-        looking_for_maintainers: "Se buscan mantenedores/as"
+        looking_for_maintainers: Se buscan mantenedores/as
       header:
         dashboard: Dashboard
         settings: Configuración
@@ -225,18 +246,21 @@ es:
   mailer:
     confirm_your_email: Por favor confirma tu dirección de correo con el enlace enviado.
     confirmation_subject: Por favor confirma tu dirección de correo con %{host}
-    link_expiration_explanation_html: Por favor ten en cuenta que este enlace es válido solo durante 3 horas. Puedes solicitar un enlace actualizado usando la página de <a href='https://rubygems.org/email_confirmations/new'>reenvío del correo de confirmación</a>.
+    link_expiration_explanation_html: Por favor ten en cuenta que este enlace es válido
+      solo durante 3 horas. Puedes solicitar un enlace actualizado usando la página
+      de <a href='https://rubygems.org/email_confirmations/new'>reenvío del correo
+      de confirmación</a>.
     email_confirmation:
       title: CONFIRMACIÓN DE EMAIL
       subtitle: "¡Último paso!"
       confirmation_link: Confirma la dirección de correo
-      welcome_message: Bienvenidos a %{host}! Haz clic en el enlace de abajo
-        para verificar tu dirección de correo.
+      welcome_message: Bienvenidos a %{host}! Haz clic en el enlace de abajo para
+        verificar tu dirección de correo.
     email_reset:
       title: CAMBIO DE EMAIL
       subtitle: "¡Hola %{handle}!"
-      visit_link_instructions: Cambiaste tu dirección de correo en %{host}. Por
-        favor visita el siguiente enlace para reactivar tu cuenta.
+      visit_link_instructions: Cambiaste tu dirección de correo en %{host}. Por favor
+        visita el siguiente enlace para reactivar tu cuenta.
     deletion_complete:
       title: ELIMINACIÓN COMPLETADA
       subtitle: "¡Adiós!"
@@ -247,15 +271,15 @@ es:
       title: ELIMINACIÓN FALLIDA
       subtitle: "¡Lo sentimos!"
       subject: Tu solicitud para eliminar tu cuenta de %{host} ha fallado
-      body_html: Has solicitado eliminar tu cuenta de %{host}. Lamentablemente,
-        no hemos podido procesar tu pedido. Por favor inténtalo de nuevo más adelante
+      body_html: Has solicitado eliminar tu cuenta de %{host}. Lamentablemente, no
+        hemos podido procesar tu pedido. Por favor inténtalo de nuevo más adelante
         o %{contact} si el problema persiste.
     notifiers_changed:
       subject: Cambiaste la configuración de tus notificaciones por email de %{host}
       title: NOTIFICACIONES POR EMAIL
       subtitle: "¡Hola %{handle}!"
-      "on": "ON"
-      off_html: <b>OFF</b>
+      'on': 'ON'
+      off_html: "<b>OFF</b>"
     gem_pushed:
       subject: Gema %{gem} subida a %{host}
       title: GEMA SUBIDA
@@ -263,7 +287,7 @@ es:
       subject: Gema %{gem} eliminada de %{host}
       title: GEMA ELIMINADA
     reset_api_key:
-      subject: "Clave de API de %{host} restablecida"
+      subject: Clave de API de %{host} restablecida
       title: CLAVE DE API RESTABLECIDA
       subtitle: "¡Hola %{handle}!"
     webauthn_credential_created:
@@ -289,29 +313,44 @@ es:
       subject: Por favor confirma la propiedad de la gema %{gem} en %{host}
       title: CONFIMACIÓN DE PROPIEDAD
       subtitle: "¡Hola %{handle}!"
-      body_text: Has sido añadido/a como propietario/a de la gema %{gem} por %{authorizer}. Por favor visita el enlace siguiente para confirmarlo.
-      body_html: Has sido añadido/a como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> por <strong>%{authorizer}</strong>. Por favor visita el enlace siguiente para confirmarlo.
-      link_expiration_explanation_html: Ten en cuenta que este enlace es válido solo durante %{expiry_hours}. Puedes reenviar el correo de confirmación desde la página de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> una vez autenticado.
+      body_text: Has sido añadido/a como propietario/a de la gema %{gem} por %{authorizer}.
+        Por favor visita el enlace siguiente para confirmarlo.
+      body_html: Has sido añadido/a como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>
+        por <strong>%{authorizer}</strong>. Por favor visita el enlace siguiente para
+        confirmarlo.
+      link_expiration_explanation_html: Ten en cuenta que este enlace es válido solo
+        durante %{expiry_hours}. Puedes reenviar el correo de confirmación desde la
+        página de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>
+        una vez autenticado.
     owner_added:
       subject_self: Has sido añadido/a como propietario/a de la gema %{gem}
-      subject_others: El usuario %{owner_handle} ha sido añadido/a como propietario/a de la gema %{gem}
+      subject_others: El usuario %{owner_handle} ha sido añadido/a como propietario/a
+        de la gema %{gem}
       title: PROPIETARIO AÑADIDO
       subtitle: "¡Hola %{handle}!"
-      body_self_html: <b>Has</b> sido añadido/a como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> en %{host}.
-      body_others_html: El usuario <b>%{owner_handle}</b> ha sido añadido/a como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> por <b>%{authorizer}</b>. Recibes esta notificación por ser propietario de %{gem}.
+      body_self_html: <b>Has</b> sido añadido/a como propietario/a de la gema <strong><a
+        href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> en %{host}.
+      body_others_html: El usuario <b>%{owner_handle}</b> ha sido añadido/a como propietario/a
+        de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>
+        por <b>%{authorizer}</b>. Recibes esta notificación por ser propietario de
+        %{gem}.
     owner_removed:
       subject: Has sido eliminado como propietario/a de la gema %{gem}
       title: PROPIETARIO ELIMINADO
       subtitle: "¡Hola %{handle}!"
-      body_html: Has sido eliminado como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> en %{host} por <b>%{remover}</b>.
+      body_html: Has sido eliminado como propietario/a de la gema <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>
+        en %{host} por <b>%{remover}</b>.
     ownerhip_request_closed:
       title: CANDIDATURA A PROPIETARIO
       subtitle: "¡Hola %{handle}!"
-      body_html: Gracias por proponerte como propietario para <strong>%{gem}</strong>. Lamentamos informarte de que el dueño de la gema ha cerrado tu solicitud.
+      body_html: Gracias por proponerte como propietario para <strong>%{gem}</strong>.
+        Lamentamos informarte de que el dueño de la gema ha cerrado tu solicitud.
     ownerhip_request_approved:
-      body_html: ¡Enhorabuena! Tu candidatura a propietario de <strong>%{gem}</strong> ha sido aprobada. Se te ha añadido a la lista de propietarios de la gema.
+      body_html: "¡Enhorabuena! Tu candidatura a propietario de <strong>%{gem}</strong>
+        ha sido aprobada. Se te ha añadido a la lista de propietarios de la gema."
     new_opwnership_requests:
-      body_html: Hay <em>%{count}</em> nuevas candidaturas a propietario para <strong>%{gem}</strong>. Por favor haz click en el botón siguiente para ver todas las candidaturas.
+      body_html: Hay <em>%{count}</em> nuevas candidaturas a propietario para <strong>%{gem}</strong>.
+        Por favor haz click en el botón siguiente para ver todas las candidaturas.
       button: CANDIDATURAS A PROPIETARIO
       disable_notifications: Para dejar de recibir estos mensajes actualiza tus
       owners_page: PROPIETARIOS
@@ -319,10 +358,13 @@ es:
       title: WEBHOOK ELIMINADO
       subject: Se ha borrado tu webhook en %{host}
       subtitle: "¡Hola %{handle}!"
-      body_text: Tu webhook que enviaba peticiones POST a %{url} ha sido eliminado tras %{failures} fallos.
-      body_html: Tu webhook que enviaba peticiones <code>POST</code> a <a href="%{url}"><code>%{url}</code></a> ha sido eliminado tras %{failures} fallos
+      body_text: Tu webhook que enviaba peticiones POST a %{url} ha sido eliminado
+        tras %{failures} fallos.
+      body_html: Tu webhook que enviaba peticiones <code>POST</code> a <a href="%{url}"><code>%{url}</code></a>
+        ha sido eliminado tras %{failures} fallos
       global_text: Este webhook se ejecutaba antes cuando se subía cualquier gema.
-      global_html: Este webhook se ejecutaba antes cuando se subía <em>cualquier</em> gema.
+      global_html: Este webhook se ejecutaba antes cuando se subía <em>cualquier</em>
+        gema.
       gem_text: Este webhook se ejecutaba antes cuando se subía %{gem}.
       gem_html: Este webhook se ejecutaba antes cuando se subía <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>.
     web_hook_disabled:
@@ -338,9 +380,12 @@ es:
         <p>La última que se ejecutó con éxito fue en <code>%{last_success}</code> y desde entonces ha fallado %{failures_since_last_success} veces.</p>
         <p>Puedes borrar este webhook usando el comando <code>%{delete_command}</code>.</p>
       global_text: Este webhook se ejecutaba antes cuando se subía cualquier gema.
-      global_html: Este webhook se ejecutaba antes cuando se subía <em>cualquier</em> gema.
+      global_html: Este webhook se ejecutaba antes cuando se subía <em>cualquier</em>
+        gema.
       gem_text: Este webhook se ejecutaba antes cuando se subía %{gem}.
       gem_html: Este webhook se ejecutaba antes cuando se subía <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>.
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: Nuevos lanzamientos — Todas las Gemas
@@ -351,11 +396,12 @@ es:
   pages:
     about:
       contributors_amount: "%{count} Rubystas"
-      downloads_amount: "millones de descargas de gemas"
-      checkout_code: "por favor echa un ojo al código"
-      mit_licensed: "MIT"
+      downloads_amount: millones de descargas de gemas
+      checkout_code: por favor echa un ojo al código
+      mit_licensed: MIT
       logo_header: "¿Buscas nuestro logo?"
-      logo_details: Usa el botón de descarga y obtendrás tres archivos .PNG y un .SVG del logo de RubyGems.
+      logo_details: Usa el botón de descarga y obtendrás tres archivos .PNG y un .SVG
+        del logo de RubyGems.
       founding_html: El proyecto comenzó en abril del 2009 por %{founder}, y desde
         entonces ha crecido para incluir las contribuciones de %{contributors} y %{downloads}.
         A partir de RubyGems 1.3.6 el sitio se renombró de Gemcutter a %{title} para
@@ -398,26 +444,41 @@ es:
     new:
       submit: Restablecer contraseña
       title: Cambiar tu contraseña
-      will_email_notice: Te enviaremos el enlace para cambiar tu contraseña por correo electrónico.
+      will_email_notice: Te enviaremos el enlace para cambiar tu contraseña por correo
+        electrónico.
   multifactor_auths:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired: Ha expirado tu sesión en la página de acceso.
-    require_totp_disabled: La autenticación de múltiples factores basada en OTP ya está activa. Para reconfigurarla debes primero eliminarla.
-    require_mfa_enabled: No se ha activado la autenticación de múltiples factores. Primero tienes que activarla.
-    require_totp_enabled: No tienes aplicación de autenticación activa. Debes activarla primero.
-    require_webauthn_enabled: No tienes ningún dispositivo de seguridad activado. Primero debes asociar un dispositivo a tu cuenta.
-    setup_required_html: Por la seguridad de tu cuenta y de tus gemas se te requiere activar la autenticación de múltiples factores.
-      Lee por favor el <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">artículo en nuestro blog</a> para saber más detalles.
-    setup_recommended: Por la seguridad de tu cuenta y de tus gemas te animamos a configurar la autenticación de múltiples factores. En el futuro será obligatorio tener AMF activada en tu cuenta.
-    strong_mfa_level_required_html: Por la seguridad de tu cuenta y de tus gemas es necesario que cambies el nivel de AMF a "Interfaz de usuario y firma de gemas" o "Interfaz de usuario y API".
-      Lee por favor el <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">artículo en nuestro blog</a> para saber más detalles.
-    strong_mfa_level_recommended: Por la seguridad de tu cuenta y de tus gemas te recomendamos que cambies el nivel de AMF a "Interfaz de usuario y firma de gemas" o "Interfaz de usuario y API". En el futuro será obligatorio tener AMF configurada en alguno de esos niveles.
-    setup_webauthn_html: 🎉 ¡Ahora soportamos dispositivos de seguridad! Aumenta la seguridad de tu cuenta <a href="/settings/edit#security-device">configurando</a> un nuevo dispositivo.
+    require_totp_disabled: La autenticación de múltiples factores basada en OTP ya
+      está activa. Para reconfigurarla debes primero eliminarla.
+    require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
+      Primero tienes que activarla.
+    require_totp_enabled: No tienes aplicación de autenticación activa. Debes activarla
+      primero.
+    require_webauthn_enabled: No tienes ningún dispositivo de seguridad activado.
+      Primero debes asociar un dispositivo a tu cuenta.
+    setup_required_html: Por la seguridad de tu cuenta y de tus gemas se te requiere
+      activar la autenticación de múltiples factores. Lee por favor el <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">artículo
+      en nuestro blog</a> para saber más detalles.
+    setup_recommended: Por la seguridad de tu cuenta y de tus gemas te animamos a
+      configurar la autenticación de múltiples factores. En el futuro será obligatorio
+      tener AMF activada en tu cuenta.
+    strong_mfa_level_required_html: Por la seguridad de tu cuenta y de tus gemas es
+      necesario que cambies el nivel de AMF a "Interfaz de usuario y firma de gemas"
+      o "Interfaz de usuario y API". Lee por favor el <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">artículo
+      en nuestro blog</a> para saber más detalles.
+    strong_mfa_level_recommended: Por la seguridad de tu cuenta y de tus gemas te
+      recomendamos que cambies el nivel de AMF a "Interfaz de usuario y firma de gemas"
+      o "Interfaz de usuario y API". En el futuro será obligatorio tener AMF configurada
+      en alguno de esos niveles.
+    setup_webauthn_html: "\U0001F389 ¡Ahora soportamos dispositivos de seguridad!
+      Aumenta la seguridad de tu cuenta <a href=\"/settings/edit#security-device\">configurando</a>
+      un nuevo dispositivo."
     new:
       title: Activando autenticación de múltiples factores
       scan_prompt: Por favor escanea el código QR con tu aplicación de autenticación.
-        Si no puedes escanear el código, agrega manualmente la información siguiente a tu
-        aplicación.
+        Si no puedes escanear el código, agrega manualmente la información siguiente
+        a tu aplicación.
       otp_prompt: Escribe el código de la aplicación de autenticación para continuar.
       confirm: He mantenido seguros mis códigos de recuperación.
       enable: Activar
@@ -425,8 +486,8 @@ es:
       key: 'Clave: %{key}'
       time_based: 'Basado en tiempo: Sí'
     create:
-      qrcode_expired: El código QR y la clave han vencido. Por favor intenta otra vez
-        registrar un nuevo dispositivo.
+      qrcode_expired: El código QR y la clave han vencido. Por favor intenta otra
+        vez registrar un nuevo dispositivo.
       success: Has activado con éxito la autenticación de múltiples factores.
     recovery:
       copied: "[ copiado ]"
@@ -434,7 +495,10 @@ es:
       title: Códigos de recuperación
       copy: "[ copiar ]"
       saved: Declaro haber guardado mis códigos de recuperación.
-      note_html: "Por favor <strong class='recovery__bold'>copia y guarda</strong> estos códigos de recuperación. Puedes usar estos códigos para acceder y restablecer tu autenticación de múltiples factores si pierdes tu dispositivo. Cada código se puede usar una sola vez."
+      note_html: Por favor <strong class='recovery__bold'>copia y guarda</strong>
+        estos códigos de recuperación. Puedes usar estos códigos para acceder y restablecer
+        tu autenticación de múltiples factores si pierdes tu dispositivo. Cada código
+        se puede usar una sola vez.
       already_generated: Ya deberías haber guardado tus códigos de recuperación.
     destroy:
       success: Has desactivado exitosamente la autenticación de múltiples factores.
@@ -442,22 +506,26 @@ es:
       invalid_level: Nivel de AMF inválido.
       success: Has actualizado exitosamente la autenticación de múltiples factores.
     prompt:
-      webauthn_credential_note: Autentícate con un dispositivo de seguridad como Touch Id, YubiKey, etc.
+      webauthn_credential_note: Autentícate con un dispositivo de seguridad como Touch
+        Id, YubiKey, etc.
       sign_in_with_webauthn_credential: Autenticar con dispositivo de seguridad
       otp_code: Código OTP
       otp_or_recovery: OTP o código de recuperación
       recovery_code: Código de recuperación
-      recovery_code_html: 'Puedes utilizar un <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">código de recuperación</a> válido si has perdido el acceso a tu dispositivo de seguridad o de autenticación de múltiples factores.'
+      recovery_code_html: Puedes utilizar un <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa",
+        class="t-link">código de recuperación</a> válido si has perdido el acceso
+        a tu dispositivo de seguridad o de autenticación de múltiples factores.
       security_device: Dispositivo de seguridad
       verify_code: Verificar código
   notifiers:
     update:
-      success: Has actualizado exitosamente la configuración de tus notificaciones por correo.
+      success: Has actualizado exitosamente la configuración de tus notificaciones
+        por correo.
     show:
-      info:
-        Para ayudar a detectar cambios no autorizados en gemas o en propietarios, te enviamos un correo electrónico
-        cada vez que se sube o se elimina una versión de cualquiera de tus gemas o se le añade un nuevo propietario.
-        Recibiendo y leyendo esos mensajes ayudas al ecosistema de Ruby.
+      info: Para ayudar a detectar cambios no autorizados en gemas o en propietarios,
+        te enviamos un correo electrónico cada vez que se sube o se elimina una versión
+        de cualquiera de tus gemas o se le añade un nuevo propietario. Recibiendo
+        y leyendo esos mensajes ayudas al ecosistema de Ruby.
       'on': Activado
       'off': Desactivado
       recommended: recomendado
@@ -467,7 +535,8 @@ es:
       owner_request_heading: Notificaciones de solicitud de propietarios
       push_heading: Notificaciones Push
   webauthn_verifications:
-    expired_or_already_used: El token del enlace utilizado ha expirado o ya ha sido utilizado.
+    expired_or_already_used: El token del enlace utilizado ha expirado o ya ha sido
+      utilizado.
     no_port: No se especifica el puerto. Por favor inténtalo de nuevo.
     pending: La autenticación del dispositivo de seguridad está pendiente todavía.
     prompt:
@@ -483,11 +552,12 @@ es:
       close_browser: Por favor cierra este navegador e inténtalo de nuevo.
   owners:
     confirm:
-      confirmed_email: "Has sido añadido/a como propietario de la gema %{gem}"
-      token_expired: El token de confirmación ha expirado. Por favor intenta reenviar el token desde la página de la gema.
+      confirmed_email: Has sido añadido/a como propietario de la gema %{gem}
+      token_expired: El token de confirmación ha expirado. Por favor intenta reenviar
+        el token desde la página de la gema.
     index:
       add_owner: AÑADIR PROPIETARIO
-      name: "PROPIETARIO/A"
+      name: PROPIETARIO/A
       mfa: ESTADO DE AMF
       status: ESTADO
       confirmed_at: CONFIRMADO
@@ -498,21 +568,25 @@ es:
       info: añadir o eliminar propietarios
       confirmed: Confirmado
       pending: Pendiente
-      confirm_remove: ¿Seguro que quieres eliminar a este usuario de los propietarios?
+      confirm_remove: "¿Seguro que quieres eliminar a este usuario de los propietarios?"
     resend_confirmation:
       resent_notice: Se ha reenviado un mensaje de confirmación a tu correo electrónico
     create:
-      success_notice: "Se ha añadido a %{handle} como propietario sin confirmar. Su acceso como propietario se activará cuando haga click en el mensaje de confirmación que se le ha enviado a su correo"
+      success_notice: Se ha añadido a %{handle} como propietario sin confirmar. Su
+        acceso como propietario se activará cuando haga click en el mensaje de confirmación
+        que se le ha enviado a su correo
     destroy:
       removed_notice: "%{owner_name} eliminado con éxito de la lista de propietarios"
       failed_notice: No se puede eliminar al único propietario de una gema
-    mfa_required: La gema tiene activado el requerimiento de AMF, configura AMF en tu cuenta por favor.
+    mfa_required: La gema tiene activado el requerimiento de AMF, configura AMF en
+      tu cuenta por favor.
   settings:
     edit:
       title: Editar configuración
       webauthn_credentials: Dispositivo de seguridad
       no_webauthn_credentials: No tienes dispositivos de seguridad
-      webauthn_credential_note: Un dispositivo de seguridad puede ser cualquier dispositivo que cumpla el estándar FIDO2 como las llaves biométrica y de seguridad.
+      webauthn_credential_note: Un dispositivo de seguridad puede ser cualquier dispositivo
+        que cumpla el estándar FIDO2 como las llaves biométrica y de seguridad.
       otp_code: Código OTP o código de recuperación
       api_access:
         confirm_reset: "¿Seguro? Este cambio no puede deshacerse."
@@ -529,10 +603,16 @@ es:
       mfa:
         multifactor_auth: Autenticación de múltiples factores
         otp: Aplicación de autenticación
-        disabled_html:  No has activado todavía la autenticación de múltiples factores basada en OTP. Por favor lee la <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía sobre AMF</a> para informarte sobre los distintos niveles de AMF.
+        disabled_html: No has activado todavía la autenticación de múltiples factores
+          basada en OTP. Por favor lee la <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía
+          sobre AMF</a> para informarte sobre los distintos niveles de AMF.
         go_settings: Registrar un nuevo dispositivo
-        level_html: Has activado la autenticación de múltiples factores. Pincha en "Actualizar" para modificar el nivel de AMF. Por favor lee la <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía sobre AMF</a> para informarte sobre los distintos niveles de AMF.
-        enabled_note: Has activado la autenticación de múltiples factores. Para desactivarla usa tu OTP o uno de tus códigos de recuperación activos.
+        level_html: Has activado la autenticación de múltiples factores. Pincha en
+          "Actualizar" para modificar el nivel de AMF. Por favor lee la <a target="_blank"
+          href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía
+          sobre AMF</a> para informarte sobre los distintos niveles de AMF.
+        enabled_note: Has activado la autenticación de múltiples factores. Para desactivarla
+          usa tu OTP o uno de tus códigos de recuperación activos.
         update: Actualizar
         disable: Desactivar
         enabled: Activado
@@ -545,17 +625,25 @@ es:
           ui_and_gem_signin: Interfaz de Usuario y firma de gemas
   profiles:
     adoptions:
-      no_ownership_calls: No has creado llamadas a ser propietario para ninguna de tus gemas
+      no_ownership_calls: No has creado llamadas a ser propietario para ninguna de
+        tus gemas
       no_ownership_requests: No has creado ninguna petición para ser propietario
       title: Adopción
-      subtitle_html: Pide nuevos responsables de mantenimiento o solicita propietarios <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer más)</a>
+      subtitle_html: Pide nuevos responsables de mantenimiento o solicita propietarios
+        <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer
+        más)</a>
     edit:
       change_avatar: Cambiar avatar
-      disabled_avatar_html: Se usa un avatar por defecto debido a la configuración de privacidad del email. Para usar un <a href='https://gravatar.com'>Gravatar</a> personalizado activa la opción 'Mostrar correo electrónico en perfil público'. Ten en cuenta que esto hará público tu correo."
-      email_awaiting_confirmation: Por favor confirma tu nueva dirección de correo %{unconfirmed_email}
+      disabled_avatar_html: Se usa un avatar por defecto debido a la configuración
+        de privacidad del email. Para usar un <a href='https://gravatar.com'>Gravatar</a>
+        personalizado activa la opción 'Mostrar correo electrónico en perfil público'.
+        Ten en cuenta que esto hará público tu correo."
+      email_awaiting_confirmation: Por favor confirma tu nueva dirección de correo
+        %{unconfirmed_email}
       enter_password: Por favor introduce tu contraseña
       optional_full_name: Opcional. Será mostrado en tu perfil público
-      optional_twitter_username: Usuario de X opcional. Será mostrado en tu perfil público
+      optional_twitter_username: Usuario de X opcional. Será mostrado en tu perfil
+        público
       title: Editar perfil
       delete:
         delete: Eliminar
@@ -614,17 +702,21 @@ es:
         ownership: Propietarios
         oidc:
           api_key_role:
-            name: "OIDC: %{name}"
-            new: "OIDC: Crear"
+            name: 'OIDC: %{name}'
+            new: 'OIDC: Crear'
+        trusted_publishers:
     reserved:
       reserved_namespace: Este namespace está reservado por rubygems.org.
     dependencies:
       header: dependencias de %{title}
     gem_members:
       authors_header: Autores
-      self_no_mfa_warning_html: Considera por favor <a href="/settings/edit">activar la autenticación de múltiples factores (AMF)</a> para mantener tu cuenta segura.
-      not_using_mfa_warning_show: "* Algunos propietarios no están usando AMF. Haga click para ver la lista completa."
-      not_using_mfa_warning_hide: "* Los siguientes propietarios no están usando AMF. Haga click para ocultar."
+      self_no_mfa_warning_html: Considera por favor <a href="/settings/edit">activar
+        la autenticación de múltiples factores (AMF)</a> para mantener tu cuenta segura.
+      not_using_mfa_warning_show: "* Algunos propietarios no están usando AMF. Haga
+        click para ver la lista completa."
+      not_using_mfa_warning_hide: "* Los siguientes propietarios no están usando AMF.
+        Haga click para ocultar."
       owners_header: Propietarios
       pushed_by: Subida por
       using_mfa_info: "* Todos los propietarios están usando AMF."
@@ -633,7 +725,7 @@ es:
       signature_period: Periodo de validez de la firma
       expired: Expirado
     version_navigation:
-      previous_version: ← Versión anterior
+      previous_version: "← Versión anterior"
       next_version: Siguiente versión →
     index:
       downloads: Descargas
@@ -671,7 +763,7 @@ es:
   reverse_dependencies:
     index:
       title: Dependencias inversas para %{name}
-      subtitle: "La última versión de las siguientes gemas requieren %{name}"
+      subtitle: La última versión de las siguientes gemas requieren %{name}
       no_reverse_dependencies: Esta gema no tiene dependencias inversas
     search:
       search_reverse_dependencies_html: Buscar dependencias inversas&hellip;
@@ -699,7 +791,8 @@ es:
       confirm: Confirmar
       notice: Por favor confirma tu contraseña para continuar.
     create:
-      account_blocked: Tu cuenta ha sido bloqueada por el equipo de rubygems. Para recuperar tu cuenta envía un mensaje a support@rubygems.org, por favor.
+      account_blocked: Tu cuenta ha sido bloqueada por el equipo de rubygems. Para
+        recuperar tu cuenta envía un mensaje a support@rubygems.org, por favor.
   stats:
     index:
       title: Estadísticas
@@ -709,7 +802,8 @@ es:
       total_users: Usuarios totales
   users:
     create:
-      email_sent: Se ha enviado un correo de confirmación a tu dirección de correo electrónico.
+      email_sent: Se ha enviado un correo de confirmación a tu dirección de correo
+        electrónico.
     new:
       have_account: "¿Ya tienes una cuenta?"
   versions:
@@ -717,16 +811,23 @@ es:
       not_hosted_notice: Esta gema no está alojada actualmente en RubyGems.org.
       title: Todas las versiones de %{name}
       versions_since: "%{count} versiones desde %{since}"
-      imported_gem_version_notice: "Esta versión de la gema se importó a RubyGems.org el %{import_date}. La fecha que se muestra fue especificada por el autor en el archivo gemspec."
+      imported_gem_version_notice: Esta versión de la gema se importó a RubyGems.org
+        el %{import_date}. La fecha que se muestra fue especificada por el autor en
+        el archivo gemspec.
     version:
       yanked: borrada
   adoptions:
     index:
       title: Adopciones
-      subtitle_owner_html: Solicita nuevos responsables de mantenimiento para %{gem} <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer más)</a>
-      subtitle_user_html: Solicita ser propietario de %{gem} <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer más)</a>
+      subtitle_owner_html: Solicita nuevos responsables de mantenimiento para %{gem}
+        <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer
+        más)</a>
+      subtitle_user_html: Solicita ser propietario de %{gem} <a class="adoption__blog__link"
+        href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer
+        más)</a>
       ownership_calls: Solicitud de propietarios
-      no_ownership_calls: No hay convocatorias de propietarios para %{gem}. Los dueños de la gema no están buscando nuevos responsables de mantenimiento.
+      no_ownership_calls: No hay convocatorias de propietarios para %{gem}. Los dueños
+        de la gema no están buscando nuevos responsables de mantenimiento.
   ownership_calls:
     update:
       success_notice: Convocatoria para propietarios de %{gem} cerrada.
@@ -734,14 +835,17 @@ es:
       success_notice: Creada convocatoria para propietarios de %{gem}.
     index:
       title: Se buscan responsables de mantenimiento
-      subtitle_html: Gemas que buscan nuevos responsables de mantenimiento <a class="adoption__blog__link" href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer más)</a>
+      subtitle_html: Gemas que buscan nuevos responsables de mantenimiento <a class="adoption__blog__link"
+        href="https://blog.rubygems.org/2022/01/19/rubygems-adoptions.html">(leer
+        más)</a>
     share_requirements: Por favor especifica en que areas necesitas ayuda
-    note_for_applicants: "Nota para candidatos:"
+    note_for_applicants: 'Nota para candidatos:'
     created_by: Creado por
     details: Detalles
     apply: Proponte
     close: Cerrar
-    markup_supported_html: <a class="adoption__rdoc__link" href="https://ruby.github.io/rdoc/RDoc/MarkupReference.html">Etiquetas Rdoc soportadas</a>
+    markup_supported_html: <a class="adoption__rdoc__link" href="https://ruby.github.io/rdoc/RDoc/MarkupReference.html">Etiquetas
+      Rdoc soportadas</a>
     create_call: Crear convocatoria para propietarios
   ownership_requests:
     create:
@@ -752,28 +856,33 @@ es:
     close:
       success_notice: Se han cerrado todas las candidaturas a propietario de %{gem}.
     ownership_requests: Candidaturas a propietario
-    note_for_owners: "Nota para propietarios:"
+    note_for_owners: 'Nota para propietarios:'
     your_ownership_requests: Tus candidaturas a propietario
     close_all: Cerrar todas
     approve: Aprobar
     gems_published: Gemas publicadas
     created_at: Creado el
-    no_ownership_requests: Las peticiones para unirse a tu proyecto aparecerán aquí. Todavia no hay candidaturas a propietario para %{gem}.
+    no_ownership_requests: Las peticiones para unirse a tu proyecto aparecerán aquí.
+      Todavia no hay candidaturas a propietario para %{gem}.
     create_req: Crea una candidatura a propietario
-    signin_to_create_html: Por favor <a href="https://rubygems.org/sign_in">accede</a> para crear una candidatura a propietario.
+    signin_to_create_html: Por favor <a href="https://rubygems.org/sign_in">accede</a>
+      para crear una candidatura a propietario.
   webauthn_credentials:
     callback:
       success: Has dado de alta con éxito un dispositivo de seguridad.
     recovery:
       continue: Continuar
       title: Has añadido con éxito un dispositivo de seguridad
-      notice_html: 'Por favor <strong class="recovery__bold">copia y guarda</strong> estos códigos de recuperación. Puedes utilizar estos códigos para acceder si pierdes tu dispositivo de seguridad. Cada código solo se puede usar una vez.'
+      notice_html: Por favor <strong class="recovery__bold">copia y guarda</strong>
+        estos códigos de recuperación. Puedes utilizar estos códigos para acceder
+        si pierdes tu dispositivo de seguridad. Cada código solo se puede usar una
+        vez.
       copied: "[ copiado ]"
       copy: "[ copiar ]"
       saved: Declaro haber guardado mis códigos de recuperación.
     webauthn_credential:
-      confirm_delete: "Credencial borrada"
-      delete_failed: "No se pudo borrar la credencial"
+      confirm_delete: Credencial borrada
+      delete_failed: No se pudo borrar la credencial
       delete: Borrar
       confirm: "¿Seguro que quieres borrar esta credencial?"
       saved: Dispositivo de seguridad creado con éxito
@@ -787,61 +896,110 @@ es:
         api_key_roles: Roles de clave API OIDC
         new_role: Crear rol de clave API
       show:
-        api_key_role_name: "Rol de clave API %{name}"
-        automate_gh_actions_publishing: "Automatizar publicación de gemas con GitHub Actions"
-        view_provider: "Ver proveedor %{issuer}"
-        edit_role: "Editar rol de clave API"
-        delete_role: "Borrar rol de clave API"
+        api_key_role_name: Rol de clave API %{name}
+        automate_gh_actions_publishing: Automatizar publicación de gemas con GitHub
+          Actions
+        view_provider: Ver proveedor %{issuer}
+        edit_role: Editar rol de clave API
+        delete_role: Borrar rol de clave API
         confirm_delete: "¿Seguro que quieres borrar este rol?"
-        deleted_at_html: "Este rol se borró hace %{time_html} y ya no puede usarse."
+        deleted_at_html: Este rol se borró hace %{time_html} y ya no puede usarse.
       edit:
-        edit_role: "Editar rol de clave API"
+        edit_role: Editar rol de clave API
       git_hub_actions_workflow:
-        title: "OIDC GitHub Actions Workflow para subir gema"
-        configured_for_html: "Este rol de clave API OIDC está configurado para permitir subir %{link_html} desde GitHub Actions."
-        to_automate_html: "Para automatizar lanzar %{link_html} cuando se suba una nueva etiqueta, añade el siguiente workflow a tu repositorio."
-        not_github: "Este rol de clave API OIDC no está configurado para usar GitHub Actions."
-        not_push: "Este rol de clave API OIDC no está configurado para permitir subir gemas."
+        title: OIDC GitHub Actions Workflow para subir gema
+        configured_for_html: Este rol de clave API OIDC está configurado para permitir
+          subir %{link_html} desde GitHub Actions.
+        to_automate_html: Para automatizar lanzar %{link_html} cuando se suba una
+          nueva etiqueta, añade el siguiente workflow a tu repositorio.
+        not_github: Este rol de clave API OIDC no está configurado para usar GitHub
+          Actions.
+        not_push: Este rol de clave API OIDC no está configurado para permitir subir
+          gemas.
         copy_to_clipboard: Copiar al portapapeles
-        copied: ¡Copiado!
+        copied: "¡Copiado!"
         a_gem: una gema
-        instructions_html: |
-          Para lanzar una gema, <a href="https://bundler.io/guides/creating_gem.html#releasing-the-gem" rel="noreferer">crea la nueva versión</a> y genera una etiqueta nueva (usando <code>rake release:source_control_push</code>) a GitHub. El workflow empaquetará y subirá automáticamente la gema a RubyGems.org.
+        instructions_html: 'Para lanzar una gema, <a href="https://bundler.io/guides/creating_gem.html#releasing-the-gem"
+          rel="noreferer">crea la nueva versión</a> y genera una etiqueta nueva (usando
+          <code>rake release:source_control_push</code>) a GitHub. El workflow empaquetará
+          y subirá automáticamente la gema a RubyGems.org.
+
+          '
       new:
-        title: "Nuevo rol de clave API OIDC"
+        title: Nuevo rol de clave API OIDC
       update:
-        success: "Rol de clave API OIDC actualizado"
+        success: Rol de clave API OIDC actualizado
       create:
-        success: "Rol de clave API OIDC creado"
+        success: Rol de clave API OIDC creado
       destroy:
-        success: "Rol de clave API OIDC borrado"
+        success: Rol de clave API OIDC borrado
       form:
-        add_condition: "Añadir condición"
-        remove_condition: "Eliminar condición!"
-        add_statement: "Añadir declaración"
-        remove_statement: "Eliminar declaración"
-      deleted: "El rol se ha eliminado."
+        add_condition: Añadir condición
+        remove_condition: Eliminar condición!
+        add_statement: Añadir declaración
+        remove_statement: Eliminar declaración
+      deleted: El rol se ha eliminado.
     providers:
       index:
-        title: "Proveedores de OIDC"
-        description_html: "Estos son los proveedores de OIDC que están configurados para RubyGems.org.<br> Por favor, contacta con soporte si necesitas añadir otro proveedor OIDC."
+        title: Proveedores de OIDC
+        description_html: Estos son los proveedores de OIDC que están configurados
+          para RubyGems.org.<br> Por favor, contacta con soporte si necesitas añadir
+          otro proveedor OIDC.
       show:
-        title: "Proveedor de OIDC"
+        title: Proveedor de OIDC
     id_tokens:
       index:
-        title: "Tokens OIDC ID"
+        title: Tokens OIDC ID
       show:
-        title: "Token OIDC ID"
+        title: Token OIDC ID
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other: "%{count} minutos"
-      one: "1 minuto"
+      one: 1 minuto
     hours:
       other: "%{count} horas"
-      one: "1 hora"
+      one: 1 hora
     days:
       other: "%{count} días"
-      one: "1 día"
+      one: 1 día
     seconds:
       other: "%{count} segundos"
-      one: "1 segundo"
+      one: 1 segundo
+  form:
+    optional:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,6 +68,10 @@ fr:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn:
@@ -84,6 +88,14 @@ fr:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user:
   activemodel:
@@ -337,6 +349,8 @@ fr:
       global_html:
       gem_text:
       gem_html:
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems
@@ -617,6 +631,7 @@ fr:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace: Ce nom est réservé par rubygems.org.
     dependencies:
@@ -833,6 +848,42 @@ fr:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -846,3 +897,5 @@ fr:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,10 @@ ja:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn: 過去にデータ侵害を受けたためお使いになれません
@@ -77,6 +81,14 @@ ja:
               taken: "%{value}は既に存在します"
             full_name:
               taken: "%{value}は既に存在します"
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user: ユーザー
   activemodel:
@@ -331,6 +343,8 @@ ja:
       global_html: このwebhookは以前<em>何らかの</em>gemがプッシュされたときに呼ばれました。
       gem_text: このwebhookは以前%{gem}がプッシュされたときに呼ばれました。
       gem_html: このwebhookは以前<strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>がプッシュされたときに呼ばれました。
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: 新しいリリース - 全てのgem
@@ -341,7 +355,7 @@ ja:
   pages:
     about:
       contributors_amount: "%{count}人以上のRubyist"
-      downloads_amount: '何億回ものgemダウンロード'
+      downloads_amount: 何億回ものgemダウンロード
       checkout_code:
       mit_licensed:
       logo_header:
@@ -583,6 +597,7 @@ ja:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace: この名前空間はrubygems.orgにより予約されています。
     dependencies:
@@ -792,6 +807,42 @@ ja:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -805,3 +856,5 @@ ja:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -60,6 +60,10 @@ nl:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn:
@@ -76,6 +80,14 @@ nl:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user:
   activemodel:
@@ -322,6 +334,8 @@ nl:
       global_html:
       gem_text:
       gem_html:
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title:
@@ -584,6 +598,7 @@ nl:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace:
     dependencies:
@@ -787,6 +802,42 @@ nl:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -800,3 +851,5 @@ nl:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -67,6 +67,10 @@ pt-BR:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn: já apareceu anteriormente em um vazamento de dados e não deve ser utilizada
@@ -83,6 +87,14 @@ pt-BR:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user: Usuário
   activemodel:
@@ -334,6 +346,8 @@ pt-BR:
       global_html:
       gem_text:
       gem_html:
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: Novos Releases - Todas as Gems
@@ -595,6 +609,7 @@ pt-BR:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace: This namespace is reserved by rubygems.org.
     dependencies:
@@ -810,6 +825,42 @@ pt-BR:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -823,3 +874,5 @@ pt-BR:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -62,6 +62,10 @@ zh-CN:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn: 曾出现过数据泄露，不应该再使用
@@ -78,6 +82,14 @@ zh-CN:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user: 用户
   activemodel:
@@ -336,6 +348,8 @@ zh-CN:
       gem_text: 这个 webhook 在 %{gem} 被推送时被调用。
       gem_html: 这个 webhook 在 <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>
         被推送时被调用。
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: 新的发布 — 所有 Gem
@@ -591,6 +605,7 @@ zh-CN:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace: 该命名空间由 RubyGems.org 保留。
     dependencies:
@@ -800,6 +815,42 @@ zh-CN:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -813,3 +864,5 @@ zh-CN:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -57,6 +57,10 @@ zh-TW:
         api_key_role:
       oidc/api_key_role:
         api_key_permissions:
+      oidc/trusted_publisher/github_action:
+        repository_owner_id:
+      oidc/pending_trusted_publisher:
+        rubygem_name:
     errors:
       messages:
         unpwn:
@@ -73,6 +77,14 @@ zh-TW:
               taken:
             full_name:
               taken:
+        oidc/rubygem_trusted_publisher:
+          attributes:
+            rubygem:
+              taken:
+        oidc/pending_trusted_publisher:
+          attributes:
+            rubygem_name:
+              unavailable:
     models:
       user:
   activemodel:
@@ -316,6 +328,8 @@ zh-TW:
       global_html:
       gem_text:
       gem_html:
+    gem_trusted_publisher_added:
+      title:
   news:
     show:
       title: 最新發佈
@@ -567,6 +581,7 @@ zh-TW:
           api_key_role:
             name:
             new:
+        trusted_publishers:
     reserved:
       reserved_namespace:
     dependencies:
@@ -770,6 +785,42 @@ zh-TW:
         title:
       show:
         title:
+    rubygem_trusted_publishers:
+      index:
+        title:
+        subtitle_owner_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+        subtitle_owner_html:
+    pending_trusted_publishers:
+      index:
+        title:
+        valid_for_html:
+        delete:
+        create:
+        description_html:
+      destroy:
+        success:
+      create:
+        success:
+      new:
+        title:
+    trusted_publisher:
+      unsupported_type:
+      github_actions:
+        repository_owner_help_html:
+        repository_name_help_html:
+        workflow_filename_help_html:
+        environment_help_html:
+      pending:
+        rubygem_name_help_html:
   duration:
     minutes:
       other:
@@ -783,3 +834,5 @@ zh-TW:
     seconds:
       other:
       one:
+  form:
+    optional:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
       resources :timeframe_versions, only: :index
 
       namespace :oidc do
+        post 'trusted_publisher/exchange_token'
         resources :api_key_roles, only: %i[index show], param: :token, format: 'json', defaults: { format: :json } do
           member do
             post :assume_role
@@ -182,6 +183,7 @@ Rails.application.routes.draw do
         resources :api_key_roles, param: :token, only: %i[show], constraints: { format: :json }
         resources :id_tokens, only: %i[index show]
         resources :providers, only: %i[index show]
+        resources :pending_trusted_publishers, except: %i[show edit update]
       end
     end
     resources :stats, only: :index
@@ -214,6 +216,7 @@ Rails.application.routes.draw do
         patch 'close_all', to: 'ownership_requests#close_all', as: :close_all, on: :collection
       end
       resources :adoptions, only: %i[index]
+      resources :trusted_publishers, controller: 'oidc/rubygem_trusted_publishers', only: %i[index create destroy new]
     end
 
     resources :ownership_calls, only: :index

--- a/db/migrate/20231027190405_create_oidc_trusted_publisher_github_actions.rb
+++ b/db/migrate/20231027190405_create_oidc_trusted_publisher_github_actions.rb
@@ -1,0 +1,17 @@
+class CreateOIDCTrustedPublisherGitHubActions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :oidc_trusted_publisher_github_actions do |t|
+      t.string :repository_owner, null: false
+      t.string :repository_name, null: false
+      t.string :repository_owner_id, null: false
+      t.string :workflow_filename, null: false
+      t.string :environment, null: true
+
+      t.timestamps
+    end
+
+    add_index :oidc_trusted_publisher_github_actions,
+      [:repository_owner, :repository_name, :repository_owner_id, :workflow_filename, :environment],
+      unique: true, name: "index_oidc_trusted_publisher_github_actions_claims"
+  end
+end

--- a/db/migrate/20231027191446_create_oidc_rubygem_trusted_publishers.rb
+++ b/db/migrate/20231027191446_create_oidc_rubygem_trusted_publishers.rb
@@ -1,0 +1,14 @@
+class CreateOIDCRubygemTrustedPublishers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :oidc_rubygem_trusted_publishers do |t|
+      t.references :rubygem, null: false, foreign_key: true
+      t.references :trusted_publisher, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :oidc_rubygem_trusted_publishers,
+      [:rubygem_id, :trusted_publisher_id, :trusted_publisher_type],
+      unique: true, name: "index_oidc_rubygem_trusted_publishers_unique"
+  end
+end

--- a/db/migrate/20231108205146_create_oidc_pending_trusted_publishers.rb
+++ b/db/migrate/20231108205146_create_oidc_pending_trusted_publishers.rb
@@ -1,0 +1,12 @@
+class CreateOIDCPendingTrustedPublishers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :oidc_pending_trusted_publishers do |t|
+      t.string :rubygem_name
+      t.references :user, null: false, foreign_key: true
+      t.references :trusted_publisher, null: false, polymorphic: true
+      t.timestamp :expires_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -284,6 +284,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_29_233528) do
     t.index ["oidc_api_key_role_id"], name: "index_oidc_id_tokens_on_oidc_api_key_role_id"
   end
 
+  create_table "oidc_pending_trusted_publishers", force: :cascade do |t|
+    t.string "rubygem_name"
+    t.bigint "user_id", null: false
+    t.string "trusted_publisher_type", null: false
+    t.bigint "trusted_publisher_id", null: false
+    t.datetime "expires_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["trusted_publisher_type", "trusted_publisher_id"], name: "index_oidc_pending_trusted_publishers_on_trusted_publisher"
+    t.index ["user_id"], name: "index_oidc_pending_trusted_publishers_on_user_id"
+  end
+
   create_table "oidc_providers", force: :cascade do |t|
     t.text "issuer"
     t.jsonb "configuration"
@@ -291,6 +303,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_29_233528) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["issuer"], name: "index_oidc_providers_on_issuer", unique: true
+  end
+
+  create_table "oidc_rubygem_trusted_publishers", force: :cascade do |t|
+    t.bigint "rubygem_id", null: false
+    t.string "trusted_publisher_type", null: false
+    t.bigint "trusted_publisher_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rubygem_id", "trusted_publisher_id", "trusted_publisher_type"], name: "index_oidc_rubygem_trusted_publishers_unique", unique: true
+    t.index ["rubygem_id"], name: "index_oidc_rubygem_trusted_publishers_on_rubygem_id"
+    t.index ["trusted_publisher_type", "trusted_publisher_id"], name: "index_oidc_rubygem_trusted_publishers_on_trusted_publisher"
+  end
+
+  create_table "oidc_trusted_publisher_github_actions", force: :cascade do |t|
+    t.string "repository_owner", null: false
+    t.string "repository_name", null: false
+    t.string "repository_owner_id", null: false
+    t.string "workflow_filename", null: false
+    t.string "environment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_owner", "repository_name", "repository_owner_id", "workflow_filename", "environment"], name: "index_oidc_trusted_publisher_github_actions_claims", unique: true
   end
 
   create_table "ownership_calls", force: :cascade do |t|
@@ -495,6 +529,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_29_233528) do
   add_foreign_key "oidc_api_key_roles", "users"
   add_foreign_key "oidc_id_tokens", "api_keys"
   add_foreign_key "oidc_id_tokens", "oidc_api_key_roles"
+  add_foreign_key "oidc_pending_trusted_publishers", "users"
+  add_foreign_key "oidc_rubygem_trusted_publishers", "rubygems"
   add_foreign_key "ownerships", "users", on_delete: :cascade
   add_foreign_key "versions", "api_keys", column: "pusher_api_key_id"
   add_foreign_key "webauthn_credentials", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -259,6 +259,37 @@ rubygem0.link_verifications.create_with(
   last_verified_at: 10.years.since,
 ).find_or_create_by!(uri: "https://example.com/rubygem0/code")
 
+trusted_publisher = OIDC::TrustedPublisher::GitHubAction.find_or_create_by!(
+  repository_owner: "example",
+  repository_name: "rubygem0",
+  repository_owner_id: "1234567890",
+  workflow_filename: "push_gem.yml",
+  environment: nil
+)
+trusted_publisher.rubygem_trusted_publishers.find_or_create_by!(rubygem: rubygem0).trusted_publisher.api_keys.find_or_create_by!(
+  name: "GitHub Actions something",
+  hashed_key: "securehashedkey-tp",
+  push_rubygem: true,
+).pushed_versions.create_with(indexed: true).find_or_create_by!(
+  rubygem: rubygem0, number: "0.1.0", platform: "ruby", gem_platform: "ruby"
+)
+trusted_publisher.rubygem_trusted_publishers.find_or_create_by!(rubygem: rubygem1)
+
+OIDC::TrustedPublisher::GitHubAction.find_or_create_by!(
+  repository_owner: "example",
+  repository_name: "rubygem0",
+  repository_owner_id: "1234567890",
+  workflow_filename: "push_gem2.yml",
+  environment: "deploy"
+).rubygem_trusted_publishers.find_or_create_by!(rubygem: rubygem0)
+
+author.oidc_pending_trusted_publishers.create_with(
+  expires_at: 100.years.from_now
+).find_or_create_by!(
+  trusted_publisher: trusted_publisher,
+  rubygem_name: "pending-trusted-publisher-rubygem"
+)
+
 puts <<~MESSAGE # rubocop:disable Rails/Output
   Four users were created, you can login with following combinations:
     - email: #{author.email}, password: #{password} -> gem author owning few example gems

--- a/test/factories/oidc/pending_trusted_publishers.rb
+++ b/test/factories/oidc/pending_trusted_publishers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :oidc_pending_trusted_publisher, class: "OIDC::PendingTrustedPublisher" do
+    sequence(:rubygem_name) { |n| "pending-rubygem#{n}" }
+    user
+    association :trusted_publisher, factory: :oidc_trusted_publisher_github_action
+    expires_at { 7.days.from_now }
+  end
+end

--- a/test/factories/oidc/rubygem_trusted_publishers.rb
+++ b/test/factories/oidc/rubygem_trusted_publishers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :oidc_rubygem_trusted_publisher, class: "OIDC::RubygemTrustedPublisher" do
+    rubygem
+    association :trusted_publisher, factory: :oidc_trusted_publisher_github_action
+  end
+end

--- a/test/factories/oidc/trusted_publisher/github_actions.rb
+++ b/test/factories/oidc/trusted_publisher/github_actions.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :oidc_trusted_publisher_github_action, class: "OIDC::TrustedPublisher::GitHubAction" do
+    repository_owner { "example" }
+    sequence(:repository_name) { |n| "rubygem#{n}" }
+    repository_owner_id { "123456" }
+    workflow_filename { "push_gem.yml" }
+    environment { nil }
+  end
+end

--- a/test/integration/api/v1/oidc/trusted_publisher_controller_test.rb
+++ b/test/integration/api/v1/oidc/trusted_publisher_controller_test.rb
@@ -1,0 +1,208 @@
+require "test_helper"
+
+class Api::V1::OIDC::TrustedPublisherControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @pkey = OpenSSL::PKey::RSA.generate(2048)
+    create(:oidc_provider, issuer: OIDC::Provider::GITHUB_ACTIONS_ISSUER, pkey: @pkey)
+
+    @claims = {
+      "aud" => Gemcutter::HOST,
+      "exp" => 1_680_020_837,
+      "iat" => 1_680_020_537,
+      "iss" => "https://token.actions.githubusercontent.com",
+      "jti" => "79685b65-945d-450a-a3d8-a36bcf72c23d",
+      "nbf" => 1_680_019_937,
+      "ref" => "refs/heads/main",
+      "sha" => "04de3558bc5861874a86f8fcd67e516554101e71",
+      "sub" => "repo:segiddins/oidc-test:ref:refs/heads/main",
+      "actor" => "segiddins",
+      "run_id" => "4545231084",
+      "actor_id" => "1946610",
+      "base_ref" => "",
+      "head_ref" => "",
+      "ref_type" => "branch",
+      "workflow" => "token",
+      "event_name" => "push",
+      "repository" => "segiddins/oidc-test",
+      "run_number" => "4",
+      "run_attempt" => "1",
+      "workflow_ref" => "segiddins/oidc-test/.github/workflows/token.yml@refs/heads/main",
+      "workflow_sha" => "04de3558bc5861874a86f8fcd67e516554101e71",
+      "repository_id" => "620393838",
+      "job_workflow_ref" => "segiddins/oidc-test/.github/workflows/token.yml@refs/heads/main",
+      "job_workflow_sha" => "04de3558bc5861874a86f8fcd67e516554101e71",
+      "repository_owner" => "segiddins",
+      "runner_environment" => "github-hosted",
+      "repository_owner_id" => "1946610",
+      "repository_visibility" => "public"
+    }
+
+    travel_to Time.zone.at(1_680_020_830) # after the JWT iat, before the exp
+  end
+
+  def jwt(claims = @claims, key: @pkey)
+    JSON::JWT.new(claims).sign(key.to_jwk)
+  end
+
+  context "POST exchange_token" do
+    should "return not found with no matching trusted publisher" do
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found when owner has changed" do
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "123",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found with an unknown issuer" do
+      @claims["iss"] = "https://unknown.example.com"
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found with an unsupported issuer" do
+      @claims["iss"] = "https://unknown.example.com"
+      create(:oidc_provider, issuer: @claims["iss"], pkey: @pkey)
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return bad request with an invalid JWT" do
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: "invalid" }
+
+      assert_response :bad_request
+    end
+
+    should "return bad request with invalid JSON" do
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: "a.a.a" }
+
+      assert_response :bad_request
+    end
+
+    should "return not found when time is before nbf" do
+      @claims["nbf"] += 1_000_000
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found when time is after exp" do
+      @claims["exp"] -= 1_000_000
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found when signature validation fails" do
+      @claims["exp"] -= 1_000_000
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt(key: OpenSSL::PKey::RSA.generate(2048)).to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found when workflow is from a different ref" do
+      @claims["job_workflow_ref"] = "segiddins/oidc-test/.github/workflows/token.yml@refs/heads/other"
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "return not found when audience is wrong" do
+      @claims["aud"] = "other.com"
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "123",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :not_found
+    end
+
+    should "succeed with matching trusted publisher" do
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: jwt.to_s }
+
+      assert_response :success
+
+      resp = response.parsed_body
+
+      assert_match(/^rubygems_/, resp["rubygems_api_key"])
+      assert_equal({
+                     "rubygems_api_key" => resp["rubygems_api_key"],
+                      "name" => "GitHub Actions segiddins/oidc-test @ .github/workflows/token.yml 2023-03-28T16:22:17Z",
+                      "scopes" => ["push_rubygem"],
+                      "expires_at" => 15.minutes.from_now
+                   }, resp)
+
+      api_key = trusted_publisher.api_keys.sole
+
+      assert_equal api_key.owner, trusted_publisher
+    end
+  end
+end

--- a/test/integration/avo/oidc_pending_trusted_publishers_controller_test.rb
+++ b/test/integration/avo/oidc_pending_trusted_publishers_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Avo::OIDCPendingTrustedPublishersControllerTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
+  test "getting pending trusted publishers as admin" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_oidc_pending_trusted_publishers_path
+
+    assert_response :success
+
+    oidc_pending_trusted_publisher = create(:oidc_pending_trusted_publisher)
+
+    get avo.resources_oidc_pending_trusted_publishers_path
+
+    assert_response :success
+    page.assert_text oidc_pending_trusted_publisher.rubygem_name
+    page.assert_text oidc_pending_trusted_publisher.trusted_publisher.name
+
+    get avo.resources_oidc_pending_trusted_publisher_path(oidc_pending_trusted_publisher)
+
+    assert_response :success
+    page.assert_text oidc_pending_trusted_publisher.rubygem_name
+    page.assert_text oidc_pending_trusted_publisher.trusted_publisher.name
+  end
+end

--- a/test/integration/avo/oidc_rubygem_trusted_publishers_controller_test.rb
+++ b/test/integration/avo/oidc_rubygem_trusted_publishers_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Avo::OIDCRubygemTrustedPublishersControllerTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
+  test "getting rubygem trusted publishers as admin" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_oidc_rubygem_trusted_publishers_path
+
+    assert_response :success
+
+    oidc_rubygem_trusted_publisher = create(:oidc_rubygem_trusted_publisher)
+
+    get avo.resources_oidc_rubygem_trusted_publishers_path
+
+    assert_response :success
+    page.assert_text oidc_rubygem_trusted_publisher.rubygem.name
+    page.assert_text oidc_rubygem_trusted_publisher.trusted_publisher.name
+
+    get avo.resources_oidc_rubygem_trusted_publisher_path(oidc_rubygem_trusted_publisher)
+
+    assert_response :success
+    page.assert_text oidc_rubygem_trusted_publisher.rubygem.name
+    page.assert_text oidc_rubygem_trusted_publisher.trusted_publisher.name
+  end
+end

--- a/test/integration/avo/oidc_trusted_publisher_github_actions_controller_test.rb
+++ b/test/integration/avo/oidc_trusted_publisher_github_actions_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Avo::OIDCTrustedPublisherGitHubActionsControllerTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
+  test "getting github actions trusted publishers as admin" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_oidc_trusted_publisher_github_actions_path
+
+    assert_response :success
+
+    oidc_trusted_publisher_github_action = create(:oidc_trusted_publisher_github_action)
+
+    get avo.resources_oidc_trusted_publisher_github_actions_path
+
+    assert_response :success
+    page.assert_text oidc_trusted_publisher_github_action.repository_owner
+
+    get avo.resources_oidc_trusted_publisher_github_action_path(oidc_trusted_publisher_github_action)
+
+    assert_response :success
+    page.assert_text oidc_trusted_publisher_github_action.repository_owner
+  end
+end

--- a/test/integration/oidc/pending_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/pending_trusted_publishers_controller_test.rb
@@ -1,0 +1,152 @@
+require "test_helper"
+
+class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    @trusted_publisher = create(:oidc_pending_trusted_publisher, user: @user)
+  end
+
+  context "with a verified session" do
+    setup do
+      post(authenticate_session_path(verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD }))
+    end
+
+    should "get index" do
+      get profile_oidc_pending_trusted_publishers_url
+
+      assert_response :success
+    end
+
+    should "get new" do
+      get new_profile_oidc_pending_trusted_publisher_url
+
+      assert_response :success
+    end
+
+    should "create trusted publisher" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_difference("OIDC::PendingTrustedPublisher.count") do
+        trusted_publisher = build(:oidc_pending_trusted_publisher)
+        post profile_oidc_pending_trusted_publishers_url, params: {
+          oidc_pending_trusted_publisher: {
+            rubygem_name: trusted_publisher.rubygem_name,
+            trusted_publisher_type: trusted_publisher.trusted_publisher_type,
+            trusted_publisher_attributes: trusted_publisher.trusted_publisher.as_json
+          }
+        }
+      end
+
+      assert_redirected_to profile_oidc_pending_trusted_publishers_url
+    end
+
+    should "error creating trusted publisher with type" do
+      assert_no_difference("OIDC::PendingTrustedPublisher.count") do
+        post profile_oidc_pending_trusted_publishers_url, params: {
+          oidc_pending_trusted_publisher: {
+            rubygem_name: "rubygem1",
+            trusted_publisher_type: "Hash",
+            trusted_publisher_attributes: { repository_owner: "example" }
+          }
+        }
+
+        assert_response :redirect
+        assert_equal "Unsupported trusted publisher type", flash[:error]
+      end
+    end
+
+    should "error creating trusted publisher with unknown repository owner" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 404, body: { message: "Not Found" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_no_difference("OIDC::PendingTrustedPublisher.count") do
+        post profile_oidc_pending_trusted_publishers_url, params: {
+          oidc_pending_trusted_publisher: {
+            rubygem_name: "rubygem1",
+            trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
+            trusted_publisher_attributes: { repository_owner: "example" }
+          }
+        }
+
+        assert_response :unprocessable_entity
+        assert_equal [
+          "Trusted publisher repository name can't be blank",
+          "Trusted publisher workflow filename can't be blank",
+          "Trusted publisher repository owner can't be blank"
+        ].to_sentence, flash[:error]
+      end
+    end
+
+    should "error creating invalid trusted publisher" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_no_difference("OIDC::PendingTrustedPublisher.count") do
+        post profile_oidc_pending_trusted_publishers_url, params: {
+          oidc_pending_trusted_publisher: {
+            rubygem_name: "rubygem1",
+            trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
+            trusted_publisher_attributes: { repository_name: "rubygem1", repository_owner: "example", workflow_filename: "ci.NO" }
+          }
+        }
+
+        assert_response :unprocessable_entity
+        assert_equal ["Trusted publisher workflow filename must end with .yml or .yaml"].to_sentence, flash[:error]
+      end
+    end
+
+    should "destroy trusted publisher" do
+      assert_difference("OIDC::PendingTrustedPublisher.count", -1) do
+        delete profile_oidc_pending_trusted_publisher_url(@trusted_publisher)
+      end
+
+      assert_redirected_to profile_oidc_pending_trusted_publishers_url
+
+      assert_raises ActiveRecord::RecordNotFound do
+        @trusted_publisher.reload
+      end
+    end
+
+    should "return not found on destroy for other users trusted publisher" do
+      trusted_publisher = create(:oidc_pending_trusted_publisher)
+      assert_no_difference("OIDC::PendingTrustedPublisher.count") do
+        delete profile_oidc_pending_trusted_publisher_url(trusted_publisher)
+
+        assert_response :not_found
+      end
+    end
+  end
+
+  context "without a verified session" do
+    should "redirect index to verify" do
+      get profile_oidc_pending_trusted_publishers_url
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect new to verify" do
+      get new_profile_oidc_pending_trusted_publisher_url
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect create to verify" do
+      post profile_oidc_pending_trusted_publishers_url
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect destroy to verify" do
+      delete new_profile_oidc_pending_trusted_publisher_url
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+  end
+end

--- a/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
@@ -1,0 +1,185 @@
+require "test_helper"
+
+class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    @rubygem = create(:rubygem, owners: [@user])
+    create(:version, rubygem: @rubygem)
+    @trusted_publisher = create(:oidc_rubygem_trusted_publisher, rubygem: @rubygem)
+  end
+
+  context "with a verified session" do
+    setup do
+      post(authenticate_session_path(verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD }))
+    end
+
+    should "respond forbidden for non-owner" do
+      @rubygem.disown
+
+      get rubygem_trusted_publishers_url(@rubygem.slug)
+
+      assert_response :forbidden
+    end
+
+    should "get index" do
+      create(:oidc_rubygem_trusted_publisher, rubygem: @rubygem,
+             trusted_publisher: create(:oidc_trusted_publisher_github_action, environment: "production"))
+      get rubygem_trusted_publishers_url(@rubygem.slug)
+
+      assert_response :success
+    end
+
+    should "get new" do
+      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+      assert_response :success
+    end
+
+    should "get new for a github rubygem" do
+      stub_request(:get, "https://api.github.com/repos/example/rubygem1/contents/.github/workflows")
+        .to_return(status: 200, body: [
+          { name: "ci.yml", type: "file" },
+          { name: "push_rubygem.yml", type: "file" },
+          { name: "push_README.md", type: "file" },
+          { name: "push.yml", type: "directory" }
+        ].to_json, headers: { "Content-Type" => "application/json" })
+
+      create(:version, rubygem: @rubygem, metadata: { "source_code_uri" => "https://github.com/example/rubygem1" })
+
+      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+      assert_response :success
+
+      page.assert_selector("input[name='oidc_rubygem_trusted_publisher[trusted_publisher_attributes][repository_owner]'][value='example']")
+      page.assert_selector("input[name='oidc_rubygem_trusted_publisher[trusted_publisher_attributes][repository_name]'][value='rubygem1']")
+      page.assert_selector("input[name='oidc_rubygem_trusted_publisher[trusted_publisher_attributes][workflow_filename]'][value='push_rubygem.yml']")
+    end
+
+    should "get new for a github rubygem with no found workflows" do
+      stub_request(:get, "https://api.github.com/repos/example/rubygem1/contents/.github/workflows")
+        .to_return(status: 404, body: { message: "Not Found" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      create(:version, rubygem: @rubygem, metadata: { "source_code_uri" => "https://github.com/example/rubygem1" })
+
+      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+      assert_response :success
+
+      page.assert_selector("input[name='oidc_rubygem_trusted_publisher[trusted_publisher_attributes][repository_owner]'][value='example']")
+      page.assert_selector("input[name='oidc_rubygem_trusted_publisher[trusted_publisher_attributes][repository_name]'][value='rubygem1']")
+    end
+
+    should "create trusted publisher" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_difference("OIDC::RubygemTrustedPublisher.count") do
+        trusted_publisher = build(:oidc_rubygem_trusted_publisher, rubygem: @rubygem)
+        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+          oidc_rubygem_trusted_publisher: {
+            trusted_publisher_type: trusted_publisher.trusted_publisher_type,
+            trusted_publisher_attributes: trusted_publisher.trusted_publisher.as_json
+          }
+        }
+      end
+
+      assert_redirected_to rubygem_trusted_publishers_url(@rubygem.slug)
+    end
+
+    should "error creating trusted publisher with type" do
+      assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
+        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+          oidc_rubygem_trusted_publisher: {
+            trusted_publisher_type: "Hash",
+            trusted_publisher_attributes: { repository_owner: "example" }
+          }
+        }
+
+        assert_response :redirect
+        assert_equal "Unsupported trusted publisher type", flash[:error]
+      end
+    end
+
+    should "error creating trusted publisher with unknown repository owner" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 404, body: { message: "Not Found" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
+        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+          oidc_rubygem_trusted_publisher: {
+            trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
+            trusted_publisher_attributes: { repository_owner: "example" }
+          }
+        }
+
+        assert_response :unprocessable_entity
+        assert_equal [
+          "Trusted publisher repository name can't be blank",
+          "Trusted publisher workflow filename can't be blank",
+          "Trusted publisher repository owner can't be blank"
+        ].to_sentence, flash[:error]
+      end
+    end
+
+    should "error creating invalid trusted publisher" do
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
+        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+          oidc_rubygem_trusted_publisher: {
+            trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
+            trusted_publisher_attributes: { repository_name: "rubygem1", repository_owner: "example", workflow_filename: "ci.NO" }
+          }
+        }
+
+        assert_response :unprocessable_entity
+        assert_equal ["Trusted publisher workflow filename must end with .yml or .yaml"].to_sentence, flash[:error]
+      end
+    end
+
+    should "destroy trusted publisher" do
+      assert_difference("OIDC::RubygemTrustedPublisher.count", -1) do
+        delete rubygem_trusted_publisher_url(@rubygem.slug, @trusted_publisher)
+      end
+
+      assert_redirected_to rubygem_trusted_publishers_url(@rubygem.slug)
+
+      assert_raises ActiveRecord::RecordNotFound do
+        @trusted_publisher.reload
+      end
+    end
+  end
+
+  context "without a verified session" do
+    should "redirect index to verify" do
+      get rubygem_trusted_publishers_url(@rubygem.slug)
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect new to verify" do
+      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect create to verify" do
+      post rubygem_trusted_publishers_url(@rubygem.slug)
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+
+    should "redirect destroy to verify" do
+      delete new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+      assert_response :redirect
+      assert_redirected_to verify_session_path
+    end
+  end
+end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -33,6 +33,19 @@ class MailerPreview < ActionMailer::Preview
     Mailer.gem_pushed(ownership.user, ownership.rubygem.versions.last.id, ownership.user_id)
   end
 
+  def gem_pushed_by_trusted_publisher
+    ownership = Ownership.where.not(user: nil).where(push_notifier: true).last
+
+    Mailer.gem_pushed(OIDC::RubygemTrustedPublisher.first.trusted_publisher, ownership.rubygem.versions.last.id, ownership.user_id)
+  end
+
+  def gem_trusted_publisher_added
+    rubygem_trusted_publisher = OIDC::RubygemTrustedPublisher.last
+    created_by_user = User.last
+    notified_user = User.first
+    Mailer.gem_trusted_publisher_added(rubygem_trusted_publisher, created_by_user, notified_user)
+  end
+
   def mfa_notification
     Mailer.mfa_notification(User.last.id)
   end
@@ -89,7 +102,7 @@ class MailerPreview < ActionMailer::Preview
   end
 
   def api_key_created_oidc_api_key_role
-    api_key = OIDC::IdToken.last.api_key
+    api_key = OIDC::IdToken.where.not(api_key_role: nil).last.api_key
     Mailer.api_key_created(api_key.id)
   end
 

--- a/test/models/oidc/pending_trusted_publisher_test.rb
+++ b/test/models/oidc/pending_trusted_publisher_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class OIDC::PendingTrustedPublisherTest < ActiveSupport::TestCase
+  setup do
+    @pending_trusted_publisher = build(:oidc_pending_trusted_publisher)
+  end
+  subject { @pending_trusted_publisher }
+
+  should belong_to(:trusted_publisher)
+  should belong_to(:user)
+
+  should validate_presence_of(:rubygem_name)
+  should validate_uniqueness_of(:rubygem_name).scoped_to(:trusted_publisher_id, :trusted_publisher_type).case_insensitive
+
+  test "validates rubygem name is available" do
+    publisher = build(:oidc_pending_trusted_publisher, rubygem_name: "foo")
+
+    assert_predicate publisher, :valid?
+
+    rubygem = create(:rubygem, name: "foo")
+
+    assert_predicate publisher, :valid?
+
+    create(:version, rubygem: rubygem)
+
+    refute_predicate publisher, :valid?
+    assert_equal ["is already in use"], publisher.errors[:rubygem_name]
+  end
+end

--- a/test/models/oidc/rubygem_trusted_publisher_test.rb
+++ b/test/models/oidc/rubygem_trusted_publisher_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class OIDC::RubygemTrustedPublisherTest < ActiveSupport::TestCase
+  setup do
+    @rubygem_trusted_publisher = build(:oidc_rubygem_trusted_publisher)
+  end
+  subject { @rubygem_trusted_publisher }
+
+  should belong_to(:rubygem)
+  should belong_to(:trusted_publisher)
+
+  should validate_uniqueness_of(:rubygem).scoped_to(:trusted_publisher_id, :trusted_publisher_type)
+end

--- a/test/models/oidc/trusted_publisher/github_action_test.rb
+++ b/test/models/oidc/trusted_publisher/github_action_test.rb
@@ -1,0 +1,138 @@
+require "test_helper"
+
+class OIDC::TrustedPublisher::GitHubActionTest < ActiveSupport::TestCase
+  make_my_diffs_pretty!
+
+  should have_many(:rubygems)
+  should have_many(:rubygem_trusted_publishers)
+  should have_many(:api_keys).inverse_of(:owner)
+
+  should validate_presence_of(:repository_owner)
+  should validate_presence_of(:repository_name)
+  should validate_presence_of(:workflow_filename)
+  should validate_presence_of(:repository_owner_id)
+
+  test "validates publisher uniqueness" do
+    publisher = create(:oidc_trusted_publisher_github_action)
+    assert_raises(ActiveRecord::RecordInvalid) do
+      create(:oidc_trusted_publisher_github_action, repository_owner: publisher.repository_owner,
+            repository_name: publisher.repository_name, workflow_filename: publisher.workflow_filename,
+            repository_owner_id: publisher.repository_owner_id, environment: publisher.environment)
+    end
+  end
+
+  test ".for_claims" do
+    bar_other_owner_id = create(:oidc_trusted_publisher_github_action, repository_name: "bar")
+    bar_other_owner_id.update!(repository_owner_id: "654321")
+    bar = create(:oidc_trusted_publisher_github_action, repository_name: "bar")
+    bar_test = create(:oidc_trusted_publisher_github_action, repository_name: "bar", environment: "test")
+    _bar_dev = create(:oidc_trusted_publisher_github_action, repository_name: "bar", environment: "dev")
+    create(:oidc_trusted_publisher_github_action, repository_name: "foo")
+
+    claims = {
+      repository: "example/bar",
+      job_workflow_ref: "example/bar/.github/workflows/push_gem.yml@refs/heads/main",
+      ref: "refs/heads/main",
+      sha: "04de3558bc5861874a86f8fcd67e516554101e71",
+      repository_owner_id: "123456"
+    }
+
+    assert_equal bar,      OIDC::TrustedPublisher::GitHubAction.for_claims(claims)
+    assert_equal bar,      OIDC::TrustedPublisher::GitHubAction.for_claims(claims.merge(environment: nil))
+    assert_equal bar,      OIDC::TrustedPublisher::GitHubAction.for_claims(claims.merge(environment: "other"))
+    assert_equal bar_test, OIDC::TrustedPublisher::GitHubAction.for_claims(claims.merge(environment: "test"))
+  end
+
+  test "#name" do
+    publisher = create(:oidc_trusted_publisher_github_action, repository_name: "bar")
+
+    assert_equal "GitHub Actions example/bar @ .github/workflows/push_gem.yml", publisher.name
+
+    publisher.update!(environment: "test")
+
+    assert_equal "GitHub Actions example/bar @ .github/workflows/push_gem.yml (test)", publisher.name
+  end
+
+  test "#owns_gem?" do
+    rubygem1 = create(:rubygem)
+    rubygem2 = create(:rubygem)
+
+    publisher = create(:oidc_trusted_publisher_github_action)
+    create(:oidc_rubygem_trusted_publisher, trusted_publisher: publisher, rubygem: rubygem1)
+
+    assert publisher.owns_gem?(rubygem1)
+    refute publisher.owns_gem?(rubygem2)
+  end
+
+  test "#to_access_policy" do
+    publisher = create(:oidc_trusted_publisher_github_action, repository_name: "rubygem1")
+
+    assert_equal(
+      {
+        statements: [
+          {
+            effect: "allow",
+            principal: {
+              oidc: "https://token.actions.githubusercontent.com"
+            },
+            conditions: [
+              { operator: "string_equals", claim: "repository", value: "example/rubygem1" },
+              { operator: "string_equals", claim: "repository_owner_id", value: "123456" },
+              { operator: "string_equals", claim: "aud", value: Gemcutter::HOST },
+              { operator: "string_equals", claim: "job_workflow_ref", value: "example/rubygem1/.github/workflows/push_gem.yml@ref" }
+            ]
+          },
+          {
+            effect: "allow",
+            principal: {
+              oidc: "https://token.actions.githubusercontent.com"
+            },
+            conditions: [
+              { operator: "string_equals", claim: "repository", value: "example/rubygem1" },
+              { operator: "string_equals", claim: "repository_owner_id", value: "123456" },
+              { operator: "string_equals", claim: "aud", value: Gemcutter::HOST },
+              { operator: "string_equals", claim: "job_workflow_ref", value: "example/rubygem1/.github/workflows/push_gem.yml@sha" }
+            ]
+          }
+        ]
+      }.deep_stringify_keys,
+      publisher.to_access_policy({ ref: "ref", sha: "sha" }).as_json
+    )
+
+    publisher.update!(environment: "test")
+
+    assert_equal(
+      {
+        statements: [
+          {
+            effect: "allow",
+            principal: {
+              oidc: "https://token.actions.githubusercontent.com"
+            },
+            conditions: [
+              { operator: "string_equals", claim: "repository", value: "example/rubygem1" },
+              { operator: "string_equals", claim: "environment", value: "test" },
+              { operator: "string_equals", claim: "repository_owner_id", value: "123456" },
+              { operator: "string_equals", claim: "aud", value: Gemcutter::HOST },
+              { operator: "string_equals", claim: "job_workflow_ref", value: "example/rubygem1/.github/workflows/push_gem.yml@ref" }
+            ]
+          },
+          {
+            effect: "allow",
+            principal: {
+              oidc: "https://token.actions.githubusercontent.com"
+            },
+            conditions: [
+              { operator: "string_equals", claim: "repository", value: "example/rubygem1" },
+              { operator: "string_equals", claim: "environment", value: "test" },
+              { operator: "string_equals", claim: "repository_owner_id", value: "123456" },
+              { operator: "string_equals", claim: "aud", value: Gemcutter::HOST },
+              { operator: "string_equals", claim: "job_workflow_ref", value: "example/rubygem1/.github/workflows/push_gem.yml@sha" }
+            ]
+          }
+        ]
+      }.deep_stringify_keys,
+      publisher.to_access_policy({ ref: "ref", sha: "sha" }).as_json
+    )
+  end
+end

--- a/test/policies/oidc/pending_trusted_publisher_policy_test.rb
+++ b/test/policies/oidc/pending_trusted_publisher_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class OIDC::PendingTrustedPublisherPolicyTest < ActiveSupport::TestCase
+  setup do
+    @pending_trusted_publisher = create(:oidc_pending_trusted_publisher)
+
+    @admin = create(:admin_github_user, :is_admin)
+    @non_admin = create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@pending_trusted_publisher], Pundit.policy_scope!(
+      @admin,
+      OIDC::PendingTrustedPublisher
+    ).to_a
+  end
+
+  def test_avo_index
+    assert_predicate Pundit.policy!(@admin, OIDC::PendingTrustedPublisher), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::PendingTrustedPublisher), :avo_index?
+  end
+
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @pending_trusted_publisher), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @pending_trusted_publisher), :avo_show?
+  end
+
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, OIDC::PendingTrustedPublisher), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::PendingTrustedPublisher), :avo_create?
+  end
+
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @pending_trusted_publisher), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @pending_trusted_publisher), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @pending_trusted_publisher), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @pending_trusted_publisher), :avo_destroy?
+  end
+end

--- a/test/policies/oidc/rubygem_trusted_publisher_policy_test.rb
+++ b/test/policies/oidc/rubygem_trusted_publisher_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class OIDC::RubygemTrustedPublisherPolicyTest < ActiveSupport::TestCase
+  setup do
+    @rubygem_trusted_publisher = create(:oidc_rubygem_trusted_publisher)
+
+    @admin = create(:admin_github_user, :is_admin)
+    @non_admin = create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@rubygem_trusted_publisher], Pundit.policy_scope!(
+      @admin,
+      OIDC::RubygemTrustedPublisher
+    ).to_a
+  end
+
+  def test_avo_index
+    assert_predicate Pundit.policy!(@admin, OIDC::RubygemTrustedPublisher), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::RubygemTrustedPublisher), :avo_index?
+  end
+
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @rubygem_trusted_publisher), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @rubygem_trusted_publisher), :avo_show?
+  end
+
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, OIDC::RubygemTrustedPublisher), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::RubygemTrustedPublisher), :avo_create?
+  end
+
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @rubygem_trusted_publisher), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @rubygem_trusted_publisher), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @rubygem_trusted_publisher), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @rubygem_trusted_publisher), :avo_destroy?
+  end
+end

--- a/test/policies/oidc/trusted_publisher/github_action_policy_test.rb
+++ b/test/policies/oidc/trusted_publisher/github_action_policy_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class OIDC::TrustedPublisher::GitHubActionPolicyTest < ActiveSupport::TestCase
+  setup do
+    @trusted_publisher_github_action = create(:oidc_trusted_publisher_github_action)
+
+    @admin = create(:admin_github_user, :is_admin)
+    @non_admin = create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@trusted_publisher_github_action], Pundit.policy_scope!(
+      @admin,
+      OIDC::TrustedPublisher::GitHubAction
+    ).to_a
+  end
+
+  def test_avo_index
+    assert_predicate Pundit.policy!(@admin, OIDC::TrustedPublisher::GitHubAction), :avo_index?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::TrustedPublisher::GitHubAction), :avo_index?
+  end
+
+  def test_avo_show
+    assert_predicate Pundit.policy!(@admin, @trusted_publisher_github_action), :avo_show?
+    refute_predicate Pundit.policy!(@non_admin, @trusted_publisher_github_action), :avo_show?
+  end
+
+  def test_avo_create
+    refute_predicate Pundit.policy!(@admin, OIDC::TrustedPublisher::GitHubAction), :avo_create?
+    refute_predicate Pundit.policy!(@non_admin, OIDC::TrustedPublisher::GitHubAction), :avo_create?
+  end
+
+  def test_avo_update
+    refute_predicate Pundit.policy!(@admin, @trusted_publisher_github_action), :avo_update?
+    refute_predicate Pundit.policy!(@non_admin, @trusted_publisher_github_action), :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_predicate Pundit.policy!(@admin, @trusted_publisher_github_action), :avo_destroy?
+    refute_predicate Pundit.policy!(@non_admin, @trusted_publisher_github_action), :avo_destroy?
+  end
+end


### PR DESCRIPTION
For now, only supports GH Actions. Guides in https://github.com/rubygems/guides/pull/348. Heavily inspired by PyPi's trusted publisher feature (https://docs.pypi.org/trusted-publishers/).

UI demo: 
![CleanShot 2023-12-08 at 12 28 24](https://github.com/rubygems/rubygems.org/assets/1946610/b025c966-f4c2-45df-926a-1f72048e8fc3)


https://docs.google.com/document/d/1iJBiH4xSx9ZqvwQpeWu8fzb8UjrwV3Ta7M7azXKtJhA/edit?usp=sharing