### PR TITLE
Avoid exceptions when authenticating users with an invalid encoding

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,9 +72,13 @@ class User < ApplicationRecord
   validate :toxic_email_domain, on: :create
 
   def self.authenticate(who, password)
+    # Avoid exceptions when string is invalid in the given encoding, _or_ cannot be converted
+    # to UTF-8.
+    who = who.encode(Encoding::UTF_8)
+
     user = find_by(email: who.downcase) || find_by(handle: who)
     user if user&.authenticated?(password)
-  rescue BCrypt::Errors::InvalidHash
+  rescue BCrypt::Errors::InvalidHash, Encoding::UndefinedConversionError
     nil
   end
 

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -207,6 +207,15 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       should_deny_access
     end
 
+    context "with credentials with invalid encoding" do
+      setup do
+        @user = create(:user)
+        authorize_with("\x12\xff\x12:creds".force_encoding(Encoding::UTF_8))
+        get :show
+      end
+      should_deny_access
+    end
+
     context "with correct credentials" do
       setup do
         @user = create(:user)


### PR DESCRIPTION
Fixes https://app.honeybadger.io/projects/40972/faults/102413552

This is a steady source of exceptions for us, this should fail more gracefully