### PR TITLE
Make pushing idempotent, and after-write job enqueuing atomic with making the version indexed

### DIFF
--- a/app/avo/actions/version_after_write.rb
+++ b/app/avo/actions/version_after_write.rb
@@ -1,0 +1,20 @@
+class VersionAfterWrite < BaseAction
+  self.name = "Run version post-write job"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") &&
+      view == :show &&
+      resource.model.deletion.blank?
+  }
+
+  self.message = lambda {
+    "Are you sure you would like to run the after-write job for #{record.full_name}? The version is #{'not ' unless record.indexed?} indexed."
+  }
+
+  self.confirm_button_label = "Run Job"
+
+  class ActionHandler < ActionHandler
+    def handle_model(version)
+      AfterVersionWriteJob.new(version: version).perform(version: version)
+    end
+  end
+end

--- a/app/avo/resources/version_resource.rb
+++ b/app/avo/resources/version_resource.rb
@@ -6,6 +6,7 @@ class VersionResource < Avo::BaseResource
   }
 
   action RestoreVersion
+  action VersionAfterWrite
 
   class IndexedFilter < ScopeBooleanFilter; end
   filter IndexedFilter, arguments: { default: { indexed: true, yanked: true } }

--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -1,0 +1,31 @@
+class AfterVersionWriteJob < ApplicationJob
+  queue_as :default
+
+  def perform(version:)
+    version.transaction do
+      rubygem = version.rubygem
+      version.rubygem.push_notifiable_owners.each do |notified_user|
+        Mailer.gem_pushed(owner, version.id, notified_user.id).deliver_later
+      end
+      Indexer.perform_later
+      UploadVersionsFileJob.perform_later
+      UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
+      UploadNamesFileJob.perform_later
+      ReindexRubygemJob.perform_later(rubygem:)
+      StoreVersionContentsJob.perform_later(version:) if ld_variation(key: "gemcutter.pusher.store_version_contents", default: false)
+      version.update!(indexed: true)
+    end
+  end
+
+  def ld_variation(key:, default:)
+    return default unless owner
+
+    Rails.configuration.launch_darkly_client.variation(
+      key, owner.ld_context, default
+    )
+  end
+
+  def owner
+    arguments.dig(0, :version).pusher_api_key&.owner
+  end
+end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -86,16 +86,36 @@ class Pusher
     MSG
   end
 
-  def find # rubocop:disable Metrics/AbcSize
+  def find # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     name = spec.name.to_s
     set_tag "gemcutter.rubygem.name", name
 
     @rubygem = Rubygem.name_is(name).first || Rubygem.new(name: name)
 
+    sha256 = Digest::SHA2.base64digest(body.string)
+    spec_sha256 = Digest::SHA2.base64digest(spec_contents)
+
+    version = @rubygem.versions
+      .create_with(indexed: false, cert_chain: spec.cert_chain)
+      .find_or_initialize_by(
+        number: spec.version.to_s,
+        platform: spec.original_platform.to_s,
+        gem_platform: spec.platform.to_s,
+        size: size,
+        sha256: sha256,
+        spec_sha256: spec_sha256,
+        pusher: api_key.user,
+        pusher_api_key: api_key
+      )
+
     unless @rubygem.new_record?
-      if (version = @rubygem.find_version_from_spec spec)
-        republish_notification(version)
-        return false
+      # Return success for idempotent pushes
+      return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
+
+      # If the gem is yanked, we can't repush it
+      # Additionally, we don't allow overwriting existing versions
+      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform))
+        return republish_notification(existing)
       end
 
       if @rubygem.name != name && @rubygem.indexed_versions?
@@ -106,19 +126,7 @@ class Pusher
 
     # Update the name to reflect a valid case change
     @rubygem.name = name
-
-    sha256 = Digest::SHA2.base64digest(body.string)
-    spec_sha256 = Digest::SHA2.base64digest(spec_contents)
-
-    @version = @rubygem.versions.new number: spec.version.to_s,
-                                     platform: spec.original_platform.to_s,
-                                     gem_platform: spec.platform.to_s,
-                                     size: size,
-                                     sha256: sha256,
-                                     spec_sha256: spec_sha256,
-                                     pusher: api_key.user,
-                                     pusher_api_key: api_key,
-                                     cert_chain: spec.cert_chain
+    @version = version
 
     set_tags "gemcutter.rubygem.version" => @version.number, "gemcutter.rubygem.platform" => @version.platform
     log_pushing
@@ -137,25 +145,10 @@ class Pusher
   private
 
   def after_write
-    @version_id = version.id
-    version.rubygem.push_notifiable_owners.each do |notified_user|
-      Mailer.gem_pushed(owner, @version_id, notified_user.id).deliver_later
-    end
-    Indexer.perform_later
-    UploadVersionsFileJob.perform_later
-    UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
-    UploadNamesFileJob.perform_later
-    ReindexRubygemJob.perform_later(rubygem:)
     GemCachePurger.call(rubygem.name)
-    StoreVersionContentsJob.perform_later(version:) if ld_variation(key: "gemcutter.pusher.store_version_contents", default: false)
     RackAttackReset.gem_push_backoff(@remote_ip, owner.to_gid) if @remote_ip.present?
+    AfterVersionWriteJob.new(version:).perform(version:)
     StatsD.increment "push.success"
-  end
-
-  def ld_variation(key:, default:)
-    Rails.configuration.launch_darkly_client.variation(
-      key, owner.ld_context, default
-    )
   end
 
   def notify(message, code)
@@ -188,6 +181,9 @@ class Pusher
       notify("Repushing of gem versions is not allowed.\n" \
              "Please bump the version number and push a new different release.\n" \
              "See also `gem yank` if you want to unpublish the bad release.", 409)
+    elsif version.deletion.nil?
+      notify("It appears that #{version.full_name} did not finish pushing.\n" \
+             "Please contact support@rubygems.org for assistance if you pushed this gem more than a minute ago.", 409)
     else
       different_owner = "pushed by a previous owner of this gem " unless owner.owns_gem?(version.rubygem)
       notify("A yanked version #{different_owner}already exists (#{version.full_name}).\n" \

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -319,10 +319,6 @@ class Rubygem < ApplicationRecord
     ownerships_including_unconfirmed.clear
   end
 
-  def find_version_from_spec(spec)
-    versions.find_by_number_and_platform(spec.version.to_s, spec.original_platform.to_s)
-  end
-
   def find_or_initialize_version_from_spec(spec)
     version = versions.find_or_initialize_by(number: spec.version.to_s,
                                              platform: spec.original_platform.to_s,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -265,8 +265,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
       requirements: spec.requirements,
       built_at: spec.date,
       required_rubygems_version: spec.required_rubygems_version.to_s,
-      required_ruby_version: spec.required_ruby_version.to_s,
-      indexed: true
+      required_ruby_version: spec.required_ruby_version.to_s
     )
   end
 

--- a/app/views/mailer/gem_pushed.html.erb
+++ b/app/views/mailer/gem_pushed.html.erb
@@ -16,10 +16,14 @@
           Gem: <strong><%= link_to @version.to_title, rubygem_version_url(@version.rubygem.slug, @version.slug), target: "_blank" %></strong>
           <br/>
           Pushed by user:
+          <% if @pushed_by_user %>
           <strong>
             <%= link_to @pushed_by_user.handle, profile_url(@pushed_by_user.display_id), target: "_blank" %> <%= mail_to(@pushed_by_user.email) if @pushed_by_user.public_email? %>
           </strong>
           <br/>
+          <% else %>
+          <strong>Unknown</strong>
+          <% end %>
           Pushed at: <strong><%= @version.created_at.to_formatted_s(:rfc822) %></strong>
         </p>
         <br/>

--- a/lib/certificate_chain_serializer.rb
+++ b/lib/certificate_chain_serializer.rb
@@ -3,7 +3,7 @@ class CertificateChainSerializer
 
   def self.load(chain)
     return [] unless chain
-    chain.scan(PATTERN).map do |cert|
+    chain.scan(PATTERN).map! do |cert|
       OpenSSL::X509::Certificate.new(cert)
     end
   end
@@ -13,6 +13,6 @@ class CertificateChainSerializer
     normalised = chain.map do |cert|
       cert.respond_to?(:to_pem) ? cert : OpenSSL::X509::Certificate.new(cert)
     end
-    normalised.map(&:to_pem).join
+    normalised.map!(&:to_pem).join
   end
 end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -182,7 +182,8 @@ class PushTest < ActionDispatch::IntegrationTest
 
   test "republish a yanked version" do
     rubygem = create(:rubygem, name: "sandworm", owners: [@user])
-    create(:version, number: "1.0.0", indexed: false, rubygem: rubygem)
+    version = create(:version, number: "1.0.0", rubygem: rubygem)
+    create(:deletion, version:)
 
     build_gem "sandworm", "1.0.0"
 
@@ -194,7 +195,8 @@ class PushTest < ActionDispatch::IntegrationTest
 
   test "republish a yanked version by a different owner" do
     rubygem = create(:rubygem, name: "sandworm")
-    create(:version, number: "1.0.0", indexed: false, rubygem: rubygem)
+    version = create(:version, number: "1.0.0", rubygem: rubygem)
+    create(:deletion, version:)
 
     build_gem "sandworm", "1.0.0"
 
@@ -202,6 +204,42 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :conflict
     assert_match(/A yanked version pushed by a previous owner of this gem already exists \(sandworm-1.0.0\)/, response.body)
+  end
+
+  test "republish an indexed version" do
+    build_gem "sandworm", "1.0.0"
+
+    push_gem "sandworm-1.0.0.gem"
+
+    assert_response :success
+
+    assert_enqueued_jobs 0 do
+      push_gem "sandworm-1.0.0.gem"
+    end
+
+    assert_response :success
+    assert_equal("Gem was already pushed: sandworm (1.0.0)", response.body)
+  end
+
+  test "republish a version where the gem is un-indexed but not yanked" do
+    build_gem "sandworm", "1.0.0"
+
+    Pusher.any_instance.stubs(:after_write)
+
+    push_gem "sandworm-1.0.0.gem"
+
+    Pusher.any_instance.unstub(:after_write)
+
+    assert_enqueued_jobs 0 do
+      push_gem "sandworm-1.0.0.gem"
+    end
+
+    assert_response :conflict
+    assert_equal(
+      "It appears that sandworm-1.0.0 did not finish pushing.\n" \
+      "Please contact support@rubygems.org for assistance if you pushed this gem more than a minute ago.",
+      response.body
+    )
   end
 
   test "publishing a gem with ceritifcate but not signatures" do

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -435,8 +435,11 @@ class PusherTest < ActiveSupport::TestCase
       spec = mock
       spec.expects(:name).returns @rubygem.name.upcase
       spec.expects(:version).returns Gem::Version.new("1.3.3.7")
+      spec.expects(:platform).returns "ruby"
       spec.expects(:original_platform).returns "ruby"
+      spec.expects(:cert_chain).returns nil
       @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
 
       refute @cutter.find
 
@@ -592,7 +595,7 @@ class PusherTest < ActiveSupport::TestCase
     setup do
       @rubygem = create(:rubygem, name: "gemsgemsgems")
       @cutter.stubs(:rubygem).returns @rubygem
-      create(:version, rubygem: @rubygem, number: "0.1.1", summary: "old summary")
+      create(:version, rubygem: @rubygem, number: "0.1.1", summary: "old summary", pusher_api_key: @cutter.api_key)
       @spec = mock
       @cutter.stubs(:version).returns @rubygem.versions[0]
       @cutter.stubs(:spec).returns(@spec)
@@ -695,7 +698,7 @@ class PusherTest < ActiveSupport::TestCase
       @rubygem = create(:rubygem)
       @cutter.stubs(:rubygem).returns @rubygem
       create(:version, rubygem: @rubygem, summary: "old summary")
-      @version = create(:version, rubygem: @rubygem, summary: "new summary")
+      @version = create(:version, rubygem: @rubygem, summary: "new summary", pusher_api_key: @cutter.api_key)
       @cutter.stubs(:version).returns @version
       @rubygem.stubs(:update_attributes_from_gem_specification!)
       @cutter.stubs(:version).returns @version

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -27,7 +27,6 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
   end
 
   test "restore a rubygem version" do
-    Minitest::Test.make_my_diffs_pretty!
     admin_user = create(:admin_github_user, :is_admin)
     sign_in_as admin_user
 
@@ -123,6 +122,41 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
         "models" => ["gid://gemcutter/Version/#{version.id}"]
       },
       audit.audited_changes
+    )
+  end
+
+  test "run afer version write job" do
+    admin_user = create(:admin_github_user, :is_admin)
+    sign_in_as admin_user
+
+    rubygem = create(:rubygem, owners: [create(:user)])
+    version = create(:version, rubygem: rubygem)
+
+    visit avo.resources_version_path(version)
+
+    click_button "Actions"
+
+    click_on "Run version post-write job"
+
+    fill_in "Comment", with: "A nice long comment"
+
+    click_button "Run Job"
+
+    page.assert_text "Action ran successfully!"
+    page.assert_text version.to_global_id.uri.to_s
+
+    perform_enqueued_jobs
+
+    assert_equal 1, ActionMailer::Base.deliveries.size
+
+    rubygem.reload
+    version.reload
+
+    audit = version.audits.sole
+
+    assert_equal(
+      ["gid://gemcutter/Version/#{version.id}"],
+      audit.audited_changes["models"]
     )
   end
 end

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -4,6 +4,10 @@ class MailerTest < ActionMailer::TestCase
   MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
   MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY = 180_000_000
 
+  setup do
+    TOPLEVEL_BINDING.receiver.stubs(:mx_exists?).returns(true)
+  end
+
   context "sending mail for mfa recommendation announcement" do
     setup do
       @user = create(:user)


### PR DESCRIPTION
Goal here is to avoid issues where the connection drops _after_ the gem has been written to storage, but _before_ all the after-write jobs get enqueued.

Fix is to delay making the gem visible (indexed=true) until the transaction where those jobs get enqueued (which is then atomic, since they get enqueued to the same postgres database)