### PR TITLE
Fix deletion version_id backfill when user has been deleted

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -1,5 +1,6 @@
 class Deletion < ApplicationRecord
-  belongs_to :user
+  # we nullify the user when they delete their account
+  belongs_to :user, optional: true
 
   belongs_to :version, ->(d) { joins(:rubygem).where(platform: d.platform, rubygem: { name: d.rubygem }) },
     class_name: "Version",
@@ -7,7 +8,8 @@ class Deletion < ApplicationRecord
     primary_key: :number,
     inverse_of: :deletion
 
-  validates :user, :rubygem, :number, presence: true
+  validates :user, presence: true, on: :create
+  validates :rubygem, :number, presence: true
   validates :version, presence: true
   validate :version_is_indexed, on: :create
   validate :metadata_matches_version

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -29,7 +29,7 @@ class DeletionTest < ActiveSupport::TestCase
   context "association" do
     subject { Deletion.new(version: @version, user: @user) }
 
-    should belong_to :user
+    should belong_to(:user).without_validating_presence
   end
 
   context "with deleted gem" do

--- a/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
+++ b/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
@@ -24,4 +24,20 @@ class Maintenance::BackfillDeletionVersionsTaskTest < ActiveSupport::TestCase
       Maintenance::BackfillDeletionVersionsTask.process(deletion)
     end
   end
+
+  test "#process with deleted user" do
+    version = create(:version)
+    deletion = create(:deletion, version:)
+
+    deletion.update_column(:version_id, nil)
+
+    assert_nil deletion.version_id
+
+    deletion.user.destroy!
+
+    Maintenance::BackfillDeletionVersionsTask.process(deletion.reload)
+
+    assert_equal version.id, deletion.version_id
+    assert_equal version, deletion.version
+  end
 end


### PR DESCRIPTION
Fixes the failure observed in https://staging.rubygems.org/admin/maintenance_tasks/tasks/Maintenance::BackfillDeletionVersionsTask