### PR TITLE
Fix deletion version_id backfill when gem name case has changed

### DIFF
--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -2,7 +2,7 @@ class Deletion < ApplicationRecord
   # we nullify the user when they delete their account
   belongs_to :user, optional: true
 
-  belongs_to :version, ->(d) { joins(:rubygem).where(platform: d.platform, rubygem: { name: d.rubygem }) },
+  belongs_to :version, ->(d) { joins(:rubygem).where(platform: d.platform).where("UPPER(rubygems.name) = UPPER(?)", d.rubygem) },
     class_name: "Version",
     foreign_key: :number,
     primary_key: :number,

--- a/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
+++ b/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
@@ -40,4 +40,21 @@ class Maintenance::BackfillDeletionVersionsTaskTest < ActiveSupport::TestCase
     assert_equal version.id, deletion.version_id
     assert_equal version, deletion.version
   end
+
+  test "#process with changed gem capitalization" do
+    rubygem = create(:rubygem, name: "rubygem0")
+    version = create(:version, rubygem:)
+    deletion = create(:deletion, version:)
+
+    deletion.update_column(:version_id, nil)
+
+    assert_nil deletion.version_id
+
+    rubygem.update!(name: "Rubygem0")
+
+    Maintenance::BackfillDeletionVersionsTask.process(deletion.reload)
+
+    assert_equal version.id, deletion.version_id
+    assert_equal version, deletion.version
+  end
 end


### PR DESCRIPTION
Fixes the failure observed in https://staging.rubygems.org/admin/maintenance_tasks/tasks/Maintenance::BackfillDeletionVersionsTask