### PR TITLE
Fix deletion version_id backfill when version is missing entirely

### DIFF
--- a/app/tasks/maintenance/backfill_deletion_versions_task.rb
+++ b/app/tasks/maintenance/backfill_deletion_versions_task.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Maintenance::BackfillDeletionVersionsTask < MaintenanceTasks::Task
+  include SemanticLogger::Loggable
+
   def collection
     Deletion.all
   end
@@ -8,6 +10,10 @@ class Maintenance::BackfillDeletionVersionsTask < MaintenanceTasks::Task
   def process(deletion)
     return if deletion.version_id?
 
-    deletion.update!(version_id: deletion.version.id)
+    if deletion.version.blank?
+      logger.warn("Deletion does not have a matching version", deletion:)
+    else
+      deletion.update!(version_id: deletion.version.id)
+    end
   end
 end

--- a/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
+++ b/test/tasks/maintenance/backfill_deletion_versions_task_test.rb
@@ -57,4 +57,15 @@ class Maintenance::BackfillDeletionVersionsTaskTest < ActiveSupport::TestCase
     assert_equal version.id, deletion.version_id
     assert_equal version, deletion.version
   end
+
+  test "#process with missing version" do
+    Deletion.insert!({ rubygem: "missing", number: "1.0.0", platform: "ruby" })
+    deletion = Deletion.where(rubygem: "missing", number: "1.0.0", platform: "ruby").sole
+
+    assert_nil deletion.version_id
+
+    Maintenance::BackfillDeletionVersionsTask.process(deletion)
+
+    assert_nil deletion.version_id
+  end
 end


### PR DESCRIPTION
Fixes the failure observed in https://staging.rubygems.org/admin/maintenance_tasks/tasks/Maintenance::BackfillDeletionVersionsTask