### PR TITLE
Fix pushing gems that require MFA when the api key owner has MFA enab…

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -33,7 +33,7 @@ class Pusher
   end
 
   def verify_mfa_requirement
-    api_key.mfa_enabled? || !(version_mfa_required? || rubygem.metadata_mfa_required?) ||
+    owner.mfa_enabled? || !(version_mfa_required? || rubygem.metadata_mfa_required?) ||
       notify("Rubygem requires owners to enable MFA. You must enable MFA before pushing new version.", 403)
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -556,7 +556,7 @@ class PusherTest < ActiveSupport::TestCase
       context "version metadata has rubygems_mfa_required set" do
         setup do
           spec = mock
-          spec.expects(:metadata).returns({ "rubygems_mfa_required" => true })
+          spec.stubs(:metadata).returns({ "rubygems_mfa_required" => true })
           @cutter.stubs(:spec).returns spec
 
           metadata = { "rubygems_mfa_required" => "true" }
@@ -565,6 +565,24 @@ class PusherTest < ActiveSupport::TestCase
 
         should "be false if user has no mfa setup" do
           refute @cutter.verify_mfa_requirement
+        end
+
+        should "be true if user has ui_and_api mfa but API key does not require MFA" do
+          @user.enable_totp!("abc123", User.mfa_levels["ui_and_api"])
+
+          assert_predicate @cutter, :verify_mfa_requirement
+        end
+
+        should "be true if user has ui_only mfa but API key does not require MFA" do
+          @user.enable_totp!("abc123", User.mfa_levels["ui_only"])
+
+          assert_predicate @cutter, :verify_mfa_requirement
+        end
+
+        should "be true if user has ui_and_gem_signin mfa but API key does not require MFA" do
+          @user.enable_totp!("abc123", User.mfa_levels["ui_and_gem_signin"])
+
+          assert_predicate @cutter, :verify_mfa_requirement
         end
       end
     end


### PR DESCRIPTION
…led but the API key does not require MFA

Fixes https://github.com/rubygems/rubygems.org/issues/4264

Verified these are the correct behaviors by testing against ea145d9~