### PR TITLE
Fix creating rubygem trusted publisher when gh action exists

### DIFF
--- a/app/models/oidc/trusted_publisher/github_action.rb
+++ b/app/models/oidc/trusted_publisher/github_action.rb
@@ -42,8 +42,9 @@ class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
   end
 
   def self.build_trusted_publisher(params)
-    params.delete(:environment) if params[:environment].blank?
     params = params.reverse_merge(repository_owner_id: nil, repository_name: nil, workflow_filename: nil, environment: nil)
+    params.delete(:environment) if params[:environment].blank?
+    params.delete(:repository_owner_id)
     find_or_initialize_by(params)
   end
 


### PR DESCRIPTION
Fix is removing repository_owner_id from search params