### PR TITLE
Add locales for rubygems.aside.links.funding

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -578,6 +578,7 @@ de:
         code: Quellcode
         docs: Dokumentation
         download: Download
+        funding:
         header: Links
         home: Homepage
         mail: Mailingliste

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -578,6 +578,7 @@ en:
         code: Source Code
         docs: Documentation
         download: Download
+        funding: Funding
         header: Links
         home: Homepage
         mail: Mailing List

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -688,6 +688,7 @@ es:
         code: Código fuente
         docs: Documentación
         download: Descarga
+        funding: Financiación
         header: Enlace
         home: Página
         mail: Lista de Correo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -615,6 +615,7 @@ fr:
         code: Code Source
         docs: Documentation
         download: Télécharger
+        funding:
         header: Liens
         home: Page d'accueil
         mail: Liste de diffusion

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -581,6 +581,7 @@ ja:
         code: ソースコード
         docs: ドキュメント
         download: ダウンロード
+        funding: 寄付
         header: リンク
         home: ホームページ
         mail: メーリングリスト

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -582,6 +582,7 @@ nl:
         code: Broncode
         docs: Documentatie
         download: Download
+        funding:
         header: Links
         home: Startpagina
         mail: Mailing-list

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -593,6 +593,7 @@ pt-BR:
         code: Código Fonte
         docs: Documentação
         download: Download
+        funding:
         header: Links
         home: Homepage
         mail: Lista de Emails

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -589,6 +589,7 @@ zh-CN:
         code: 源代码
         docs: 文档
         download: 下载
+        funding: 募集资金
         header: 链接
         home: 主页
         mail: 邮件列表

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -565,6 +565,7 @@ zh-TW:
         code: 原始碼
         docs: 文件
         download: 下載
+        funding:
         header: 相關連結
         home: 首頁
         mail: 郵件群組


### PR DESCRIPTION
The translation used matches what's currently in `activerecord.attributes.linkset.funding`. For those don't have a current translation, I left it empty.