### PR TITLE
Passing the slug to rubygem_reverse_dependencies_path. Fixes #4350

### DIFF
--- a/app/views/reverse_dependencies/_search.html.erb
+++ b/app/views/reverse_dependencies/_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag rubygem_reverse_dependencies_path(rubygem),
+<%= form_tag rubygem_reverse_dependencies_path(rubygem.slug),
   id: "rdeps-search", class: "home__search-wrap", method: :get do %>
   <%= search_field_tag :rdeps_query, params[:rdeps_query], placeholder: t('.search_reverse_dependencies_html'), class: "home__search" %>
   <%= label_tag :rdeps_query do %>


### PR DESCRIPTION
The form_tag was rendering a path with the `id` instead of the slug, which produces an invalid route.