### PR TITLE
Providing users with a copy-to-clipboard feature for the checksum

### DIFF
--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -60,8 +60,8 @@
     <div class="gem__code-wrap">
       <input type="text" class="gem__code" id="gem_sha_256_checksum" value="<%= latest_version.sha256_hex %>" readonly="readonly">
       <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-target="#gem_sha_256_checksum">=</span>
-      <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
-      <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
+      <span class="gem__code__tooltip--copy"><%= t('copy_to_clipboard') %></span>
+      <span class="gem__code__tooltip--copied"><%= t('copied') %></span>
     </div>
   <% end %>
 

--- a/app/views/rubygems/_gem_members.html.erb
+++ b/app/views/rubygems/_gem_members.html.erb
@@ -57,15 +57,18 @@
 
   <% if latest_version.sha256.present? %>
     <h3 class="t-list__heading"><%= t '.sha_256_checksum' %>:</h3>
-    <div class="gem__sha">
-      <%= latest_version.sha256_hex %>
+    <div class="gem__code-wrap">
+      <input type="text" class="gem__code" id="gem_sha_256_checksum" value="<%= latest_version.sha256_hex %>" readonly="readonly">
+      <span class="gem__code__icon" id="js-gem__code--gemfile" data-clipboard-target="#gem_sha_256_checksum">=</span>
+      <span class="gem__code__tooltip--copy"><%= t('.copy_to_clipboard') %></span>
+      <span class="gem__code__tooltip--copied"><%= t('.copied') %></span>
     </div>
   <% end %>
 
   <% if latest_version.cert_chain.present? %>
     <h3 class="t-list__heading"><%= t '.signature_period' %>:</h3>
     <div class="gem__expiry">
-      <%= nice_date_for(latest_version.cert_chain_valid_not_before) %> - 
+      <%= nice_date_for(latest_version.cert_chain_valid_not_before) %> -
       <%= nice_date_for(latest_version.cert_chain_valid_not_after) %>
       <% if latest_version.signature_expired? %>
         (<%= t '.expired' %>)

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -163,7 +163,7 @@ class VersionsControllerTest < ActionController::TestCase
     end
 
     should "render the checksum version" do
-      assert page.has_content?(@latest_version.sha256_hex)
+      assert page.has_field?("gem_sha_256_checksum", with: @latest_version.sha256_hex)
     end
   end
 


### PR DESCRIPTION
When viewing an individual Rubygem version, let's make it simple for users to copy/paste the SHA 256 Checksum quickly. This change uses the existing copy/clipboard functionality.

Currently, it looks like this:

![image](https://github.com/rubygems/rubygems.org/assets/257/348fa1b9-a8c8-4d17-9208-381712b15e86)

Proposed change:

![image](https://github.com/rubygems/rubygems.org/assets/257/c40e6995-b1c5-4c36-bf41-e466181f2409)

![2024011226](https://github.com/rubygems/rubygems.org/assets/257/7084b536-c38e-4fb9-862b-1966d0a9a44b)

Thanks for your consideration!