### PR TITLE
Change to unique GH failed tests artifacts names.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ failure() && steps.test-all.outcome == 'failure' }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: capybara-screenshots
+          name: capybara-screenshots-${{ matrix.tests.name }}-${{ matrix.rubygems.name }}
           path: tmp/capybara
           if-no-files-found: ignore
 


### PR DESCRIPTION
randomly spotted at https://github.com/rubygems/rubygems.org/actions/runs/7509340315

## with this change

![image](https://github.com/rubygems/rubygems.org/assets/193936/8e5f036b-ee0f-487f-9725-1acf28adc847)
