### PR TITLE
Ensure session cookie is set on admin login page

### DIFF
--- a/app/views/avo/login.html.erb
+++ b/app/views/avo/login.html.erb
@@ -42,3 +42,5 @@
     </div>
   </body>
 </html>
+
+<% request.commit_csrf_token  %>

--- a/lib/gemcutter/middleware/admin_auth.rb
+++ b/lib/gemcutter/middleware/admin_auth.rb
@@ -31,9 +31,8 @@ class Gemcutter::Middleware::AdminAuth
         return
       end
       return if allow_unauthenticated_request?(request)
-
-      login_page = ApplicationController.renderer.new(request.env).render(template: "avo/login", layout: false, locals: { request: })
-      [200, { "Cache-Control" => "private, max-age=0" }, [login_page]]
+      login_page = ApplicationController.renderer.new(request.env).render(template: "avo/login", layout: false)
+      [200, { "Cache-Control" => "private, max-age=0", "Set-Cookie" => cookies.to_header }, [login_page]]
     end
 
     private


### PR DESCRIPTION
Otherwise CSRF validation will fail

Needed in rails 7.1 because the request forgery protection module no longer writes directly to the session storage, but rather to the (controller copy of the) request env, which then needs to be committed to the session separately

This is kinda gross, but this is the easiest fix given the Renderer API were using