### PR TITLE
Fix adoption link in app/views/rubygems/_aside.html.erb

### DIFF
--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: "rubygems/github_button", locals: { github_data_params: github_data_params } %>
   <% end %>
   <% if @adoption %>
-    <%= link_to "adoption", rubygem_adoptions_path(@rubygem), class: "adoption__tag" %>
+    <%= link_to "adoption", rubygem_adoptions_path(@rubygem.slug), class: "adoption__tag" %>
   <% end %>
   <div class="gem__downloads-wrap" data-href="<%= api_v1_download_path(@latest_version.full_name, :format => 'json') %>">
     <h2 class="gem__downloads__heading t-text--s">


### PR DESCRIPTION
fix  adoption link in `app/views/rubygems/_aside.html.erb`;

from
```
https://rubygems.org/gems/1/adoptions
```
(which returns 404)

to
```
https://rubygems.org/gems/gem-name/adoptions
```