### PR TITLE
Move to rails cache format version 7.0

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -39,7 +39,7 @@ Rails.application.config.active_support.remove_deprecated_time_with_zone_name = 
 # will have a different format that is not supported by Rails 6.1 applications.
 # Only change this value after your application is fully deployed to Rails 7.0
 # and you have no plans to rollback.
-# Rails.application.config.active_support.cache_format_version = 7.0
+Rails.application.config.active_support.cache_format_version = 7.0
 
 # Calls `Rails.application.executor.wrap` around test cases.
 # This makes test cases behave closer to an actual request or job.


### PR DESCRIPTION
Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Rails 7.0 is able to read both formats so the cache won't be invalidated during the upgrade.