### PR TITLE
Remove Clearance from password reset controller

### DIFF
--- a/app/controllers/concerns/mfa_expiry_methods.rb
+++ b/app/controllers/concerns/mfa_expiry_methods.rb
@@ -10,9 +10,11 @@ module MfaExpiryMethods
       session.delete(:mfa_expires_at)
     end
 
+    # Clear the session key when mfa has expired. This makes session_active? before_action guards simpler to write.
     def session_active?
       return false if session[:mfa_expires_at].nil?
-      session[:mfa_expires_at] > Time.current
+      delete_mfa_expiry_session if Time.current > session[:mfa_expires_at]
+      session[:mfa_expires_at].present?
     end
   end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -76,7 +76,7 @@ class EmailConfirmationsController < ApplicationController
 
   def validate_confirmation_token
     @user = User.find_by(confirmation_token: token_params)
-    redirect_to root_path, alert: t("failure_when_forbidden") unless @user&.valid_confirmation_token?
+    redirect_to root_path, alert: t("email_confirmations.update.token_failure") unless @user&.valid_confirmation_token?
   end
 
   def confirm_email

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,16 +1,20 @@
-class PasswordsController < Clearance::PasswordsController
+class PasswordsController < ApplicationController
   include MfaExpiryMethods
   include WebauthnVerifiable
   include SessionVerifiable
 
+  before_action :ensure_email_present, only: %i[create]
+
   before_action :validate_confirmation_token, only: %i[edit otp_edit webauthn_edit]
+  before_action :session_expired_failure, only: %i[otp_edit webauthn_edit], unless: :session_active?
+  before_action :webauthn_failure, only: %i[webauthn_edit], unless: :webauthn_credential_verified?
+  before_action :otp_failure, only: %i[otp_edit], unless: :otp_edit_conditions_met?
   after_action :delete_mfa_expiry_session, only: %i[otp_edit webauthn_edit]
 
-  # By default, clearance expects the token to be submitted with the password update.
-  # We already invalidated the token when the user became verified by token(+mfa).
-  skip_before_action :ensure_existing_user, only: %i[update]
-  # Instead of the token, we now require the user to have been verified recently.
   verify_session_before only: %i[update]
+
+  def new
+  end
 
   def edit
     if @user.mfa_enabled?
@@ -23,45 +27,41 @@ class PasswordsController < Clearance::PasswordsController
     else
       # When user doesn't have mfa, a valid token is a full "magic link" sign in.
       verified_sign_in
-      render template: "passwords/edit"
+      render :edit
     end
   end
 
+  def create
+    user = User.find_by_normalized_email(@email)
+
+    if user
+      user.forgot_password!
+      ::PasswordMailer.change_password(user).deliver_later
+    end
+
+    render :create, status: :accepted
+  end
+
   def update
-    if current_user.update_password password_from_password_reset_params
-      current_user.reset_api_key! if reset_params[:reset_api_key] == "true"
-      current_user.api_keys.expire_all! if reset_params[:reset_api_keys] == "true"
-      redirect_to url_after_update
+    if current_user.update_password reset_params[:password]
+      current_user.reset_api_key! if reset_params[:reset_api_key] == "true" # singular
+      current_user.api_keys.expire_all! if reset_params[:reset_api_keys] == "true" # plural
+      redirect_to dashboard_path
       session[:password_reset_token] = nil
     else
-      flash_failure_after_update
-      render template: "passwords/edit"
+      flash.now[:alert] = t(".failure")
+      render :edit
     end
   end
 
   def otp_edit
-    if otp_edit_conditions_met?
-      # When the user identified by the email token submits adequate totp, they are logged in
-      verified_sign_in
-      render template: "passwords/edit"
-    elsif !session_active?
-      login_failure(t("multifactor_auths.session_expired"))
-    else
-      login_failure(t("multifactor_auths.incorrect_otp"))
-    end
+    verified_sign_in
+    render :edit
   end
 
   def webauthn_edit
-    unless session_active?
-      login_failure(t("multifactor_auths.session_expired"))
-      return
-    end
-
-    return login_failure(@webauthn_error) unless webauthn_credential_verified?
-
-    # When the user identified by the email token submits verified webauthn, they are logged in
     verified_sign_in
-    render template: "passwords/edit"
+    render :edit
   end
 
   private
@@ -73,26 +73,28 @@ class PasswordsController < Clearance::PasswordsController
     StatsD.increment "login.success"
   end
 
-  def url_after_update
-    dashboard_path
+  def reset_params
+    params.fetch(:password_reset, {}).permit(:password, :reset_api_key, :reset_api_keys)
   end
 
-  def reset_params
-    params.fetch(:password_reset, {}).permit(:reset_api_key, :reset_api_keys)
+  def ensure_email_present
+    @email = params.dig(:password, :email)
+    return if @email.present?
+
+    flash.now[:alert] = t(".failure_on_missing_email")
+    render template: "passwords/new", status: :unprocessable_entity
   end
 
   def validate_confirmation_token
-    @user = find_user_for_edit
-    redirect_to root_path, alert: t("failure_when_forbidden") unless @user&.valid_confirmation_token?
+    @user = User.find_by(id: params[:user_id], confirmation_token: params[:token].to_s)
+    redirect_to root_path, alert: t("passwords.edit.token_failure") unless @user&.valid_confirmation_token?
   end
 
-  def deliver_email(user)
-    ::PasswordMailer.change_password(user).deliver_later
-  end
+  def otp_edit_conditions_met? = @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
 
-  def otp_edit_conditions_met?
-    @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
-  end
+  def session_expired_failure = login_failure(t("multifactor_auths.session_expired"))
+  def webauthn_failure = login_failure(@webauthn_error)
+  def otp_failure = login_failure(t("multifactor_auths.incorrect_otp"))
 
   def login_failure(message)
     flash.now.alert = message

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
   validates :password,
     length: { within: 10..200 },
     unpwn: true,
-    allow_nil: true,
+    allow_blank: true, # avoid double errors with can't be blank
     unless: :skip_password_validation?
 
   validates :full_name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, allow_nil: true

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,0 +1,3 @@
+<div id="clearance" class="password-reset">
+  <p><%= t(".success") %></p>
+</div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4,7 +4,6 @@ de:
   copied: Kopiert!
   copy_to_clipboard: In die Zwischenablage kopieren
   edit: Bearbeiten
-  failure_when_forbidden:
   verification_expired:
   feed_latest: RubyGems.org | Neueste Gems
   feed_subscribed: RubyGems.org | Abonnierte Gems
@@ -177,6 +176,7 @@ de:
       will_email_notice:
     update:
       confirmed_email:
+      token_failure:
   home:
     index:
       downloads_counting_html: Gezählte Downloads
@@ -393,10 +393,16 @@ de:
     edit:
       submit: Speichern dieses Passworts
       title: Zurücksetzen des Passworts
+      token_failure:
     new:
       submit: Zurücksetzen des Passworts
       title: Ändere dein Passwort
       will_email_notice: Wir senden dir einen Link damit du dein Passwort ändern kannst.
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp:
     session_expired:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
   copied: Copied!
   copy_to_clipboard: Copy to clipboard
   edit: Edit
-  failure_when_forbidden: Please double check the URL or try submitting it again.
   verification_expired: The verification has expired. Please verify again.
   feed_latest: RubyGems.org | Latest Gems
   feed_subscribed: RubyGems.org | Subscribed Gems
@@ -185,6 +184,7 @@ en:
       will_email_notice: We will email you confirmation link to activate your account.
     update:
       confirmed_email: Your email address has been verified.
+      token_failure: Please double check the URL or try submitting it again.
   home:
     index:
       downloads_counting_html: downloads &amp; counting
@@ -392,10 +392,16 @@ en:
     edit:
       submit: Save this password
       title: Reset password
+      token_failure: Please double check the URL or try submitting a new password reset.
     new:
       submit: Reset password
       title: Change your password
       will_email_notice: We will email you a link to change your password.
+    create:
+      success: You will receive an email within the next few minutes. It contains instructions for changing your password.
+      failure_on_missing_email: Email can't be blank.
+    update:
+      failure: Your password could not be changed. Please try again.
   multifactor_auths:
     incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,7 +4,6 @@ es:
   copied: "¡Copiado!"
   copy_to_clipboard: Copiar al portapapeles
   edit: Editar
-  failure_when_forbidden: Por favor verifica la URL o inténtalo nuevamente.
   verification_expired:
   feed_latest: RubyGems.org | Gemas más recientes
   feed_subscribed: RubyGems.org | Suscripciones a gemas
@@ -199,6 +198,7 @@ es:
         activar tu cuenta.
     update:
       confirmed_email: Tu dirección de correo se ha verificado.
+      token_failure: Por favor verifica la URL o inténtalo nuevamente.
   home:
     index:
       downloads_counting_html: descargas y contando
@@ -446,11 +446,17 @@ es:
     edit:
       submit: Guardar esta contraseña
       title: Restablecer contraseña
+      token_failure: Por favor verifica la URL o inténtalo nuevamente.
     new:
       submit: Restablecer contraseña
       title: Cambiar tu contraseña
       will_email_notice: Te enviaremos el enlace para cambiar tu contraseña por correo
         electrónico.
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp: Tu código OTP no es correcto.
     session_expired: Ha expirado tu sesión en la página de acceso.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,7 +4,6 @@ fr:
   copied: Copié!
   copy_to_clipboard: Copier
   edit: Modification
-  failure_when_forbidden: Veuillez vérifier l'URL ou réessayer.
   verification_expired:
   feed_latest: RubyGems.org | Derniers Gems
   feed_subscribed: RubyGems.org | Gems abonnés
@@ -190,6 +189,7 @@ fr:
         de confirmation pour l'activer.
     update:
       confirmed_email: Votre adresse email a été vérifiée.
+      token_failure: Veuillez vérifier l'URL ou réessayer.
   home:
     index:
       downloads_counting_html: téléchargements à ce jour
@@ -411,10 +411,16 @@ fr:
     edit:
       submit: Enregistrer ce mot de passe
       title: Nouveau mot de passe
+      token_failure: Veuillez vérifier l'URL ou réessayer.
     new:
       submit: Réinitialisez votre mot de passe
       title: Changement de mot de passe
       will_email_notice: Nous vous enverrons un email pour changer votre mot de passe.
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,7 +4,6 @@ ja:
   copied: コピー完了!
   copy_to_clipboard: クリップボードにコピー
   edit: 編集
-  failure_when_forbidden: URLを見返すか、再度送信してみてください。
   verification_expired:
   feed_latest: RubyGems.org | 最新のgemの一覧
   feed_subscribed: RubyGems.org | 購読したgemの一覧
@@ -179,6 +178,7 @@ ja:
       will_email_notice: アカウントを有効化するための確認リンクをメールで送ります。
     update:
       confirmed_email: メールアドレスが確認されました。
+      token_failure: URLを見返すか、再度送信してみてください。
   home:
     index:
       downloads_counting_html: ダウンロード数
@@ -391,10 +391,16 @@ ja:
     edit:
       submit: このパスワードを保存する
       title: パスワードをリセット
+      token_failure: URLを見返すか、再度送信してみてください。
     new:
       submit: パスワードをリセット
       title: パスワードを変更する
       will_email_notice: パスワード変更のためのリンクをEメールで送ります。
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp: OTPのコードが正しくありません。
     session_expired: ログインページのセッションが期限切れになりました。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -4,7 +4,6 @@ nl:
   copied:
   copy_to_clipboard:
   edit: Wijzig
-  failure_when_forbidden: Controleer het webadres, en probeer het opnieuw.
   verification_expired:
   feed_latest: RubyGems.org | Nieuwste Gems
   feed_subscribed: RubyGems.org | Geabonneerde Gems
@@ -182,6 +181,7 @@ nl:
       will_email_notice: We zullen je een nieuwe email sturen met een bevestigingslink
     update:
       confirmed_email:
+      token_failure: Controleer het webadres, en probeer het opnieuw.
   home:
     index:
       downloads_counting_html:
@@ -397,10 +397,16 @@ nl:
     edit:
       submit: Sla dit wachtwoord op
       title: reset wachtwoord
+      token_failure: Controleer het webadres, en probeer het opnieuw.
     new:
       submit: Wachtwoord wijzigen
       title: Wachtwoord wijzigen
       will_email_notice: We sturen een link om je wachtwoord te wijzigen.
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp:
     session_expired:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -4,7 +4,6 @@ pt-BR:
   copied:
   copy_to_clipboard:
   edit: Editar
-  failure_when_forbidden: Por favor, confira a URL ou tente submetê-la novamente.
   verification_expired:
   feed_latest: RubyGems.org | Últimas Gems
   feed_subscribed: RubyGems.org | Gems do seu Feed
@@ -187,6 +186,7 @@ pt-BR:
       will_email_notice:
     update:
       confirmed_email:
+      token_failure: Por favor, confira a URL ou tente submetê-la novamente.
   home:
     index:
       downloads_counting_html: downloads
@@ -408,10 +408,16 @@ pt-BR:
     edit:
       submit: Salvar senha
       title: Resetar senha
+      token_failure: Por favor, confira a URL ou tente submetê-la novamente.
     new:
       submit: Resetar senha
       title: Alterar senha
       will_email_notice: Você vai receber um email com o link para atualizar sua senha.
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp:
     session_expired:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -4,7 +4,6 @@ zh-CN:
   copied: 已复制！
   copy_to_clipboard: 复制到剪贴板
   edit: 编辑
-  failure_when_forbidden: 请再次确认 URL 或尝试重新提交
   verification_expired:
   feed_latest: RubyGems.org | 最新的 Gem
   feed_subscribed: RubyGems.org | 订阅的 Gem
@@ -181,6 +180,7 @@ zh-CN:
       will_email_notice: 我们将会通过 Email 发送确认激活账号的链接给您。
     update:
       confirmed_email: 邮箱地址验证成功。
+      token_failure: 请再次确认 URL 或尝试重新提交
   home:
     index:
       downloads_counting_html: 总下载次数
@@ -399,10 +399,16 @@ zh-CN:
     edit:
       submit: 保存该密码
       title: 重置密码
+      token_failure: 请再次确认 URL 或尝试重新提交
     new:
       submit: 重置密码
       title: 修改您的密码
       will_email_notice: 我们将会向您发送一封包含修改密码链接的邮件。
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp: 你的 OTP 码 不正确。
     session_expired: 您的登录页面会话已过期。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -4,7 +4,6 @@ zh-TW:
   copied: 已複製
   copy_to_clipboard: 複製
   edit: 編輯
-  failure_when_forbidden: 請確認 URL 或再次提交
   verification_expired:
   feed_latest: RubyGems.org | 最新 Gems
   feed_subscribed: RubyGems.org | 訂閱 Gems
@@ -176,6 +175,7 @@ zh-TW:
       will_email_notice: 我們將會通過 Email 發送帳號認證信連結給你。
     update:
       confirmed_email: Email 驗證成功。
+      token_failure: 請確認 URL 或再次提交
   home:
     index:
       downloads_counting_html: 總下載次數
@@ -381,10 +381,16 @@ zh-TW:
     edit:
       submit: 更新密碼
       title: 重設密碼
+      token_failure: 請確認 URL 或再次提交
     new:
       submit: 更新密碼
       title: 修改密碼
       will_email_notice: 系統將會寄一封包含重設密碼連結的電子郵件給你
+    create:
+      success:
+      failure_on_missing_email:
+    update:
+      failure:
   multifactor_auths:
     incorrect_otp: 你的 OTP 碼 不正確。
     session_expired:

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -50,7 +50,7 @@ class PasswordResetTest < SystemTest
     assert page.has_content? "Sign out"
   end
 
-  test "resetting a password with a blank password" do
+  test "resetting a password with a blank or short password" do
     forgot_password_with @user.email
 
     visit password_reset_link
@@ -60,10 +60,18 @@ class PasswordResetTest < SystemTest
     fill_in "Password", with: ""
     click_button "Save this password"
 
-    assert page.has_content? "Password can't be blank."
+    assert page.has_content? "Your password could not be changed. Please try again."
+    assert page.has_content? "Password can't be blank"
     assert page.has_content? "Reset password"
 
-    # try again
+    # try again with short password
+    fill_in "Password", with: "pass"
+    click_button "Save this password"
+
+    assert page.has_content? "Password is too short (minimum is 10 characters)"
+    assert page.has_content? "Reset password"
+
+    # try again with valid password
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
 


### PR DESCRIPTION
The Clearance password reset controller behavior was mostly skipped or overridden. This completes the process and makes all the behavior clearly expressed in the passwords controller.

On moving functionality over, a few thing were changed:
- Sometimes the failure message on bad url would vary. Now it is consistent (and reworded to indicate clearly what should happen next).
- Added missing translations from clearance translation file.
- Correct a case where instead of redirecting to the root path on failure, it would render the passwords/new template on a request for edit. This may "make sense" in some ways, but it's not the behavior you would expect by reading the controller, but was hidden in clearance.
- Don't use the session[:password_reset_token] at all. You must finish the password reset flow continuously using the forms we render. This also prevents a user from abandoning a reset password flow at, e.g., the OTP challenge from persisting the state in their session that would allow continuing the password reset.

Additional thing I did not update that I think would be an improvement:
- [ ] It's weird that we render passwords/create.html.erb after submitting the passwords/new email form.
       It places you on a nearly empty page with only a message that could be in flash, and the page has no GET equivalent. Reloading the page will trigger the "are you sure you want to resubmit this form?". Overall this doesn't seem like a great design.
- [ ] I think it would make more sense for the password reset link to take you through a email token based login process, then redirect to password edit. That would set us up to allow password changes on verify while logged in without the email loop (technically this is possible now if you submit the `update` action directly after verifying using another action that request verification.)
- [ ] Instead of redirecting to root on token not found, I think it should redirect to `new_password_path` because that's what we're suggesting that they do to fix the problem.
- [ ] If you enter the wrong totp code, you will get the form re-rendered but it loses the token from the form action, so you can't submit it again even though it rendered. **I chose not to fix this because it would make it much easier to retry totp codes.**