### PR TITLE
Update hash_digest_class to SHA256

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -28,7 +28,7 @@ Rails.application.config.active_support.key_generator_hash_digest_class = OpenSS
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.


### PR DESCRIPTION
This is the last 7.0 default to change

This will lead to cache invalidation, but I think that is OK, since it is 1-time and we have shielding from fastly
