### PR TITLE
Validate that version shas are valid base64

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -41,6 +41,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :description, :summary, :authors, :requirements, :cert_chain,
     length: { minimum: 0, maximum: Gemcutter::MAX_TEXT_FIELD_LENGTH },
     allow_blank: true
+  validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
 
   validate :unique_canonical_number, on: :create
   validate :platform_and_number_are_unique, on: :create

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -12,4 +12,5 @@ module Patterns
   URL_VALIDATION_REGEXP = %r{\Ahttps?://([^\s:@]+:[^\s:@]*@)?[A-Za-z\d-]+(\.[A-Za-z\d-]+)+\.?(:\d{1,5})?([/?]\S*)?\z}
   VERSION_PATTERN       = /\A#{Gem::Version::VERSION_PATTERN}\z/o
   REQUIREMENT_PATTERN   = Gem::Requirement::PATTERN
+  BASE64_SHA256_PATTERN = %r{\A[0-9a-zA-Z_+/-]{43}={0,2}\z}
 end

--- a/test/models/dependency_test.rb
+++ b/test/models/dependency_test.rb
@@ -124,7 +124,7 @@ class DependencyTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture("with_dependencies-0.0.0")
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
 
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
 

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -783,7 +783,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture("test-0.0.0")
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
       end
 
@@ -815,7 +815,7 @@ class RubygemTest < ActiveSupport::TestCase
 
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
       end
 
@@ -840,7 +840,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture("with_dependencies-0.0.0")
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
       end
 
       should "save the gem" do
@@ -860,7 +860,7 @@ class RubygemTest < ActiveSupport::TestCase
         @specification = gem_specification_from_gem_fixture("with_dependencies-0.0.0")
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
 
         @rubygem.update_attributes_from_gem_specification!(@version, @specification)
 
@@ -885,7 +885,7 @@ class RubygemTest < ActiveSupport::TestCase
 
         @rubygem       = Rubygem.new(name: @specification.name)
         @version       = @rubygem.find_or_initialize_version_from_spec(@specification)
-        @version.sha256 = "dummy"
+        @version.sha256 = Digest::SHA256.base64digest("dummy")
       end
 
       should "save the gem" do

--- a/test/unit/patterns_test.rb
+++ b/test/unit/patterns_test.rb
@@ -44,4 +44,8 @@ class PatternsTest < ActiveSupport::TestCase
   test "SPECIAL_CHAR_PREFIX_REGEXP is linear" do
     assert Regexp.linear_time?(Patterns::SPECIAL_CHAR_PREFIX_REGEXP)
   end
+
+  test "BASE64_SHA256_PATTERN is linear" do
+    assert Regexp.linear_time?(Patterns::BASE64_SHA256_PATTERN)
+  end
 end


### PR DESCRIPTION
Otherwise, getting the hex version blows up

Made my life easier writing tests for event logging
