### PR TITLE
Stop passing AR objects to logger

### DIFF
--- a/app/jobs/notify_web_hook_job.rb
+++ b/app/jobs/notify_web_hook_job.rb
@@ -22,7 +22,7 @@ class NotifyWebHookJob < ApplicationJob
   # has to come after the retry on
   discard_on(Faraday::UnprocessableEntityError) do |j, e|
     raise unless j.use_hook_relay?
-    Rails.logger.info({ webhook_id: j.webhook.id, url: j.webhook.url, response: JSON.parse(e.response_body) }.to_json)
+    logger.info({ webhook_id: j.webhook.id, url: j.webhook.url, response: JSON.parse(e.response_body) })
     j.webhook.increment! :failure_count
   end
 

--- a/app/jobs/verify_link_job.rb
+++ b/app/jobs/verify_link_job.rb
@@ -15,7 +15,7 @@ class VerifyLinkJob < ApplicationJob
 
   rescue_from LinkNotPresentError, HTTPResponseError, *ERRORS do |error|
     logger.info "Linkback verification failed with error: #{error.message}", error: error, uri: link_verification.uri,
-      linkable: link_verification.linkable
+      linkable: link_verification.linkable.to_gid
 
     link_verification.transaction do
       record_failure

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -159,7 +159,7 @@ class Pusher
   end
 
   def notify(message, code)
-    logger.info { { message:, code:, owner: owner, api_key: api_key&.id, rubygem: rubygem&.name, version: version&.full_name } }
+    logger.info { { message:, code:, owner: owner.to_gid, api_key: api_key&.id, rubygem: rubygem&.name, version: version&.full_name } }
 
     @message = message
     @code    = code

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -499,7 +499,7 @@ class PusherTest < ActiveSupport::TestCase
     should "be false if rubygem is new and api key has unexpected owner type" do
       @cutter.stubs(:rubygem).returns Rubygem.new
 
-      owner = stub("owner")
+      owner = stub("owner", to_gid: nil)
       @api_key.update_columns(owner_id: 0, owner_type: "stub")
       @cutter.stubs(:owner).returns owner
       owner.expects(:owns_gem?).with(@cutter.rubygem).returns(false)
@@ -536,7 +536,7 @@ class PusherTest < ActiveSupport::TestCase
       end
 
       should "be false if api key has unexpected owner type" do
-        owner = stub("owner")
+        owner = stub("owner", to_gid: nil)
         @api_key.update_columns(owner_id: 0, owner_type: "stub")
         @cutter.stubs(:owner).returns owner
         owner.expects(:owns_gem?).with(@rubygem).returns(false)


### PR DESCRIPTION
It causes the objects to be accessed on a different thread, making headaches when running tests
