### PR TITLE
Do not cache Webauthn polling endpoint

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -2,6 +2,7 @@
 # the user with a Webauthn login. That is done in controllers/webauthn_verifications_controller.
 class Api::V1::WebauthnVerificationsController < Api::BaseController
   before_action :authenticate_with_credentials
+  before_action :set_cache_headers, only: :status
 
   def create
     if @user.webauthn_enabled?


### PR DESCRIPTION
Fixes: https://github.com/rubygems/rubygems.org/issues/4393

Currently the webauthn polling url caches the response when the client first polls. This response will be a pending response. When the user authenticates, the response will still be pending. 

We should disable caching for this endpoint so that when the user authenticates, the success response with the OTP will be returned instead of the cached pending response. 