### PR TITLE
Rename `set_cache_headers` to `disable_cache`

### DIFF
--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -2,7 +2,7 @@
 # the user with a Webauthn login. That is done in controllers/webauthn_verifications_controller.
 class Api::V1::WebauthnVerificationsController < Api::BaseController
   before_action :authenticate_with_credentials
-  before_action :set_cache_headers, only: :status
+  before_action :disable_cache, only: :status
 
   def create
     if @user.webauthn_enabled?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,7 +165,7 @@ class ApplicationController < ActionController::Base
     params.delete(:params)
   end
 
-  def set_cache_headers
+  def disable_cache
     response.headers["Cache-Control"] = "no-cache, no-store"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,7 @@ class ProfilesController < ApplicationController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, except: :show
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, except: :show
   before_action :verify_password, only: %i[update destroy]
-  before_action :set_cache_headers, only: :edit
+  before_action :disable_cache, only: :edit
 
   def show
     @user           = User.find_by_slug!(params[:id])

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,7 +1,7 @@
 class SettingsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
-  before_action :set_cache_headers
+  before_action :disable_cache
 
   def edit
     @user = current_user


### PR DESCRIPTION
From https://github.com/rubygems/rubygems.org/pull/4412

Even though `set_cache_headers` is setting the cache header, it's setting the header to turn off the cache for the request. 

Renaming it as it is more clear that the method is used to make sure the request isn't cached. 