### PR TITLE
Fix CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ build will fail.
 If you'd like RuboCop to attempt to automatically fix your style offenses, you
 can try running:
 
-    bundle exec rake rubocop:auto_correct
+    bundle exec rake rubocop:autocorrect
 
 #### Importing gems into the database
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ Database Layout
 
 Courtesy of [Rails ERD](https://voormedia.github.io/rails-erd/)
 
-![Rubygems.org Domain Model](https://cdn.rawgit.com/rubygems/rubygems.org/master/doc/erd.svg)
+    bin/rails gen_erd
 
 Locales
 -------


### PR DESCRIPTION
- Replace not displayed link with `gen_erd` command
  - follows #4144
- Fix deprecated task
  - The original command resulted in an error when executed and displayed the message: `rubocop:auto_correct task is deprecated; use rubocop:autocorrect task or rubocop:autocorrect_all task instead.`