### PR TITLE
Verify that the JWKS is not empty before verifying signature

### DIFF
--- a/app/controllers/api/v1/oidc/api_key_roles_controller.rb
+++ b/app/controllers/api/v1/oidc/api_key_roles_controller.rb
@@ -70,6 +70,7 @@ class Api::V1::OIDC::ApiKeyRolesController < Api::BaseController
   end
 
   def decode_jwt
+    raise UnverifiedJWT, "Provider missing JWKS" if @api_key_role.provider.jwks.blank?
     @jwt = JSON::JWT.decode_compact_serialized(params.require(:jwt), @api_key_role.provider.jwks)
   rescue JSON::ParserError
     raise UnverifiedJWT, "Invalid JSON"

--- a/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
+++ b/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
@@ -50,6 +50,7 @@ class Api::V1::OIDC::TrustedPublisherController < Api::BaseController
   end
 
   def verify_signature
+    raise UnsupportedIssuer, "Provider is missing jwks" if @provider.jwks.blank?
     raise UnverifiedJWT, "Invalid time" unless (@jwt["nbf"]..@jwt["exp"]).cover?(Time.now.to_i)
     @jwt.verify!(@provider.jwks)
   end

--- a/test/integration/api/v1/oidc/trusted_publisher_controller_test.rb
+++ b/test/integration/api/v1/oidc/trusted_publisher_controller_test.rb
@@ -178,6 +178,22 @@ class Api::V1::OIDC::TrustedPublisherControllerTest < ActionDispatch::Integratio
       assert_response :not_found
     end
 
+    should "return not found when issuer has no jwks and jwt is unsigned" do
+      trusted_publisher = build(:oidc_trusted_publisher_github_action,
+        repository_name: "oidc-test",
+        repository_owner_id: "1946610",
+        workflow_filename: "token.yml")
+      trusted_publisher.repository_owner = "segiddins"
+      trusted_publisher.save!
+
+      OIDC::Provider.github_actions.update!(jwks: nil)
+
+      post api_v1_oidc_trusted_publisher_exchange_token_path,
+        params: { jwt: JSON::JWT.new(@claims).to_s }
+
+      assert_response :not_found
+    end
+
     should "succeed with matching trusted publisher" do
       trusted_publisher = build(:oidc_trusted_publisher_github_action,
         repository_name: "oidc-test",


### PR DESCRIPTION
Otherwise, an unsigned JWT will validate against a nil jwks
