### PR TITLE
Expire ApiKey without validation.

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -103,7 +103,10 @@ class ApiKey < ApplicationRecord
   end
 
   def expire!
-    update!(expires_at: Time.current)
+    transaction do
+      update_column(:expires_at, Time.current)
+      record_expire_event
+    end
   end
 
   private

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -850,6 +850,24 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "block invalid legacy user" do
+    setup do
+      @user = create(:user, handle: "MikeJudge")
+      @api_key = create(:api_key, owner: @user)
+
+      # simulate legacy invalid api key
+      @api_key.update_columns(show_dashboard: true, add_owner: true)
+
+      refute_predicate @api_key, :valid?
+    end
+
+    should "block user anyway" do
+      assert_changed(@user, :email, :password, :api_key, :remember_token) do
+        @user.block!
+      end
+    end
+  end
+
   context ".normalize_email" do
     should "return the normalized email" do
       assert_equal "user@example.com", User.normalize_email(:"UsEr@ example . COM")


### PR DESCRIPTION
auto-expiration/block job emits errors thanks to invalid api keys sometimes and is restarted