### PR TITLE
Fix missing host in email title

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -20,7 +20,7 @@ class Mailer < ApplicationMailer
   def email_reset_update(user)
     @user = user
     mail to: @user.email,
-         subject: I18n.t("mailer.email_reset_update.subject")
+         subject: I18n.t("mailer.email_reset_update.subject", host: Gemcutter::HOST_DISPLAY)
   end
 
   def email_confirmation(user)

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class MailerTest < ActionMailer::TestCase
   setup do

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class MailerTest < ActionMailer::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  context "#email_reset_update" do
+    should "include host in subject" do
+      email = Mailer.email_reset_update(@user)
+
+      assert_emails(1) { email.deliver_now }
+
+      assert_includes email.subject, Gemcutter::HOST_DISPLAY
+    end
+  end
+end


### PR DESCRIPTION
![image](https://github.com/rubygems/rubygems.org/assets/1319150/5487605c-6e0f-4bbb-aa30-48240d4496ac)
