### PR TITLE
Add rel=”noopener” to target="_blank" links to appease CodeQL.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -176,35 +176,35 @@
         </div>
       </div>
       <div class="footer__sponsors">
-        <a class="footer__sponsor footer__sponsor__ruby_central" href="https://rubycentral.org/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__ruby_central" href="https://rubycentral.org/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.supported_by") %>
           <span class="t-hidden">Ruby Central</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__dockyard" href="https://dockyard.com/ruby-on-rails-consulting" target="_blank">
+        <a class="footer__sponsor footer__sponsor__dockyard" href="https://dockyard.com/ruby-on-rails-consulting" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.designed_by") %>
           <span class="t-hidden">DockYard</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__dnsimple" href="https://dnsimple.link/resolving-rubygems" target="_blank">
+        <a class="footer__sponsor footer__sponsor__dnsimple" href="https://dnsimple.link/resolving-rubygems" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.resolved_with") %>
           <span class="t-hidden">DNSimple</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__datadog" href="https://www.datadoghq.com/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__datadog" href="https://www.datadoghq.com/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.monitored_by") %>
           <span class="t-hidden">Datadog</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__fastly" href="https://www.fastly.com/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__fastly" href="https://www.fastly.com/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.gems_served_by") %>
           <span class="t-hidden">Fastly</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__honeybadger" href="https://www.honeybadger.io/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__honeybadger" href="https://www.honeybadger.io/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.monitored_by") %>
           <span class="t-hidden">Honeybadger</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__domainr" href="https://domainr.com/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__domainr" href="https://domainr.com/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.verified_by") %>
           <span class="t-hidden">Domainr</span>
         </a>
-        <a class="footer__sponsor footer__sponsor__whitesource" href="https://www.whitesourcesoftware.com/" target="_blank">
+        <a class="footer__sponsor footer__sponsor__whitesource" href="https://www.whitesourcesoftware.com/" target="_blank" rel="noopener">
           <%= t("layouts.application.footer.secured_by") %>
           <span class="t-hidden">Whitesource</span>
         </a>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -107,13 +107,13 @@
 
 										<div class="hide-for-mobile">
 											<div class="text-nav" style="color:#000000; font-family:Arial, sans-serif; min-width:auto !important; font-size:12px; line-height:22px; text-align:center">
-												<a href=<%= root_url %> target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">HOME</span></a>
+												<a href=<%= root_url %> target="_blank" rel="noopener" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">HOME</span></a>
 												&nbsp;&nbsp;|&nbsp;&nbsp;
-												<a href="https://guides.rubygems.org/" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">GUIDES</span></a>
+												<a href="https://guides.rubygems.org/" target="_blank" rel="noopener" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">GUIDES</span></a>
 												&nbsp;&nbsp;|&nbsp;&nbsp;
-												<a href="https://blog.rubygems.org/" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">BLOG</span></a>
+												<a href="https://blog.rubygems.org/" target="_blank" rel="noopener" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">BLOG</span></a>
 												&nbsp;&nbsp;|&nbsp;&nbsp;
-												<a href="mailto:support@rubygems.org" target="_blank" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">CONTACT US</span></a>
+												<a href="mailto:support@rubygems.org" target="_blank" rel="noopener" class="link-white" style="color:#000000; text-decoration:none"><span class="link-white" style="color:#000000; text-decoration:none">CONTACT US</span></a>
 											</div>
 											<table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="20" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
@@ -199,9 +199,9 @@
 																		<td align="center">
 																			<table border="0" cellspacing="0" cellpadding="0">
 																				<tr>
-																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://twitter.com/rubygems_status" target="_blank"><img src="<%= image_url("twitter_mail_icon.png") %>" border="0" width="34" height="34" alt="" /></a></td>
-																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://github.com/rubygems" target="_blank"><img src="<%= image_url("github_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
-																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://groups.google.com/forum/#!forum/rubygems-org" target="_blank"><img src="<%= image_url("google_group_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
+																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://twitter.com/rubygems_status" target="_blank" rel="noopener"><img src="<%= image_url("twitter_mail_icon.png") %>" border="0" width="34" height="34" alt="" /></a></td>
+																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://github.com/rubygems" target="_blank" rel="noopener"><img src="<%= image_url("github_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
+																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://groups.google.com/forum/#!forum/rubygems-org" target="_blank" rel="noopener"><img src="<%= image_url("google_group_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																				</tr>
 																			</table>
 																		</td>

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -60,7 +60,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                          <a href=<%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -29,7 +29,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                          <a href=<%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/mailer/mfa_notification.html.erb
+++ b/app/views/mailer/mfa_notification.html.erb
@@ -34,7 +34,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTI-FACTOR AUTHENTICATION (MFA)</span></a>
+                          <a href=<%= new_multifactor_auth_url %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTI-FACTOR AUTHENTICATION (MFA)</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/owners_mailer/new_ownership_requests.html.erb
+++ b/app/views/owners_mailer/new_ownership_requests.html.erb
@@ -34,7 +34,7 @@
                       </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= rubygem_adoptions_url(@rubygem) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none"><%= t("mailer.new_opwnership_requests.button") %></span></a>
+                          <a href=<%= rubygem_adoptions_url(@rubygem) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none"><%= t("mailer.new_opwnership_requests.button") %></span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/owners_mailer/ownership_confirmation.html.erb
+++ b/app/views/owners_mailer/ownership_confirmation.html.erb
@@ -29,7 +29,7 @@
                       </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                          <a href=<%= confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/owners_mailer/ownership_request_approved.html.erb
+++ b/app/views/owners_mailer/ownership_request_approved.html.erb
@@ -26,7 +26,7 @@
                         </td>
                         <td bgcolor="#e9573f">
                           <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                            <a href=<%= rubygem_owners_url(@rubygem.slug) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none"><%= t("mailer.new_opwnership_requests.owners_page") %></span></a>
+                            <a href=<%= rubygem_owners_url(@rubygem.slug) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none"><%= t("mailer.new_opwnership_requests.owners_page") %></span></a>
                           </div>
                         </td>
                         <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/password_mailer/change_password.html.erb
+++ b/app/views/password_mailer/change_password.html.erb
@@ -29,7 +29,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
+                          <a href=<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -531,9 +531,9 @@ en:
       mfa:
         multifactor_auth: Multi-factor authentication
         otp: Authentication app
-        disabled_html: You have not yet enabled OTP based multi-factor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
+        disabled_html: You have not yet enabled OTP based multi-factor authentication. Please refer to <a target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
         go_settings: Register a new device
-        level_html: You have enabled multi-factor authentication. Please click 'Update' to change your MFA level. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
+        level_html: You have enabled multi-factor authentication. Please click 'Update' to change your MFA level. Please refer to <a target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on MFA levels.
         enabled_note:
           You have enabled multi-factor authentication. Please input your OTP from your authenticator or one of your active
           recovery codes to disable it.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -620,11 +620,11 @@ es:
         multifactor_auth: Autenticación de múltiples factores
         otp: Aplicación de autenticación
         disabled_html: No has activado todavía la autenticación de múltiples factores
-          basada en OTP. Por favor lee la <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía
+          basada en OTP. Por favor lee la <a target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía
           sobre AMF</a> para informarte sobre los distintos niveles de AMF.
         go_settings: Registrar un nuevo dispositivo
         level_html: Has activado la autenticación de múltiples factores. Pincha en
-          "Actualizar" para modificar el nivel de AMF. Por favor lee la <a target="_blank"
+          "Actualizar" para modificar el nivel de AMF. Por favor lee la <a target="_blank" rel="noopener"
           href="https://guides.rubygems.org/setting-up-multifactor-authentication">guía
           sobre AMF</a> para informarte sobre los distintos niveles de AMF.
         enabled_note: Has activado la autenticación de múltiples factores. Para desactivarla

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -532,11 +532,11 @@ ja:
       mfa:
         multifactor_auth: 多要素認証
         otp: 認証アプリ
-        disabled_html: OTPベースの多要素認証を有効にしていません。MFAの水準に関する詳細情報については<a target="_blank"
+        disabled_html: OTPベースの多要素認証を有効にしていません。MFAの水準に関する詳細情報については<a target="_blank" rel="noopener"
           href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGemsのMFAのガイド</a>をご参照ください。
         go_settings: 新しい機器を登録
         level_html: 多要素認証が有効になっています。「更新」をクリックしてMFAの水準を変更してください。MFAの水準についての詳細情報は<a
-          target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGemsのMFAのガイド</a>をご参照ください。
+          target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGemsのMFAのガイド</a>をご参照ください。
         enabled_note: 多要素認証が有効化済みです。認証器上のOTPか有効な復旧コードの1つを入力して無効にしてください。
         update: 更新
         disable: 無効

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -539,10 +539,10 @@ zh-CN:
       mfa:
         multifactor_auth: 多因素验证
         otp: 身份认证应用
-        disabled_html: 您尚未启用基于 OTP 的多因素身份验证。请参考<a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems
+        disabled_html: 您尚未启用基于 OTP 的多因素身份验证。请参考<a target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems
           多因素验证指南</a> 来了解更多关于多因素验证级别的信息。
         go_settings: 注册新设备
-        level_html: 您已启用多因素身份验证。请点击 “更新” 来改变您的 MFA 级别。请参考 <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems
+        level_html: 您已启用多因素身份验证。请点击 “更新” 来改变您的 MFA 级别。请参考 <a target="_blank" rel="noopener" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems
           多重身份验证指南 来了解更多 MFA 级别的信息。
         enabled_note: 您已启用多因素身份验证。请输入您从身份验证器上获得的 OTP 码，或使用您已生效的恢复码来禁用。
         update: 更新


### PR DESCRIPTION
In #4462, CodeQL is making noise about `target="_blank"` links without `rel="noopener"`. I added it here to quiet CodeQL in future PRs. I doubt that any self respecting client is actually breaking this rule, but might as well.

It has also been suggested, and we do this in a few places, to add `noreferrer` as in `rel="noopener noreferrer"`. I don't think it's necessary as long as CodeQL is fine with it.

For email, I suggest that we remove the target attribute entirely and allow the email client to do its thing.

What do you think? Should we...
1. Remove target="_blank" from emails and let the client do it's thing.
2. Leave it and add the rel="noopener" so CodeQL will work.