### PR TITLE
Don't use nonces in Content-Security-Policy, use hashes.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Clearance::Authentication
   include ApplicationMultifactorMethods
   include TraceTagger
+  include InlineScripts
 
   helper ActiveSupport::NumberHelper
 
@@ -17,22 +18,10 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :notice_html
 
-  ###
-  # Content security policy override for script-src
-  # This is necessary because we use a SHA256 for the importmap script tag
-  # because caching behavior of the mostly static pages could mean longer lived nonces
-  # being served from cache instead of unique nonces for each request.
-  # This ensures that importmap passes CSP and can be cached safely.
-  content_security_policy do |policy|
-    policy.script_src(
-      :self,
-      "'sha256-#{Digest::SHA256.base64digest(Rails.application.importmap.to_json(resolver: ApplicationController.helpers))}'",
-      "https://secure.gaug.es",
-      "https://www.fastly-insights.com",
-      "https://unpkg.com/@hotwired/stimulus/dist/stimulus.umd.js",
-      "https://unpkg.com/stimulus-rails-nested-form/dist/stimulus-rails-nested-form.umd.js"
-    )
+  inline_script :importmap do
+    Rails.application.importmap.to_json(resolver: helpers)
   end
+  inline_script :entrypoint, %(import "application")
 
   def set_locale
     I18n.locale = user_locale

--- a/app/controllers/concerns/inline_scripts.rb
+++ b/app/controllers/concerns/inline_scripts.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This concern allows us to define inline scripts in the controller.
+# This means that scripts can be generated and then their sha256 hash can be
+# calculated for use in the content security policy.
+#
+# This is useful for importmap and other inline scripts that are generated
+# and need to be included in the content security policy.
+#
+# We rely on the sha256 hash because a nonce doesn't work as well with caching.
+# The nonce would otherwise get cached and served to everyone. Not very nonce-y.
+module InlineScripts
+  extend ActiveSupport::Concern
+
+  module Helper
+    def javascript_inline_importmap_tag(importmap)
+      importmap = inline_script_content(importmap) if importmap.is_a?(Symbol)
+      tag.script importmap.html_safe, type: "importmap", "data-turbo-track": "reload"
+    end
+
+    def javascript_module_tag(content)
+      content = inline_script_content(content) if content.is_a?(Symbol)
+      tag.script content.html_safe, type: "module"
+    end
+  end
+
+  class_methods do
+    def inline_script(name, content = nil, &block)
+      content = block if block
+      inline_scripts[name] = content
+    end
+  end
+
+  included do
+    class_attribute :inline_scripts
+    self.inline_scripts = {}
+
+    helper InlineScripts::Helper
+    helper_method :inline_script_content
+
+    private :inline_scripts
+    private :inline_script_content
+    private :inline_script_content_security_hashes
+
+    content_security_policy do |policy|
+      script_srcs = policy.script_src + inline_script_content_security_hashes
+      policy.script_src(*script_srcs)
+    end
+  end
+
+  def inline_script_content(name)
+    content = inline_scripts[name]
+    case content
+    when Proc then instance_exec(&content)
+    when Symbol then send(content)
+    else content
+    end
+  end
+
+  def inline_script_content_security_hashes
+    inline_scripts.map do |name, _|
+      content = inline_script_content(name)
+      "'sha256-#{Digest::SHA256.base64digest(content)}'"
+    end
+  end
+
+  def inline_scripts
+    self.class.inline_scripts
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,13 +13,6 @@ module ApplicationHelper
                 title: title)
   end
 
-  # Copied from importmap-rails but with the nonce removed. We rely on the sha256 hash instead.
-  # Relying on the hash improves the caching behavior by not sending the cached nonce to the client.
-  def javascript_inline_importmap_tag(importmap_json = Rails.application.importmap.to_json(resolver: self))
-    tag.script importmap_json.html_safe,
-      type: "importmap", "data-turbo-track": "reload"
-  end
-
   def short_info(rubygem)
     info = gem_info(rubygem).strip.truncate(90)
     escape_once(sanitize(info))

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,9 @@
     <%= render "layouts/feeds" %>
     <%= csrf_meta_tag %>
     <%= yield :head %>
-    <%= javascript_importmap_tags %>
+    <%= javascript_inline_importmap_tag :importmap %>
+    <%= javascript_importmap_module_preload_tags %>
+    <%= javascript_module_tag :entrypoint %>
   </head>
 
   <body class="<%= 'body--index' if request.path_info == '/' %>" data-controller="nav">

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -50,14 +50,9 @@ Rails.application.config.content_security_policy do |policy|
   }
 end
 
-# Generate session nonces for permitted importmap, inline scripts, and inline styles.
-Rails.application.config.content_security_policy_nonce_generator = lambda { |request|
-  # Suggested nonce generator doesn't work on first page load https://github.com/rails/rails/issues/48463
-  # Related PR attempting to fix: https://github.com/rails/rails/pull/48510
-  request.session.send(:load_for_write!) # force session to be created
-  request.session.id.to_s.presence || SecureRandom.base64(16)
-}
-Rails.application.config.content_security_policy_nonce_directives = %w[script-src style-src]
+# We purposely do not use nonce directives. It doesn't play as nice with edge caching.
+# Instead, we use sha256 hashes for inline scripts. See InlineScripts for more details.
+Rails.application.config.content_security_policy_nonce_directives = nil
 
 # Report CSP violations to a specified URI. See:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only


### PR DESCRIPTION
This adds a concern that provides the `inline_script` and `inline_script_content` interface which allows us to declare and then render inline scripts in a way that is compatible with computing hashes.

The nonce is not ideal because it gets cached by Fastly, with each page caching a different nonce based on the user requests that happened to be cached. Not very nonce-y.

This also remove the nonce hack that caused some session generation problems originally, even though they are fixed now.