### PR TITLE
Correctly pluralize "version(s) since" on versions index page

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -705,7 +705,9 @@ de:
     index:
       not_hosted_notice: Dieses Gem wird nicht gerade von RubyGems.org gehostet.
       title: Alle Versionen von %{name}
-      versions_since: "%{count} Versionen seit %{since}"
+      versions_since:
+        other: "%{count} Versionen seit %{since}"
+        one: "%{count} Version seit %{since}"
       imported_gem_version_notice:
     version:
       yanked:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,7 +707,9 @@ en:
     index:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org.
       title: All versions of %{name}
-      versions_since: "%{count} versions since %{since}"
+      versions_since:
+        other: "%{count} versions since %{since}"
+        one: "1 version since %{since}"
       imported_gem_version_notice: "This gem version was imported to RubyGems.org on %{import_date}. The date displayed was specified by the author in the gemspec."
     version:
       yanked: yanked

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -831,7 +831,9 @@ es:
     index:
       not_hosted_notice: Esta gema no está alojada actualmente en RubyGems.org.
       title: Todas las versiones de %{name}
-      versions_since: "%{count} versiones desde %{since}"
+      versions_since:
+        other: "%{count} versiones desde %{since}"
+        one: "%{count} versión desde %{since}"
       imported_gem_version_notice: Esta versión de la gema se importó a RubyGems.org
         el %{import_date}. La fecha que se muestra fue especificada por el autor en
         el archivo gemspec.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -755,7 +755,9 @@ fr:
     index:
       not_hosted_notice: Gem non hébergé sur Rubygems.
       title: Toutes les versions de %{name}
-      versions_since: "%{count} versions depuis %{since}"
+      versions_since:
+        other: "%{count} versions depuis %{since}"
+        one: "%{count} version depuis %{since}"
       imported_gem_version_notice:
     version:
       yanked: retiré

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -713,7 +713,9 @@ ja:
     index:
       not_hosted_notice: このgemは現在RubyGems.org上ではホストされていません。
       title: "%{name}の全バージョン履歴"
-      versions_since: "%{since}からの%{count}件"
+      versions_since:
+        other: "%{since}からの%{count}件"
+        one: "%{since}からの%{count}件"
       imported_gem_version_notice: このgemのバージョンは%{import_date}にRubyGems.orgにインポートされました。表示されている日付は作者によってgemspec中で指定されました。
     version:
       yanked: ヤンク済み

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -709,7 +709,9 @@ nl:
     index:
       not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org
       title: Alle versies van %{name}
-      versions_since: "%{count} versies sinds %{since}"
+      versions_since:
+        other: "%{count} versies sinds %{since}"
+        one: "%{count} versie sinds %{since}"
       imported_gem_version_notice:
     version:
       yanked: verwijderd

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -732,7 +732,9 @@ pt-BR:
     index:
       not_hosted_notice: Esta gem não está hospdada no Gemcutter.
       title: Todas as versões para %{name}
-      versions_since: "%{count} versões desde %{since}"
+      versions_since:
+        other: "%{count} versões desde %{since}"
+        one: "%{count} versão desde %{since}"
       imported_gem_version_notice:
     version:
       yanked: removida

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -720,7 +720,9 @@ zh-CN:
     index:
       not_hosted_notice: 此 Gem 目前没有托管在 RubyGems.org 中。
       title: "%{name} 的所有版本"
-      versions_since: 自 %{since} 以来有 %{count} 个版本
+      versions_since:
+        other: 自 %{since} 以来有 %{count} 个版本
+        one: 自 %{since} 以来有 %{count} 个版本
       imported_gem_version_notice: 此版本的 Gem 已在 %{import_date} 导入到 RubyGems.org 中。显示的日期由作者在
         gemspec 中指定。
     version:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -692,7 +692,9 @@ zh-TW:
     index:
       not_hosted_notice: 這個 Gem 目前沒有在 Gemcutter 上
       title: "%{name} 的所有版本"
-      versions_since: 自從 %{since} 以來，有 %{count} 個版本
+      versions_since:
+        other: 自從 %{since} 以來，有 %{count} 個版本
+        one: 自從 %{since} 以來，有 %{count} 個版本
       imported_gem_version_notice:
     version:
       yanked: 已被移除

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -64,6 +64,33 @@ class VersionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "on GET to index - pluralization" do
+    context "with one version" do
+      setup do
+        rubygem = create(:rubygem)
+        create(:version, number: "1.1.2", rubygem: rubygem)
+        get :index, params: { rubygem_id: rubygem.name }
+      end
+
+      should "use the singular version" do
+        assert_select ".t-list__heading", text: /1 version\b/, count: 1
+      end
+    end
+
+    context "with two versions" do
+      setup do
+        rubygem = create(:rubygem)
+        create(:version, number: "1.1.2", rubygem: rubygem)
+        create(:version, number: "1.1.3", rubygem: rubygem)
+        get :index, params: { rubygem_id: rubygem.name }
+      end
+
+      should "use the plural version" do
+        assert_select ".t-list__heading", text: /2 versions\b/, count: 1
+      end
+    end
+  end
+
   context "on GET to index with imported versions" do
     setup do
       @built_at = Date.parse("2000-01-01")


### PR DESCRIPTION
From https://github.com/rubygems/rubygems.org/pull/4460#discussion_r1493244905

Added a test to verify this string is being pluralized properly.

Also added every locale with varying degrees of confidence
- es/pt-BR: I know enough to be fairly confident this is correct
- ja: I know enough to be fairly confident this is correct and verified
  with native speaker
- fr: I verified with native speaker
- de/nl: I used online translation tools to check singular vs plural
- zh-CN/zh-TW: I don't think they pluralize, but I just copied the
  existing string into both `other` and `one` which maintains behavior
  before this PR anyway.
