### PR TITLE
Fix bin/fill-locales when the key in en is a hash and not in other

### DIFF
--- a/bin/fill-locales
+++ b/bin/fill-locales
@@ -10,7 +10,8 @@ EN = YAML.safe_load_file(EN_PATH)
 def fill(en, other)
   if en.is_a?(Hash)
     en.map do |key, _|
-      [key, fill(en[key], other&.dig(key))]
+      next_other = other.is_a?(Hash) ? other&.dig(key) : nil
+      [key, fill(en[key], next_other)]
     end.to_h
   elsif en.is_a?(String)
     other


### PR DESCRIPTION
The script would fail if the current `en` was a hash but `other` wasn't
because we would try to call `dig` on a string. In this case, return
`nil` so that we can recursively copy the shape of `en` to `other`
