### PR TITLE
Allow sorting gems alphabetically in the Profile show page

### DIFF
--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -196,7 +196,21 @@
   .profile__downloads-wrap {
     padding-top: 32px; } }
 
+.sorting form {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
 
+.sorting form label:first-child,
+.sorting form select{
+  margin-bottom: 0.5rem;
+}
+
+.sorting form select,
+.sorting form button {
+  width: fit-content;
+}
 
 /* Dashboard Gems and Subscriptions */
 

--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -194,21 +194,25 @@
     text-align: right; } }
 @media (min-width: 780px) {
   .profile__downloads-wrap {
-    padding-top: 32px; } }
-
-.sorting form {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+    padding-top: 32px;
+  }
+  .profile__downloads-wrap form {
+    align-items: flex-end;
+  }
 }
 
-.sorting form label:first-child,
-.sorting form select{
+.profile__downloads-wrap form {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile__downloads-wrap form label:first-child,
+.profile__downloads-wrap form select{
   margin-bottom: 0.5rem;
 }
 
-.sorting form select,
-.sorting form button {
+.profile__downloads-wrap form select,
+.profile__downloads-wrap form button {
   width: fit-content;
 }
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,14 +8,14 @@ class ProfilesController < ApplicationController
   before_action :disable_cache, only: :edit
 
   def show
-    @user = User.find_by_slug!(params[:id])
-    rubygems = @user.rubygems
-    @rubygems = case params[:sort_by]
-                when "name"
-                  rubygems.reorder(:name)
-                else
-                  rubygems.by_downloads
-                end
+    @user           = User.find_by_slug!(params[:id])
+    rubygems        = @user.rubygems
+    @rubygems       = case params[:sort_by]
+                      when "name"
+                        rubygems.reorder(:name)
+                      else
+                        rubygems.by_downloads
+                      end
   end
 
   def me

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,10 +8,14 @@ class ProfilesController < ApplicationController
   before_action :disable_cache, only: :edit
 
   def show
-    @user           = User.find_by_slug!(params[:id])
-    rubygems        = @user.rubygems_downloaded
-    @rubygems       = rubygems.slice!(0, 10)
-    @extra_rubygems = rubygems
+    @user = User.find_by_slug!(params[:id])
+    rubygems = @user.rubygems
+    @rubygems = case params[:sort_by]
+                when "name"
+                  rubygems.reorder(:name)
+                else
+                  rubygems.by_downloads
+                end
   end
 
   def me

--- a/app/javascript/controllers/gem_sort_controller.js
+++ b/app/javascript/controllers/gem_sort_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="gem-sort"
+export default class extends Controller {
+  static targets = ["form", "select"]
+  connect() {
+    this.selectTarget.onchange = () => this.formSubmit();
+  }
+
+  formSubmit = () => {
+    this.formTarget.submit();
+  }
+}

--- a/app/views/profiles/_sort_form.html.erb
+++ b/app/views/profiles/_sort_form.html.erb
@@ -1,7 +1,25 @@
 <div class="sorting">
-  <%= form_with url: profile_path(@user&.handle), method: :get do |f| %>
+  <%=
+    form_with(
+      data: {
+        "controller": "gem-sort",
+        "gem-sort-target": "form",
+      },
+      method: :get,
+      url: profile_path(@user&.handle)
+    ) do |f|
+  %>
     <%= f.label :sort_by, class: "t-text--s"%>
-    <%= f.select :sort_by, options_for_select([["Name", "name"], ["Downloads", "downloads"]]) %>
-    <%= f.submit "Sort" %>
+    <%=
+      select_tag :sort_by,
+                 options_for_select(
+                   [
+                     ["Name", "name"],
+                     ["Downloads", "downloads"]
+                   ],
+                   params[:sort_by] || "downloads"
+                 ),
+                 data: { "gem-sort-target" => "select" }
+    %>
   <% end %>
 </div>

--- a/app/views/profiles/_sort_form.html.erb
+++ b/app/views/profiles/_sort_form.html.erb
@@ -1,0 +1,7 @@
+<div class="sorting">
+  <%= form_with url: profile_path(@user&.handle), method: :get do |f| %>
+    <%= f.label :sort_by, class: "t-text--s"%>
+    <%= f.select :sort_by, options_for_select([["Name", "name"], ["Downloads", "downloads"]]) %>
+    <%= f.submit "Sort" %>
+  <% end %>
+</div>

--- a/app/views/profiles/_sort_form.html.erb
+++ b/app/views/profiles/_sort_form.html.erb
@@ -1,25 +1,23 @@
-<div class="sorting">
+<%=
+  form_with(
+    data: {
+      "controller": "gem-sort",
+      "gem-sort-target": "form",
+    },
+    method: :get,
+    url: profile_path(@user&.handle)
+  ) do |f|
+%>
+  <%= f.label :sort_by, class: "t-text--s"%>
   <%=
-    form_with(
-      data: {
-        "controller": "gem-sort",
-        "gem-sort-target": "form",
-      },
-      method: :get,
-      url: profile_path(@user&.handle)
-    ) do |f|
+    select_tag :sort_by,
+               options_for_select(
+                 [
+                   ["Name", "name"],
+                   ["Downloads", "downloads"]
+                 ],
+                 params[:sort_by] || "downloads"
+               ),
+               data: { "gem-sort-target" => "select" }
   %>
-    <%= f.label :sort_by, class: "t-text--s"%>
-    <%=
-      select_tag :sort_by,
-                 options_for_select(
-                   [
-                     ["Name", "name"],
-                     ["Downloads", "downloads"]
-                   ],
-                   params[:sort_by] || "downloads"
-                 ),
-                 data: { "gem-sort-target" => "select" }
-    %>
-  <% end %>
-</div>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -113,6 +113,14 @@
       <h2 id="downloads_count" class="gem__downloads">
         <%= number_with_delimiter(@user.total_downloads_count) %>
       </h2>
+
+      <div class="sorting">
+        <%= form_with url: profile_path(@user&.handle), method: :get do |f| %>
+          <%= f.label :sort_by, class: "t-text--s"%>
+          <%= f.select :sort_by, options_for_select([["Name", "name"], ["Downloads", "downloads"]]) %>
+          <%= f.submit "Sort" %>
+        <% end %>
+      </div>
     </div>
   </header>
 <% end %>
@@ -123,7 +131,7 @@
       <%=
         render(
           partial: 'rubygem',
-          collection: @rubygems + @extra_rubygems,
+          collection: @rubygems,
           locals: {graph: false}
         )
       %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -114,13 +114,7 @@
         <%= number_with_delimiter(@user.total_downloads_count) %>
       </h2>
 
-      <div class="sorting">
-        <%= form_with url: profile_path(@user&.handle), method: :get do |f| %>
-          <%= f.label :sort_by, class: "t-text--s"%>
-          <%= f.select :sort_by, options_for_select([["Name", "name"], ["Downloads", "downloads"]]) %>
-          <%= f.submit "Sort" %>
-        <% end %>
-      </div>
+      <%= render partial: "sort_form" %>
     </div>
   </header>
 <% end %>

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -177,4 +177,19 @@ class ProfileTest < SystemTest
     assert page.has_content? "special note"
     assert page.has_content? "request note"
   end
+
+  test "sort gems alphabetically in profile" do
+    alphabetical_first = FactoryBot.create(:rubygem, name: "AGem", owners: [@user], downloads: 1)
+    alphabetical_last = FactoryBot.create(:rubygem, name: "ZGem", owners: [@user], downloads: 999)
+
+    visit profile_path(@user.handle)
+    dropdown = find(:element, "data-gem-sort-target": "select")
+    form = find(:element, "data-gem-sort-target": "form")
+    dropdown.select("Name")
+    # Submit form without button
+    Capybara::RackTest::Form.new(form.base.driver, form.native).submit({})
+    rubygem_links = page.all(:element, "a", class: "gems__gem__name")
+    assert rubygem_links.first.text == alphabetical_first.name
+    assert rubygem_links.last.text == alphabetical_last.name
+  end
 end


### PR DESCRIPTION
Hi! 👋 Looking at #3270, the idea of sorting gems in the rubygems.org page resonated with me. While this Pull Request does not implement all the sorting options mentioned in the issue (yet), it tries to lay the foundation for allowing to sort the gems displayed in the page.

If this approach is accepted, some follow-up questions are:
- Would this be implemented in other pages? (e.g. search results)
- How should we handle toggling between ascending or descending order? 

Thanks for taking the time to review this! ☺️