### PR TITLE
Add pghero under admin namespace.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "strong_migrations", "~> 1.7"
 gem "phlex-rails", "~> 1.1"
 gem "discard", "~> 1.3"
 gem "user_agent_parser", "~> 2.17"
+gem "pghero", "~> 3.4"
 
 # Admin dashboard
 gem "avo", "~> 2.48"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pghero (3.4.1)
+      activerecord (>= 6)
     phlex (1.9.0)
       concurrent-ruby (~> 1.2)
       erb (>= 4)
@@ -810,6 +812,7 @@ DEPENDENCIES
   openid_connect (~> 2.3)
   opensearch-ruby (~> 3.1)
   pg (~> 1.5)
+  pghero (~> 3.4)
   phlex-rails (~> 1.1)
   pp (= 0.5.0)
   pry-byebug (~> 3.10)
@@ -1034,6 +1037,7 @@ CHECKSUMS
   parallel (1.24.0) sha256=5bf38efb9b37865f8e93d7a762727f8c5fc5deb19949f4040c76481d5eee9397
   parser (3.3.0.5) sha256=7748313e505ca87045dc0465c776c802043f777581796eb79b1654c5d19d2687
   pg (1.5.6) sha256=4bc3ad2438825eea68457373555e3fd4ea1a82027b8a6be98ef57c0d57292b1c
+  pghero (3.4.1) sha256=7f949828119ab17de22ebaef1854ab8c738106bdc31bee3ac0acd0462c0efa88
   phlex (1.9.0) sha256=75b06a334833542594ef65d0532c6c964c78648f459d855cb54cd8c0ddcdb549
   phlex-rails (1.1.1) sha256=b0e82d0ba541eca55ca39051de8be2817a7ed400f8a630e21b261239c8f812d0
   pp (0.5.0) sha256=f8f40bc2ba9e1ab351b9458151da3a89f46034f7f599a8e0a06abb9b9f4411dd

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,7 @@ Rails.application.routes.draw do
       namespace :admin, constraints: Constraints::Admin::RubygemsOrgAdmin do
         mount GoodJob::Engine, at: 'good_job'
         mount MaintenanceTasks::Engine, at: "maintenance_tasks"
+        mount PgHero::Engine, at: "pghero"
       end
 
       mount Avo::Engine, at: Avo.configuration.root_path


### PR DESCRIPTION
I have used [PgHero](https://github.com/rubygems/rubygems.org/pull/4480) to locate [not used indices](https://github.com/rubygems/rubygems.org/pull/4480). Is it worth to add permanently to admin namespace?