### PR TITLE
Correct capitalization of Touch ID trade name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,7 +449,7 @@ en:
       invalid_level: Invalid MFA level.
       success: You have successfully updated your multi-factor authentication level.
     prompt:
-      webauthn_credential_note: Authenticate with a security device such as Touch Id, YubiKey, etc.
+      webauthn_credential_note: Authenticate with a security device such as Touch ID, YubiKey, etc.
       sign_in_with_webauthn_credential: Authenticate with security device
       otp_code: OTP code
       otp_or_recovery: OTP or recovery code

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -450,7 +450,7 @@ ja:
       invalid_level: 不正なMFAの水準です。
       success: 多要素認証の水準が正常に更新されました。
     prompt:
-      webauthn_credential_note: Touch Id、YubiKeyなどのセキュリティ機器で認証してください。
+      webauthn_credential_note: Touch ID、YubiKeyなどのセキュリティ機器で認証してください。
       sign_in_with_webauthn_credential: セキュリティ機器で認証
       otp_code: OTPのコード
       otp_or_recovery: OTPまたは復旧コード

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -458,7 +458,7 @@ zh-CN:
       invalid_level: 无效的 MFA 级别。
       success: 您已成功修改多因素验证级别。
     prompt:
-      webauthn_credential_note: 使用如 Touch Id, YubiKey 等安全设备来认证身份。
+      webauthn_credential_note: 使用如 Touch ID, YubiKey 等安全设备来认证身份。
       sign_in_with_webauthn_credential: 通过安全设备认证人身
       otp_code: 一次性密码
       otp_or_recovery: OTP 或 恢复码


### PR DESCRIPTION
A very small pull request that updates three translation files to use the correct capitalization on "Touch ID" in the "Security Device" section of the sign in page. A fourth translation file correctly capitalized "ID."

Thanks for considering this proposed update!

<img width="568" alt="image" src="https://github.com/rubygems/rubygems.org/assets/73866/9da7e7f2-3fbb-4b08-9571-eb4222a58924">
