### PR TITLE
Consistently use config.enable_reloading

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -104,7 +104,7 @@ Rails.application.configure do
   # and benchmarking the application locally. All changes you make to the app
   # will require restart.
   if ENV['PROFILE']
-    config.cache_classes = true
+    config.enable_reloading = false
     config.eager_load = true
 
     config.log_level = :info

--- a/config/environments/oidc-api-token.rb
+++ b/config/environments/oidc-api-token.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
Instead of cache_classes. I missed a couple of spots in the rails 7.1 config upgrade (https://github.com/rubygems/rubygems.org/pull/4121)