### PR TITLE
Revert to string interpolation for dependency link

### DIFF
--- a/app/views/dependencies/_dependencies.html.erb
+++ b/app/views/dependencies/_dependencies.html.erb
@@ -7,7 +7,7 @@
         <span>
           <span class="deps_expanded deps_expanded-link" data-gem_id="<%= name %>" data-version="<%= version %>"></span>
         </span>
-        <%= link_to rubygem_version_url(name, version), target: :_blank do %>
+        <%= link_to "/gems/#{name}/versions/#{version}", target: :_blank do %>
           <span class="deps_item"><%= name %> <%= version %>
           <span class='deps_item--details'> <%= req %></span></span>
         <% end %>


### PR DESCRIPTION
Using link_to was causing 500s

https://app.datadoghq.com/apm/error-tracking/issue/56946ef8-e0eb-11ee-a2e6-da7ad0900002?query=env%3Aproduction%20service%3Arubygems.org&refresh_mode=sliding&view=spans&from_ts=1710243904088&to_ts=1710330277500