### PR TITLE
Simplify profile views.

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,9 +10,7 @@ class ProfilesController < ApplicationController
   def show
     @user = User.includes(rubygems_downloaded: %i[most_recent_version gem_download]).strict_loading
       .find_by_slug!(params[:id])
-    rubygems        = @user.rubygems_downloaded.to_a
-    @rubygems       = rubygems.slice!(0, 10)
-    @extra_rubygems = rubygems
+    @rubygems = @user.rubygems_downloaded.to_a
   end
 
   def me

--- a/app/views/profiles/_rubygem.html.erb
+++ b/app/views/profiles/_rubygem.html.erb
@@ -1,4 +1,4 @@
-<li class="<%= "small" unless graph %>">
+<li class="small">
   <div class="gems__gem">
     <span class="gems__gem__info">
       <a href="<%= rubygem_path(rubygem.slug) %>" class="gems__gem__name">
@@ -10,10 +10,6 @@
       <%= number_with_delimiter(rubygem.downloads) %>
       <span class="gems__gem__downloads__heading">Downloads</span>
     </p>
-    <% if graph %>
-      <div id="graph-<%= rubygem.id %>" class="profile-graph">
-      </div>
-    <% end %>
     <% if local_assigns[:owners] %>
       <div class="owners">
         <h3 class="t-list__heading"><%= t '.owners_header'%>:</h3>

--- a/app/views/profiles/delete.html.erb
+++ b/app/views/profiles/delete.html.erb
@@ -7,7 +7,7 @@
   <div id="profile">
     <div class="profile-list">
       <ul>
-        <%= render partial: 'rubygem', collection: @only_owner_gems, locals: {graph: false, owners: true}  %>
+        <%= render partial: 'rubygem', collection: @only_owner_gems, locals: {owners: true}  %>
       </ul>
     </div>
   </div>
@@ -20,7 +20,7 @@
   <div id="profile">
     <div class="profile-list">
       <ul>
-        <%= render partial: 'rubygem', collection: @multi_owner_gems, locals: {graph: false, owners: true}  %>
+        <%= render partial: 'rubygem', collection: @multi_owner_gems, locals: {owners: true}  %>
       </ul>
     </div>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -120,13 +120,7 @@
 <div id="profile">
   <div class="profile-list">
     <ul>
-      <%=
-        render(
-          partial: 'rubygem',
-          collection: @rubygems + @extra_rubygems,
-          locals: {graph: false}
-        )
-      %>
+      <%= render partial: 'rubygem', collection: @rubygems %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
While looking at https://github.com/rubygems/rubygems.org/issues/4540 and https://github.com/rubygems/rubygems.org/pull/4544, I have realized, there is no need for extra gems separate variable and for "graph" local var.

Long time ago, there was graph functionality (https://github.com/rubygems/rubygems.org/blob/edf2bd42d23202db0d490c1060a11024909e3c7c/app/views/profiles/show.html.erb#L18-L45) and extra gems were added in https://github.com/rubygems/rubygems.org/commit/edf2bd42d23202db0d490c1060a11024909e3c7c to show top 10 gems with graph and rest without. This was finally removed at https://github.com/rubygems/rubygems.org/commit/481c5e2b807fed6c7d3c75fa4c6b87277d7b7f01 (and partially before with redesign years ago).

This makes simpler to fix #4540 as well.