### PR TITLE
Remove MFA unused method.

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -353,17 +353,6 @@ class Rubygem < ApplicationRecord
     user.mfa_enabled? || !metadata_mfa_required?
   end
 
-  # TODO: broken. don't use until #2964 is resolved.
-  def mfa_required_since_version
-    return unless metadata_mfa_required?
-    non_mfa_version = public_versions.find { |v| !v.rubygems_metadata_mfa_required? }
-    if non_mfa_version
-      non_mfa_version.next.number
-    else
-      public_versions.last.number
-    end
-  end
-
   def version_manifest(number, platform = nil)
     VersionManifest.new(gem: name, number: number, platform: platform)
   end

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -1117,41 +1117,6 @@ class RubygemTest < ActiveSupport::TestCase
     end
   end
 
-  context "#mfa_required_since_version" do
-    setup do
-      @rubygem = create(:rubygem)
-      metadata = { "rubygems_mfa_required" => "true" }
-      @version = create(:version, number: "1.0.0", rubygem: @rubygem, metadata: metadata)
-    end
-
-    context "rubygems_mfa_required is set on the latest version" do
-      should "return latest version number" do
-        assert_equal @version.number, @rubygem.mfa_required_since_version
-      end
-    end
-
-    context "rubygems_mfa_required was unset and set" do
-      setup do
-        create(:version, number: "1.0.1", rubygem: @rubygem)
-        create(:version, number: "1.0.2", rubygem: @rubygem, metadata: { "rubygems_mfa_required" => "true" })
-      end
-
-      should "return latest version number with mfa required" do
-        assert_equal "1.0.2", @rubygem.mfa_required_since_version
-      end
-    end
-
-    context "rubygems_mfa_required is not set on the latest version" do
-      setup do
-        create(:version, number: "1.0.1", rubygem: @rubygem)
-      end
-
-      should "return nil" do
-        assert_nil @rubygem.mfa_required_since_version
-      end
-    end
-  end
-
   context "#version_manifest" do
     should "return a VersionManifest for the given version number" do
       rubygem = build(:rubygem)


### PR DESCRIPTION
- it was replaced with different approach in 08f808cacffd06a2110615978e519e902abdfebe

I have found this randomly, looking at different stuff in codebase. Replaced by https://github.com/rubygems/rubygems.org/commit/08f808cacffd06a2110615978e519e902abdfebe, disabled by https://github.com/rubygems/rubygems.org/commit/66cc8aac75cf0dac2da9acf7425240585b5b89fd.