### PR TITLE
Fix password reset links being expired too quickly

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,17 +1,18 @@
 class PasswordsController < ApplicationController
   include MfaExpiryMethods
   include WebauthnVerifiable
-  include SessionVerifiable
 
   before_action :ensure_email_present, only: %i[create]
+  before_action :clear_password_reset_session, only: %i[create edit]
 
+  before_action :no_referrer, only: %i[edit]
   before_action :validate_confirmation_token, only: %i[edit otp_edit webauthn_edit]
   before_action :session_expired_failure, only: %i[otp_edit webauthn_edit], unless: :session_active?
   before_action :webauthn_failure, only: %i[webauthn_edit], unless: :webauthn_credential_verified?
   before_action :otp_failure, only: %i[otp_edit], unless: :otp_edit_conditions_met?
   after_action :delete_mfa_expiry_session, only: %i[otp_edit webauthn_edit]
 
-  verify_session_before only: %i[update]
+  before_action :validate_password_reset_session, only: %i[update]
 
   def new
   end
@@ -25,8 +26,7 @@ class PasswordsController < ApplicationController
 
       render template: "multifactor_auths/prompt"
     else
-      # When user doesn't have mfa, a valid token is a full "magic link" sign in.
-      verified_sign_in
+      password_reset_verified
       render :edit
     end
   end
@@ -43,11 +43,12 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if current_user.update_password reset_params[:password]
-      current_user.reset_api_key! if reset_params[:reset_api_key] == "true" # singular
-      current_user.api_keys.expire_all! if reset_params[:reset_api_keys] == "true" # plural
+    if @user.update_password reset_params[:password]
+      @user.reset_api_key! if reset_params[:reset_api_key] == "true" # singular
+      @user.api_keys.expire_all! if reset_params[:reset_api_keys] == "true" # plural
+      clear_password_reset_session
+      sign_in @user
       redirect_to dashboard_path
-      session[:password_reset_token] = nil
     else
       flash.now[:alert] = t(".failure")
       render :edit
@@ -55,23 +56,16 @@ class PasswordsController < ApplicationController
   end
 
   def otp_edit
-    verified_sign_in
+    password_reset_verified
     render :edit
   end
 
   def webauthn_edit
-    verified_sign_in
+    password_reset_verified
     render :edit
   end
 
   private
-
-  def verified_sign_in
-    sign_in @user
-    session_verified
-    @user.update!(confirmation_token: nil)
-    StatsD.increment "login.success"
-  end
 
   def reset_params
     params.fetch(:password_reset, {}).permit(:password, :reset_api_key, :reset_api_keys)
@@ -86,23 +80,52 @@ class PasswordsController < ApplicationController
   end
 
   def validate_confirmation_token
-    @user = User.find_by(id: params[:user_id], confirmation_token: params[:token].to_s)
-    redirect_to root_path, alert: t("passwords.edit.token_failure") unless @user&.valid_confirmation_token?
+    confirmation_token = params[:token] || session[:password_reset_token]
+    @user = User.find_by(id: params[:user_id], confirmation_token:)
+    return token_failure(t("passwords.edit.token_failure")) unless @user&.valid_confirmation_token?
+    session[:password_reset_token] = confirmation_token
   end
 
   def otp_edit_conditions_met? = @user.mfa_enabled? && @user.ui_mfa_verified?(params[:otp]) && session_active?
 
-  def session_expired_failure = login_failure(t("multifactor_auths.session_expired"))
-  def webauthn_failure = login_failure(@webauthn_error)
-  def otp_failure = login_failure(t("multifactor_auths.incorrect_otp"))
+  def session_expired_failure = mfa_failure(t("multifactor_auths.session_expired"))
+  def webauthn_failure = mfa_failure(@webauthn_error)
+  def otp_failure = mfa_failure(t("multifactor_auths.incorrect_otp"))
 
-  def login_failure(message)
+  def mfa_failure(message)
     flash.now.alert = message
     render template: "multifactor_auths/prompt", status: :unauthorized
   end
 
-  def redirect_to_verify
-    session[:redirect_uri] = verify_session_redirect_path
-    redirect_to verify_session_path, alert: t("verification_expired")
+  def token_failure(message)
+    clear_password_reset_session
+    redirect_to root_path, alert: message
+  end
+
+  # password reset session is a short lived session that can only perform password reset.
+  def password_reset_verified
+    clear_password_reset_session
+    session[:password_reset_user] = @user.id
+    session[:password_reset_verification] = Gemcutter::PASSWORD_VERIFICATION_EXPIRY.from_now
+  end
+
+  def validate_password_reset_session
+    return token_failure(t("passwords.edit.session_expired")) unless password_reset_session_active?
+    @user = User.find(session[:password_reset_user])
+  end
+
+  def password_reset_session_active?
+    session[:password_reset_verification] && session[:password_reset_verification] > Time.current
+  end
+
+  def clear_password_reset_session
+    session.delete(:password_reset_token)
+    session.delete(:password_reset_user)
+    session.delete(:password_reset_verification)
+  end
+
+  # Avoid leaking token in referrer header (OWASP: forgot password)
+  def no_referrer
+    headers["Referrer-Policy"] = "no-referrer"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,7 @@ class User < ApplicationRecord
     update!(email_confirmed: true, confirmation_token: nil)
   end
 
-  # confirmation token expires after 15 minutes
+  # confirmation token expires after Gemcutter::EMAIL_TOKEN_EXPIRES_AFTER
   def valid_confirmation_token?
     token_expires_at > Time.zone.now
   end

--- a/app/views/password_mailer/change_password.html.erb
+++ b/app/views/password_mailer/change_password.html.erb
@@ -29,7 +29,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
+                          <a href="<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,9 +1,9 @@
 <% @title = t('.title') %>
 
 <%= form_for(:password_reset,
-             :url => user_password_path(current_user),
+             :url => user_password_path(@user),
              :html => { :method => :put }) do |form| %>
-  <%= error_messages_for current_user %>
+  <%= error_messages_for @user %>
   <div class="password_field">
     <%= form.label :password, "Password", :class => 'form__label' %>
     <%= form.password_field :password, autocomplete: 'new-password', class: 'form__input' %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -421,6 +421,7 @@ de:
       submit: Speichern dieses Passworts
       title: Zurücksetzen des Passworts
       token_failure:
+      session_expired:
     new:
       submit: Zurücksetzen des Passworts
       title: Ändere dein Passwort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -402,6 +402,7 @@ en:
       submit: Save this password
       title: Reset password
       token_failure: Please double check the URL or try submitting a new password reset.
+      session_expired: Your password reset session has expired.
     new:
       submit: Reset password
       title: Change your password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -455,6 +455,7 @@ es:
       submit: Guardar esta contraseña
       title: Restablecer contraseña
       token_failure: Por favor verifica la URL o inténtalo nuevamente.
+      session_expired:
     new:
       submit: Restablecer contraseña
       title: Cambiar tu contraseña

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -421,6 +421,7 @@ fr:
       submit: Enregistrer ce mot de passe
       title: Nouveau mot de passe
       token_failure: Veuillez vérifier l'URL ou réessayer.
+      session_expired:
     new:
       submit: Réinitialisez votre mot de passe
       title: Changement de mot de passe

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -401,6 +401,7 @@ ja:
       submit: このパスワードを保存する
       title: パスワードをリセット
       token_failure: URLを見返すか、再度送信してみてください。
+      session_expired:
     new:
       submit: パスワードをリセット
       title: パスワードを変更する

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -407,6 +407,7 @@ nl:
       submit: Sla dit wachtwoord op
       title: reset wachtwoord
       token_failure: Controleer het webadres, en probeer het opnieuw.
+      session_expired:
     new:
       submit: Wachtwoord wijzigen
       title: Wachtwoord wijzigen

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -418,6 +418,7 @@ pt-BR:
       submit: Salvar senha
       title: Resetar senha
       token_failure: Por favor, confira a URL ou tente submetê-la novamente.
+      session_expired:
     new:
       submit: Resetar senha
       title: Alterar senha

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -409,6 +409,7 @@ zh-CN:
       submit: 保存该密码
       title: 重置密码
       token_failure: 请再次确认 URL 或尝试重新提交
+      session_expired:
     new:
       submit: 重置密码
       title: 修改您的密码

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -391,6 +391,7 @@ zh-TW:
       submit: 更新密碼
       title: 重設密碼
       token_failure: 請確認 URL 或再次提交
+      session_expired:
     new:
       submit: 更新密碼
       title: 修改密碼


### PR DESCRIPTION
This solves the problem where the previous approach caused password reset links to sometimes become invalidated when scanning software loaded the links in emails before the user clicked them, invalidating the password reset token. This is similar to how verification worked, but narrowly scoped to password reset only.

I tried to keep this as tidy as possible so it's easier to review. Please look closely since this change was originally made to fix a vulnerability. All the previous vulnerability fix tests are still passing and I added a few new tests. Thanks!