### PR TITLE
Fix: partially hidden tooltip text in /gems/:id

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -203,14 +203,10 @@
   .clipboard-is-active:before {
     content: "";
     position: absolute;
-    top: -4px;
+    top: -15px;
     right: 8px;
-    height: 15px;
-    width: 15px;
-    background-color: #141c22;
-    -ms-transform: rotate(45deg);
-    -webkit-transform: rotate(45deg);
-    transform: rotate(45deg); }
+    border: 8px solid transparent;
+    border-bottom: 8px solid #141c22; }
 
 .gem__link:before {
   margin-right: 16px; }


### PR DESCRIPTION
Hi.
I found a CSS issue where the tooltip text was partially hidden in `/gems/:id`. I fixed it with this pull request.

| before | after |
| - | - |
| ![image](https://github.com/rubygems/rubygems.org/assets/46666464/a6cb2114-2bc5-48eb-a837-ea85d95dbd2d) | ![image](https://github.com/rubygems/rubygems.org/assets/46666464/33031839-886b-43f5-85c0-11881e007bb6) |
| ![image](https://github.com/rubygems/rubygems.org/assets/46666464/80397924-69d4-4e0e-b7c1-053f946d6122) | ![image](https://github.com/rubygems/rubygems.org/assets/46666464/e990dfd0-7c6b-49ee-aad8-c66ddeb4a653) |


