### PR TITLE
Simplify mailers.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,11 @@
 class ApplicationMailer < ActionMailer::Base
   include SemanticLogger::Loggable
+  include Roadie::Rails::Automatic
+  include MailerHelper
+
+  default from: Gemcutter::MAIL_SENDER
+  default_url_options[:host] = Gemcutter::HOST
+  default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   layout "mailer"
 

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,12 +1,4 @@
 class Mailer < ApplicationMailer
-  include Roadie::Rails::Automatic
-  include MailerHelper
-
-  default from: Clearance.configuration.mailer_sender
-
-  default_url_options[:host] = Gemcutter::HOST
-  default_url_options[:protocol] = Gemcutter::PROTOCOL
-
   def email_reset(user)
     @user = user
     mail to: @user.unconfirmed_email,

--- a/app/mailers/owners_mailer.rb
+++ b/app/mailers/owners_mailer.rb
@@ -1,13 +1,6 @@
 class OwnersMailer < ApplicationMailer
-  include Roadie::Rails::Automatic
-
   include OwnersHelper
   helper :owners
-
-  default from: Clearance.configuration.mailer_sender
-
-  default_url_options[:host] = Gemcutter::HOST
-  default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   def ownership_confirmation(ownership)
     @ownership = ownership

--- a/app/mailers/password_mailer.rb
+++ b/app/mailers/password_mailer.rb
@@ -1,9 +1,4 @@
 class PasswordMailer < ApplicationMailer
-  include Roadie::Rails::Automatic
-
-  default_url_options[:host] = Gemcutter::HOST
-  default_url_options[:protocol] = Gemcutter::PROTOCOL
-
   def change_password(user)
     @user = User.find(user["id"])
     mail from: Clearance.configuration.mailer_sender,

--- a/app/mailers/web_hooks_mailer.rb
+++ b/app/mailers/web_hooks_mailer.rb
@@ -1,11 +1,4 @@
 class WebHooksMailer < ApplicationMailer
-  include Roadie::Rails::Automatic
-
-  default from: Clearance.configuration.mailer_sender
-
-  default_url_options[:host] = Gemcutter::HOST
-  default_url_options[:protocol] = Gemcutter::PROTOCOL
-
   def webhook_deleted(user_id, rubygem_id, url, failure_count)
     @user = User.find(user_id)
     @rubygem = Rubygem.find(rubygem_id) if rubygem_id

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,4 +101,5 @@ module Gemcutter
   VERSIONS_PER_PAGE = 100
   SEPARATE_ADMIN_HOST = config["separate_admin_host"]
   ENABLE_DEVELOPMENT_ADMIN_LOG_IN = Rails.env.local?
+  MAIL_SENDER = "RubyGems.org <no-reply@mailer.rubygems.org>".freeze
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -2,7 +2,7 @@ require_relative "../../lib/confirmed_user_guard"
 
 Clearance.configure do |config|
   config.allow_sign_up = ENV['DISABLE_SIGNUP'].to_s != 'true'
-  config.mailer_sender = "RubyGems.org <no-reply@mailer.rubygems.org>"
+  config.mailer_sender = Gemcutter::MAIL_SENDER
   config.secure_cookie = true unless Rails.env.local?
   config.password_strategy = Clearance::PasswordStrategies::BCrypt
   config.sign_in_guards = [ConfirmedUserGuard]


### PR DESCRIPTION
- remove Cleareance from mailers (that was main motivation, another small step to decouple from Clearance)
- share configuration in base mailer