### PR TITLE
Docker compose `version:` is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres:13.14


### PR DESCRIPTION
Fixes the following warning when running `docker compose up`:

```
$ docker compose up
WARN[0000] /path/to/rubygems.org/docker-compose.yml: `version` is obsolete
(...)
```

See https://github.com/compose-spec/compose-spec/blob/e1b7020286e51d7e04e9b47c1f15457640fb63d3/spec.md#version-top-level-element