### PR TITLE
Scrub path_params to avoid crashing in `url_for`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::Base
 
   # Fix for https://github.com/kaminari/kaminari/pull/1123, remove after this is merged and in use.
   def reject_path_params_param
-    render plain: "bad request", status: :bad_request if params.key?(:path_params)
+    params.delete(:path_params)
   end
 
   def reject_null_char_cookie

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::Base
 
   # Fix for https://github.com/kaminari/kaminari/pull/1123, remove after this is merged and in use.
   def reject_path_params_param
-    params.delete(:path_params)
+    render plain: "bad request", status: :bad_request if params.key?(:path_params)
   end
 
   def reject_null_char_cookie

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
   before_action :reject_null_char_param
+  before_action :reject_path_params_param
   before_action :reject_null_char_cookie
   before_action :set_error_context_user
   before_action :set_user_tag
@@ -152,6 +153,11 @@ class ApplicationController < ActionController::Base
 
   def reject_null_char_param
     render plain: "bad request", status: :bad_request if params.to_s.include?("\\u0000")
+  end
+
+  # Fix for https://github.com/kaminari/kaminari/pull/1123, remove after this is merged and in use.
+  def reject_path_params_param
+    params.delete(:path_params)
   end
 
   def reject_null_char_cookie

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -167,6 +167,35 @@ class VersionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "On GET to show with bad params" do
+    setup do
+      @latest_version = create(:version, built_at: 1.week.ago, created_at: 1.day.ago)
+      @rubygem = @latest_version.rubygem
+      @versions = (1..5).map do
+        FactoryBot.create(:version, rubygem: @rubygem)
+      end
+      get :show, params: { rubygem_id: @rubygem.name, id: @latest_version.number, path_params: "injection_attempt" }
+    end
+
+    should respond_with :success
+
+    should "render info about the gem" do
+      assert page.has_content?(@rubygem.name)
+    end
+    should "render the specified version" do
+      assert page.has_content?(@latest_version.number)
+    end
+    should "render other related versions" do
+      @versions.each do |version|
+        assert page.has_content?(version.number)
+      end
+    end
+
+    should "render the checksum version" do
+      assert page.has_content?(@latest_version.sha256_hex)
+    end
+  end
+
   context "On GET to show with *a* yanked version" do
     setup do
       @version = create(:version, number: "1.0.1")

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -167,35 +167,6 @@ class VersionsControllerTest < ActionController::TestCase
     end
   end
 
-  context "On GET to show with bad params" do
-    setup do
-      @latest_version = create(:version, built_at: 1.week.ago, created_at: 1.day.ago)
-      @rubygem = @latest_version.rubygem
-      @versions = (1..5).map do
-        FactoryBot.create(:version, rubygem: @rubygem)
-      end
-      get :show, params: { rubygem_id: @rubygem.name, id: @latest_version.number, path_params: "injection_attempt" }
-    end
-
-    should respond_with :success
-
-    should "render info about the gem" do
-      assert page.has_content?(@rubygem.name)
-    end
-    should "render the specified version" do
-      assert page.has_content?(@latest_version.number)
-    end
-    should "render other related versions" do
-      @versions.each do |version|
-        assert page.has_content?(version.number)
-      end
-    end
-
-    should "render the checksum version" do
-      assert page.has_content?(@latest_version.sha256_hex)
-    end
-  end
-
   context "On GET to show with *a* yanked version" do
     setup do
       @version = create(:version, number: "1.0.1")

--- a/test/integration/rubygems_test.rb
+++ b/test/integration/rubygems_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class RubygemsTest < ActionDispatch::IntegrationTest
+  setup do
+    create_list(:rubygem, 20) # rubocop:disable FactoryBot/ExcessiveCreateList
+    create(:rubygem, name: "arrakis", number: "1.0.0")
+  end
+
+  test "gems list shows pagination" do
+    get "/gems"
+
+    assert page.has_content? "arrakis"
+  end
+
+  test "gems list doesn't fall pray to path_params query param" do
+    get "/gems?path_params=string"
+
+    assert page.has_content? "arrakis"
+  end
+end


### PR DESCRIPTION
This comes through in `kaminari` pagination links and can cause crashes by end-users until kaminari/kaminari#1123 is merged.

Also submitted rails/rails#51496 with a fix to prevent 500s.