### PR TITLE
Refactor 400 Bad Request responses into render_bad_request

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -127,4 +127,9 @@ class Api::BaseController < ApplicationController
   def skip_session
     request.session_options[:skip] = true
   end
+
+  def render_bad_request(error = "bad request")
+    error = error.message if error.is_a?(Exception)
+    render json: { error: error.to_s }, status: :bad_request
+  end
 end

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::SearchesController < Api::BaseController
   before_action :verify_query_string, only: %i[show autocomplete]
 
   rescue_from ElasticSearcher::SearchNotAvailableError, with: :search_not_available_error
-  rescue_from ElasticSearcher::InvalidQueryError, with: :invalid_query_error
+  rescue_from ElasticSearcher::InvalidQueryError, with: :render_bad_request
 
   def show
     @rubygems = ElasticSearcher.new(query_params, page: @page).api_search
@@ -21,15 +21,11 @@ class Api::V1::SearchesController < Api::BaseController
   private
 
   def verify_query_string
-    render plain: "bad request", status: :bad_request unless query_params.is_a?(String)
+    render_bad_request unless query_params.is_a?(String)
   end
 
   def search_not_available_error(error)
     render plain: error.message, status: :service_unavailable
-  end
-
-  def invalid_query_error(error)
-    render plain: error.message, status: :bad_request
   end
 
   def query_params

--- a/app/controllers/api/v1/timeframe_versions_controller.rb
+++ b/app/controllers/api/v1/timeframe_versions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TimeframeVersionsController < Api::BaseController
   class InvalidTimeframeParameterError < StandardError; end
-  rescue_from InvalidTimeframeParameterError, with: :bad_request_response
+  rescue_from InvalidTimeframeParameterError, with: :render_bad_request
   before_action :set_page, :ensure_valid_timerange, only: :index
 
   MAXIMUM_TIMEFRAME_QUERY_IN_DAYS = 7
@@ -12,10 +12,6 @@ class Api::V1::TimeframeVersionsController < Api::BaseController
   end
 
   private
-
-  def bad_request_response(exception)
-    render plain: exception.message, status: :bad_request
-  end
 
   def ensure_valid_timerange
     if (to_time - from_time).to_i > MAXIMUM_TIMEFRAME_QUERY_IN_DAYS.days

--- a/app/controllers/api/v1/web_hooks_controller.rb
+++ b/app/controllers/api/v1/web_hooks_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::WebHooksController < Api::BaseController
                     @rubygem.most_recent_version, delayed: false)
       render plain: webhook.deployed_message(@rubygem)
     else
-      render plain: webhook.failed_message(@rubygem), status: :bad_request
+      render_bad_request webhook.failed_message(@rubygem)
     end
   end
 
@@ -50,7 +50,7 @@ class Api::V1::WebHooksController < Api::BaseController
   end
 
   def set_url
-    render plain: "URL was not provided", status: :bad_request unless params[:url]
+    render_bad_request "URL was not provided" unless params[:url]
     @url = params[:url]
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_forbidden
+  rescue_from ActionController::UnpermittedParameters, with: :render_bad_request
 
   before_action :set_locale
   before_action :reject_null_char_param
@@ -47,7 +48,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from(ActionController::ParameterMissing) do |e|
-    render plain: "Request is missing param '#{e.param}'", status: :bad_request
+    render_bad_request "Request is missing param '#{e.param}'"
   end
 
   def self.http_basic_authenticate_with(**options)
@@ -139,6 +140,11 @@ class ApplicationController < ActionController::Base
     render plain: error, status: :forbidden
   end
 
+  def render_bad_request(error = "bad request")
+    error = error.message if error.is_a?(Exception)
+    render plain: error.to_s, status: :bad_request
+  end
+
   def redirect_to_page_with_error
     flash[:error] = t("invalid_page") unless controller_path.starts_with? "api"
     page_params = params.except(:controller, :action, :page)
@@ -152,7 +158,7 @@ class ApplicationController < ActionController::Base
   end
 
   def reject_null_char_param
-    render plain: "bad request", status: :bad_request if params.to_s.include?("\\u0000")
+    render_bad_request if params.to_s.include?("\\u0000")
   end
 
   # Fix for https://github.com/kaminari/kaminari/pull/1123, remove after this is merged and in use.
@@ -162,7 +168,7 @@ class ApplicationController < ActionController::Base
 
   def reject_null_char_cookie
     contains_null_char = cookies.map { |cookie| cookie.join("=") }.join(";").include?("\u0000")
-    render plain: "bad request", status: :bad_request if contains_null_char
+    render_bad_request if contains_null_char
   end
 
   def sanitize_params

--- a/test/functional/api/v1/searches_controller_test.rb
+++ b/test/functional/api/v1/searches_controller_test.rb
@@ -69,7 +69,7 @@ class Api::V1::SearchesControllerTest < ActionController::TestCase
         get :show, params: { query: "AND other" }, format: :json
 
         assert_response :bad_request
-        assert_equal "Failed to parse search term: 'AND other'.", @response.body
+        assert_equal "Failed to parse search term: 'AND other'.", JSON.parse(@response.body)["error"]
       end
     end
   end


### PR DESCRIPTION
Cleans up the different ways that we return bad_request, plus adds one for UnpermittedParameters error.