### PR TITLE
Disable loading YAML with aliases

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -77,6 +77,13 @@ class Pusher
     @spec = package.spec
     @files = package.files
     validate_spec && serialize_spec
+  rescue Psych::AliasesNotEnabled
+    notify <<~MSG, 422
+      RubyGems.org cannot process this gem.
+      Pushing gems where there are aliases in the YAML gemspec is no longer supported.
+      Ensure you are using a recent version of RubyGems to build the gem by running
+      `gem update --system` and then try pushing again.
+    MSG
   rescue StandardError => e
     notify <<~MSG, 422
       RubyGems.org cannot process this gem.

--- a/config/initializers/gem_safe_yaml.rb
+++ b/config/initializers/gem_safe_yaml.rb
@@ -1,0 +1,10 @@
+require 'rubygems/package'
+
+Gem.load_yaml
+raise "Update rubygems to 3.5.7 or greater for Gem::SafeYAML.aliases_enabled= support" unless Gem::SafeYAML.respond_to?(:aliases_enabled=)
+Gem::SafeYAML.aliases_enabled = false
+
+Gem::Package.class_eval do
+  include SemanticLogger::Loggable
+  delegate :warn, to: :logger
+end

--- a/config/initializers/requires.rb
+++ b/config/initializers/requires.rb
@@ -1,4 +1,3 @@
-require 'rubygems/package'
 require 'rdoc/markup'
 require 'rdoc/markup/to_html'
 require 'patterns'


### PR DESCRIPTION
Prevent loading YAML files with aliases, which can be used to construct YAML bombs that lead to OOMs

Makes use of https://github.com/rubygems/rubygems/pull/7464

Fixes https://github.com/rubygems/rubygems.org/security/advisories/GHSA-4vc5-whwr-7hh2
