### PR TITLE
Redirect GET /passwords => /passwords/new

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,7 @@ Rails.application.routes.draw do
     end
 
     resources :passwords, only: %i[new create]
+    get "/passwords", to: redirect("/passwords/new")
 
     resource :session, only: %i[create destroy] do
       post 'otp_create', to: 'sessions#otp_create', as: :otp_create

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -24,7 +24,7 @@ class PasswordResetTest < SystemTest
   test "GET to /passwords redirects to /passwords/new" do
     visit "/passwords"
 
-    assert_equal new_password_path, page.current_path, "redirects to homepage if link is invalid"
+    assert_equal new_password_path, page.current_path, "redirects to new password reset when reloading password create resulting page."
   end
 
   test "reset password form does not tell if a user exists" do

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -21,6 +21,12 @@ class PasswordResetTest < SystemTest
     perform_enqueued_jobs { click_button "Reset password" }
   end
 
+  test "GET to /passwords redirects to /passwords/new" do
+    visit "/passwords"
+
+    assert_equal new_password_path, page.current_path, "redirects to homepage if link is invalid"
+  end
+
   test "reset password form does not tell if a user exists" do
     forgot_password_with "someone@example.com"
 


### PR DESCRIPTION
Sometimes you end up on the page `/passwords` and you just want to reload it, but the route doesn't exist.