### PR TITLE
Set explicit WEB_CONCURRENCY for production & staging

### DIFF
--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -62,9 +62,9 @@ spec:
           - name: ENV
             value: "<%= environment %>"
           - name: WEB_CONCURRENCY
-            value: <%= environment == 'production' ? 8 : 2 %>
+            value: "<%= environment == 'production' ? 8 : 2 %>"
           - name: RAILS_MAX_THREADS
-            value: 5
+            value: "5"
           - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -62,7 +62,7 @@ spec:
           - name: ENV
             value: "<%= environment %>"
           - name: WEB_CONCURRENCY
-            value: <%= if environment == 'production' ? 8 : 2 %>
+            value: <%= environment == 'production' ? 8 : 2 %>
           - name: RAILS_MAX_THREADS
             value: 5
           - name: DD_AGENT_HOST

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -61,6 +61,10 @@ spec:
             value: "<%= environment %>"
           - name: ENV
             value: "<%= environment %>"
+          - name: WEB_CONCURRENCY
+            value: <%= if environment == 'production' ? 8 : 2 %>
+          - name: RAILS_MAX_THREADS
+            value: 5
           - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Currently, we set the following Puma configuration for all environments:

| Environment Variable | Value |
|-------------------|---|
| WEB_CONCURRENCY   | 8 (From `Concurrent.physical_processor_count`) |
| RAILS_MAX_THREADS | 5 |

This configuration is suitable for production, but is over provisioned for our staging environments and needs to be reduced to better fit into the allocated resources. 

For reference, we allocate the following resources per environment:

**Production**

| Resource       | Value |
|----------------|-------|
| CPU Request    | 4000m |
| Memory Request | 5Gi   |
| CPU Limit      | 5000m |
| Memory Limit   | 6Gi   |

**Staging**

| Resource       | Value |
|----------------|-------|
| CPU Request    | 200m  |
| Memory Request | 1.5Gi   |
| CPU Limit      | 1000m |
| Memory Limit   | 2Gi   |

8 workers in staging's puma configuration is too many and does not leave enough memory for Rake tasks to be processed, so this Pull Request sets explicit adjustments to the pod configuration to set more suitable values.

**Production**

| Environment Variable | Value |
|-------------------|---|
| WEB_CONCURRENCY   | 8 (unchanged) | 
| RAILS_MAX_THREADS | 5 |

**Staging**

| Environment Variable | Value |
|-------------------|---|
| WEB_CONCURRENCY   | 2 | 
| RAILS_MAX_THREADS | 5 |
