### PR TITLE
Update OpenSearch service to the latest version

### DIFF
--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -13,11 +13,7 @@ runs:
     - name: Install and start services
       shell: bash
       run: |
-        docker-compose up -d
-    - name: Wait for ES to boot
-      shell: bash
-      run: |
-        timeout 300 bash -c "until curl --silent --output /dev/null http://localhost:9200/_cat/health?h=st; do printf '.'; sleep 5; done; printf '\n'"
+        docker-compose up -d --wait
     - uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Install and start services
       shell: bash
       run: |
-        docker-compose up -d --wait
+        docker compose up -d --wait
     - uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "11211:11211"
   search:
-    image: opensearchproject/opensearch:1.3.7
+    image: opensearchproject/opensearch:2.13.0
     environment:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - plugins.security.disabled=true
     ports:
       - "9200:9200"
+    healthcheck:
+      test: ["CMD", "curl", "-s", "http://localhost:9200/_cluster/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
   toxiproxy:
     image: ghcr.io/shopify/toxiproxy:2.5.0
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,18 @@ services:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Opensearch1
     ports:
       - "9200:9200"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:9200/_cluster/health"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "--fail",
+          "--silent",
+          "http://localhost:9200/_cluster/health",
+        ]
       interval: 5s
       timeout: 5s
       retries: 6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "9200:9200"
     healthcheck:
-      test: ["CMD", "curl", "-s", "http://localhost:9200/_cluster/health"]
+      test: ["CMD", "curl", "--fail", "--silent", "http://localhost:9200/_cluster/health"]
       interval: 5s
       timeout: 5s
       retries: 6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,8 @@ services:
   search:
     image: opensearchproject/opensearch:2.13.0
     environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - plugins.security.disabled=true
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=Opensearch1
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
     ports:
       - "9200:9200"
     healthcheck:
@@ -25,11 +23,29 @@ services:
           "curl",
           "--fail",
           "--silent",
-          "http://localhost:9200/_cluster/health",
+          "http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s",
         ]
       interval: 5s
       timeout: 5s
       retries: 6
+  search-console:
+    image: opensearchproject/opensearch-dashboards:2.13.0
+    ports:
+      - "5601:5601"
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://search:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl --fail --silent http://localhost:5601/api/status || exit 1",
+        ]
+      interval: 5s
+      timeout: 3s
+    depends_on:
+      search:
+        condition: service_healthy
   toxiproxy:
     image: ghcr.io/shopify/toxiproxy:2.5.0
     network_mode: "host"


### PR DESCRIPTION
In preparation to updating our search cluster, this Pull Request is updating the OpenSearch service used for testing & local development to the latest version (`2.13.0`)