### PR TITLE
Update OpenSearch configuration

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -6,7 +6,7 @@ module RubygemSearchable
       callbacks: false,
       settings: {
         number_of_shards: 1,
-        number_of_replicas: 1,
+        number_of_replicas: Gemcutter::SEARCH_NUM_REPLICAS,
         analysis: {
           analyzer: {
             rubygem: {

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,7 @@ module Gemcutter
   PROTOCOL = config["protocol"]
   REMEMBER_FOR = 2.weeks
   SEARCH_INDEX_NAME = "rubygems-#{Rails.env}".freeze
+  SEARCH_NUM_REPLICAS = ENV.fetch("SEARCH_NUM_REPLICAS", 1).to_i
   SEARCH_MAX_PAGES = 100 # Limit max page as ES result window is upper bounded by 10_000 records
   STATS_MAX_PAGES = 10
   STATS_PER_PAGE = 10

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -137,6 +137,8 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: elasticsearch_url
+          - name: SEARCH_NUM_REPLICAS
+            value: "1"
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -116,6 +116,8 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: elasticsearch_url
+          - name: SEARCH_NUM_REPLICAS
+            value: "1"
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -12,7 +12,7 @@
         "fastly_api_key": "EJ[1:jnrbdGY2s+ZVCF8BStxF4ZGp1yhxk+x/sXxH8x32qmg=:Hig6V1MQP4qgUM0ONuSJ1baySFEjBUtv:38lnkxBDiihzxIKy1qRFlNIkFVK6w77KHkrKAFv23Bcn/Z3h13NjXZO/tkr27AcV]",
         "fastly_service_id": "EJ[1:dMyBt/+IWFvyZkXJmQMOmef2menhqHv6PFoaTCCjUks=:gJyo+Fk4j9bEbYr+Jl7zv0PmenMl2zF7:zkButJ5HOF+6hN4R0GOzPLtXv7tzqP44EUgUGRMqByrG0dRHY10=]",
         "_fastly_domains": "staging.rubygems.org",
-        "elasticsearch_url": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:md53NdJnx5PVn95M4NAotzMGZ06ub5wf:pBIlOJ3GHAe1PFeoUzQ0rLQ/uuT/rkXDpOZuJiltcuE30QIdqfmVhT7BoGKl0TRAO6EihH22u46hUarfZugyHZoJN71AD8YngxFgYTFMCH4VXEKEj6YNow6lG+3gshupYK7V9YIP+Bu9]",
+        "elasticsearch_url": "EJ[1:uKvVLrtokYQZAf4y+Iqxk4UuF/o5N835453+L8Ogcxs=:hio79tioW/oZM0ZTJlLRqtQIQLG5V2RN:11Re9VUIFjbzvBVT2TUgYk0D/f3tTMcE3Zb7uA0hU2+izp9Di10ajftelhWH/FoUHCwIbkmj9La3jSJw/AdMwBtgaOGaU4CTFT5ZZKLybArAwmONl4j2TcWTt2GFiruDH8uVTp1aEg==]",
         "memcached_endpoint": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:EMi4FLAdV9tWQ8IevfUfr75o6pTo0GAC:ylZl7qFloCf1iUqtEyDsam2ZsEUYcws56jQiR3mT1quTlNQr38fDz5MjeNhMAQfbdGY8KnC2v50Vs1wb1AuKbRUNwU9bGO9pl3E2]",
         "sendgrid_username": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:SBrWz77BfZ7BECNMAwhSB+MrfezIsjl4:1vc/AeDn3zWbEyseu88JyUc6rHV6yw==]",
         "sendgrid_password": "EJ[1:Xk79y8wlVtjKFyZbEE5AXxm2/u3S32Y+3ZDYEd7qqSA=:iAr4Xsjv0weAkakwQqTFiItVQ2IF7Gq2:jm47iHFp0zthpMxHwcH+tWEN7hu85qxvqN7JTGMUSnkRZCdmt/J2ljE6AqpwOk6vHleaXUPUwhsapZv0Ivk42a7pziVLUUxiY3P1vYZQfzKp+WsVqQ==]",

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -135,6 +135,8 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: elasticsearch_url
+          - name: SEARCH_NUM_REPLICAS
+            value: "1"
           - name: MEMCACHED_ENDPOINT
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This Pull Request:
* Updates the staging OpenSearch configuration to point to the new staging search cluster (OpenSearch v2.x)
* Adds an option to set the number of replicas for our Search index via Environment variables. Staging will be set to the default, 1, Production will be set to 2. (I will update the environment var to `"2"` when deploying the new cluster, putting a draft PR together now)