### PR TITLE
Report Puma metrics to Datadog

### DIFF
--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -27,7 +27,8 @@
         "hook_relay_account_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:JsT1PTsSpMaxE0FV7ODyJ5E1FQAzv9v/:tMUgIFIUJH+WhT+kHS5pne5Uw9qvdLqLd2aAfJ9EehzIYpH6Bl6EQg==]",
         "hook_relay_hook_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:Vt1tMd8/9ZhSHL80yrWIWUy2wMOh8Iqt:MUwOcVrjWl7i8RRNg68Sb/Fa+RYsLL54yc+adRK84i5jWWa9fmSgRg==]",
         "launch_darkly_sdk_key": "EJ[1:RM2yVm4yMZPQR0lgPaM4pw8dBEvD3rts+nLnn9E7ZRs=:mR2ODNG9w0B71T5ivgrKahW0vm5QDWjv:NQTLulKnLIbRtmxOXUWM1LVQ3sJzoB9C6eslf6Y8WHYJJTWeuTgfRvpcQraZf0rC+eE/guR2d/U=]",
-        "rubygems_proxy_token": "EJ[1:Zi0QsZH550MKhxfxIghQiwCidie/1S7P0b8T7di4/jQ=:OJYa/K8pVTordk7kGpwif2gL/Wm8hZPX:N+m4TcsVfo4A8zuzgIse0lgspJo3HPQvdlNrbktxaK9YyfuQFVIiVSrGGRf0kB1y]"
+        "rubygems_proxy_token": "EJ[1:Zi0QsZH550MKhxfxIghQiwCidie/1S7P0b8T7di4/jQ=:OJYa/K8pVTordk7kGpwif2gL/Wm8hZPX:N+m4TcsVfo4A8zuzgIse0lgspJo3HPQvdlNrbktxaK9YyfuQFVIiVSrGGRf0kB1y]",
+        "puma_control_auth_token": "EJ[1:/OIWl/02PBM654vznnM46bBW37D4AH09Og7Uzzjm13s=:DtCq6pz7Cfq3sRPFZbwpSf8Umc6Aso/u:ELWEdijdcy9zRtELOdZ/ENC8h2Lvkz0ojeTaniBLWx8n1sN+]"
       }
     }
   }

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -27,7 +27,8 @@
         "hook_relay_account_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:OUkdjS28VFFsXWnK0c2zBubgen83JLIZ:r9s3A3e3UuNrYRelD3HzIKsNvEGlGhvKmZayZt7wZGHrxB+yTb8gQQ==]",
         "hook_relay_hook_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:n1YqUGXM5FdcwoAJjIXXgHxWqiF/voeL:sj7Gbn405v2hw4CKkU6N7Fhgb3J/5RnrAZpp+Xcn61ZTNJq0qFXBiA==]",
         "launch_darkly_sdk_key": "EJ[1:4JArBqOhUkobGC64JyCBRb/ceJYjVQ0E0EA3xMzo1mQ=:aBhPiBN5Tw168oFguBxtcehteIzHlRi4:bKn0Qxs1fdJklK0SVA0ngAg9C1lMWtaXnh/HP9ohYd6tu1vLvjhj7svdRVVugeKaXm/+Dslf+E8=]",
-        "rubygems_proxy_token": "EJ[1:x9FURsKxlgp9gfXiLojWsrNgW318z5iiKvDE4459F30=:qjWeIvg6d/YH1CLE9Sf4bzp+ACCjRIcA:rytgZ9foMBXodqn+NBQ7SxrQ3rCN2+8CwWvjmPkXLUraT/wtj1KxC7JnXG3b9Kd0]"
+        "rubygems_proxy_token": "EJ[1:x9FURsKxlgp9gfXiLojWsrNgW318z5iiKvDE4459F30=:qjWeIvg6d/YH1CLE9Sf4bzp+ACCjRIcA:rytgZ9foMBXodqn+NBQ7SxrQ3rCN2+8CwWvjmPkXLUraT/wtj1KxC7JnXG3b9Kd0]",
+        "puma_control_auth_token": "EJ[1:/xjv69alPpMMf8NXGPr/PrH+NwK+wZ42xyVtWrLS/BE=:VFupast+I0v1c64iSXRfGjf3CA+xql4r:pZB1yLoCfunCQgHKgOuYD2W6a7av1ZNfZKfDehcYk5W2JQDD]"
       }
     },
     "nginx-basic-auth": {

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -18,16 +18,16 @@ spec:
       annotations:
         ad.datadoghq.com/puma.logs: '[{"source":"rails","service":"rubygems.org","version": <%= current_sha.dump %>},"environment": <%= environment.dump %>]'
         ad.datadoghq.com/puma.checks: |
-        {
-          "puma": {
-            "init_config": {
-              service: "rubygems.org",
-            },
-            "instances": [
-              "control_url": "http://%%host%%:9293/stats?token=%%ENC[k8s_secret@rubygems-<%= environment %>/<%= environment %>/puma_control_auth_token]%%"
-            ]
+          {
+            "puma": {
+              "init_config": {
+                service: "rubygems.org",
+              },
+              "instances": [
+                "control_url": "http://%%host%%:9293/stats?token=%%ENC[k8s_secret@rubygems-<%= environment %>/<%= environment %>/puma_control_auth_token]%%"
+              ]
+            }
           }
-        }
       labels:
         name: web
         tags.datadoghq.com/env: "<%= environment %>"

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -16,7 +16,18 @@ spec:
   template:
     metadata:
       annotations:
-        ad.datadoghq.com/puma.logs: '[{"source":"rails","service":"rubygems.org","version": <%= current_sha.dump %>}]'
+        ad.datadoghq.com/puma.logs: '[{"source":"rails","service":"rubygems.org","version": <%= current_sha.dump %>},"environment": <%= environment.dump %>]'
+        ad.datadoghq.com/puma.checks: |
+        {
+          "puma": {
+            "init_config": {
+              service: "rubygems.org",
+            },
+            "instances": [
+              "control_url": "http://%%host%%:9293/stats?token=%%ENC[k8s_secret@rubygems-<%= environment %>/<%= environment %>/puma_control_auth_token]%%"
+            ]
+          }
+        }
       labels:
         name: web
         tags.datadoghq.com/env: "<%= environment %>"
@@ -30,6 +41,8 @@ spec:
         ports:
         - containerPort: 3000
           name: http-puma
+        - containerPort: 9293
+          name: puma-control
         readinessProbe:
           httpGet:
             path: /internal/ping
@@ -213,6 +226,13 @@ spec:
               secretKeyRef:
                 name: <%= environment %>
                 key: database_url
+          - name: PUMA_CONTROL_ENABLED
+            value: "true"
+          - name: PUMA_CONTROL_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: <%= environment %>
+                key: puma_control_auth_token
         securityContext:
           privileged: false
         lifecycle:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,6 +42,11 @@ environment rails_env
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
+# Optionally enable the Puma Control/Metrics API
+if ENV["PUMA_CONTROL_ENABLED"]&.present?
+  activate_control_app "tcp://127.0.0.1:9293", { auth_token: ENV.fetch("PUMA_CONTROL_AUTH_TOKEN") }
+end
+
 before_fork do
   sleep 1
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,9 +43,7 @@ environment rails_env
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Optionally enable the Puma Control/Metrics API
-if ENV["PUMA_CONTROL_ENABLED"]&.present?
-  activate_control_app "tcp://127.0.0.1:9293", { auth_token: ENV.fetch("PUMA_CONTROL_AUTH_TOKEN") }
-end
+activate_control_app "tcp://127.0.0.1:9293", { auth_token: ENV.fetch("PUMA_CONTROL_AUTH_TOKEN") } if ENV["PUMA_CONTROL_ENABLED"].present?
 
 before_fork do
   sleep 1


### PR DESCRIPTION
This PR opens up the [Puma control/metrics server](https://github.com/puma/puma?tab=readme-ov-file#configuration-file) to expose numerous puma metrics such as num of backlogged requests, active workers, threads, etc for [Datadog to collect](https://docs.datadoghq.com/integrations/puma/) that allows us to report and monitor.