### PR TITLE
Use `#latest_version` when loading the profile page rubygems

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
 
   def show
     @user = User.find_by_slug!(params[:id])
-    @rubygems = @user.rubygems_downloaded.includes(%i[most_recent_version gem_download]).strict_loading
+    @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading
   end
 
   def me

--- a/app/views/profiles/_rubygem.html.erb
+++ b/app/views/profiles/_rubygem.html.erb
@@ -3,7 +3,7 @@
     <span class="gems__gem__info">
       <a href="<%= rubygem_path(rubygem.slug) %>" class="gems__gem__name">
         <%= rubygem.name %>
-        <span class="gems__gem__version"><%= rubygem.most_recent_version %></span>
+        <span class="gems__gem__version"><%= rubygem.latest_version %></span>
       </a>
     </span>
     <p class="gems__gem__downloads__count">

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -192,4 +192,16 @@ class ProfileTest < SystemTest
     assert_equal("5 Downloads", downloads[1].text)
     assert_equal("2 Downloads", downloads[2].text)
   end
+
+  test "seeing the latest version when there is a newer previous version" do
+    create(:rubygem, owners: [@user], number: "1.0.1")
+    create(:version, rubygem: Rubygem.first, number: "0.0.2")
+
+    sign_in
+    visit profile_path("nick1")
+
+    version = page.find(".gems__gem__version").text
+
+    assert_equal("1.0.1", version)
+  end
 end


### PR DESCRIPTION
Fixes #4624

This PR targets fixing the profile page gem versions issue described in #4624. I've pulled down a copy of the data using the instructions in https://github.com/rubygems/rubygems.org/blob/master/CONTRIBUTING.md#getting-the-data-dumps and tried it out locally. The fix seems to work correctly 👍 

I'm not sure if this is the best approach though 🤔 I also found that this is somewhat related to eager loading the `gem_download` association in https://github.com/rubygems/rubygems.org/blob/master/app/controllers/profiles_controller.rb#L12. 

So if on `master` I remove the `gem_download` eager load and stub out the `rubygem.downloads` call from the view (so I don't hit the `ActiveRecord::StrictLoadingViolationError` exception) I see the correct `invisible_captcha` `2.2.0` version (this is using the `most_recent_version` call). There's something happening with the scope there but I'm having trouble piecing it together 🤔 

```
diff --git a/app/controllers/profiles_controller.rb b/app/controllers/profiles_controller.rb
index 82a3c1a2d..2680413d4 100644
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController

   def show
     @user = User.find_by_slug!(params[:id])
-    @rubygems = @user.rubygems_downloaded.includes(%i[most_recent_version gem_download]).strict_loading
+    @rubygems = @user.rubygems_downloaded.includes(%i[most_recent_version]).strict_loading
   end

   def me
diff --git a/app/views/profiles/_rubygem.html.erb b/app/views/profiles/_rubygem.html.erb
index c8fa121d2..df50829aa 100644
--- a/app/views/profiles/_rubygem.html.erb
+++ b/app/views/profiles/_rubygem.html.erb
@@ -7,7 +7,7 @@
       </a>
     </span>
     <p class="gems__gem__downloads__count">
-      <%= number_with_delimiter(rubygem.downloads) %>
+      <%#= number_with_delimiter(rubygem.downloads) %>
       <span class="gems__gem__downloads__heading">Downloads</span>
     </p>
     <% if local_assigns[:owners] %>
```

---

So this is what the page looks like before the PR updates

<img width="1726" alt="Screenshot 2024-04-21 at 14 05 05" src="https://github.com/rubygems/rubygems.org/assets/32739319/7717f9aa-1885-4f1c-ae7e-a49b9f2b2db6">
<img width="1612" alt="Screenshot 2024-04-21 at 14 05 45" src="https://github.com/rubygems/rubygems.org/assets/32739319/ddd1f8d6-923e-4933-b08b-fd37fa2ea7ce">

This is what the page looks like after the PR updates ✅

<img width="1737" alt="Screenshot 2024-04-21 at 14 06 35" src="https://github.com/rubygems/rubygems.org/assets/32739319/ffea6ff4-db9c-4449-9ac4-564689a863e6">
