### PR TITLE
Check gems for eligibility before deletion

### DIFF
--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -518,6 +518,59 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "rubygem that is deletion ineligible" do
+      context "with too many downloads" do
+        setup do
+          @rubygem   = create(:rubygem, name: "SomeGem")
+          @v1        = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "ruby")
+          @ownership = create(:ownership, user: @user, rubygem: @rubygem)
+
+          GemDownload.increment(
+            100_001,
+            rubygem_id: @rubygem.id,
+            version_id: @v1.id,
+          )
+          delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
+        end
+
+        should respond_with :forbidden
+        should "respond with a message" do
+          assert_equal(
+            "Versions with more than 100,000 downloads cannot be deleted. " \
+            "Please contact RubyGems support to request deletion of this version if it represents a legal or security risk.",
+            @response.body
+          )
+        end
+        should "not record the deletion" do
+          assert_empty Deletion.where(user: @user, rubygem: @rubygem.name, number: @v1.number)
+        end
+      end
+
+      context "published too long ago" do
+        setup do
+          travel_to 31.days.ago do
+            @rubygem   = create(:rubygem, name: "SomeGem")
+            @v1        = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "ruby")
+            @ownership = create(:ownership, user: @user, rubygem: @rubygem)
+          end
+
+          delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
+        end
+
+        should respond_with :forbidden
+        should "respond with a message" do
+          assert_equal(
+            "Versions published more than 30 days ago cannot be deleted. " \
+            "Please contact RubyGems support to request deletion of this version if it represents a legal or security risk.",
+            @response.body
+          )
+        end
+        should "not record the deletion" do
+          assert_empty Deletion.where(user: @user, rubygem: @rubygem.name, number: @v1.number)
+        end
+      end
+    end
   end
 
   context "without yank rubygem api key scope" do

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -529,12 +529,13 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
           GemDownload.increment(
             100_001,
             rubygem_id: @rubygem.id,
-            version_id: @v1.id,
+            version_id: @v1.id
           )
           delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
         end
 
         should respond_with :forbidden
+
         should "respond with a message" do
           assert_equal(
             "Versions with more than 100,000 downloads cannot be deleted. " \
@@ -559,6 +560,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         end
 
         should respond_with :forbidden
+
         should "respond with a message" do
           assert_equal(
             "Versions published more than 30 days ago cannot be deleted. " \


### PR DESCRIPTION
Gems that have been on the index for a while or have a lot of downloads have a higher likelihood of causing service disruption if they are deleted. Contact support before yanking a gem that fits these criteria.