### PR TITLE
Fix header rendering under other elements

### DIFF
--- a/app/assets/stylesheets/modules/header.css
+++ b/app/assets/stylesheets/modules/header.css
@@ -12,6 +12,8 @@
     margin-left: auto; } }
 
 .header {
+  position: relative;
+  z-index: 1;
   -webkit-transform: translateZ(0); }
   @media (max-width: 1019px) {
     .header {


### PR DESCRIPTION
This PR fixes the issue of rendering the header under some other elements in the body.

For example, check the [Rails reverse dependencies](https://rubygems.org/gems/rails/reverse_dependencies) page where the form in the body appears above the search suggestion list:
 
![image](https://github.com/rubygems/rubygems.org/assets/11241315/28cef270-340d-43f4-b436-64ff3c7d2c94)
