### PR TITLE
Update shoulda-context to 3.0 rc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,7 +128,7 @@ group :test do
   gem "rack-test", "~> 2.1", require: "rack/test"
   gem "rails-controller-testing", "~> 1.0"
   gem "mocha", "~> 2.2", require: false
-  gem "shoulda-context", "~> 2.0"
+  gem "shoulda-context", "~> 3.0.0.rc1"
   gem "shoulda-matchers", "~> 6.2"
   gem "selenium-webdriver", "~> 4.19"
   gem "webmock", "~> 3.23"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -660,7 +660,7 @@ GEM
       aws-sdk-core (>= 2)
       concurrent-ruby
       thor
-    shoulda-context (2.0.0)
+    shoulda-context (3.0.0.rc1)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -851,7 +851,7 @@ DEPENDENCIES
   searchkick (~> 5.3)
   selenium-webdriver (~> 4.19)
   shoryuken (~> 6.2)
-  shoulda-context (~> 2.0)
+  shoulda-context (~> 3.0.0.rc1)
   shoulda-matchers (~> 6.2)
   simplecov (~> 0.22)
   simplecov-cobertura (~> 2.1)
@@ -1117,7 +1117,7 @@ CHECKSUMS
   semantic (1.6.1) sha256=3cdbb48f59198ebb782a3fdfb87b559e0822a311610db153bae22777a7d0c163
   semantic_logger (4.15.0) sha256=ec4f56122b5d2e2117d148b86c69fb62c1194a2b01a271be04ba8678a85f81ff
   shoryuken (6.2.1) sha256=95ddc0a717624a54e799d25a0a05100cb5a0c3728a96211935c214faaf16b3b6
-  shoulda-context (2.0.0) sha256=7adf45342cd800f507d2a053658cb1cce2884b616b26004d39684b912ea32c34
+  shoulda-context (3.0.0.rc1) sha256=6e0d9d52ab798c13bc2b490c8537d4bf30cfd318a1ea839c39a66d1d293c6a1a
   shoulda-matchers (6.2.0) sha256=a702c059c5f3bbda2295827231a28654e33063d7c4d409662980ec630207d8dd
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-cobertura (2.1.0) sha256=2c6532e34df2e38a379d72cef9a05c3b16c64ce90566beebc6887801c4ad3f02


### PR DESCRIPTION
Includes major performance improvements, plus better source locations for failing tests

See https://github.com/thoughtbot/shoulda-context/pull/100
