### PR TITLE
Update cbor to v0.5.9.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cbor (0.5.9.6)
+    cbor (0.5.9.8)
     chartkick (5.0.6)
     childprocess (5.0.0)
     choice (0.2.0)
@@ -908,7 +908,7 @@ CHECKSUMS
   builder (3.2.4) sha256=99caf08af60c8d7f3a6b004029c4c3c0bdaebced6c949165fe98f1db27fbbc10
   byebug (11.1.3) sha256=2485944d2bb21283c593d562f9ae1019bf80002143cc3a255aaffd4e9cf4a35b
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
-  cbor (0.5.9.6) sha256=434a147658dd1df24ec9e7b3297c1fd4f8a691c97d0e688b3049df8e728b2114
+  cbor (0.5.9.8) sha256=9ee097fc58d9bc5e406d112cd2d4e112c7354ec16f8b6ff34e4732c1e44b4eb7
   chartkick (5.0.6) sha256=96c5984471d4c2017b28914bd1bcda7f9e8a3a9d1903059aaadc7a4044c87193
   childprocess (5.0.0) sha256=0746b7ab1d6c68156e64a3767631d7124121516192c0492929a7f0af7310d835
   choice (0.2.0) sha256=a19617f7dfd4921b38a85d0616446620de685a113ec6d1ecc85bdb67bf38c974


### PR DESCRIPTION
 This PR updates the cbor dependency to fix not being able `bundle install` due to a build error.


```
$ bundle install
Fetching gem metadata from https://rubygems.org/........
Installing cbor 0.5.9.6 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/cbor-0.5.9.6/ext/cbor
/Users/colby/.local/share/mise/installs/ruby/3.3.1/bin/ruby extconf.rb
checking for ruby/st.h... yes
checking for st.h... no
checking for rb_str_replace() in ruby.h... yes
checking for rb_big_new() in ruby.h... yes
checking for rb_intern_str() in ruby.h... yes
checking for rb_sym2str() in ruby.h... yes
checking for rb_str_intern() in ruby.h... yes
checking for rb_integer_unpack() in ruby.h... yes
creating Makefile

current directory: /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/cbor-0.5.9.6/ext/cbor
make DESTDIR\= sitearchdir\=./.gem.20240426-7146-2cmv89 sitelibdir\=./.gem.20240426-7146-2cmv89 clean

current directory: /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/cbor-0.5.9.6/ext/cbor
make DESTDIR\= sitearchdir\=./.gem.20240426-7146-2cmv89 sitelibdir\=./.gem.20240426-7146-2cmv89
compiling buffer.c
compiling buffer_class.c
buffer_class.c:270:17: error: incompatible function pointer types passing 'VALUE (VALUE)' (aka 'unsigned long (unsigned long)') to parameter of
type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
                read_until_eof_error, (VALUE)(void*) args,
                ^~~~~~~~~~~~~~~~~~~~
/Users/colby/.local/share/mise/installs/ruby/3.3.1/include/ruby-3.3.0/ruby/internal/iterator.h:388:63: note: passing argument to parameter 'r_proc'
here
VALUE rb_rescue2(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, ...);
                                                              ^
1 error generated.
make: *** [buffer_class.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/cbor-0.5.9.6 for inspection.
Results logged to /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/extensions/arm64-darwin-23/3.3.0/cbor-0.5.9.6/gem_make.out

  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:125:in `run'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:51:in `block in make'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:43:in `each'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:43:in `make'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/ext_conf_builder.rb:42:in `build'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:193:in `build_extension'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:227:in `block in build_extensions'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:224:in `each'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/ext/builder.rb:224:in `build_extensions'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/rubygems/installer.rb:852:in `build_extensions'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/rubygems_gem_installer.rb:76:in `build_extensions'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/rubygems_gem_installer.rb:28:in `install'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/source/rubygems.rb:205:in `install'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/installer/parallel_installer.rb:132:in `do_install'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/installer/parallel_installer.rb:123:in `block in worker_pool'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/worker.rb:62:in `apply_func'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/worker.rb:57:in `block in process_queue'
  <internal:kernel>:187:in `loop'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/worker.rb:54:in `process_queue'
  /Users/colby/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing cbor (0.5.9.6), and Bundler cannot continue.

In Gemfile:
  webauthn was resolved to 3.1.0, which depends on
    cose was resolved to 1.3.0, which depends on
      cbor
```