### PR TITLE
Remove user_id from password reset url

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -18,8 +18,8 @@ class PasswordsController < ApplicationController
 
   def edit
     if @user.mfa_enabled?
-      @otp_verification_url = otp_edit_user_password_url(@user, token: @user.confirmation_token)
-      setup_webauthn_authentication(form_url: webauthn_edit_user_password_url(token: @user.confirmation_token))
+      @otp_verification_url = otp_edit_password_url(token: @user.confirmation_token)
+      setup_webauthn_authentication(form_url: webauthn_edit_password_url(token: @user.confirmation_token))
 
       create_new_mfa_expiry
 
@@ -86,7 +86,7 @@ class PasswordsController < ApplicationController
   end
 
   def validate_confirmation_token
-    @user = User.find_by(id: params[:user_id], confirmation_token: params[:token].to_s)
+    @user = User.find_by(confirmation_token: params[:token].to_s)
     redirect_to root_path, alert: t("passwords.edit.token_failure") unless @user&.valid_confirmation_token?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User < ApplicationRecord
 
   def generate_confirmation_token(reset_unconfirmed_email: true)
     self.unconfirmed_email = nil if reset_unconfirmed_email
-    self.confirmation_token = Clearance::Token.new
+    self.confirmation_token = SecureRandom.hex(24)
     self.token_expires_at = Time.zone.now + Gemcutter::EMAIL_TOKEN_EXPIRES_AFTER
   end
 

--- a/app/views/password_mailer/change_password.html.erb
+++ b/app/views/password_mailer/change_password.html.erb
@@ -29,7 +29,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
+                          <a href="<%= edit_password_url(token: @user.confirmation_token.html_safe) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/password_mailer/change_password.text.erb
+++ b/app/views/password_mailer/change_password.text.erb
@@ -1,4 +1,4 @@
 <%= t(".subtitle", handle: @user.name) %>
 
 <%= t(".opening") %>
-<%= edit_user_password_url(@user, token: @user.confirmation_token.html_safe) %>
+<%= edit_password_url(token: @user.confirmation_token.html_safe) %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,8 +1,6 @@
 <% @title = t('.title') %>
 
-<%= form_for(:password_reset,
-             :url => user_password_path(current_user),
-             :html => { :method => :put }) do |form| %>
+<%= form_for(:password_reset, url: password_path, html: { method: :put }) do |form| %>
   <%= error_messages_for current_user %>
   <div class="password_field">
     <%= form.label :password, "Password", :class => 'form__label' %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -4,7 +4,7 @@
   <p><%= t '.will_email_notice' %></p>
 </div>
 
-<%= form_for :password, :url => passwords_path do |form| %>
+<%= form_for :password, url: password_path do |form| %>
   <div class="text_field">
     <%= form.label :email, t('activerecord.attributes.user.email'), :class => 'form__label' %>
     <%= form.email_field :email, :size => '25', :class => 'form__input' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,7 +241,15 @@ Rails.application.routes.draw do
       patch 'unconfirmed'
     end
 
-    resources :passwords, only: %i[new create]
+    # The resource was plural path /passwords/new, but now we are using singular path /password/new
+    # TODO: remove the following get/post routes a few days after this PR is deployed
+    get "passwords/new", to: "passwords#new"
+    post "passwords", to: "passwords#create"
+
+    resource :password, only: %i[new create edit update] do
+      post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
+      post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
+    end
 
     resource :session, only: %i[create destroy] do
       post 'otp_create', to: 'sessions#otp_create', as: :otp_create
@@ -253,6 +261,8 @@ Rails.application.routes.draw do
     end
 
     resources :users, only: %i[new create] do
+      # TODO: remove the password resource a few days after this PR is deployed
+      # allowing time for existing password reset emails to be used
       resource :password, only: %i[create edit update] do
         post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
         post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -30,7 +30,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "with incorrect token" do
       setup do
-        get :edit, params: { token: @user.confirmation_token.succ }
+        get :edit, params: { token: "invalidtoken" }
       end
 
       should redirect_to("the home page") { root_path }

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -431,7 +431,6 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "when signed in as another user" do
       setup do
-        sign_in_as @user
         @other_user = create(:user, api_key: "otheruserkey")
         @other_api_key = @other_user.api_key
         @other_new_api_key = create(:api_key, owner: @other_user, key: "rubygems_otheruserkey")

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -28,9 +28,9 @@ class PasswordsControllerTest < ActionController::TestCase
       @user.forgot_password!
     end
 
-    context "with not found user" do
+    context "with incorrect token" do
       setup do
-        get :edit, params: { token: @user.confirmation_token, user_id: 0 }
+        get :edit, params: { token: @user.confirmation_token.succ }
       end
 
       should redirect_to("the home page") { root_path }
@@ -46,7 +46,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "with valid confirmation_token" do
       setup do
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should respond_with :success
@@ -68,7 +68,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "with expired confirmation_token" do
       setup do
         @user.update_attribute(:token_expires_at, 1.minute.ago)
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should redirect_to("the home page") { root_path }
@@ -85,7 +85,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "with totp enabled" do
       setup do
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should respond_with :success
@@ -107,7 +107,7 @@ class PasswordsControllerTest < ActionController::TestCase
         @user.new_mfa_recovery_codes = nil
         @user.mfa_hashed_recovery_codes = []
         @user.save!
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should respond_with :success
@@ -128,7 +128,7 @@ class PasswordsControllerTest < ActionController::TestCase
     context "when user has webauthn credentials and recovery codes" do
       setup do
         create(:webauthn_credential, user: @user)
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should respond_with :success
@@ -150,7 +150,7 @@ class PasswordsControllerTest < ActionController::TestCase
       setup do
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
         create(:webauthn_credential, user: @user)
-        get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+        get :edit, params: { token: @user.confirmation_token }
       end
 
       should respond_with :success
@@ -180,8 +180,8 @@ class PasswordsControllerTest < ActionController::TestCase
 
       context "when OTP is correct" do
         setup do
-          get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+          get :edit, params: { token: @user.confirmation_token }
+          post :otp_edit, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
         should respond_with :success
@@ -205,8 +205,8 @@ class PasswordsControllerTest < ActionController::TestCase
 
       context "when OTP is incorrect" do
         setup do
-          get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
-          post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: "eatthis" }
+          get :edit, params: { token: @user.confirmation_token }
+          post :otp_edit, params: { token: @user.confirmation_token, otp: "eatthis" }
         end
 
         should respond_with :unauthorized
@@ -222,9 +222,9 @@ class PasswordsControllerTest < ActionController::TestCase
 
       context "when the OTP session is expired" do
         setup do
-          get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+          get :edit, params: { token: @user.confirmation_token }
           travel 16.minutes do
-            post :otp_edit, params: { user_id: @user.id, token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post :otp_edit, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
         end
 
@@ -250,7 +250,7 @@ class PasswordsControllerTest < ActionController::TestCase
     setup do
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
-      get :edit, params: { token: @user.confirmation_token, user_id: @user.id }
+      get :edit, params: { token: @user.confirmation_token }
       @origin = WebAuthn.configuration.origin
       @rp_id = URI.parse(@origin).host
       @client = WebAuthn::FakeClient.new(@origin, encoding: false)
@@ -266,7 +266,6 @@ class PasswordsControllerTest < ActionController::TestCase
         post(
           :webauthn_edit,
           params: {
-            user_id: @user.id,
             token: @user.confirmation_token,
             credentials:
             WebauthnHelpers.get_result(
@@ -298,7 +297,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "when providing incorrect token" do
       setup do
-        post(:webauthn_edit, params: { user_id: @user.id, token: "badtoken" })
+        post(:webauthn_edit, params: { token: "badtoken" })
       end
 
       should redirect_to("the home page") { root_path }
@@ -314,7 +313,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "when not providing credentials" do
       setup do
-        post :webauthn_edit, params: { user_id: @user.id, token: @user.confirmation_token }, format: :html
+        post :webauthn_edit, params: { token: @user.confirmation_token }, format: :html
       end
 
       should respond_with :unauthorized
@@ -338,7 +337,6 @@ class PasswordsControllerTest < ActionController::TestCase
         post(
           :webauthn_edit,
           params: {
-            user_id: @user.id,
             token: @user.confirmation_token,
             credentials:
             WebauthnHelpers.get_result(
@@ -375,7 +373,6 @@ class PasswordsControllerTest < ActionController::TestCase
           post(
             :webauthn_edit,
             params: {
-              user_id: @user.id,
               token: @user.confirmation_token,
               credentials:
               WebauthnHelpers.get_result(
@@ -415,7 +412,6 @@ class PasswordsControllerTest < ActionController::TestCase
     context "when not signed in" do
       setup do
         put :update, params: {
-          user_id: @user.id,
           password_reset: { reset_api_key: "true", reset_api_keys: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
@@ -435,6 +431,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
     context "when signed in as another user" do
       setup do
+        sign_in_as @user
         @other_user = create(:user, api_key: "otheruserkey")
         @other_api_key = @other_user.api_key
         @other_new_api_key = create(:api_key, owner: @other_user, key: "rubygems_otheruserkey")
@@ -444,7 +441,6 @@ class PasswordsControllerTest < ActionController::TestCase
         session[:verified_user] = @other_user.id
 
         put :update, params: {
-          user_id: @user.id,
           password_reset: { reset_api_key: "true", reset_api_keys: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
@@ -456,14 +452,14 @@ class PasswordsControllerTest < ActionController::TestCase
 
       should redirect_to("the dashboard") { dashboard_path }
 
-      should "not change user_id user's api_key" do
+      should "not change the signed in user's api_key" do
         assert_equal(@user.reload.api_key, @api_key)
       end
-      should "not change user_id user's password" do
+      should "not change the sign in user's password" do
         assert_equal(@user.reload.encrypted_password, @old_encrypted_password)
       end
 
-      # The password controller does not care what user_id is in the url for the update action.
+      # The password controller does not care who is signed in.
       should "change logged in user's api_key" do
         refute_equal(@other_user.reload.api_key, @other_api_key)
       end
@@ -480,7 +476,6 @@ class PasswordsControllerTest < ActionController::TestCase
       setup do
         sign_in_as @user
         put :update, params: {
-          user_id: @user.id,
           password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
       end
@@ -510,7 +505,6 @@ class PasswordsControllerTest < ActionController::TestCase
       context "with invalid password" do
         setup do
           put :update, params: {
-            user_id: @user.id,
             password_reset: { reset_api_key: "true", password: "pass" }
           }
         end
@@ -533,7 +527,6 @@ class PasswordsControllerTest < ActionController::TestCase
           setup do
             travel 16.minutes do
               put :update, params: {
-                user_id: @user.id,
                 password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
               }
             end
@@ -550,7 +543,6 @@ class PasswordsControllerTest < ActionController::TestCase
         context "without reset_api_key" do
           setup do
             put :update, params: {
-              user_id: @user.id,
               password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
             }
           end
@@ -568,7 +560,6 @@ class PasswordsControllerTest < ActionController::TestCase
         context "with reset_api_key false" do
           setup do
             put :update, params: {
-              user_id: @user.id,
               password_reset: { reset_api_key: "false", password: PasswordHelpers::SECURE_TEST_PASSWORD }
             }
           end
@@ -586,7 +577,6 @@ class PasswordsControllerTest < ActionController::TestCase
         context "with reset_api_key" do
           setup do
             put :update, params: {
-              user_id: @user.id,
               password_reset: { reset_api_key: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
             }
           end
@@ -608,7 +598,6 @@ class PasswordsControllerTest < ActionController::TestCase
         context "with reset_api_key and reset_api_keys" do
           setup do
             put :update, params: {
-              user_id: @user.id,
               password_reset: { reset_api_key: "true", reset_api_keys: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
             }
           end

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -5,7 +5,7 @@ class PasswordResetTest < SystemTest
 
   def password_reset_link
     body = ActionMailer::Base.deliveries.last.parts[1].body.decoded.to_s
-    link = %r{http://localhost(?::\d+)?/users([^";]*)}.match(body)
+    link = %r{http://localhost(?::\d+)?/password([^";]*)}.match(body)
     link[0]
   end
 
@@ -31,7 +31,7 @@ class PasswordResetTest < SystemTest
     forgot_password_with @user.email
 
     visit password_reset_link
-    expected_path = "/users/#{@user.id}/password/edit"
+    expected_path = "/password/edit"
 
     assert_equal expected_path, page.current_path, "removes confirmation token from url"
 

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -41,7 +41,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       stay_under_limit_for("clearance/ip")
       stay_under_email_limit_for("password/email")
 
-      post "/passwords",
+      post "/password",
         params: { password: { email: @user.email } },
         headers: { REMOTE_ADDR: @ip_address }
 
@@ -174,9 +174,9 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
         should "allow mfa forgot password" do
           @user.forgot_password!
-          get "/users/#{@user.id}/password/edit",
+          get "/password/edit",
             params: { token: @user.confirmation_token, user_id: @user.id }
-          post "/users/#{@user.id}/password/otp_edit",
+          post "/password/otp_edit",
             params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now },
             headers: { REMOTE_ADDR: @ip_address }
 
@@ -274,7 +274,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     should "throttle forgot password" do
       exceed_limit_for("clearance/ip")
 
-      post "/passwords",
+      post "/password",
         params: { password: { email: @user.email } },
         headers: { REMOTE_ADDR: @ip_address }
 
@@ -395,7 +395,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       should "throttle by ip" do
         exceed_limit_for("clearance/ip")
 
-        post "/passwords",
+        post "/password",
           params: { password: { email: @user.email } },
           headers: { REMOTE_ADDR: @ip_address }
 
@@ -405,7 +405,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       should "throttle by email" do
         exceed_email_limit_for("password/email")
 
-        post "/passwords", params: { password: { email: @user.email } }
+        post "/password", params: { password: { email: @user.email } }
 
         assert_response :too_many_requests
       end
@@ -547,7 +547,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         should "throttle mfa forgot password at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
-            post "/users/#{@user.id}/password/otp_edit", headers: { REMOTE_ADDR: @ip_address }
+            post "/password/otp_edit", headers: { REMOTE_ADDR: @ip_address }
 
             assert_throttle_at(level)
           end
@@ -558,7 +558,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
             @user.forgot_password!
             exceed_exponential_user_limit_for("clearance/user/#{level}", @user.confirmation_token, level)
 
-            post "/users/#{@user.id}/password/otp_edit",
+            post "/password/otp_edit",
               params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
 
             assert_throttle_at(level)
@@ -626,14 +626,14 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         setup { update_limit_for("password/email:#{@user.email}", exceeding_limit) }
 
         should "throttle for sign in ignoring case" do
-          post "/passwords",
+          post "/password",
                params: { password: { email: "Nick@example.com" } }
 
           assert_response :too_many_requests
         end
 
         should "throttle for sign in ignoring spaces" do
-          post "/passwords",
+          post "/password",
                params: { password: { email: "n ick@example.com" } }
 
           assert_response :too_many_requests

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -292,15 +292,28 @@ class UserTest < ActiveSupport::TestCase
         end
       end
 
-      should "clear unconfirmed_email if requested" do
-        @user.update(unconfirmed_email: "unconfirmed@example.com")
-
-        assert_changed(@user, :unconfirmed_email, :confirmation_token, :token_expires_at) do
-          @user.generate_confirmation_token(reset_unconfirmed_email: true)
-          @user.save!
+      context "when user has an unconfirmed email" do
+        setup do
+          @user.update(unconfirmed_email: "unconfirmed@example.com")
         end
 
-        assert_nil @user.unconfirmed_email
+        should "delete the unconfirmed email by default" do
+          assert_changed(@user, :unconfirmed_email, :confirmation_token, :token_expires_at) do
+            @user.generate_confirmation_token
+            @user.save!
+          end
+
+          assert_nil @user.unconfirmed_email
+        end
+
+        should "not delete unconfirmed email when reset_unconfirmed_email is false" do
+          assert_changed(@user, :confirmation_token, :token_expires_at) do
+            @user.generate_confirmation_token(reset_unconfirmed_email: false)
+            @user.save!
+          end
+
+          assert_equal "unconfirmed@example.com", @user.unconfirmed_email
+        end
       end
 
       should "generate a sufficiently long token" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -284,6 +284,33 @@ class UserTest < ActiveSupport::TestCase
       assert_equal [my_rubygem], @user.rubygems
     end
 
+    context "generate_confirmation_token" do
+      should "set confirmation token and token_expires_at" do
+        assert_changed(@user, :confirmation_token, :token_expires_at) do
+          @user.generate_confirmation_token
+          @user.save!
+        end
+      end
+
+      should "clear unconfirmed_email if requested" do
+        @user.update(unconfirmed_email: "unconfirmed@example.com")
+
+        assert_changed(@user, :unconfirmed_email, :confirmation_token, :token_expires_at) do
+          @user.generate_confirmation_token(reset_unconfirmed_email: true)
+          @user.save!
+        end
+
+        assert_nil @user.unconfirmed_email
+      end
+
+      should "generate a sufficiently long token" do
+        @user.generate_confirmation_token
+        @user.save!
+
+        assert_operator @user.confirmation_token.length, :>=, 24, "Token must be at least 24 characters long"
+      end
+    end
+
     context "unconfirmed_email update" do
       should "set confirmation token and token_expires_at" do
         assert_changed(@user, :confirmation_token, :token_expires_at) do


### PR DESCRIPTION
Somewhere it came up that having the user_id in the password reset url was an anti-pattern. Now I can't remember exactly what was so bad about it, but I have already completed the code. 

Why we should do this:
* `/password` is a better url than `/users/153528/passwords`. You could just go to this url from memory (and we should add that going to it takes you to the `/password/new`
* The token, especially now, has all the entropy needed to ensure that it's impossible to guess. Adding a number (the user_id) is less entropy than the increased token size (but it was already long enough anyway at 16 bytes).
* The code becomes a bit simpler and more identical to the email_confirmations controller pattern.
* `edit_password_url` is simpler than `edit_user_password_url(@user)`

Why we should not do this:
* It provides no benefit besides asthetics.
* It solves no real problem and changes part of a critical flow for purely a code preference reason.
* It changes a url that might conceivably be linked to somewhere else (though I doubt this is actually an issue beyond pages that are open _at deploy time_)
* It means that we disambiguate `create` from `update` only based on http verb `post` vs `patch`. This can be a little annoying when it comes to the edit password flow and improving our MFA check.

Feedback welcome.