### PR TITLE
Avoid brakeman warning by being more explicit in render

### DIFF
--- a/app/views/oidc/api_key_roles/show.html.erb
+++ b/app/views/oidc/api_key_roles/show.html.erb
@@ -18,11 +18,11 @@
   </div>
   <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:api_key_permissions) %></h3>
   <div class="push--s">
-    <%= render @api_key_role.api_key_permissions %>
+    <%= render partial: "oidc/api_key_permissions/api_key_permissions", object: @api_key_role.api_key_permissions %>
   </div>
   <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:access_policy) %></h3>
   <div class="push--s">
-    <%= render @api_key_role.access_policy %>
+    <%= render partial: "oidc/access_policies/access_policy", object: @api_key_role.access_policy %>
   </div>
 
   <% unless @api_key_role.deleted_at? %>


### PR DESCRIPTION
Even though this was not actually a flaw, Brakeman insisted on flagging it. Rather than ignore it, just change the render to be more explicit so that Brakeman doesn't mind.