### PR TITLE
Advanced search fields styles fix

### DIFF
--- a/app/views/searches/advanced.html.erb
+++ b/app/views/searches/advanced.html.erb
@@ -9,7 +9,7 @@
     <%= submit_tag "⌕", id: "advanced_search_submit", name: nil, class: "home__search__icon" %>
   <% end %>
 
-  <dl id="search-fields">
+  <dl class="search-fields">
     <dt><%= label_tag :name, t(".name"), class: "form__label" %></dt>
     <dd><%= text_field_tag :name, "", placeholder: "active OR action", class: "form__input"%></dd>
 


### PR DESCRIPTION
## Purpose

This is a fix for the advanced search fields styles, there was a change that started using css class selector to apply the rules.
With this change the former styles rules are applied again.


## See

Before
![image](https://github.com/rubygems/rubygems.org/assets/8846835/613ae621-4dd6-4f7a-82e7-491ec2049598)

After
![image](https://github.com/rubygems/rubygems.org/assets/8846835/c8e87ddf-df86-4454-b1a7-ac6cfc53810f)
![image](https://github.com/rubygems/rubygems.org/assets/8846835/79e442e2-1d0c-49a1-b8c7-abe451429f43)

