### PR TITLE
Test session controller with saved user models and avoid stubbing

### DIFF
--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SessionsControllerTest < ActionController::TestCase
   context "when user has mfa enabled" do
     setup do
-      @user = User.new(email_confirmed: true, handle: "test")
+      @user = create(:user, email_confirmed: true, handle: "login")
       @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
     end
 
@@ -13,12 +13,11 @@ class SessionsControllerTest < ActionController::TestCase
         travel_to @current_time
         freeze_time
 
-        User.expects(:authenticate).with("login", "pass").returns @user
-        post :create, params: { session: { who: "login", password: "pass" } }
+        post :create, params: { session: { who: "login", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
       end
 
       should respond_with :success
-      should "save user name in session" do
+      should "save user id in session" do
         assert_equal @controller.session[:mfa_user], @user.id
         assert page.has_content? "Multi-factor authentication"
       end
@@ -38,8 +37,7 @@ class SessionsControllerTest < ActionController::TestCase
         travel_to @current_time
         freeze_time
 
-        User.expects(:authenticate).with("login", "pass").returns @user
-        post :create, params: { session: { who: "login", password: "pass" } }
+        post :create, params: { session: { who: "login", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
       end
 
       context "when OTP is correct" do
@@ -133,8 +131,8 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when OTP is correct but session expired" do
       setup do
-        @controller.session[:mfa_user] = @user.id
-        @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
+        post :create, params: { session: { who: "login", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
+
         travel 30.minutes
 
         post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
@@ -181,14 +179,13 @@ class SessionsControllerTest < ActionController::TestCase
   context "on POST to create" do
     context "when login and password are correct" do
       setup do
-        @user = User.new(email_confirmed: true)
+        @user = create(:user, handle: "login")
         @controller.session[:mfa_expires_at] = 15.minutes.from_now.to_s
       end
 
       context "when mfa is not recommended" do
         setup do
-          User.expects(:authenticate).with("login", "pass").returns @user
-          post :create, params: { session: { who: "login", password: "pass" } }
+          post :create, params: { session: { who: "login", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         end
 
         should respond_with :redirect
@@ -210,13 +207,12 @@ class SessionsControllerTest < ActionController::TestCase
 
       context "when mfa is recommended" do
         setup do
-          @user.stubs(:mfa_recommended?).returns true
+          User.any_instance.stubs(:mfa_recommended?).returns true
         end
 
         context "when mfa is disabled" do
           setup do
-            User.expects(:authenticate).with("login", "pass").returns @user
-            post :create, params: { session: { who: "login", password: "pass" } }
+            post :create, params: { session: { who: "login", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
           end
 
           should respond_with :redirect
@@ -235,7 +231,6 @@ class SessionsControllerTest < ActionController::TestCase
           setup do
             @controller.session[:mfa_login_started_at] = Time.now.utc.to_s
             @controller.session[:mfa_user] = @user.id
-            User.expects(:find).with(@user.id).returns @user
           end
 
           context "on `ui_only` level" do
@@ -282,8 +277,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     context "when login and password are incorrect" do
       setup do
-        User.expects(:authenticate).with("login", "pass")
-        post :create, params: { session: { who: "login", password: "pass" } }
+        post :create, params: { session: { who: "login", password: "incorrectpassword" } }
       end
 
       should respond_with :unauthorized
@@ -298,9 +292,9 @@ class SessionsControllerTest < ActionController::TestCase
       end
     end
 
-    context "when login is an array" do
+    context "when login params are invalid" do
       setup do
-        post :create, params: { session: { who: ["1"], password: "pass" } }
+        post :create, params: { session: { who: ["1"], password: PasswordHelpers::SECURE_TEST_PASSWORD } }
       end
 
       should respond_with :bad_request


### PR DESCRIPTION
The SessionController tests were using unsaved user models, which resulted in a few assertions like:

```ruby
        assert_equal @user.id, session[:mfa_user]
        # @user.id is nil because @user is not saved, so this is meaningless.
```

This uses a real saved user for the tests. I only had to resort to stubbing in the case of `mfa_recommended?` since it would otherwise require creating a rubygem with the conditions that require mfa. This seemed tangential to the actual test.