### PR TITLE
Update message to include email for RubyGems.org support

### DIFF
--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::DeletionsController < Api::BaseController
     elsif @deletion.ineligible?
       StatsD.increment "yank.forbidden"
       @deletion.record_yank_forbidden_event!
-      contact = "Please contact RubyGems support (support@rubygems.org) to request deletion of this version if it represents a legal or security risk."
+      contact = "Please contact RubyGems support (support@rubygems.org) to request deletion of this version " \
+                "if it represents a legal or security risk."
       message = "#{@deletion.ineligible_reason} #{contact}"
       render plain: response_with_mfa_warning(message), status: :forbidden
     else

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::DeletionsController < Api::BaseController
     elsif @deletion.ineligible?
       StatsD.increment "yank.forbidden"
       @deletion.record_yank_forbidden_event!
-      contact = "Please contact RubyGems support to request deletion of this version if it represents a legal or security risk."
+      contact = "Please contact RubyGems support (support@rubygems.org) to request deletion of this version if it represents a legal or security risk."
       message = "#{@deletion.ineligible_reason} #{contact}"
       render plain: response_with_mfa_warning(message), status: :forbidden
     else

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -539,7 +539,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         should "respond with a message" do
           assert_equal(
             "Versions with more than 100,000 downloads cannot be deleted. " \
-            "Please contact RubyGems support to request deletion of this version if it represents a legal or security risk.",
+            "Please contact RubyGems support (support@rubygems.org) to request deletion of this version if it represents a legal or security risk.",
             @response.body
           )
         end
@@ -574,7 +574,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         should "respond with a message" do
           assert_equal(
             "Versions published more than 30 days ago cannot be deleted. " \
-            "Please contact RubyGems support to request deletion of this version if it represents a legal or security risk.",
+            "Please contact RubyGems support (support@rubygems.org) to request deletion of this version if it represents a legal or security risk.",
             @response.body
           )
         end


### PR DESCRIPTION
Since adding eligibility criteria to yanking gems from rubygems.org, people have been trying to contact support through incorrect channels. This Pull Request updates the ineligible error message to include the email for rubygems.org.