### PR TITLE
Allow creating API keys with an expiration date

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -87,7 +87,7 @@ class Api::V1::ApiKeysController < Api::BaseController
   end
 
   def api_key_create_params
-    ApiKeysHelper.api_key_params(params.permit(:name, *ApiKey::API_SCOPES, :mfa, :rubygem_name, scopes: [ApiKey::API_SCOPES]))
+    ApiKeysHelper.api_key_params(params.permit(:name, *ApiKey::API_SCOPES, :mfa, :rubygem_name, :expires_at, scopes: [ApiKey::API_SCOPES]))
   end
 
   def api_key_update_params(key)

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -24,12 +24,12 @@ class ApiKeysController < ApplicationController
 
   def create
     key = generate_unique_rubygems_key
-    build_params = { owner: current_user, hashed_key: hashed_key(key), **api_key_params }
+    build_params = { owner: current_user, hashed_key: hashed_key(key), **api_key_create_params }
     @api_key = ApiKey.new(build_params)
 
     if @api_key.errors.present?
       flash.now[:error] = @api_key.errors.full_messages.to_sentence
-      @api_key = current_user.api_keys.build(api_key_params.merge(rubygem_id: nil))
+      @api_key = current_user.api_keys.build(api_key_create_params.merge(rubygem_id: nil))
       return render :new
     end
 
@@ -46,7 +46,7 @@ class ApiKeysController < ApplicationController
 
   def update
     @api_key = current_user.api_keys.find(params.permit(:id).require(:id))
-    @api_key.assign_attributes(api_key_params(@api_key))
+    @api_key.assign_attributes(api_key_update_params(@api_key))
 
     if @api_key.errors.present?
       flash.now[:error] = @api_key.errors.full_messages.to_sentence
@@ -96,9 +96,13 @@ class ApiKeysController < ApplicationController
     end
   end
 
-  def api_key_params(existing_api_key = nil)
-    ApiKeysHelper.api_key_params(params.permit(api_key: PERMITTED_API_KEY_PARAMS).require(:api_key), existing_api_key)
+  def api_key_create_params
+    ApiKeysHelper.api_key_params(params.permit(api_key: [:name, *ApiKey::API_SCOPES, :mfa, :rubygem_id, :expires_at]).require(:api_key))
   end
 
-  PERMITTED_API_KEY_PARAMS = [:name, *ApiKey::API_SCOPES, :mfa, :rubygem_id, { scopes: [ApiKey::API_SCOPES] }].freeze
+  def api_key_update_params(existing_api_key = nil)
+    ApiKeysHelper.api_key_params(
+      params.permit(api_key: [*ApiKey::API_SCOPES, :mfa, :rubygem_id, { scopes: [ApiKey::API_SCOPES] }]).require(:api_key), existing_api_key
+    )
+  end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -20,6 +20,7 @@ class ApiKey < ApplicationRecord
   validate :exclusive_show_dashboard_scope, if: :can_show_dashboard?
   validate :scope_presence
   validates :name, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validates :expires_at, inclusion: { in: -> { 1.minute.from_now.. } }, allow_nil: true, on: :create
   validate :rubygem_scope_definition, if: :ownership
   validate :known_scopes
   validate :not_soft_deleted?

--- a/app/views/api_keys/_form.html.erb
+++ b/app/views/api_keys/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [:profile, @api_key], data: { controller: "exclusive-checkbox gem-scope" } do |f| %>
   <%= label_tag :name, t("api_keys.index.name"), class: "form__label" %>
-  <%= f.text_field :name, class: "form__input", autocomplete: :off %>
+  <%= f.text_field :name, class: "form__input", autocomplete: :off, disabled: f.object.persisted? %>
 
   <div class="form__group">
     <%= label_tag :scope, t(".exclusive_scopes"), class: "form__label" %>
@@ -25,6 +25,11 @@
     <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
     <p><%= t(".rubygem_scope_info") %></p>
     <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, selected: :rubygem_id, class: "form__input form__select", data: { gem_scope_target: "selector" } %>
+  </div>
+
+  <div class="form__group">
+    <%= label_tag :expires_at, t(".expiration"), class: "form__label" %>
+    <%= f.datetime_field :expires_at, min: 5.minutes.from_now, include_seconds: false, class: "form__input", disabled: f.object.persisted?  %>
   </div>
 
   <% unless current_user.mfa_disabled? || current_user.mfa_ui_and_api? %>

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -24,6 +24,9 @@
       <th class="owners__cell">
         <%= t(".age") %>
       </th>
+      <th class="owners__cell">
+        <%= t(".expiration") %>
+      </th>
       <% if current_user.mfa_enabled? %>
         <th class="owners__cell">
           <%= t(".mfa") %>
@@ -62,6 +65,9 @@
         <td class="owners__cell" data-title="Last access">
           <%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %>
         </td>
+        <td class="owners__cell" data-title="Expiration">
+          <%= api_key.expires_at&.strftime("%Y-%m-%d %H:%M %Z") %>
+        </td>
         <td class="owners__cell">
           <% unless api_key.soft_deleted? %>
             <%= button_to t("edit"),
@@ -80,6 +86,8 @@
       </tr>
     <% end %>
     <tr class="owners__row">
+      <td class="owners__cell">
+      </td>
       <td class="owners__cell">
       </td>
       <td class="owners__cell">

--- a/app/views/mailer/api_key_created.html.erb
+++ b/app/views/mailer/api_key_created.html.erb
@@ -22,6 +22,10 @@
             <br>
             <%= ApiKey.human_attribute_name(:oidc_api_key_role) %>: <strong><%= link_to(@api_key.oidc_api_key_role.name, profile_oidc_api_key_role_url(@api_key.oidc_api_key_role.token), target: :_blank) %></strong>
           <% end %>
+          <% if @api_key.expires_at.present? %>
+            <br>
+            <%= ApiKey.human_attribute_name(:expires_at) %>: <strong><%= @api_key.expires_at.to_formatted_s(:rfc822) %></strong>
+          <% end %>
           <br>
         </p>
         <br/>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -87,6 +87,10 @@ de:
         blocked: Die Domain '%{domain}' wurde wegen Spam blockiert. Bitte verwenden
           Sie eine gültige persönliche E-Mail-Adresse.
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -134,6 +138,7 @@ de:
         owner add/remove auf ein bestimmtes Gem.
       multifactor_auth: Mehrfaktor-Authentifizierung
       enable_mfa: MFA aktivieren
+      expiration:
     create:
       success: Neuen API-Schlüssel erstellt
       invalid_gem: Das ausgewählte Gem kann diesem Schlüssel nicht zugeordnet werden
@@ -162,6 +167,7 @@ de:
       save_key: 'Beachten Sie, dass wir Ihnen den Schlüssel nicht erneut anzeigen
         können. Neuer API-Schlüssel:'
       mfa: MFA
+      expiration:
     new:
       new_api_key: Neuer API-Schlüssel
     reset:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,10 @@ en:
         unpwn: has previously appeared in a data breach and should not be used
         blocked: "domain '%{domain}' has been blocked for spamming. Please use a valid personal email."
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion: "must be in the future"
         ownership:
           attributes:
             user_id:
@@ -127,6 +131,7 @@ en:
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
       multifactor_auth: Multi-factor authentication
       enable_mfa: Enable MFA
+      expiration: Expiration
     create:
       success: "Created new API key"
       invalid_gem: Selected gem cannot be scoped to this key
@@ -154,6 +159,7 @@ en:
       reset: Reset
       save_key: "Note that we won't be able to show the key to you again. New API key:"
       mfa: MFA
+      expiration: Expiration
     new:
       new_api_key: New API key
     reset:
@@ -318,7 +324,7 @@ en:
     ownerhip_request_approved:
       body_html: Congratulations! Your ownership request for <strong>%{gem}</strong> was approved. You were added as an owner to the gem.
     new_ownership_requests:
-      body_html: 
+      body_html:
         zero: There are <em>no</em> new ownership requests for <strong>%{gem}</strong>.
         one: There is <em>one</em> new ownership request for <strong>%{gem}</strong>. Please click on the button below to see it.
         other: There are <em>%{count}</em> new ownership requests for <strong>%{gem}</strong>. Please click on the button below to see all requests.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -85,6 +85,10 @@ es:
         blocked: El dominio '%{domain}' ha sido bloqueado por spam. Por favor utiliza
           un email personal válido.
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -132,6 +136,7 @@ es:
         y añadir/eliminar propietarios a una gema específica.
       multifactor_auth: Autenticación multifactor
       enable_mfa: Activar AMF
+      expiration:
     create:
       success: Nueva clave de API creada
       invalid_gem: La gema seleccionada no se puede incluir en esta clave
@@ -160,6 +165,7 @@ es:
       save_key: 'Ten en cuenta que no se volverá a mostrar la clave de API. Nueva
         clave de API:'
       mfa: AMF
+      expiration:
     new:
       new_api_key: Nueva clave de API
     reset:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -83,6 +83,10 @@ fr:
         unpwn:
         blocked:
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -128,6 +132,7 @@ fr:
       rubygem_scope_info:
       multifactor_auth:
       enable_mfa:
+      expiration:
     create:
       success:
       invalid_gem:
@@ -155,6 +160,7 @@ fr:
       reset:
       save_key:
       mfa:
+      expiration:
     new:
       new_api_key:
     reset:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -76,6 +76,10 @@ ja:
         unpwn: 過去にデータ侵害を受けたためお使いになれません
         blocked: ドメイン %{domain} はスパムのため差し止められました。正しい個人のEメールを使ってください。
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -121,6 +125,7 @@ ja:
       rubygem_scope_info: このスコープはgemのプッシュ・ヤンクないし所有者の追加・削除のコマンドを特定のgemに制限します。
       multifactor_auth: 多要素認証
       enable_mfa: MFAを有効にする
+      expiration:
     create:
       success: 新しいAPIキーを作成しました
       invalid_gem: 選択されたgemはこのキーのスコープにありません
@@ -148,6 +153,7 @@ ja:
       reset: リセット
       save_key: キーを二度と表示できなくなるためご注意ください。新しいAPIキー：
       mfa: MFA
+      expiration:
     new:
       new_api_key: 新しいAPIキー
     reset:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -75,6 +75,10 @@ nl:
         unpwn:
         blocked:
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -120,6 +124,7 @@ nl:
       rubygem_scope_info:
       multifactor_auth:
       enable_mfa:
+      expiration:
     create:
       success:
       invalid_gem:
@@ -147,6 +152,7 @@ nl:
       reset:
       save_key:
       mfa:
+      expiration:
     new:
       new_api_key:
     reset:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -82,6 +82,10 @@ pt-BR:
         unpwn: já apareceu anteriormente em um vazamento de dados e não deve ser utilizada
         blocked:
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -127,6 +131,7 @@ pt-BR:
       rubygem_scope_info:
       multifactor_auth:
       enable_mfa:
+      expiration:
     create:
       success:
       invalid_gem:
@@ -154,6 +159,7 @@ pt-BR:
       reset:
       save_key:
       mfa:
+      expiration:
     new:
       new_api_key:
     reset:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -77,6 +77,10 @@ zh-CN:
         unpwn: 曾出现过数据泄露，不应该再使用
         blocked: 域名 '%{domain}' 因发送垃圾邮件已被禁用。请使用另外有效的个人邮箱。
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -122,6 +126,7 @@ zh-CN:
       rubygem_scope_info: 该作用范围仅允许对一个 Gem 进行 推送/撤回 以及 对业主的 添加/移除
       multifactor_auth: 多因素验证——身份认证
       enable_mfa: 启用多因素验证
+      expiration:
     create:
       success: 新的 API 密钥已创建
       invalid_gem: 该 Gem 未被此 API 密钥所允许的作用范围包含
@@ -149,6 +154,7 @@ zh-CN:
       reset: 重置
       save_key: 请注意在此之后我们不会再次向您显示该密钥。新的 API 密钥为：
       mfa: 多因素验证
+      expiration:
     new:
       new_api_key: 生成新 API 密钥
     reset:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -72,6 +72,10 @@ zh-TW:
         unpwn:
         blocked:
       models:
+        api_key:
+          attributes:
+            expires_at:
+              inclusion:
         ownership:
           attributes:
             user_id:
@@ -117,6 +121,7 @@ zh-TW:
       rubygem_scope_info:
       multifactor_auth:
       enable_mfa:
+      expiration:
     create:
       success:
       invalid_gem:
@@ -144,6 +149,7 @@ zh-TW:
       reset:
       save_key:
       mfa:
+      expiration:
     new:
       new_api_key:
     reset:

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -525,6 +525,29 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "expiration" do
+      setup do
+        authorize_with("#{@user.email}:#{@user.password}")
+      end
+
+      should "not allow setting expiration in the past" do
+        assert_no_difference -> { @user.api_keys.count } do
+          post :create, params: { name: "test-key", index_rubygems: "true", expires_at: 1.day.ago }, format: "text"
+
+          assert_response :unprocessable_entity
+        end
+      end
+
+      should "allow setting expiration in the future" do
+        expires_at = 1.day.from_now
+        post :create, params: { name: "test-key", index_rubygems: "true", expires_at: }, format: "text"
+
+        assert_response :success
+
+        assert_equal expires_at.change(usec: 0), @user.api_keys.last.expires_at
+      end
+    end
   end
 
   context "on PUT to update" do
@@ -582,6 +605,21 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
           error = "Failed to update scopes for the API key ci-key: [\"Show dashboard scope must be enabled exclusively\"]"
 
           assert_equal @response.body, error
+        end
+      end
+
+      context "expiration" do
+        should "not allow updating expiration" do
+          @api_key.update!(expires_at: 1.month.from_now)
+          assert_no_changes -> { @api_key.expires_at } do
+            put :update, params: { api_key: "12345", expires_at: 1.day.from_now }
+          end
+        end
+
+        should "not allow adding expiration" do
+          assert_no_changes -> { @api_key.expires_at } do
+            put :update, params: { api_key: "12345", expires_at: 1.day.from_now }
+          end
         end
       end
     end


### PR DESCRIPTION
Will be used for CLI workflow to add trusted publishing to a gem, since we dont want the resulting API key that can manage trusted publishing to be long-lived
