### PR TITLE
Allow API keys valid for less than 15min total to skip MFA

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -73,7 +73,13 @@ class ApiKey < ApplicationRecord
   def mfa_enabled?
     return false unless user?
     return false unless user.mfa_enabled?
+    return false if short_lived?
     user.mfa_ui_and_api? || mfa
+  end
+
+  def short_lived?
+    return false unless created_at && expires_at
+    (expires_at - created_at) < 15.minutes
   end
 
   def rubygem_id=(id)

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -313,5 +313,19 @@ class ApiKeyTest < ActiveSupport::TestCase
 
       assert_predicate @api_key, :mfa_enabled?
     end
+
+    should "return false with MFA UI and API enabled user & short duration token" do
+      @api_key.user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+
+      [false, true].each do |mfa|
+        @api_key.update(mfa: mfa, expires_at: @api_key.created_at + 14.minutes)
+
+        refute_predicate @api_key, :mfa_enabled?
+
+        @api_key.update(mfa: mfa, expires_at: @api_key.created_at + 15.minutes)
+
+        assert_predicate @api_key, :mfa_enabled?
+      end
+    end
   end
 end


### PR DESCRIPTION
Now that we allow creating API keys with a custom expiration time (that is immutable to users), we want to allow API keys made to be intentionally super short-lived to skip MFA

This is useful for allowing a user to mint a single API token for 10 minutes and use it for multiple requests in that timeframe without needing to supply MFA on each request
