### PR TITLE
docker-compose.yml: memcache 1.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   cache:
-    image: memcached:1.5.22
+    image: memcached:1.4.39
     ports:
       - "11211:11211"
   search:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   cache:
-    image: memcached:1.4.24
+    image: memcached:1.5.22
     ports:
       - "11211:11211"
   search:


### PR DESCRIPTION
memcached 1.4 no longer pulls due to a deprecation notice.

```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/memcached:1.4.24 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

1.6 exists, but I figured I'd just upgrade to the lowest version that still works. Maybe someone who runs rubygems.org in prod can change this to the version that's actually used there.