### PR TITLE
Preload searchkick import

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -29,7 +29,7 @@ module RubygemSearchable
         }
       }
     scope :search_import, -> { includes(:linkset, :gem_download, :most_recent_version, :versions, :latest_version) }
-    
+
     def search_data # rubocop:disable Metrics/MethodLength
       if (latest_version = most_recent_version)
         deps = latest_version.dependencies.to_a

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -28,7 +28,8 @@ module RubygemSearchable
           updated: { type: "date" }
         }
       }
-
+    scope :search_import, -> { includes(:linkset, :gem_download, :most_recent_version, :versions, :latest_version) }
+    
     def search_data # rubocop:disable Metrics/MethodLength
       if (latest_version = most_recent_version)
         deps = latest_version.dependencies.to_a


### PR DESCRIPTION
Before:

```
SQL (1.6ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."indexed" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = 249327 ORDER BY "rubygems"."name" ASC
  ↳ app/models/concerns/rubygem_searchable.rb:34:in `search_data'
  Linkset Load (1.2ms)  SELECT "linksets".* FROM "linksets" WHERE "linksets"."rubygem_id" = 45403 LIMIT 1
  ↳ app/models/links.rb:25:in `initialize'
  GemDownload Load (1.2ms)  SELECT "gem_downloads".* FROM "gem_downloads" WHERE "gem_downloads"."rubygem_id" = 45403 AND "gem_downloads"."version_id" = 0 LIMIT 1
  ↳ app/models/rubygem.rb:201:in `downloads'
  GemDownload Load (1.3ms)  SELECT "gem_downloads".* FROM "gem_downloads" WHERE "gem_downloads"."version_id" = 249327 LIMIT 1
  ↳ app/models/version.rb:296:in `downloads_count'
  Version Load (1.3ms)  SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = 45403
  ↳ app/models/concerns/rubygem_searchable.rb:59:in `search_data'
  Version Load (2.1ms)  SELECT "versions".* FROM "versions" WHERE "versions"."rubygem_id" = 45404 ORDER BY case when "versions".latest AND "versions".platform = 'ruby' then 2 else 1 end desc, case when "versions".latest then "versions".number else NULL end desc, "versions"."id" DESC LIMIT 1
  ↳ app/models/concerns/rubygem_searchable.rb:33:in `search_data'
```

After:

```
  SQL (0.5ms)  SELECT "dependencies"."id" AS t0_r0, "dependencies"."requirements" AS t0_r1, "dependencies"."created_at" AS t0_r2, "dependencies"."updated_at" AS t0_r3, "dependencies"."rubygem_id" AS t0_r4, "dependencies"."version_id" AS t0_r5, "dependencies"."scope" AS t0_r6, "dependencies"."unresolved_name" AS t0_r7, "rubygems"."id" AS t1_r0, "rubygems"."name" AS t1_r1, "rubygems"."created_at" AS t1_r2, "rubygems"."updated_at" AS t1_r3, "rubygems"."indexed" AS t1_r4 FROM "dependencies" LEFT OUTER JOIN "rubygems" ON "rubygems"."id" = "dependencies"."rubygem_id" WHERE "dependencies"."version_id" = 201160 ORDER BY "rubygems"."name" ASC
  ↳ app/models/concerns/rubygem_searchable.rb:36:in `search_data'
  GemDownload Load (0.3ms)  SELECT "gem_downloads".* FROM "gem_downloads" WHERE "gem_downloads"."version_id" = 201160 LIMIT 1
  ↳ app/models/version.rb:296:in `downloads_count'
```

I tried adding `latest_version: [:gem_download, :dependencies]` but that doesn't seem to work. Not sure why.