### PR TITLE
Remove deprecated /passwords (plural) routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,11 +242,6 @@ Rails.application.routes.draw do
       patch 'unconfirmed'
     end
 
-    # The resource was plural path /passwords/new, but now we are using singular path /password/new
-    # TODO: remove the following get/post routes a few days after this PR is deployed
-    get "passwords/new", to: "passwords#new"
-    post "passwords", to: "passwords#create"
-
     resource :password, only: %i[new create edit update] do
       post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
       post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
@@ -261,14 +256,7 @@ Rails.application.routes.draw do
       post 'webauthn_authenticate', to: 'sessions#webauthn_authenticate', as: :webauthn_authenticate
     end
 
-    resources :users, only: %i[new create] do
-      # TODO: remove the password resource a few days after this PR is deployed
-      # allowing time for existing password reset emails to be used
-      resource :password, only: %i[create edit update] do
-        post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
-        post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
-      end
-    end
+    resources :users, only: %i[new create]
 
     get '/sign_in' => 'sessions#new', as: 'sign_in'
     delete '/sign_out' => 'sessions#destroy', as: 'sign_out'


### PR DESCRIPTION
These were replaced when user was removed from the route.

As long as tests all pass, this is basically zero risk since all emails for this route have long ago expired.