### PR TITLE
Restore Rail log output

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -95,7 +95,7 @@ Rails.application.configure do
   config.rails_semantic_logger.rendered   = !enable_semantic_log_format
   unless enable_semantic_log_format
     require 'rails_development_log_formatter'
-    SemanticLogger.add_appender(io: $stdout, formatter: RailsDevelopmentLogFormatter.new)
+    config.semantic_logger.add_appender(io: $stdout, formatter: RailsDevelopmentLogFormatter.new)
     config.rails_semantic_logger.format = RailsDevelopmentLogFormatter.new
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,11 +61,12 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
+  $stdout.sync = true
   config.log_level = :info
   config.rails_semantic_logger.format = :json
   config.rails_semantic_logger.semantic = true
   config.rails_semantic_logger.add_file_appender = false
-  SemanticLogger.add_appender(io: $stdout, formatter: :json)
+  config.semantic_logger.add_appender(io: $stdout, formatter: config.rails_semantic_logger.format)
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :request_id ]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -46,6 +46,11 @@ before_fork do
   sleep 1
 end
 
+on_worker_boot do
+  # Re-open appenders after forking the process. https://logger.rocketjob.io/forking.html
+  SemanticLogger.reopen
+end
+
 on_restart do
   Rails.configuration.launch_darkly_client&.close
 end


### PR DESCRIPTION
We're currently not receiving any logs from the Rails/Puma process in Kubernetes & Datadog. It's actually been so long since this issue was introduced that all our previous logs retention period has been exceeded and removed. 

I'm not able to isolate the particular change to a commit/PR to better understand what the issue is, so for now i want to adjust the configuration to what's currently documented: https://logger.rocketjob.io/rails.html

If this change works, logs from staging should start immediately coming through again. 