### PR TITLE
Include spec_sha in webhook request bodies

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -205,7 +205,7 @@ class Rubygem < ApplicationRecord
     Links.new(self, version)
   end
 
-  def payload(version = most_recent_version, protocol = Gemcutter::PROTOCOL, host_with_port = Gemcutter::HOST)
+  def payload(version = most_recent_version, protocol = Gemcutter::PROTOCOL, host_with_port = Gemcutter::HOST) # rubocop:disable Metrics/MethodLength
     versioned_links = links(version)
     deps = version.dependencies.to_a.select(&:rubygem)
     {
@@ -221,6 +221,7 @@ class Rubygem < ApplicationRecord
       "metadata"           => version.metadata,
       "yanked"             => version.yanked?,
       "sha"                => version.sha256_hex,
+      "spec_sha"           => version.spec_sha256_hex,
       "project_uri"        => "#{protocol}://#{host_with_port}/gems/#{name}",
       "gem_uri"            => "#{protocol}://#{host_with_port}/gems/#{version.gem_file_name}",
       "homepage_uri"       => versioned_links.homepage_uri,

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -217,11 +217,11 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       assert_equal(
         %w[
           name downloads version version_created_at version_downloads platform
-          authors info licenses metadata yanked sha project_uri gem_uri
+          authors info licenses metadata yanked sha spec_sha project_uri gem_uri
           homepage_uri wiki_uri documentation_uri mailing_list_uri
           source_code_uri bug_tracker_uri changelog_uri funding_uri dependencies
           built_at created_at description downloads_count number summary
-          rubygems_version ruby_version prerelease requirements spec_sha
+          rubygems_version ruby_version prerelease requirements
         ],
         @response.keys
       )


### PR DESCRIPTION
It is present when getting the versions of a gem from the API (https://rubygems.org/api/v1/versions/puppet-lint-spaceship_operator_without_tag-check.json) but not in the web hook since the web hook uses the rubygem to generate the payload, vs the version