### PR TITLE
Move pundit policy has_association above other predicates

### DIFF
--- a/app/policies/api_key_policy.rb
+++ b/app/policies/api_key_policy.rb
@@ -5,11 +5,11 @@ class ApiKeyPolicy < ApplicationPolicy
     end
   end
 
-  def avo_show?
-    Pundit.policy!(user, record.owner).avo_show?
-  end
-
   has_association :api_key_rubygem_scope
   has_association :ownership
   has_association :oidc_id_token
+
+  def avo_show?
+    Pundit.policy!(user, record.owner).avo_show?
+  end
 end

--- a/app/policies/deletion_policy.rb
+++ b/app/policies/deletion_policy.rb
@@ -5,6 +5,8 @@ class DeletionPolicy < ApplicationPolicy
     end
   end
 
+  has_association :version
+
   def avo_index?
     rubygems_org_admin?
   end
@@ -12,6 +14,4 @@ class DeletionPolicy < ApplicationPolicy
   def avo_show?
     rubygems_org_admin?
   end
-
-  has_association :version
 end

--- a/app/policies/events/rubygem_event_policy.rb
+++ b/app/policies/events/rubygem_event_policy.rb
@@ -5,9 +5,9 @@ class Events::RubygemEventPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :rubygem
   has_association :ip_address
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/events/user_event_policy.rb
+++ b/app/policies/events/user_event_policy.rb
@@ -5,9 +5,9 @@ class Events::UserEventPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :user
   has_association :ip_address
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/geoip_info_policy.rb
+++ b/app/policies/geoip_info_policy.rb
@@ -5,8 +5,8 @@ class GeoipInfoPolicy < ApplicationPolicy
     end
   end
 
+  has_association :ip_addresses
+
   def avo_index? = rubygems_org_admin?
   def avo_show? = rubygems_org_admin?
-
-  has_association :ip_addresses
 end

--- a/app/policies/ip_address_policy.rb
+++ b/app/policies/ip_address_policy.rb
@@ -5,9 +5,9 @@ class IpAddressPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :user_events
   has_association :rubygem_events
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/oidc/api_key_role_policy.rb
+++ b/app/policies/oidc/api_key_role_policy.rb
@@ -5,12 +5,12 @@ class OIDC::ApiKeyRolePolicy < ApplicationPolicy
     end
   end
 
+  has_association :provider
+  has_association :id_tokens
+
   def avo_index? = rubygems_org_admin?
   def avo_show? = rubygems_org_admin?
   def avo_create? = rubygems_org_admin?
   def avo_update? = rubygems_org_admin?
   def act_on? = rubygems_org_admin?
-
-  has_association :provider
-  has_association :id_tokens
 end

--- a/app/policies/oidc/id_token_policy.rb
+++ b/app/policies/oidc/id_token_policy.rb
@@ -5,10 +5,10 @@ class OIDC::IdTokenPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :provider
   has_association :api_key_role
   has_association :api_key
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/oidc/pending_trusted_publisher_policy.rb
+++ b/app/policies/oidc/pending_trusted_publisher_policy.rb
@@ -5,9 +5,9 @@ class OIDC::PendingTrustedPublisherPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :rubygem
   has_association :trusted_publisher
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/oidc/provider_policy.rb
+++ b/app/policies/oidc/provider_policy.rb
@@ -5,11 +5,11 @@ class OIDC::ProviderPolicy < ApplicationPolicy
     end
   end
 
+  has_association :api_key_roles
+
   def avo_index? = rubygems_org_admin?
   def avo_show? = rubygems_org_admin?
   def avo_create? = rubygems_org_admin?
   def avo_update? = rubygems_org_admin?
   def act_on? = rubygems_org_admin?
-
-  has_association :api_key_roles
 end

--- a/app/policies/oidc/rubygem_trusted_publisher_policy.rb
+++ b/app/policies/oidc/rubygem_trusted_publisher_policy.rb
@@ -5,9 +5,9 @@ class OIDC::RubygemTrustedPublisherPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :rubygem
   has_association :trusted_publisher
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/oidc/trusted_publisher/github_action_policy.rb
+++ b/app/policies/oidc/trusted_publisher/github_action_policy.rb
@@ -5,12 +5,12 @@ class OIDC::TrustedPublisher::GitHubActionPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index? = rubygems_org_admin?
-  def avo_show? = rubygems_org_admin?
-
   has_association :trusted_publishers
   has_association :rubygem_trusted_publishers
   has_association :pending_trusted_publishers
   has_association :rubygems
   has_association :api_keys
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
 end

--- a/app/policies/ownership_policy.rb
+++ b/app/policies/ownership_policy.rb
@@ -5,9 +5,9 @@ class OwnershipPolicy < ApplicationPolicy
     end
   end
 
+  has_association :api_key_rubygem_scopes
+
   def avo_show?
     rubygems_org_admin?
   end
-
-  has_association :api_key_rubygem_scopes
 end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -9,18 +9,6 @@ class RubygemPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index?
-    rubygems_org_admin?
-  end
-
-  def avo_show?
-    rubygems_org_admin?
-  end
-
-  def act_on?
-    rubygems_org_admin?
-  end
-
   has_association :versions
   has_association :latest_version
   has_association :ownerships
@@ -34,6 +22,17 @@ class RubygemPolicy < ApplicationPolicy
   has_association :gem_download
   has_association :audits
   has_association :link_verifications
-
   has_association :oidc_rubygem_trusted_publishers
+
+  def avo_index?
+    rubygems_org_admin?
+  end
+
+  def avo_show?
+    rubygems_org_admin?
+  end
+
+  def act_on?
+    rubygems_org_admin?
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,18 +6,6 @@ class UserPolicy < ApplicationPolicy
     end
   end
 
-  def avo_index?
-    rubygems_org_admin?
-  end
-
-  def avo_show?
-    rubygems_org_admin?
-  end
-
-  def act_on?
-    rubygems_org_admin?
-  end
-
   has_association :ownerships
   has_association :rubygems
   has_association :subscriptions
@@ -34,4 +22,16 @@ class UserPolicy < ApplicationPolicy
   has_association :webauthn_credentials
   has_association :webauthn_verification
   has_association :events
+
+  def avo_index?
+    rubygems_org_admin?
+  end
+
+  def avo_show?
+    rubygems_org_admin?
+  end
+
+  def act_on?
+    rubygems_org_admin?
+  end
 end

--- a/app/policies/version_policy.rb
+++ b/app/policies/version_policy.rb
@@ -9,6 +9,10 @@ class VersionPolicy < ApplicationPolicy
     end
   end
 
+  has_association :dependencies
+  has_association :gem_download
+  has_association :deletion
+
   def avo_index?
     rubygems_org_admin?
   end
@@ -20,8 +24,4 @@ class VersionPolicy < ApplicationPolicy
   def act_on?
     rubygems_org_admin?
   end
-
-  has_association :dependencies
-  has_association :gem_download
-  has_association :deletion
 end

--- a/app/policies/web_hook_policy.rb
+++ b/app/policies/web_hook_policy.rb
@@ -5,6 +5,8 @@ class WebHookPolicy < ApplicationPolicy
     end
   end
 
+  has_association :audits
+
   def avo_index?
     rubygems_org_admin?
   end
@@ -16,6 +18,4 @@ class WebHookPolicy < ApplicationPolicy
   def act_on?
     rubygems_org_admin?
   end
-
-  has_association :audits
 end

--- a/app/policies/webauthn_credential_policy.rb
+++ b/app/policies/webauthn_credential_policy.rb
@@ -5,9 +5,9 @@ class WebauthnCredentialPolicy < ApplicationPolicy
     end
   end
 
+  has_association :user
+
   def avo_show?
     Pundit.policy!(user, record.user).avo_show?
   end
-
-  has_association :user
 end

--- a/app/policies/webauthn_verification_policy.rb
+++ b/app/policies/webauthn_verification_policy.rb
@@ -5,9 +5,9 @@ class WebauthnVerificationPolicy < ApplicationPolicy
     end
   end
 
+  has_association :user
+
   def avo_show?
     Pundit.policy!(user, record.user).avo_show?
   end
-
-  has_association :user
 end


### PR DESCRIPTION
It's natural to want to override some of the methods created by `has_association`, so they need to be defined above the other policy predicates.