### PR TITLE
Add pundit to owners controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Clearance::Authentication
+  include Pundit::Authorization
   include ApplicationMultifactorMethods
   include TraceTagger
 
@@ -8,6 +9,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_forbidden
   rescue_from ActionController::UnpermittedParameters, with: :render_bad_request
+  rescue_from Pundit::NotAuthorizedError, with: :render_forbidden
 
   before_action :set_locale
   before_action :reject_null_char_param

--- a/app/policies/ownership_policy.rb
+++ b/app/policies/ownership_policy.rb
@@ -1,0 +1,15 @@
+class OwnershipPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.none # unused
+    end
+  end
+
+  def create?
+    record.rubygem.owned_by?(user) && record.authorizer == user
+  end
+
+  def destroy?
+    record.rubygem.owned_by?(user)
+  end
+end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -1,0 +1,27 @@
+class RubygemPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.none # unused
+    end
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    user.present?
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
+  def show_unconfirmed_ownerships?
+    record.owned_by?(user)
+  end
+end

--- a/test/factories/ownership.rb
+++ b/test/factories/ownership.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     rubygem
     user
     confirmed_at { Time.current }
-    authorizer { user }
+    authorizer { association :user }
     trait :unconfirmed do
       confirmed_at { nil }
     end

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -8,9 +8,7 @@ class OwnersControllerTest < ActionController::TestCase
       @user = create(:user)
       @rubygem = create(:rubygem)
       create(:ownership, user: @user, rubygem: @rubygem)
-      sign_in_as(@user)
-      session[:verification] = 10.minutes.from_now
-      session[:verified_user] = @user.id
+      verified_sign_in_as(@user)
     end
 
     teardown do
@@ -37,7 +35,7 @@ class OwnersControllerTest < ActionController::TestCase
       context "when user does not own the gem" do
         setup do
           @other_user = create(:user)
-          sign_in_as(@other_user)
+          verified_sign_in_as(@other_user)
           get :index, params: { rubygem_id: @rubygem.name }
         end
 
@@ -148,7 +146,7 @@ class OwnersControllerTest < ActionController::TestCase
       context "when user does not own the gem" do
         setup do
           @other_user = create(:user)
-          sign_in_as(@other_user)
+          verified_sign_in_as(@other_user)
           post :create, params: { handle: @other_user.display_id, rubygem_id: @rubygem.name }
         end
 
@@ -272,7 +270,7 @@ class OwnersControllerTest < ActionController::TestCase
       context "when user does not own the gem" do
         setup do
           @other_user = create(:user)
-          sign_in_as(@other_user)
+          verified_sign_in_as(@other_user)
 
           @last_owner = @rubygem.owners.last
           delete :destroy, params: { rubygem_id: @rubygem.name, handle: @last_owner.display_id }
@@ -289,7 +287,7 @@ class OwnersControllerTest < ActionController::TestCase
     context "on GET to resend confirmation" do
       setup do
         @new_owner = create(:user)
-        sign_in_as(@new_owner)
+        verified_sign_in_as(@new_owner)
       end
 
       context "when unconfirmed ownership exists" do

--- a/test/policies/ownership_policy_test.rb
+++ b/test/policies/ownership_policy_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class OwnershipPolicyTest < ActiveSupport::TestCase
+  setup do
+    @authorizer = FactoryBot.create(:user)
+    @rubygem = FactoryBot.create(:rubygem, owners: [@authorizer])
+    @confirmed_ownership = @rubygem.ownerships.first
+    @unconfirmed_ownership = FactoryBot.build(:ownership, :unconfirmed, rubygem: @rubygem, authorizer: @authorizer)
+
+    @invited = @unconfirmed_ownership.user
+    @user = FactoryBot.create(:user)
+  end
+
+  def test_scope
+    # Tests that nothing is returned currently because scope is unused
+    assert_empty Pundit.policy_scope!(@authorizer, Ownership).to_a
+    assert_empty Pundit.policy_scope!(@invited, Ownership).to_a
+    assert_empty Pundit.policy_scope!(@user, Ownership).to_a
+  end
+
+  def test_create
+    assert_predicate Pundit.policy!(@authorizer, @unconfirmed_ownership), :create?
+    refute_predicate Pundit.policy!(@invited, @unconfirmed_ownership), :create?
+    refute_predicate Pundit.policy!(@user, @unconfirmed_ownership), :create?
+  end
+
+  def test_destroy
+    assert_predicate Pundit.policy!(@authorizer, @confirmed_ownership), :destroy?
+    refute_predicate Pundit.policy!(@owner, @confirmed_ownership), :destroy?
+    refute_predicate Pundit.policy!(@user, @confirmed_ownership), :destroy?
+  end
+end

--- a/test/policies/rubygem_policy_test.rb
+++ b/test/policies/rubygem_policy_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class RubygemPolicyTest < ActiveSupport::TestCase
+  setup do
+    @owner = FactoryBot.create(:user)
+    @rubygem = FactoryBot.create(:rubygem, owners: [@owner])
+    @user = FactoryBot.create(:user)
+  end
+
+  def test_scope
+    # Tests that nothing is returned currently because scope is unused
+    assert_empty Pundit.policy_scope!(@owner, Rubygem).to_a
+    assert_empty Pundit.policy_scope!(@user, Rubygem).to_a
+  end
+
+  def test_show
+    assert_predicate Pundit.policy!(@owner, @rubygem), :show?
+    assert_predicate Pundit.policy!(nil, @rubygem), :show?
+  end
+
+  def test_show_unconfirmed_ownerships?
+    assert_predicate Pundit.policy!(@owner, @rubygem), :show_unconfirmed_ownerships?
+    refute_predicate Pundit.policy!(@user, @rubygem), :show_unconfirmed_ownerships?
+    refute_predicate Pundit.policy!(nil, @rubygem), :show_unconfirmed_ownerships?
+  end
+
+  def test_create
+    assert_predicate Pundit.policy!(@owner, @rubygem), :create?
+    refute_predicate Pundit.policy!(nil, @rubygem), :create?
+  end
+
+  def test_update
+    refute_predicate Pundit.policy!(@owner, @rubygem), :update?
+    refute_predicate Pundit.policy!(nil, @rubygem), :update?
+  end
+
+  def test_destroy
+    refute_predicate Pundit.policy!(@owner, @rubygem), :destroy?
+    refute_predicate Pundit.policy!(nil, @rubygem), :destroy?
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -209,6 +209,12 @@ class ActionController::TestCase
       super
     end
   end
+
+  def verified_sign_in_as(user)
+    sign_in_as(user)
+    session[:verification] = 10.minutes.from_now
+    session[:verified_user] = user.id
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
Slightly changes behavior: You are now expected to verify before you will be forbidden. I think this makes sense because you shouldn't be able to find out what an account has access to without having passed authentication.

This is an example of pundit-ification of our controllers. I'd like to hear feedback on how this looks so we can decide on the style.