### PR TITLE
Add minitest-retry to fix flaky (mostly) Avo tests for now.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ end
 
 group :test do
   gem "minitest", "~> 5.23", require: false
+  gem "minitest-retry", "~> 0.2.2"
   gem "capybara", "~> 3.40"
   gem "launchy", "~> 3.0"
   gem "rack-test", "~> 2.1", require: "rack/test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,8 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-retry (0.2.2)
+      minitest (>= 5.0)
     mocha (2.3.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
@@ -808,6 +810,7 @@ DEPENDENCIES
   minitest (~> 5.23)
   minitest-gcstats (~> 1.3)
   minitest-reporters (~> 1.6)
+  minitest-retry (~> 0.2.2)
   mocha (~> 2.3)
   observer (~> 0.1.2)
   octokit (~> 8.1)
@@ -1016,6 +1019,7 @@ CHECKSUMS
   minitest (5.23.1) sha256=f1e8f8d6ffd96fb17339ce50768bcbbdbbadff5073cb9583d084403877a77abe
   minitest-gcstats (1.3.1) sha256=cb25490f93aac02e3a5ff307e560d41afcdcafa7952c1c32efdeb9886b1f4711
   minitest-reporters (1.6.1) sha256=f8fe74e46ab40dada29402f55ca236368d0af65afc410db4219189b7a1c0fc38
+  minitest-retry (0.2.2) sha256=ea39f8abc3d67a8145ead04ff3828eb45169655c9e6078f182c0271516c03fb0
   mocha (2.3.0) sha256=f3af2eee619afe9b67a960a24fcdea3a05f548b528e6974458c89121a0204408
   msgpack (1.7.2) sha256=59ab62fd8a4d0dfbde45009f87eb6f158ab2628a7c48886b0256f175166baaa8
   multi_json (1.15.0) sha256=1fd04138b6e4a90017e8d1b804c039031399866ff3fbabb7822aea367c78615d

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,10 @@ require "helpers/webauthn_helpers"
 require "helpers/oauth_helpers"
 require "webmock/minitest"
 require "phlex/testing/rails/view_helper"
+require "minitest/retry"
+
+# Avo tests are super fragile :'(
+Minitest::Retry.use!
 
 # setup license early since some tests are testing Avo outside of requests
 # and license is set with first request


### PR DESCRIPTION
ℹ️ Mostly Avo tests are randomly failing, since browser state is not consistent at given moment at test time. Before we find a way to resolve this, let's retry 3 times during tests to ensure test is fialing consistently to prevent randomly failing CI (and need of manual restart to fix it).