### PR TITLE
Fix MFA level change with webauthn, add tests for mfa level change

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -167,6 +167,6 @@ class MultifactorAuthsController < ApplicationController
   end
 
   def webauthn_verification_url
-    setup_webauthn_authentication(form_url: webauthn_update_multifactor_auth_url(token: current_user.confirmation_token))
+    webauthn_update_multifactor_auth_url(token: current_user.confirmation_token)
   end
 end

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -3,122 +3,165 @@ require "application_system_test_case"
 class MultifactorAuthsTest < ApplicationSystemTestCase
   setup do
     @user = create(:user, email: "testuser@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "testuser")
-    @rubygem = create(:rubygem)
-    create(:ownership, rubygem: @rubygem, user: @user)
-    GemDownload.increment(
-      Rubygem::MFA_REQUIRED_THRESHOLD + 1,
-      rubygem_id: @rubygem.id
-    )
     @seed = ROTP::Base32.random_base32
     @totp = ROTP::TOTP.new(@seed)
   end
 
   teardown do
     @user.disable_totp!
+    @authenticator&.remove!
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
   end
 
-  test "setup mfa does not cache OTP setup" do
-    sign_in
-    visit edit_settings_path
+  context "cache-control" do
+    should "setup mfa does not cache OTP setup" do
+      sign_in
 
-    click_button "Register a new device"
-    saved_otp_key = otp_key
-    totp = ROTP::TOTP.new(saved_otp_key)
-    fill_in "otp", with: totp.now
-    click_button "Enable"
+      register_otp_device
 
-    assert page.has_content? "Recovery codes"
+      assert page.has_content? "Recovery codes"
 
-    go_back
+      go_back
 
-    assert page.has_content? "has already been enabled"
-    refute page.has_content? "Register a new device"
-    refute page.has_content? saved_otp_key
+      assert page.has_content? "has already been enabled"
+      refute page.has_content? "Register a new device"
+      refute page.has_content? @otp_key
+    end
+
+    should "setup mfa does not cache recovery codes" do
+      sign_in
+
+      register_otp_device
+
+      assert page.has_content? "Recovery codes"
+      click_link "[ copy ]"
+      check "ack"
+      click_button "Continue"
+
+      go_back
+
+      refute page.has_content? "Recovery codes"
+    end
   end
 
-  test "setup mfa does not cache recovery codes" do
-    sign_in
-    visit edit_settings_path
+  context "strong mfa required" do
+    setup do
+      @rubygem = create(:rubygem)
+      create(:ownership, rubygem: @rubygem, user: @user)
+      GemDownload.increment(
+        Rubygem::MFA_REQUIRED_THRESHOLD + 1,
+        rubygem_id: @rubygem.id
+      )
+    end
 
-    click_button "Register a new device"
-    totp = ROTP::TOTP.new(otp_key)
-    fill_in "otp", with: totp.now
-    click_button "Enable"
+    context "with mfa disabled" do
+      should "user with mfa disabled gets redirected back to adoptions after setting up mfa" do
+        redirect_test_mfa_disabled(adoptions_profile_path)
+      end
 
-    assert page.has_content? "Recovery codes"
-    click_link "[ copy ]"
-    check "ack"
-    click_button "Continue"
+      should "user with mfa disabled gets redirected back to dashboard pages after setting up mfa" do
+        redirect_test_mfa_disabled(dashboard_path)
+      end
 
-    go_back
+      should "user with mfa disabled gets redirected back to delete profile pages after setting up mfa" do
+        redirect_test_mfa_disabled(delete_profile_path)
+      end
 
-    refute page.has_content? "Recovery codes"
+      should "user with mfa disabled gets redirected back to edit profile pages after setting up mfa" do
+        redirect_test_mfa_disabled(edit_profile_path)
+      end
+
+      should "user with mfa disabled gets redirected back to new api keys pages after setting up mfa" do
+        redirect_test_mfa_disabled(new_profile_api_key_path) { verify_password }
+      end
+
+      should "user with mfa disabled gets redirected back to notifier pages after setting up mfa" do
+        redirect_test_mfa_disabled(notifier_path)
+      end
+
+      should "user with mfa disabled gets redirected back to profile api keys pages after setting up mfa" do
+        create(:api_key, scopes: %i[push_rubygem], owner: @user, ownership: @ownership)
+        redirect_test_mfa_disabled(profile_api_keys_path) { verify_password }
+      end
+
+      should "user with mfa disabled gets redirected back to verify session pages after setting up mfa" do
+        redirect_test_mfa_disabled(verify_session_path)
+      end
+    end
+
+    context "with weak level mfa" do
+      should "user gets redirected back to adoptions after setting up mfa" do
+        redirect_test_mfa_weak_level(adoptions_profile_path)
+      end
+
+      should "user gets redirected back to dashboard pages after setting up mfa" do
+        redirect_test_mfa_weak_level(dashboard_path)
+      end
+
+      should "user gets redirected back to delete profile pages after setting up mfa" do
+        redirect_test_mfa_weak_level(delete_profile_path)
+      end
+
+      should "user gets redirected back to edit profile pages after setting up mfa" do
+        redirect_test_mfa_weak_level(edit_profile_path)
+      end
+
+      should "user gets redirected back to new api keys pages after setting up mfa" do
+        redirect_test_mfa_weak_level(new_profile_api_key_path) { verify_password }
+      end
+
+      should "user gets redirected back to notifier pages after setting up mfa" do
+        redirect_test_mfa_weak_level(notifier_path)
+      end
+
+      should "user gets redirected back to profile api keys pages after setting up mfa" do
+        create(:api_key, scopes: %i[push_rubygem], owner: @user, ownership: @ownership)
+        redirect_test_mfa_weak_level(profile_api_keys_path) { verify_password }
+      end
+
+      should "user gets redirected back to verify session pages after setting up mfa" do
+        redirect_test_mfa_weak_level(verify_session_path)
+      end
+    end
   end
 
-  test "user with mfa disabled gets redirected back to adoptions after setting up mfa" do
-    redirect_test_mfa_disabled(adoptions_profile_path)
-  end
+  context "updating mfa level" do
+    should "user with otp can change mfa level" do
+      sign_in
+      @user.enable_totp!(@seed, :ui_and_gem_signin)
 
-  test "user with mfa disabled gets redirected back to dashboard pages after setting up mfa" do
-    redirect_test_mfa_disabled(dashboard_path)
-  end
+      visit edit_settings_path
 
-  test "user with mfa disabled gets redirected back to delete profile pages after setting up mfa" do
-    redirect_test_mfa_disabled(delete_profile_path)
-  end
+      assert page.has_content?("UI and gem signin"), "UI and gem signin was not the default level"
 
-  test "user with mfa disabled gets redirected back to edit profile pages after setting up mfa" do
-    redirect_test_mfa_disabled(edit_profile_path)
-  end
+      change_auth_level "UI and API (Recommended)"
+      fill_in "otp", with: @totp.now
+      click_button "Authenticate"
 
-  test "user with mfa disabled gets redirected back to new api keys pages after setting up mfa" do
-    redirect_test_mfa_disabled(new_profile_api_key_path) { verify_password }
-  end
+      assert_current_path(edit_settings_path)
+      assert page.has_content?("UI and API (Recommended)"), "MFA level was not updated"
+    end
 
-  test "user with mfa disabled gets redirected back to notifier pages after setting up mfa" do
-    redirect_test_mfa_disabled(notifier_path)
-  end
+    should "user with webauthn can change mfa level" do
+      fullscreen_headless_chrome_driver
 
-  test "user with mfa disabled gets redirected back to profile api keys pages after setting up mfa" do
-    create(:api_key, scopes: %i[push_rubygem], owner: @user, ownership: @ownership)
-    redirect_test_mfa_disabled(profile_api_keys_path) { verify_password }
-  end
+      sign_in
+      visit edit_settings_path
 
-  test "user with mfa disabled gets redirected back to verify session pages after setting up mfa" do
-    redirect_test_mfa_disabled(verify_session_path)
-  end
+      @authenticator = create_webauthn_credential_while_signed_in
 
-  test "user with weak level mfa gets redirected back to adoptions after setting up mfa" do
-    redirect_test_mfa_weak_level(adoptions_profile_path)
-  end
+      assert page.has_content?("UI and gem signin"), "UI and gem signin was not the default level"
 
-  test "user with weak level mfa gets redirected back to dashboard pages after setting up mfa" do
-    redirect_test_mfa_weak_level(dashboard_path)
-  end
+      change_auth_level "UI and API (Recommended)"
 
-  test "user with weak level mfa gets redirected back to delete profile pages after setting up mfa" do
-    redirect_test_mfa_weak_level(delete_profile_path)
-  end
+      assert page.has_content? "Multi-factor authentication"
+      assert page.has_content? "Security Device"
+      click_on "Authenticate with security device"
 
-  test "user with weak level mfa gets redirected back to edit profile pages after setting up mfa" do
-    redirect_test_mfa_weak_level(edit_profile_path)
-  end
-
-  test "user with weak level mfa gets redirected back to new api keys pages after setting up mfa" do
-    redirect_test_mfa_weak_level(new_profile_api_key_path) { verify_password }
-  end
-
-  test "user with weak level mfa gets redirected back to notifier pages after setting up mfa" do
-    redirect_test_mfa_weak_level(notifier_path)
-  end
-
-  test "user with weak level mfa gets redirected back to profile api keys pages after setting up mfa" do
-    create(:api_key, scopes: %i[push_rubygem], owner: @user, ownership: @ownership)
-    redirect_test_mfa_weak_level(profile_api_keys_path) { verify_password }
-  end
-
-  test "user with weak level mfa gets redirected back to verify session pages after setting up mfa" do
-    redirect_test_mfa_weak_level(verify_session_path)
+      assert_current_path(edit_settings_path)
+      assert page.has_content?("UI and API (Recommended)"), "MFA level was not updated"
+    end
   end
 
   def redirect_test_mfa_disabled(path)
@@ -128,10 +171,7 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     assert(page.has_content?("you are required to set up multi-factor authentication"))
     assert_current_path(edit_settings_path)
 
-    click_button "Register a new device"
-    totp = ROTP::TOTP.new(otp_key)
-    fill_in "otp", with: totp.now
-    click_button "Enable"
+    register_otp_device
 
     assert page.has_content? "Recovery codes"
     click_link "[ copy ]"
@@ -169,6 +209,16 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
   def otp_key
     key_regex = /( (\w{4})){8}/
     page.find_by_id("otp-key").text.match(key_regex)[0].delete("\s")
+  end
+
+  def register_otp_device
+    visit edit_settings_path
+    click_button "Register a new device"
+    @otp_key = otp_key
+    totp = ROTP::TOTP.new(@otp_key)
+    fill_in "otp", with: totp.now
+    click_button "Enable"
+    @otp_key
   end
 
   def verify_password

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,6 +155,16 @@ class ActiveSupport::TestCase
     fill_in "Email or Username", with: @user.reload.email
     fill_in "Password", with: @user.password
     click_button "Sign in"
+
+    @authenticator = create_webauthn_credential_while_signed_in
+
+    find(:css, ".header__popup-link").click
+    click_on "Sign out"
+
+    @authenticator
+  end
+
+  def create_webauthn_credential_while_signed_in
     visit edit_settings_path
 
     options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
@@ -173,10 +183,8 @@ class ActiveSupport::TestCase
     check "ack"
     click_on "Continue"
 
+    visit edit_settings_path
     find("div", text: credential_nickname, match: :first)
-
-    find(:css, ".header__popup-link").click
-    click_on "Sign out"
 
     @user.reload
     @authenticator


### PR DESCRIPTION
There were no tests for this specific action to change mfa level, so the url being wrong didn't fail anything.

Most of the changes are re-indenting the tests so I could only add an mfa-required rubygem to the tests that needed it, because they otherwise broke the tests where it wasn't needed.