### PR TITLE
Retry tests on CI only.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,10 @@ SimpleCov.start "rails" do
   if ENV["CI"]
     require "simplecov-cobertura"
     formatter SimpleCov::Formatter::CoberturaFormatter
+
+    # Avo tests are super fragile :'(
+    require "minitest/retry"
+    Minitest::Retry.use!
   end
 end
 
@@ -29,10 +33,6 @@ require "helpers/webauthn_helpers"
 require "helpers/oauth_helpers"
 require "webmock/minitest"
 require "phlex/testing/rails/view_helper"
-require "minitest/retry"
-
-# Avo tests are super fragile :'(
-Minitest::Retry.use!
 
 # setup license early since some tests are testing Avo outside of requests
 # and license is set with first request


### PR DESCRIPTION
:information_source: could be annoying to get restarts locally during development.