### PR TITLE
Default to 'forbidden' body on pundit error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,6 +139,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_forbidden(error = "forbidden")
+    error = "forbidden" if error.is_a?(Pundit::NotAuthorizedError)
     render plain: error, status: :forbidden
   end
 

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -40,6 +40,10 @@ class OwnersControllerTest < ActionController::TestCase
         end
 
         should respond_with :forbidden
+
+        should "render forbidden message" do
+          assert page.has_content?("forbidden")
+        end
       end
     end
 


### PR DESCRIPTION
We don't need to reveal the pundit check that triggered forbidden.