### PR TITLE
No auto sign in after email confirmation

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -8,7 +8,7 @@ class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: :unconfirmed
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: :unconfirmed
   before_action :validate_confirmation_token, only: %i[update otp_update webauthn_update]
-  before_action :require_mfa, only: %i[update]
+  before_action :require_mfa, only: :update
   before_action :validate_otp, only: :otp_update
   before_action :validate_webauthn, only: :webauthn_update
   after_action :delete_mfa_expiry_session, only: %i[otp_update webauthn_update]
@@ -63,11 +63,11 @@ class EmailConfirmationsController < ApplicationController
 
   def confirm_email
     if @user.confirm_email!
-      sign_in @user
-      redirect_to root_path, notice: t("email_confirmations.update.confirmed_email")
+      flash[:notice] = t("email_confirmations.update.confirmed_email")
     else
-      redirect_to root_path, alert: @user.errors.full_messages.to_sentence
+      flash[:alert] = @user.errors.full_messages.to_sentence
     end
+    redirect_to signed_in? ? dashboard_path : sign_in_path
   end
 
   def email_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,8 +280,7 @@ uniqueness: { case_sensitive: false }
   private
 
   def update_email
-    self.attributes = { email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0 }
-    save
+    update(email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0)
   end
 
   def unconfirmed_email_uniqueness

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -13,6 +13,11 @@ FactoryBot.define do
     end
     mfa_hashed_recovery_codes { mfa_recovery_codes.map { |code| BCrypt::Password.create(code) } }
 
+    trait :unconfirmed do
+      email_confirmed { false }
+      unconfirmed_email { "#{SecureRandom.hex(8)}#{email}" }
+    end
+
     trait :mfa_enabled do
       totp_seed { "123abc" }
       mfa_level { User.mfa_levels["ui_and_api"] }

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -168,7 +168,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       context "when OTP is correct" do
         setup do
-          get :update, params: { token: @user.confirmation_token, user_id: @user.id }
+          get :update, params: { token: @user.confirmation_token }
           post :otp_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
         end
 
@@ -184,7 +184,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       context "when OTP is incorrect" do
         setup do
-          get :update, params: { token: @user.confirmation_token, user_id: @user.id }
+          get :update, params: { token: @user.confirmation_token }
           post :otp_update, params: { token: @user.confirmation_token, otp: "incorrect" }
         end
 
@@ -197,7 +197,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       context "when the OTP session is expired" do
         setup do
-          get :update, params: { token: @user.confirmation_token, user_id: @user.id }
+          get :update, params: { token: @user.confirmation_token }
           travel 16.minutes do
             post :otp_update, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
@@ -225,7 +225,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
     setup do
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
-      get :update, params: { token: @user.confirmation_token, user_id: @user.id }
+      get :update, params: { token: @user.confirmation_token }
       @origin = WebAuthn.configuration.origin
       @rp_id = URI.parse(@origin).host
       @client = WebAuthn::FakeClient.new(@origin, encoding: false)
@@ -241,7 +241,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         post(
           :webauthn_update,
           params: {
-            user_id: @user.id,
             token: @user.confirmation_token,
             credentials:
             WebauthnHelpers.get_result(
@@ -270,7 +269,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         post(
           :webauthn_update,
           params: {
-            user_id: @user.id,
             token: @user.confirmation_token
           }
         )
@@ -293,7 +291,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         post(
           :webauthn_update,
           params: {
-            user_id: @user.id,
             token: @user.confirmation_token,
             credentials:
             WebauthnHelpers.get_result(
@@ -325,7 +322,6 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
           post(
             :webauthn_update,
             params: {
-              user_id: @user.id,
               token: @user.confirmation_token,
               credentials:
               WebauthnHelpers.get_result(

--- a/test/integration/sign_up_test.rb
+++ b/test/integration/sign_up_test.rb
@@ -94,8 +94,14 @@ class SignUpTest < SystemTest
     assert_not_nil link
     visit link
 
-    assert page.has_content? "Sign out"
+    assert page.has_content? "Sign in"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
+
+    fill_in "Email or Username", with: "email@person.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Sign out"
   end
 
   teardown do


### PR DESCRIPTION
Basing this decision on [OWASP guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html#user-resets-password) (for password resets, but the same principal applies):

> Once they have set their new password, the user should then login through the usual mechanism. Don't automatically log the user in, as this introduces additional complexity to the authentication and session handling code, and increases the likelihood of introducing vulnerabilities.

The main goal being simpler login flows that are less likely to have mistakes or allow bypasses.