### PR TITLE
Set Referrer-Policy header with 'no-referrer' on confirmation token pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,6 +184,11 @@ class ApplicationController < ActionController::Base
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
+  # Avoid leaking confirmation token in referrer header on certain pages
+  def no_referrer
+    headers["Referrer-Policy"] = "no-referrer"
+  end
+
   def set_error_context_user
     return unless current_user
 

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -7,6 +7,7 @@ class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: :unconfirmed
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: :unconfirmed
+  before_action :no_referrer, only: %i[update otp_update webauthn_update]
   before_action :validate_confirmation_token, only: %i[update otp_update webauthn_update]
   before_action :require_mfa, only: :update
   before_action :validate_otp, only: :otp_update

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,6 +6,7 @@ class PasswordsController < ApplicationController
 
   before_action :ensure_email_present, only: %i[create]
 
+  before_action :no_referrer, only: %i[edit otp_edit webauthn_edit]
   before_action :validate_confirmation_token, only: %i[edit otp_edit webauthn_edit]
   before_action :require_mfa, only: %i[edit]
   before_action :validate_otp, only: %i[otp_edit]

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -18,6 +18,9 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       should "not sign in user" do
         refute cookies[:remember_token]
       end
+      should "instruct the browser not to send referrer that contains the token" do
+        assert_equal "no-referrer", response.headers["Referrer-Policy"]
+      end
     end
 
     context "successful confirmation while signed in" do

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -63,6 +63,10 @@ class PasswordsControllerTest < ActionController::TestCase
         page.assert_text("Reset password")
         page.assert_selector("input[type=password][autocomplete=new-password]")
       end
+
+      should "instruct the browser not to send referrer that contains the token" do
+        assert_equal "no-referrer", response.headers["Referrer-Policy"]
+      end
     end
 
     context "with expired confirmation_token" do


### PR DESCRIPTION
Recommended in the OWASP page for password resets, this is unlikely to affect us but also very easy to implement.

https://portswigger.net/kb/issues/00500400_cross-domain-referer-leakage