### PR TITLE
use link to ruby.social page without the '@' symbol

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -199,7 +199,7 @@
 																		<td align="center">
 																			<table border="0" cellspacing="0" cellpadding="0">
 																				<tr>																					
-																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href=" https://ruby.social/@rubygems" target="_blank" rel="noopener"><img src="<%= image_url("mastodon_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
+																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://ruby.social/users/rubygems" target="_blank" rel="noopener"><img src="<%= image_url("mastodon_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://github.com/rubygems" target="_blank" rel="noopener"><img src="<%= image_url("github_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://groups.google.com/forum/#!forum/rubygems-org" target="_blank" rel="noopener"><img src="<%= image_url("google_group_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																				</tr>


### PR DESCRIPTION
Fixes an error raised from the addition of the [ruby.social](https://ruby.social) link in #4803 

```
bad URI(is not URI?): " https://ruby.social/@rubygems"
URI::InvalidURIError
```