### PR TITLE
Move TOTP CRUD actions to TotpsController

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,7 +59,7 @@ class Api::BaseController < ApplicationController
 
 
         [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
-        at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+        at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future.
       WARN
     elsif @api_key.mfa_recommended_weak_level_enabled?
       message += <<~WARN.chomp
@@ -77,7 +77,7 @@ class Api::BaseController < ApplicationController
   def render_mfa_setup_required_error
     error = <<~ERROR.chomp
       [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-      at https://rubygems.org/multifactor_auth/new.
+      at https://rubygems.org/totp/new.
 
       Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
     ERROR

--- a/app/controllers/concerns/require_mfa.rb
+++ b/app/controllers/concerns/require_mfa.rb
@@ -50,7 +50,7 @@ module RequireMfa
   end
 
   def incorrect_otp
-    mfa_failure(t("multifactor_auths.incorrect_otp"))
+    mfa_failure(t("totps.incorrect_otp"))
   end
 
   def webauthn_failure

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -142,7 +142,7 @@ class SessionsController < Clearance::SessionsController
 
   def url_after_create
     if current_user.mfa_recommended_not_yet_enabled?
-      new_multifactor_auth_path
+      new_totp_path
     elsif current_user.mfa_recommended_weak_level_enabled?
       edit_settings_path
     else

--- a/app/controllers/totps_controller.rb
+++ b/app/controllers/totps_controller.rb
@@ -1,0 +1,80 @@
+class TotpsController < ApplicationController
+  include MfaExpiryMethods
+  include RequireMfa
+  include WebauthnVerifiable
+
+  before_action :redirect_to_signin, unless: :signed_in?
+  before_action :require_totp_disabled, only: %i[new create]
+  before_action :require_totp_enabled, only: :destroy
+  before_action :seed_and_expire, only: :create
+  before_action :disable_cache, only: %i[new]
+  helper_method :issuer
+
+  def new
+    @seed = ROTP::Base32.random_base32
+    session[:totp_seed] = @seed
+    session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
+    text = ROTP::TOTP.new(@seed, issuer: issuer).provisioning_uri(current_user.email)
+    @qrcode_svg = RQRCode::QRCode.new(text, level: :l).as_svg(module_size: 6)
+  end
+
+  def create
+    current_user.verify_and_enable_totp!(@seed, :ui_and_api, otp_param, @expire)
+    if current_user.errors.any?
+      flash[:error] = current_user.errors[:base].join
+      redirect_to edit_settings_url
+    else
+      flash[:success] = t(".success")
+      @continue_path = session.fetch("mfa_redirect_uri", edit_settings_path)
+
+      if current_user.mfa_device_count_one?
+        session[:show_recovery_codes] = current_user.new_mfa_recovery_codes
+        redirect_to recovery_multifactor_auth_path
+      else
+        redirect_to @continue_path
+        session.delete("mfa_redirect_uri")
+      end
+    end
+  end
+
+  def destroy
+    if current_user.ui_mfa_verified?(otp_param)
+      flash[:success] = t(".success")
+      current_user.disable_totp!
+      redirect_to session.fetch("mfa_redirect_uri", edit_settings_path)
+      session.delete("mfa_redirect_uri")
+    else
+      flash[:error] = t("totps.incorrect_otp")
+      redirect_to edit_settings_path
+    end
+  end
+
+  private
+
+  def otp_param
+    params.permit(:otp).fetch(:otp, "")
+  end
+
+  def issuer
+    request.host || "rubygems.org"
+  end
+
+  def require_totp_disabled
+    return if current_user.totp_disabled?
+    flash[:error] = t("totps.require_totp_disabled", host: Gemcutter::HOST_DISPLAY)
+    redirect_to edit_settings_path
+  end
+
+  def require_totp_enabled
+    return if current_user.totp_enabled?
+
+    flash[:error] = t("totps.require_totp_enabled")
+    delete_mfa_session
+    redirect_to edit_settings_path
+  end
+
+  def seed_and_expire
+    @seed = session.delete(:totp_seed)
+    @expire = Time.at(session.delete(:totp_seed_expire) || 0).utc
+  end
+end

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -23,11 +23,11 @@ module UserTotpMethods
 
   def verify_and_enable_totp!(seed, level, otp, expiry)
     if expiry < Time.now.utc
-      errors.add(:base, I18n.t("multifactor_auths.create.qrcode_expired"))
+      errors.add(:base, I18n.t("totps.create.qrcode_expired"))
     elsif verify_totp(seed, otp)
       enable_totp!(seed, level)
     else
-      errors.add(:base, I18n.t("multifactor_auths.incorrect_otp"))
+      errors.add(:base, I18n.t("totps.incorrect_otp"))
     end
   end
 

--- a/app/models/user/with_private_fields.rb
+++ b/app/models/user/with_private_fields.rb
@@ -11,7 +11,7 @@ class User::WithPrivateFields < User
   def mfa_warning
     if mfa_recommended_not_yet_enabled?
       "[WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication " \
-        "at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+        "at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future."
     elsif mfa_recommended_weak_level_enabled?
       "[WARNING] For protection of your account and gems, we encourage you to change your multi-factor authentication " \
         "level to 'UI and gem signin' or 'UI and API' at https://rubygems.org/settings/edit. " \

--- a/app/views/mailer/mfa_notification.html.erb
+++ b/app/views/mailer/mfa_notification.html.erb
@@ -34,7 +34,7 @@
 </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= new_multifactor_auth_url %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTI-FACTOR AUTHENTICATION (MFA)</span></a>
+                          <a href=<%= new_totp_url %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">ENABLE MULTI-FACTOR AUTHENTICATION (MFA)</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -91,7 +91,7 @@
                         </td>
                         <td bgcolor="#e9573f">
                           <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                            <a href=<%= new_totp_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
                               <span class="link-white" style="color:#ffffff; text-decoration:none">
                                 <%= "ENABLE MFA" if @user.mfa_disabled? %>
                                 <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>

--- a/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
+++ b/app/views/mailer/mfa_required_popular_gems_announcement.html.erb
@@ -78,7 +78,7 @@
                         </td>
                         <td bgcolor="#e9573f">
                           <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                            <a href=<%= new_totp_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
                               <span class="link-white" style="color:#ffffff; text-decoration:none">
                                 <%= "ENABLE MFA" if @user.mfa_disabled? %>
                                 <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>

--- a/app/views/mailer/mfa_required_soon_announcement.html.erb
+++ b/app/views/mailer/mfa_required_soon_announcement.html.erb
@@ -73,7 +73,7 @@
                         </td>
                         <td bgcolor="#e9573f">
                           <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                            <a href=<%= new_totp_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
                               <span class="link-white" style="color:#ffffff; text-decoration:none">
                                 <%= "ENABLE MFA" if @user.mfa_disabled? %>
                                 <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -42,7 +42,7 @@
       <span class="badge badge--success"><%= t(".mfa.enabled") %></span>
     </div>
     <p><%= t(".mfa.enabled_note") %></p>
-    <%= form_tag multifactor_auth_path, method: :delete, id: "mfa-delete" do %>
+    <%= form_tag totp_path, method: :delete, id: "mfa-delete" do %>
       <div class="text_field">
         <%= label_tag :otp, t(".otp_code"), class: "form__label" %>
         <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>
@@ -56,7 +56,7 @@
     </div>
     <p>
       <%= t(".mfa.disabled_html") %>
-      <%= button_to t(".mfa.go_settings"), new_multifactor_auth_path, method: "get", class: "form__submit" %>
+      <%= button_to t(".mfa.go_settings"), new_totp_path, method: "get", class: "form__submit" %>
     </p>
   <% end %>
 </div>

--- a/app/views/totps/new.html.erb
+++ b/app/views/totps/new.html.erb
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<%= form_tag multifactor_auth_path, method: :post do %>
+<%= form_tag totp_path, method: :post do %>
   <div class="text_field">
     <%= label_tag :otp, 'OTP code', class: 'form__label' %>
     <p class='form__field__instructions'><%= t '.otp_prompt' %></p>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,8 +44,9 @@ class Rack::Attack
   protected_ui_mfa_actions = [
     otp_create_action,
     mfa_password_edit_action,
-    { controller: "multifactor_auths",   action: "create" },
-    { controller: "multifactor_auths",   action: "update" }
+    { controller: "totps", action: "create" },
+    { controller: "totps", action: "destroy" },
+    { controller: "multifactor_auths", action: "update" }
   ]
 
   protected_api_key_actions = [

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -488,14 +488,9 @@ de:
     update:
       failure: Dein Passwort konnte nicht geändert werden. Bitte versuche es erneut.
   multifactor_auths:
-    incorrect_otp: Dein OTP-Code ist falsch.
     session_expired: Deine Sitzung auf der Anmeldeseite ist abgelaufen.
-    require_totp_disabled: Deine auf OTP basierende Zwei-Faktor-Authentifizierung
-      ist bereits aktiviert. Um sie neu zu konfigurieren, musst du sie zuerst entfernen.
     require_mfa_enabled: Deine Zwei-Faktor-Authentifizierung ist nicht aktiviert.
       Du musst sie zuerst aktivieren.
-    require_totp_enabled: Du hast keine Authenticator-App aktiviert. Du musst sie
-      zuerst aktivieren.
     require_webauthn_enabled: Du hast keine Sicherheitsgeräte aktiviert. Du musst
       zuerst ein Gerät mit deinem Konto verknüpfen.
     setup_required_html: Zum Schutz deines Kontos und deiner Gems musst du die Zwei-Faktor-Authentifizierung
@@ -516,6 +511,40 @@ de:
       die Sicherheit deines Kontos, indem du <a href=\"/settings/edit#security-device\">ein
       neues Gerät einrichtest</a>. <a href=\"https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html\">Erfahre
       mehr</a>!"
+    recovery:
+      copied: "[ kopiert ]"
+      continue: Weiter
+      title: Wiederherstellungscodes
+      copy: "[ kopieren ]"
+      saved: Ich bestätige, dass ich meine Wiederherstellungscodes gespeichert habe.
+      note_html: Bitte <strong class='recovery__bold'>kopieren und speichern</strong>
+        Sie diese Wiederherstellungscodes. Sie können diese Codes verwenden, um sich
+        anzumelden und Ihre MFA zurückzusetzen, wenn Sie Ihr Authentifizierungsgerät
+        verlieren. Jeder Code kann nur einmal verwendet werden.
+      already_generated: Sie sollten Ihre Wiederherstellungscodes bereits gespeichert
+        haben.
+    update:
+      invalid_level: Ungültiges MFA-Level.
+      success: Sie haben Ihr Multi-Faktor-Authentifizierungslevel erfolgreich aktualisiert.
+    prompt:
+      webauthn_credential_note: Authentifizieren Sie sich mit einem Sicherheitsgerät
+        wie Touch ID, YubiKey usw.
+      sign_in_with_webauthn_credential: Authentifizieren Sie sich mit einem Sicherheitsgerät
+      otp_code: OTP-Code
+      otp_or_recovery: OTP- oder Wiederherstellungscodes
+      recovery_code: Wiederherstellungscodes
+      recovery_code_html: Sie können einen gültigen <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa",
+        class="t-link">Wiederherstellungscodes</a> verwenden, wenn Sie den Zugriff
+        auf Ihr Multi-Faktor-Authentifizierungsgerät oder Ihr Sicherheitsgerät verloren
+        haben.
+      security_device: Sicherheitsgerät
+      verify_code: Verifizieren Sie den Code
+  totps:
+    incorrect_otp: Dein OTP-Code ist falsch.
+    require_totp_disabled: Deine auf OTP basierende Zwei-Faktor-Authentifizierung
+      ist bereits aktiviert. Um sie neu zu konfigurieren, musst du sie zuerst entfernen.
+    require_totp_enabled: Du hast keine Authenticator-App aktiviert. Du musst sie
+      zuerst aktivieren.
     new:
       title: Aktivierung der Zwei-Faktor-Authentifizierung
       scan_prompt: Bitte scannen Sie den QR-Code mit Ihrer Authenticator-App. Wenn
@@ -533,37 +562,9 @@ de:
         Sie, ein neues Gerät zu registrieren.
       success: Sie haben die OTP-basierte Zwei-Faktor-Authentifizierung erfolgreich
         aktiviert.
-    recovery:
-      copied: "[ kopiert ]"
-      continue: Weiter
-      title: Wiederherstellungscodes
-      copy: "[ kopieren ]"
-      saved: Ich bestätige, dass ich meine Wiederherstellungscodes gespeichert habe.
-      note_html: Bitte <strong class='recovery__bold'>kopieren und speichern</strong>
-        Sie diese Wiederherstellungscodes. Sie können diese Codes verwenden, um sich
-        anzumelden und Ihre MFA zurückzusetzen, wenn Sie Ihr Authentifizierungsgerät
-        verlieren. Jeder Code kann nur einmal verwendet werden.
-      already_generated: Sie sollten Ihre Wiederherstellungscodes bereits gespeichert
-        haben.
     destroy:
       success: Sie haben die OTP-basierte Zwei-Faktor-Authentifizierung erfolgreich
         deaktiviert.
-    update:
-      invalid_level: Ungültiges MFA-Level.
-      success: Sie haben Ihr Multi-Faktor-Authentifizierungslevel erfolgreich aktualisiert.
-    prompt:
-      webauthn_credential_note: Authentifizieren Sie sich mit einem Sicherheitsgerät
-        wie Touch ID, YubiKey usw.
-      sign_in_with_webauthn_credential: Authentifizieren Sie sich mit einem Sicherheitsgerät
-      otp_code: OTP-Code
-      otp_or_recovery: OTP- oder Wiederherstellungscodes
-      recovery_code: Wiederherstellungscodes
-      recovery_code_html: Sie können einen gültigen <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa",
-        class="t-link">Wiederherstellungscodes</a> verwenden, wenn Sie den Zugriff
-        auf Ihr Multi-Faktor-Authentifizierungsgerät oder Ihr Sicherheitsgerät verloren
-        haben.
-      security_device: Sicherheitsgerät
-      verify_code: Verifizieren Sie den Code
   notifiers:
     update:
       success:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,29 +419,14 @@ en:
     update:
       failure: Your password could not be changed. Please try again.
   multifactor_auths:
-    incorrect_otp: Your OTP code is incorrect.
     session_expired: Your login page session has expired.
-    require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
     require_mfa_enabled: Your multi-factor authentication has not been enabled. You have to enable it first.
-    require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
     require_webauthn_enabled: You don't have any security devices enabled. You have to associate a device to your account first.
     setup_required_html: For protection of your account and your gems, you are required to set up multi-factor authentication. Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication. Your account will be required to have MFA enabled in the future.
     strong_mfa_level_required_html: For protection of your account and your gems, you are required to change your MFA level to "UI and gem signin" or "UI and API". Please read our <a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">blog post</a> for more details.
     strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API". Your account will be required to have MFA enabled on one of these levels in the future.
     setup_webauthn_html: 🎉 We now support security devices! Improve your account security by <a href="/settings/edit#security-device">setting up</a> a new device. <a href="https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html">Learn more</a>!
-    new:
-      title: Enabling multi-factor auth
-      scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.
-      otp_prompt: Type digit code from auth app to continue.
-      confirm: I have kept my recovery codes safe.
-      enable: Enable
-      account: "Account: %{account}"
-      key: "Key: %{key}"
-      time_based: "Time based: Yes"
-    create:
-      qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
-      success: You have successfully enabled OTP based multi-factor authentication.
     recovery:
       copied: "[ copied ]"
       continue: Continue
@@ -450,8 +435,6 @@ en:
       saved: I acknowledge that I have saved my recovery codes.
       note_html: "Please <strong class='recovery__bold'>copy and save</strong> these recovery codes. You can use these codes to login and reset your MFA if your lose your authentication device. Each code can be used once."
       already_generated: You should have already saved your recovery codes.
-    destroy:
-      success: You have successfully disabled OTP based multi-factor authentication.
     update:
       invalid_level: Invalid MFA level.
       success: You have successfully updated your multi-factor authentication level.
@@ -464,6 +447,24 @@ en:
       recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your multi-factor authentication device or to your security device.'
       security_device: Security Device
       verify_code: Verify code
+  totps:
+    incorrect_otp: Your OTP code is incorrect.
+    require_totp_disabled: Your OTP based multi-factor authentication has already been enabled. To reconfigure your OTP based authentication, you'll have to remove it first.
+    require_totp_enabled: You don't have an authenticator app enabled. You have to enable it first.
+    new:
+      title: Enabling multi-factor auth
+      scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.
+      otp_prompt: Type digit code from auth app to continue.
+      confirm: I have kept my recovery codes safe.
+      enable: Enable
+      account: "Account: %{account}"
+      key: "Key: %{key}"
+      time_based: "Time based: Yes"
+    create:
+      qrcode_expired: The QR-code and key is expired. Please try registering a new device again.
+      success: You have successfully enabled OTP based multi-factor authentication.
+    destroy:
+      success: You have successfully disabled OTP based multi-factor authentication.
   notifiers:
     update:
       success: You have successfully updated your email notification settings.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -474,14 +474,9 @@ es:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp: Tu código OTP no es correcto.
     session_expired: Ha expirado tu sesión en la página de acceso.
-    require_totp_disabled: La autenticación de múltiples factores basada en OTP ya
-      está activa. Para reconfigurarla debes primero eliminarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
-    require_totp_enabled: No tienes aplicación de autenticación activa. Debes activarla
-      primero.
     require_webauthn_enabled: No tienes ningún dispositivo de seguridad activado.
       Primero debes asociar un dispositivo a tu cuenta.
     setup_required_html: Por la seguridad de tu cuenta y de tus gemas se te requiere
@@ -501,21 +496,6 @@ es:
     setup_webauthn_html: "\U0001F389 ¡Ahora soportamos dispositivos de seguridad!
       Aumenta la seguridad de tu cuenta <a href=\"/settings/edit#security-device\">configurando</a>
       un nuevo dispositivo."
-    new:
-      title: Activando autenticación de múltiples factores
-      scan_prompt: Por favor escanea el código QR con tu aplicación de autenticación.
-        Si no puedes escanear el código, agrega manualmente la información siguiente
-        a tu aplicación.
-      otp_prompt: Escribe el código de la aplicación de autenticación para continuar.
-      confirm: He mantenido seguros mis códigos de recuperación.
-      enable: Activar
-      account: 'Cuenta: %{account}'
-      key: 'Clave: %{key}'
-      time_based: 'Basado en tiempo: Sí'
-    create:
-      qrcode_expired: El código QR y la clave han vencido. Por favor intenta otra
-        vez registrar un nuevo dispositivo.
-      success: Has activado con éxito la autenticación de múltiples factores.
     recovery:
       copied: "[ copiado ]"
       continue: Continuar
@@ -527,8 +507,6 @@ es:
         tu autenticación de múltiples factores si pierdes tu dispositivo. Cada código
         se puede usar una sola vez.
       already_generated: Ya deberías haber guardado tus códigos de recuperación.
-    destroy:
-      success: Has desactivado exitosamente la autenticación de múltiples factores.
     update:
       invalid_level: Nivel de AMF inválido.
       success: Has actualizado exitosamente la autenticación de múltiples factores.
@@ -544,6 +522,29 @@ es:
         a tu dispositivo de seguridad o de autenticación de múltiples factores.
       security_device: Dispositivo de seguridad
       verify_code: Verificar código
+  totps:
+    incorrect_otp: Tu código OTP no es correcto.
+    require_totp_disabled: La autenticación de múltiples factores basada en OTP ya
+      está activa. Para reconfigurarla debes primero eliminarla.
+    require_totp_enabled: No tienes aplicación de autenticación activa. Debes activarla
+      primero.
+    new:
+      title: Activando autenticación de múltiples factores
+      scan_prompt: Por favor escanea el código QR con tu aplicación de autenticación.
+        Si no puedes escanear el código, agrega manualmente la información siguiente
+        a tu aplicación.
+      otp_prompt: Escribe el código de la aplicación de autenticación para continuar.
+      confirm: He mantenido seguros mis códigos de recuperación.
+      enable: Activar
+      account: 'Cuenta: %{account}'
+      key: 'Clave: %{key}'
+      time_based: 'Basado en tiempo: Sí'
+    create:
+      qrcode_expired: El código QR y la clave han vencido. Por favor intenta otra
+        vez registrar un nuevo dispositivo.
+      success: Has activado con éxito la autenticación de múltiples factores.
+    destroy:
+      success: Has desactivado exitosamente la autenticación de múltiples factores.
   notifiers:
     update:
       success: Has actualizado exitosamente la configuración de tus notificaciones

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -438,18 +438,39 @@ fr:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp: Votre clé OTP est incorrecte.
     session_expired:
-    require_totp_disabled:
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
-    require_totp_enabled:
     require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     setup_webauthn_html:
+    recovery:
+      copied:
+      continue: Continuer
+      title: Codes de récupération
+      copy:
+      saved:
+      note_html:
+      already_generated:
+    update:
+      invalid_level:
+      success:
+    prompt:
+      webauthn_credential_note:
+      sign_in_with_webauthn_credential:
+      otp_code:
+      otp_or_recovery:
+      recovery_code:
+      recovery_code_html:
+      security_device:
+      verify_code:
+  totps:
+    incorrect_otp: Votre clé OTP est incorrecte.
+    require_totp_disabled:
+    require_totp_enabled:
     new:
       title: Activer l'authentification multifacteur
       scan_prompt: Veuillez scanner le QR code avec votre app d'authentification.
@@ -466,28 +487,8 @@ fr:
       qrcode_expired: Le QR code et la clé sont expirés. Veuillez essayer d'enregistrer
         un nouvel appareil.
       success: Vous avez activé l'authentification multifacteur.
-    recovery:
-      copied:
-      continue: Continuer
-      title: Codes de récupération
-      copy:
-      saved:
-      note_html:
-      already_generated:
     destroy:
       success: Vous avez désactivé l'authentification multifacteur.
-    update:
-      invalid_level:
-      success:
-    prompt:
-      webauthn_credential_note:
-      sign_in_with_webauthn_credential:
-      otp_code:
-      otp_or_recovery:
-      recovery_code:
-      recovery_code_html:
-      security_device:
-      verify_code:
   notifiers:
     update:
       success:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -418,11 +418,8 @@ ja:
     update:
       failure: パスワードを変更できませんでした。もう一度お試しください。
   multifactor_auths:
-    incorrect_otp: OTPのコードが正しくありません。
     session_expired: ログインページのセッションが期限切れになりました。
-    require_totp_disabled: OTPベースの多要素認証が既に有効になっています。OTPベースの認証を再構成するには最初に削除しなければなりません。
     require_mfa_enabled: 多要素認証が有効になっていません。最初に有効にしなくてはなりません。
-    require_totp_enabled: 有効になっている認証器がありません。最初に有効にしなければなりません。
     require_webauthn_enabled: 有効になっているセキュリティ機器がありません。最初に機器をアカウントに紐付けなければなりません。
     setup_required_html: アカウントとgemの保護のため、多要素認証の設定が必要です。詳細は<a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">ブログ記事</a>をお読みください。
     setup_recommended: アカウントとgemの保護のため、多要素認証を設定することを推奨します。今後アカウントにはMFAの有効化が必須になります。
@@ -431,18 +428,6 @@ ja:
     strong_mfa_level_recommended: アカウントとgemの保護のため、MFAの水準を「UIとgemのサインイン」または「UIとAPI」に変更することをお勧めします。将来のアカウントはこれらの水準のどちらか1つにMFAが有効になっていることが必須になります。
     setup_webauthn_html: "\U0001F389 セキュリティ機器に対応しました！新しい機器を<a href=\"/settings/edit#security-device\">設定</a>してアカウントのセキュリティを向上しましょう。<a
       href=\"https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html\">詳細はこちら</a>！"
-    new:
-      title: 多要素認証を有効にする
-      scan_prompt: 認証アプリでQRコードを読み取ってください。コードを読み取れないようであれば手作業でアプリに以下の情報を追加してください。
-      otp_prompt: 認証アプリ上の数値のコードを入力して続けてください。
-      confirm: 復旧コードを安全に保持しました。
-      enable: 有効
-      account: アカウント：%{account}
-      key: キー：%{key}
-      time_based: 時間ベース：はい
-    create:
-      qrcode_expired: QRコードとキーが期限切れです。新しい機器を再度登録してみてください。
-      success: OTPベースの多要素認証が正常に有効になりました。
     recovery:
       copied: "[ コピーしました ]"
       continue: 続ける
@@ -451,8 +436,6 @@ ja:
       saved: 復旧コードを保存したことを確認しました。
       note_html: これらの復旧コードを<strong class='recovery__bold'>コピー及び保存</strong>してください。認証機器を紛失した場合にこれらのコードを使ってログインしMFAをリセットできます。各コードは1回使えます。
       already_generated: 既に復旧コードを保存したはずです。
-    destroy:
-      success: OTPベースの多要素認証の有効化に失敗しました。
     update:
       invalid_level: 不正なMFAの水準です。
       success: 多要素認証の水準が正常に更新されました。
@@ -466,6 +449,24 @@ ja:
         class="t-link">復旧コード</a>を使えます。
       security_device: セキュリティ機器
       verify_code: コードを検証
+  totps:
+    incorrect_otp: OTPのコードが正しくありません。
+    require_totp_disabled: OTPベースの多要素認証が既に有効になっています。OTPベースの認証を再構成するには最初に削除しなければなりません。
+    require_totp_enabled: 有効になっている認証器がありません。最初に有効にしなければなりません。
+    new:
+      title: 多要素認証を有効にする
+      scan_prompt: 認証アプリでQRコードを読み取ってください。コードを読み取れないようであれば手作業でアプリに以下の情報を追加してください。
+      otp_prompt: 認証アプリ上の数値のコードを入力して続けてください。
+      confirm: 復旧コードを安全に保持しました。
+      enable: 有効
+      account: アカウント：%{account}
+      key: キー：%{key}
+      time_based: 時間ベース：はい
+    create:
+      qrcode_expired: QRコードとキーが期限切れです。新しい機器を再度登録してみてください。
+      success: OTPベースの多要素認証が正常に有効になりました。
+    destroy:
+      success: OTPベースの多要素認証の有効化に失敗しました。
   notifiers:
     update:
       success: Eメール通知設定が正常に更新されました。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -424,29 +424,14 @@ nl:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp:
     session_expired:
-    require_totp_disabled:
     require_mfa_enabled:
-    require_totp_enabled:
     require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     setup_webauthn_html:
-    new:
-      title:
-      scan_prompt:
-      otp_prompt:
-      confirm:
-      enable:
-      account:
-      key:
-      time_based:
-    create:
-      qrcode_expired:
-      success:
     recovery:
       copied:
       continue:
@@ -455,8 +440,6 @@ nl:
       saved:
       note_html:
       already_generated:
-    destroy:
-      success:
     update:
       invalid_level:
       success:
@@ -469,6 +452,24 @@ nl:
       recovery_code_html:
       security_device:
       verify_code:
+  totps:
+    incorrect_otp:
+    require_totp_disabled:
+    require_totp_enabled:
+    new:
+      title:
+      scan_prompt:
+      otp_prompt:
+      confirm:
+      enable:
+      account:
+      key:
+      time_based:
+    create:
+      qrcode_expired:
+      success:
+    destroy:
+      success:
   notifiers:
     update:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -435,29 +435,14 @@ pt-BR:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp:
     session_expired:
-    require_totp_disabled:
     require_mfa_enabled:
-    require_totp_enabled:
     require_webauthn_enabled:
     setup_required_html:
     setup_recommended:
     strong_mfa_level_required_html:
     strong_mfa_level_recommended:
     setup_webauthn_html:
-    new:
-      title:
-      scan_prompt:
-      otp_prompt:
-      confirm:
-      enable:
-      account:
-      key:
-      time_based:
-    create:
-      qrcode_expired:
-      success:
     recovery:
       copied:
       continue:
@@ -466,8 +451,6 @@ pt-BR:
       saved:
       note_html:
       already_generated:
-    destroy:
-      success:
     update:
       invalid_level:
       success:
@@ -480,6 +463,24 @@ pt-BR:
       recovery_code_html:
       security_device:
       verify_code:
+  totps:
+    incorrect_otp:
+    require_totp_disabled:
+    require_totp_enabled:
+    new:
+      title:
+      scan_prompt:
+      otp_prompt:
+      confirm:
+      enable:
+      account:
+      key:
+      time_based:
+    create:
+      qrcode_expired:
+      success:
+    destroy:
+      success:
   notifiers:
     update:
       success:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -426,11 +426,8 @@ zh-CN:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp: 你的 OTP 码 不正确。
     session_expired: 您的登录页面会话已过期。
-    require_totp_disabled: 您的多因素验证已启用。要重新配置多因素验证，您必须首先停用它。
     require_mfa_enabled: 您的多因素验证已停用，请先启用。
-    require_totp_enabled: 您还没有启用一个身份验证器应用。您必须先启用它。
     require_webauthn_enabled: 您还没有启用任何安全设备。您必须首先关联一个设备到您的账户。
     setup_required_html: 为了保护您的帐户和您的 Gem，您需要设置多因素验证。请阅读我们的<a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">博客文章</a>了解详情。
     setup_recommended: 为了保护您的帐户和您的 Gem，我们鼓励您设置多因素验证。在将来，您的帐户将被要求启用多因素验证。
@@ -439,18 +436,6 @@ zh-CN:
     strong_mfa_level_recommended: 为了保护您的帐户和您的 Gem，我们建议您将您的多因素验证级别更改为 "UI and gem signin"
       或 "UI and API"。在将来，您的帐户将被要求在其中某一个级别上启用多因素验证。
     setup_webauthn_html:
-    new:
-      title: 启用多因素验证
-      scan_prompt: 请用您的身份验证程序扫描二维码。如果您没办法扫描，请在您的程序中手动输入下面的内容。
-      otp_prompt: 输入身份验证程序上的数字代码以继续。
-      confirm: 我已把复原码存放在安全的地方。
-      enable: 启用
-      account: 账户：%{account}
-      key: 密钥：%{key}
-      time_based: 基于时间的：是
-    create:
-      qrcode_expired: 二维码和密钥已过期。请尝试重新注册一个新的设备。
-      success: 您已成功启用多因素验证。
     recovery:
       copied: "[ 已复制 ]"
       continue: 继续
@@ -459,8 +444,6 @@ zh-CN:
       saved: 我声明我已经保存了我的恢复码。
       note_html: 请 <strong class='recovery__bold'>复制并保存</strong> 这些恢复码。如果您丢失了身份验证设备，您可以使用这些恢复码登录并重置您的多因素验证配置。每个恢复码只能使用一次。
       already_generated: 您应该已经保存了您的恢复码。
-    destroy:
-      success: 您已成功停用多因素验证。
     update:
       invalid_level: 无效的 MFA 级别。
       success: 您已成功修改多因素验证级别。
@@ -473,6 +456,24 @@ zh-CN:
       recovery_code_html: 如果您无法访问用于多因素验证的设备或安全设备，您可以使用一个有效的 <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa"，class="t-link">恢复码</a>。
       security_device: 安全设备
       verify_code: 验证码
+  totps:
+    incorrect_otp: 你的 OTP 码 不正确。
+    require_totp_disabled: 您的多因素验证已启用。要重新配置多因素验证，您必须首先停用它。
+    require_totp_enabled: 您还没有启用一个身份验证器应用。您必须先启用它。
+    new:
+      title: 启用多因素验证
+      scan_prompt: 请用您的身份验证程序扫描二维码。如果您没办法扫描，请在您的程序中手动输入下面的内容。
+      otp_prompt: 输入身份验证程序上的数字代码以继续。
+      confirm: 我已把复原码存放在安全的地方。
+      enable: 启用
+      account: 账户：%{account}
+      key: 密钥：%{key}
+      time_based: 基于时间的：是
+    create:
+      qrcode_expired: 二维码和密钥已过期。请尝试重新注册一个新的设备。
+      success: 您已成功启用多因素验证。
+    destroy:
+      success: 您已成功停用多因素验证。
   notifiers:
     update:
       success: 您已成功更新邮件通知设置。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -420,11 +420,8 @@ zh-TW:
     update:
       failure:
   multifactor_auths:
-    incorrect_otp: 您的 OTP 碼不正確。
     session_expired: 您的登入頁面工作階段已過期。
-    require_totp_disabled: 您基於 OTP 的多重要素驗證已經啟用。您需要先移除才能重新設定。
     require_mfa_enabled: 您尚未啟用多重要素驗證，請先啟用。
-    require_totp_enabled: 您未啟用驗證器應用程式。請先啟用。
     require_webauthn_enabled: 您未啟用任何安全裝置。您需要先將裝置綁定到您的帳號。
     setup_required_html: 您必須設定多重要素驗證以保護您的帳號和 Gems。請閱讀我們的<a href="https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html">部落格文章</a>以了解詳情。
     setup_recommended: 為保護您的帳號和 Gems，我們建議您設定多重要素驗證。未來我們將強制要求所有帳號啟用 MFA。
@@ -434,18 +431,6 @@ zh-TW:
       或 "使用者介面和 API"。未來我們將強制要求所有帳號將設為上述 MFA 等級。
     setup_webauthn_html: "\U0001F389 我們現在支援安全裝置了！<a href=\"/settings/edit#security-device\">設定</a>新的裝置來提升您的帳號安全。<a
       href=\"https://blog.rubygems.org/2023/08/03/level-up-using-security-devices.html\">了解詳情</a>！"
-    new:
-      title: 啟用多重要素驗證
-      scan_prompt: 請用您的驗證裝置掃描 QR-code。如果您沒辦法掃描，手動輸入下面的資料。
-      otp_prompt: 輸入驗證裝置上的數字來繼續。
-      confirm: 我已把復原碼收在安全的地方。
-      enable: 啟用
-      account: 帳號：%{account}
-      key: 金鑰：%{key}
-      time_based: 基於時間：是
-    create:
-      qrcode_expired: QR-code 和金鑰已過期。請重新註冊裝置。
-      success: 您已成功啟用基於 OTP 的多重要素驗證。
     recovery:
       copied: "[ 已複製 ]"
       continue: 繼續
@@ -454,8 +439,6 @@ zh-TW:
       saved:
       note_html:
       already_generated:
-    destroy:
-      success: 您已成功停用基於 OTP 的多重要素驗證。
     update:
       invalid_level: MFA 等級無效。
       success: 您已成功修改多重驗證等級。
@@ -468,6 +451,24 @@ zh-TW:
       recovery_code_html:
       security_device: 安全裝置
       verify_code: 驗證碼
+  totps:
+    incorrect_otp: 您的 OTP 碼不正確。
+    require_totp_disabled: 您基於 OTP 的多重要素驗證已經啟用。您需要先移除才能重新設定。
+    require_totp_enabled: 您未啟用驗證器應用程式。請先啟用。
+    new:
+      title: 啟用多重要素驗證
+      scan_prompt: 請用您的驗證裝置掃描 QR-code。如果您沒辦法掃描，手動輸入下面的資料。
+      otp_prompt: 輸入驗證裝置上的數字來繼續。
+      confirm: 我已把復原碼收在安全的地方。
+      enable: 啟用
+      account: 帳號：%{account}
+      key: 金鑰：%{key}
+      time_based: 基於時間：是
+    create:
+      qrcode_expired: QR-code 和金鑰已過期。請重新註冊裝置。
+      success: 您已成功啟用基於 OTP 的多重要素驗證。
+    destroy:
+      success: 您已成功停用基於 OTP 的多重要素驗證。
   notifiers:
     update:
       success: 您已成功更新您的電子郵件通知設定。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,11 +159,12 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show, constraints: { format: /html|atom/ }
     resources :profiles, only: :show
     get "profile/me", to: "profiles#me", as: :my_profile
-    resource :multifactor_auth, only: %i[new create update destroy] do
+    resource :multifactor_auth, only: %i[update] do
       get 'recovery'
       post 'otp_update', to: 'multifactor_auths#otp_update', as: :otp_update
       post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
     end
+    resource :totp, only: %i[new create destroy]
     resource :settings, only: :edit
     resource :profile, only: %i[edit update] do
       get :adoptions

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -471,7 +471,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
           assert_response 403
           mfa_error = <<~ERROR.chomp
             [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-            at https://rubygems.org/multifactor_auth/new.
+            at https://rubygems.org/totp/new.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
           ERROR

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -191,7 +191,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
           should "show error message" do
             mfa_error = <<~ERROR.chomp
               [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-              at https://rubygems.org/multifactor_auth/new.
+              at https://rubygems.org/totp/new.
 
               Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
             ERROR
@@ -294,7 +294,7 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
 
                 [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
-                at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+                at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future.
               WARN
 
               assert_includes @response.body, mfa_warning

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -386,7 +386,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               assert_equal 403, @response.status
               mfa_error = <<~ERROR.chomp
                 [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-                at https://rubygems.org/multifactor_auth/new.
+                at https://rubygems.org/totp/new.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
               ERROR
@@ -460,7 +460,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
 
                 [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
-                at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+                at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future.
               WARN
 
               assert_includes @response.body, mfa_warning
@@ -752,7 +752,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
               assert_equal 403, response.status
               mfa_error = <<~ERROR.chomp
                 [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-                at https://rubygems.org/multifactor_auth/new.
+                at https://rubygems.org/totp/new.
 
                 Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
               ERROR
@@ -826,7 +826,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
 
                 [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
-                at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+                at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future.
               WARN
 
               assert_includes @response.body, mfa_warning

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -103,7 +103,7 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
             should "include warning" do
               expected_warning =
                 "For protection of your account and gems, we encourage you to set up multi-factor authentication " \
-                "at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+                "at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future."
 
               assert_warning_included(expected_warning)
             end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -562,7 +562,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
         should "show error message" do
           mfa_error = <<~ERROR.chomp
             [ERROR] For protection of your account and your gems, you are required to set up multi-factor authentication \
-            at https://rubygems.org/multifactor_auth/new.
+            at https://rubygems.org/totp/new.
 
             Please read our blog post for more details (https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html).
           ERROR
@@ -634,7 +634,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
 
             [WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication \
-            at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future.
+            at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future.
           WARN
 
           assert_includes @response.body, mfa_warning

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -15,42 +15,6 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
       end
 
-      context "on GET to new totp" do
-        setup do
-          get :new
-        end
-
-        should respond_with :redirect
-        should redirect_to("the settings page") { edit_settings_path }
-
-        should "say TOTP is already enabled" do
-          assert_equal "Your OTP based multi-factor authentication has already been enabled. " \
-                       "To reconfigure your OTP based authentication, you'll have to remove it first.", flash[:error]
-        end
-      end
-
-      context "on POST to create mfa" do
-        setup do
-          @seed = ROTP::Base32.random_base32
-          @controller.session[:totp_seed] = @seed
-          @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
-          post :create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
-        end
-
-        should respond_with :redirect
-        should redirect_to("the settings page") { edit_settings_path }
-
-        should "keep mfa enabled" do
-          assert_predicate @user.reload, :mfa_enabled?
-          assert_emails 0
-        end
-
-        should "say TOTP is already enabled" do
-          assert_equal "Your OTP based multi-factor authentication has already been enabled. " \
-                       "To reconfigure your OTP based authentication, you'll have to remove it first.", flash[:error]
-        end
-      end
-
       context "on PUT to update mfa level" do
         setup do
           freeze_time
@@ -217,99 +181,12 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           assert_nil @controller.session[:mfa_redirect_uri]
         end
       end
-
-      context "on DELETE to destroy" do
-        context "with correct OTP" do
-          setup do
-            @controller.session["mfa_redirect_uri"] = edit_settings_path
-
-            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-              delete :destroy, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
-            end
-          end
-
-          should respond_with :redirect
-          should redirect_to("the settings page") { edit_settings_path }
-
-          should "disable mfa and clear recovery codes" do
-            assert_predicate @user.reload, :totp_disabled?
-            assert_predicate @user.reload, :mfa_disabled?
-            assert_empty @user.mfa_hashed_recovery_codes
-          end
-
-          should "send mfa disabled email" do
-            assert_emails 1
-
-            assert_equal "Authentication app disabled on RubyGems.org",
-                         last_email.subject
-            assert_equal [@user.email], last_email.to
-          end
-
-          should "flash success" do
-            assert_equal "You have successfully disabled OTP based multi-factor authentication.", flash[:success]
-          end
-
-          should "delete mfa_redirect_uri from session" do
-            assert_nil session[:mfa_redirect_uri]
-          end
-        end
-
-        context "with incorrect OTP" do
-          setup do
-            @controller.session["mfa_redirect_uri"] = edit_settings_path
-
-            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-              delete :destroy, params: { otp: "123456" }
-            end
-          end
-
-          should respond_with :redirect
-          should redirect_to("the settings page") { edit_settings_path }
-
-          should "keep mfa and recovery codes enabled" do
-            assert_predicate @user.reload, :totp_enabled?
-            assert_not_empty @user.mfa_hashed_recovery_codes
-          end
-
-          should "flash error" do
-            assert_equal "Your OTP code is incorrect.", flash[:error]
-          end
-
-          should "not send mfa disabled email" do
-            assert_emails 0
-          end
-
-          should "not clear mfa_redirect_uri from session" do
-            assert_not_nil session[:mfa_redirect_uri]
-          end
-        end
-      end
     end
 
     context "when a webauthn device is enabled" do
       setup do
         @webauthn_credential = create(:webauthn_credential, user: @user)
         @user.update!(mfa_level: :ui_only)
-      end
-
-      context "on POST to create totp mfa" do
-        setup do
-          @seed = ROTP::Base32.random_base32
-          @controller.session[:totp_seed] = @seed
-          @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
-          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-            post :create, params: { otp: ROTP::TOTP.new(@seed).now }
-          end
-        end
-
-        should redirect_to("the edit settings page") { edit_settings_path }
-
-        should "send totp enabled email" do
-          assert_emails 1
-          assert_equal "Authentication app enabled on RubyGems.org",
-                       last_email.subject
-          assert_equal [@user.email], last_email.to
-        end
       end
 
       context "on PUT to update mfa level" do
@@ -612,82 +489,9 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
           end
         end
       end
-
-      context "on DELETE to destroy" do
-        should "redirect to settings page" do
-          delete :destroy
-
-          assert_redirected_to edit_settings_path
-        end
-
-        should "not change mfa level and recovery codes" do
-          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_hashed_recovery_codes] } do
-            delete :destroy
-          end
-        end
-
-        should "display flash error" do
-          delete :destroy
-
-          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
-        end
-      end
     end
 
     context "when there are no mfa devices" do
-      context "on POST to create totp mfa" do
-        setup do
-          @seed = ROTP::Base32.random_base32
-          @controller.session[:totp_seed] = @seed
-        end
-
-        context "when qr-code is not expired" do
-          setup do
-            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-              @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
-              post :create, params: { otp: ROTP::TOTP.new(@seed).now }
-            end
-          end
-
-          should redirect_to("the recovery page") { recovery_multifactor_auth_path }
-
-          should "enable mfa" do
-            assert_predicate @user.reload, :mfa_enabled?
-          end
-
-          should "send totp enabled email" do
-            assert_emails 1
-            assert_equal "Authentication app enabled on RubyGems.org",
-                         last_email.subject
-            assert_equal [@user.email], last_email.to
-          end
-
-          should "flash success" do
-            assert_equal "You have successfully enabled OTP based multi-factor authentication.", flash[:success]
-          end
-        end
-
-        context "when qr-code is expired" do
-          setup do
-            @controller.session[:totp_seed_expire] = 1.minute.ago
-            post :create, params: { otp: ROTP::TOTP.new(@seed).now }
-          end
-
-          should respond_with :redirect
-          should redirect_to("the settings page") { edit_settings_path }
-
-          should "set error flash message" do
-            refute_empty flash[:error]
-          end
-          should "keep mfa disabled" do
-            refute_predicate @user.reload, :mfa_enabled?
-          end
-          should "not send mfa enabled email" do
-            assert_emails 0
-          end
-        end
-      end
-
       context "on PUT to update mfa level" do
         setup do
           put :update
@@ -734,26 +538,6 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
         should "set flash error" do
           assert_equal "You don't have any security devices enabled. " \
                        "You have to associate a device to your account first.", flash[:error]
-        end
-      end
-
-      context "on DELETE to destroy" do
-        should "redirect to settings page" do
-          delete :destroy
-
-          assert_redirected_to edit_settings_path
-        end
-
-        should "not change mfa level and recovery codes" do
-          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_hashed_recovery_codes] } do
-            delete :destroy
-          end
-        end
-
-        should "display flash error" do
-          delete :destroy
-
-          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
         end
       end
     end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -235,7 +235,7 @@ class SessionsControllerTest < ActionController::TestCase
           end
 
           should respond_with :redirect
-          should redirect_to("the mfa setup page") { new_multifactor_auth_path }
+          should redirect_to("the mfa setup page") { new_totp_path }
 
           should "set notice flash" do
             expected_notice = "For protection of your account and your gems, we encourage you to set up multi-factor authentication. " \

--- a/test/functional/totps_controller_test.rb
+++ b/test/functional/totps_controller_test.rb
@@ -1,0 +1,244 @@
+require "test_helper"
+
+class TotpsControllerTest < ActionController::TestCase
+  include ActionMailer::TestHelper
+
+  context "when logged in" do
+    setup do
+      @user = create(:user)
+      sign_in_as(@user)
+      @request.cookies[:mfa_feature] = "true"
+    end
+
+    context "when totp is enabled" do
+      setup do
+        @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+      end
+
+      context "on GET to new totp" do
+        setup do
+          get :new
+        end
+
+        should respond_with :redirect
+        should redirect_to("the settings page") { edit_settings_path }
+
+        should "say TOTP is already enabled" do
+          assert_equal "Your OTP based multi-factor authentication has already been enabled. " \
+                       "To reconfigure your OTP based authentication, you'll have to remove it first.", flash[:error]
+        end
+      end
+
+      context "on POST to create mfa" do
+        setup do
+          @seed = ROTP::Base32.random_base32
+          @controller.session[:totp_seed] = @seed
+          @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
+          post :create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+        end
+
+        should respond_with :redirect
+        should redirect_to("the settings page") { edit_settings_path }
+
+        should "keep mfa enabled" do
+          assert_predicate @user.reload, :mfa_enabled?
+          assert_emails 0
+        end
+
+        should "say TOTP is already enabled" do
+          assert_equal "Your OTP based multi-factor authentication has already been enabled. " \
+                       "To reconfigure your OTP based authentication, you'll have to remove it first.", flash[:error]
+        end
+      end
+
+      context "on DELETE to destroy" do
+        context "with correct OTP" do
+          setup do
+            @controller.session["mfa_redirect_uri"] = edit_settings_path
+
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+            end
+          end
+
+          should respond_with :redirect
+          should redirect_to("the settings page") { edit_settings_path }
+
+          should "disable mfa and clear recovery codes" do
+            assert_predicate @user.reload, :totp_disabled?
+            assert_predicate @user.reload, :mfa_disabled?
+            assert_empty @user.mfa_hashed_recovery_codes
+          end
+
+          should "send mfa disabled email" do
+            assert_emails 1
+
+            assert_equal "Authentication app disabled on RubyGems.org",
+                         last_email.subject
+            assert_equal [@user.email], last_email.to
+          end
+
+          should "flash success" do
+            assert_equal "You have successfully disabled OTP based multi-factor authentication.", flash[:success]
+          end
+
+          should "delete mfa_redirect_uri from session" do
+            assert_nil session[:mfa_redirect_uri]
+          end
+        end
+
+        context "with incorrect OTP" do
+          setup do
+            @controller.session["mfa_redirect_uri"] = edit_settings_path
+
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              delete :destroy, params: { otp: "123456" }
+            end
+          end
+
+          should respond_with :redirect
+          should redirect_to("the settings page") { edit_settings_path }
+
+          should "keep mfa and recovery codes enabled" do
+            assert_predicate @user.reload, :totp_enabled?
+            assert_not_empty @user.mfa_hashed_recovery_codes
+          end
+
+          should "flash error" do
+            assert_equal "Your OTP code is incorrect.", flash[:error]
+          end
+
+          should "not send mfa disabled email" do
+            assert_emails 0
+          end
+
+          should "not clear mfa_redirect_uri from session" do
+            assert_not_nil session[:mfa_redirect_uri]
+          end
+        end
+      end
+    end
+
+    context "when a webauthn device is enabled" do
+      setup do
+        @webauthn_credential = create(:webauthn_credential, user: @user)
+        @user.update!(mfa_level: :ui_only)
+      end
+
+      context "on POST to create totp mfa" do
+        setup do
+          @seed = ROTP::Base32.random_base32
+          @controller.session[:totp_seed] = @seed
+          @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
+          perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+            post :create, params: { otp: ROTP::TOTP.new(@seed).now }
+          end
+        end
+
+        should redirect_to("the edit settings page") { edit_settings_path }
+
+        should "send totp enabled email" do
+          assert_emails 1
+          assert_equal "Authentication app enabled on RubyGems.org",
+                       last_email.subject
+          assert_equal [@user.email], last_email.to
+        end
+      end
+
+      context "on DELETE to destroy" do
+        should "redirect to settings page" do
+          delete :destroy
+
+          assert_redirected_to edit_settings_path
+        end
+
+        should "not change mfa level and recovery codes" do
+          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_hashed_recovery_codes] } do
+            delete :destroy
+          end
+        end
+
+        should "display flash error" do
+          delete :destroy
+
+          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
+        end
+      end
+    end
+
+    context "when there are no mfa devices" do
+      context "on POST to create totp mfa" do
+        setup do
+          @seed = ROTP::Base32.random_base32
+          @controller.session[:totp_seed] = @seed
+        end
+
+        context "when qr-code is not expired" do
+          setup do
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              @controller.session[:totp_seed_expire] = Gemcutter::MFA_KEY_EXPIRY.from_now.utc.to_i
+              post :create, params: { otp: ROTP::TOTP.new(@seed).now }
+            end
+          end
+
+          should redirect_to("the recovery page") { recovery_multifactor_auth_path }
+
+          should "enable mfa" do
+            assert_predicate @user.reload, :mfa_enabled?
+          end
+
+          should "send totp enabled email" do
+            assert_emails 1
+            assert_equal "Authentication app enabled on RubyGems.org",
+                         last_email.subject
+            assert_equal [@user.email], last_email.to
+          end
+
+          should "flash success" do
+            assert_equal "You have successfully enabled OTP based multi-factor authentication.", flash[:success]
+          end
+        end
+
+        context "when qr-code is expired" do
+          setup do
+            @controller.session[:totp_seed_expire] = 1.minute.ago
+            post :create, params: { otp: ROTP::TOTP.new(@seed).now }
+          end
+
+          should respond_with :redirect
+          should redirect_to("the settings page") { edit_settings_path }
+
+          should "set error flash message" do
+            refute_empty flash[:error]
+          end
+          should "keep mfa disabled" do
+            refute_predicate @user.reload, :mfa_enabled?
+          end
+          should "not send mfa enabled email" do
+            assert_emails 0
+          end
+        end
+      end
+
+      context "on DELETE to destroy" do
+        should "redirect to settings page" do
+          delete :destroy
+
+          assert_redirected_to edit_settings_path
+        end
+
+        should "not change mfa level and recovery codes" do
+          assert_no_changes -> { [@user.reload.mfa_level, @user.reload.mfa_hashed_recovery_codes] } do
+            delete :destroy
+          end
+        end
+
+        should "display flash error" do
+          delete :destroy
+
+          assert_equal "You don't have an authenticator app enabled. You have to enable it first.", flash[:error]
+        end
+      end
+    end
+  end
+end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -481,20 +481,39 @@ class RackAttackTest < ActionDispatch::IntegrationTest
           end
         end
 
-        should "throttle mfa create at level #{level}" do
+        should "throttle totp create at level #{level}" do
           freeze_time do
             exceed_exponential_limit_for("clearance/ip/#{level}", level)
-            post "/multifactor_auth", headers: { REMOTE_ADDR: @ip_address }
+            post "/totp", headers: { REMOTE_ADDR: @ip_address }
 
             assert_throttle_at(level)
           end
         end
 
-        should "throttle mfa create per user at level #{level}" do
+        should "throttle totp create per user at level #{level}" do
           freeze_time do
             sign_in_as(@user)
             exceed_exponential_user_limit_for("clearance/user/#{level}", @user.email, level)
-            post "/multifactor_auth"
+            post "/totp"
+
+            assert_throttle_at(level)
+          end
+        end
+
+        should "throttle totp destroy at level #{level}" do
+          freeze_time do
+            exceed_exponential_limit_for("clearance/ip/#{level}", level)
+            post "/totp", headers: { REMOTE_ADDR: @ip_address }
+
+            assert_throttle_at(level)
+          end
+        end
+
+        should "throttle totp destroy per user at level #{level}" do
+          freeze_time do
+            sign_in_as(@user)
+            exceed_exponential_user_limit_for("clearance/user/#{level}", @user.email, level)
+            post "/totp"
 
             assert_throttle_at(level)
           end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -161,7 +161,7 @@ class SignInTest < SystemTest
                       "Your account will be required to have MFA enabled in the future."
 
     assert page.has_selector? "#flash_notice", text: expected_notice
-    assert_current_path(new_multifactor_auth_path)
+    assert_current_path(new_totp_path)
     assert page.has_content? "Sign out"
   end
 

--- a/test/models/user/with_private_fields_test.rb
+++ b/test/models/user/with_private_fields_test.rb
@@ -16,7 +16,7 @@ class User::WithPrivateFieldsTest < ActiveSupport::TestCase
         should "include warning in user json" do
           expected_notice =
             "[WARNING] For protection of your account and gems, we encourage you to set up multi-factor authentication " \
-            "at https://rubygems.org/multifactor_auth/new. Your account will be required to have MFA enabled in the future."
+            "at https://rubygems.org/totp/new. Your account will be required to have MFA enabled in the future."
 
           assert_match expected_notice, @user.to_json
         end


### PR DESCRIPTION
Extracted from `MultifactorAuthsController` and contains no code or behavior changes, just moved code.

This seems worth doing because it simplifies a complex controller that has no overlap in behavior and no shared code. In the new controller we only do TOTP create and destroy, while` MultifactorAuthsController` now does just recovery and mfa levels.

This also mirrors the organization of Webauthn creation.

In a follow-up PR, I'd suggest created a landing page for `/multifactor_auth/new` that gives both TOTP and WebAuthN as options on the same page. Currently this is only presented on `/settings/edit` but we direct people to the page that's only useful for creating a TOTP.