### PR TITLE
Add Pundit policy for RubygemTrustedPublisher (except api)

### DIFF
--- a/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
@@ -2,7 +2,6 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
   include OIDC::Concerns::TrustedPublisherCreation
 
   before_action :find_rubygem
-  before_action :render_forbidden, unless: :owner?
   before_action :find_rubygem_trusted_publisher, except: %i[index new create]
 
   def index
@@ -19,10 +18,7 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
   end
 
   def create
-    trusted_publisher = @rubygem.oidc_rubygem_trusted_publishers.new(
-      create_params
-    )
-
+    trusted_publisher = authorize @rubygem.oidc_rubygem_trusted_publishers.new(create_params)
     if trusted_publisher.save
       redirect_to rubygem_trusted_publishers_path(@rubygem.slug), flash: { notice: t(".success") }
     else
@@ -55,8 +51,13 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
 
   def create_params_key = :oidc_rubygem_trusted_publisher
 
+  def find_rubygem
+    super
+    authorize @rubygem, :show_trusted_publishers?
+  end
+
   def find_rubygem_trusted_publisher
-    @rubygem_trusted_publisher = @rubygem.oidc_rubygem_trusted_publishers.find(params.permit(:id).require(:id))
+    @rubygem_trusted_publisher = authorize @rubygem.oidc_rubygem_trusted_publishers.find(params.permit(:id).require(:id))
   end
 
   def gh_actions_trusted_publisher

--- a/app/policies/oidc/rubygem_trusted_publisher_policy.rb
+++ b/app/policies/oidc/rubygem_trusted_publisher_policy.rb
@@ -1,0 +1,19 @@
+class OIDC::RubygemTrustedPublisherPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.none
+    end
+  end
+
+  def show?
+    record.rubygem.owned_by?(user)
+  end
+
+  def create?
+    record.rubygem.owned_by?(user)
+  end
+
+  def destroy?
+    record.rubygem.owned_by?(user)
+  end
+end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -21,11 +21,15 @@ class RubygemPolicy < ApplicationPolicy
     false
   end
 
-  def show_unconfirmed_ownerships?
+  def show_events?
     record.owned_by?(user)
   end
 
-  def show_events?
+  def show_trusted_publishers?
+    record.owned_by?(user)
+  end
+
+  def show_unconfirmed_ownerships?
     record.owned_by?(user)
   end
 end

--- a/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
@@ -211,4 +211,43 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
       assert_redirected_to verify_session_path
     end
   end
+
+  context "when not authorized for rubygem trusted publishing" do
+    context "not owner" do
+      setup do
+        # must be verified before finding out if you have access to this action
+        post(authenticate_session_path(verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD }))
+        @rubygem.ownerships.destroy_all
+      end
+
+      should "render forbidden on show" do
+        get rubygem_trusted_publishers_url(@rubygem.slug)
+
+        assert_response :forbidden
+      end
+
+      should "render forbidden on new" do
+        get new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+        assert_response :forbidden
+      end
+
+      should "render forbidden on create" do
+        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+          oidc_rubygem_trusted_publisher: { # avoid params permit error before authorization check
+            trusted_publisher_type: "OIDC::TrustedPublisher::GitHubAction",
+            trusted_publisher_attributes: {}
+          }
+        }
+
+        assert_response :forbidden
+      end
+
+      should "render forbidden on destroy" do
+        delete new_rubygem_trusted_publisher_url(@rubygem.slug)
+
+        assert_response :forbidden
+      end
+    end
+  end
 end

--- a/test/policies/oidc/rubygem_trusted_publisher_policy_test.rb
+++ b/test/policies/oidc/rubygem_trusted_publisher_policy_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class OIDC::RubygemTrustedPublisherPolicyTest < ActiveSupport::TestCase
+  setup do
+    @owner = FactoryBot.create(:user)
+    @rubygem = FactoryBot.create(:rubygem, owners: [@owner])
+    @trusted_publisher = create(:oidc_rubygem_trusted_publisher, rubygem: @rubygem)
+    @user = FactoryBot.create(:user)
+  end
+
+  def test_scope
+    assert_empty Pundit.policy_scope!(@owner, OIDC::RubygemTrustedPublisher).to_a
+    assert_empty Pundit.policy_scope!(@owner, @rubygem.oidc_rubygem_trusted_publishers).to_a
+  end
+
+  def test_show
+    assert_predicate Pundit.policy!(@owner, @trusted_publisher), :show?
+    refute_predicate Pundit.policy!(@user, @trusted_publisher), :show?
+    refute_predicate Pundit.policy!(nil, @trusted_publisher), :show?
+  end
+
+  def test_create
+    assert_predicate Pundit.policy!(@owner, @trusted_publisher), :create?
+    refute_predicate Pundit.policy!(@user, @trusted_publisher), :create?
+    refute_predicate Pundit.policy!(nil, @trusted_publisher), :create?
+  end
+
+  def test_destroy
+    assert_predicate Pundit.policy!(@owner, @trusted_publisher), :destroy?
+    refute_predicate Pundit.policy!(@user, @trusted_publisher), :destroy?
+    refute_predicate Pundit.policy!(nil, @trusted_publisher), :destroy?
+  end
+end

--- a/test/policies/rubygem_policy_test.rb
+++ b/test/policies/rubygem_policy_test.rb
@@ -18,16 +18,22 @@ class RubygemPolicyTest < ActiveSupport::TestCase
     assert_predicate Pundit.policy!(nil, @rubygem), :show?
   end
 
-  def test_show_unconfirmed_ownerships?
-    assert_predicate Pundit.policy!(@owner, @rubygem), :show_unconfirmed_ownerships?
-    refute_predicate Pundit.policy!(@user, @rubygem), :show_unconfirmed_ownerships?
-    refute_predicate Pundit.policy!(nil, @rubygem), :show_unconfirmed_ownerships?
-  end
-
   def test_show_events?
     assert_predicate Pundit.policy!(@owner, @rubygem), :show_events?
     refute_predicate Pundit.policy!(@user, @rubygem), :show_events?
     refute_predicate Pundit.policy!(nil, @rubygem), :show_events?
+  end
+
+  def test_show_trusted_publishers?
+    assert_predicate Pundit.policy!(@owner, @rubygem), :show_trusted_publishers?
+    refute_predicate Pundit.policy!(@user, @rubygem), :show_trusted_publishers?
+    refute_predicate Pundit.policy!(nil, @rubygem), :show_trusted_publishers?
+  end
+
+  def test_show_unconfirmed_ownerships?
+    assert_predicate Pundit.policy!(@owner, @rubygem), :show_unconfirmed_ownerships?
+    refute_predicate Pundit.policy!(@user, @rubygem), :show_unconfirmed_ownerships?
+    refute_predicate Pundit.policy!(nil, @rubygem), :show_unconfirmed_ownerships?
   end
 
   def test_create


### PR DESCRIPTION
I'm punting on the api key policies for now (discussed in #4801). We can come back to it after this is merged, focusing just on how we do api key policies.