### PR TITLE
OwnershipRequests refactor for pundit authorization

### DIFF
--- a/app/controllers/adoptions_controller.rb
+++ b/app/controllers/adoptions_controller.rb
@@ -2,8 +2,7 @@ class AdoptionsController < ApplicationController
   include SessionVerifiable
 
   before_action :find_rubygem
-  before_action :verify_ownership_requestable
-  before_action :redirect_to_verify, if: -> { current_user_is_owner? && !verified_session_active? }
+  before_action :redirect_to_verify, if: -> { @rubygem.owned_by?(current_user) && !verified_session_active? }
 
   def index
     @ownership_call     = @rubygem.ownership_call
@@ -13,11 +12,8 @@ class AdoptionsController < ApplicationController
 
   private
 
-  def verify_ownership_requestable
-    render_forbidden unless @rubygem.owned_by?(current_user) || @rubygem.ownership_requestable?
-  end
-
-  def current_user_is_owner?
-    @rubygem.owned_by?(current_user)
+  def find_rubygem
+    super
+    authorize @rubygem, :show_adoption? if @rubygem
   end
 end

--- a/app/controllers/ownership_requests_controller.rb
+++ b/app/controllers/ownership_requests_controller.rb
@@ -1,67 +1,53 @@
 class OwnershipRequestsController < ApplicationController
   before_action :find_rubygem
-  before_action :find_ownership_request, only: :update
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
 
-  def create
-    render_forbidden && return unless current_user.can_request_ownership?(@rubygem)
+  rescue_from ActiveRecord::RecordInvalid, with: :redirect_try_again
+  rescue_from ActiveRecord::RecordNotSaved, with: :redirect_try_again
 
-    @ownership_request = @rubygem.ownership_requests.new(ownership_call: @rubygem.ownership_call, user: current_user, note: params[:note])
-    if @ownership_request.save
+  def create
+    ownership_request = authorize @rubygem.ownership_requests.new(
+      ownership_call: @rubygem.ownership_call,
+      user: current_user,
+      note: params[:note]
+    )
+    if ownership_request.save
       redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t(".success_notice")
     else
-      redirect_to rubygem_adoptions_path(@rubygem.slug), alert: @ownership_request.errors.full_messages.to_sentence
+      redirect_to rubygem_adoptions_path(@rubygem.slug), alert: ownership_request.errors.full_messages.to_sentence
     end
   end
 
   def update
-    if status_params == "close" && @ownership_request.close(current_user)
-      notify_request_closed
-      redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t(".closed_notice")
-    elsif status_params == "approve" && @ownership_request.approve(current_user)
-      notify_request_approved
-      redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t(".approved_notice", name: current_user.display_id)
-    else
-      redirect_to rubygem_adoptions_path(@rubygem.slug), alert: t("try_again")
+    @ownership_request = OwnershipRequest.find(params[:id])
+
+    case params.permit(:status).require(:status)
+    when "close" then close
+    when "approve" then approve
+    else redirect_try_again
     end
   end
 
   def close_all
-    render_forbidden && return unless owner?
-
-    if @rubygem.ownership_requests.close_all
-      redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t("ownership_requests.close.success_notice", gem: @rubygem.name)
-    else
-      redirect_to rubygem_adoptions_path(@rubygem.slug), alert: t("try_again")
-    end
+    authorize(@rubygem, :close_ownership_requests?).ownership_requests.each(&:close!)
+    redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t("ownership_requests.close.success_notice", gem: @rubygem.name)
   end
 
   private
 
-  def find_ownership_request
-    @ownership_request = OwnershipRequest.find(params[:id])
+  def approve
+    authorize(@ownership_request, :approve?).approve!(current_user)
+    redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t(".approved_notice", name: current_user.display_id)
   end
 
-  def notify_request_closed
-    OwnersMailer.ownership_request_closed(@ownership_request.id).deliver_later unless @ownership_request.user == current_user
+  def close
+    authorize(@ownership_request, :close?).close!(current_user)
+    redirect_to rubygem_adoptions_path(@rubygem.slug), notice: t(".closed_notice")
   end
 
-  def notify_request_approved
-    @rubygem.ownership_notifiable_owners.each do |notified_user|
-      OwnersMailer.owner_added(
-        notified_user.id,
-        @ownership_request.user_id,
-        current_user.id,
-        @ownership_request.rubygem_id
-      ).deliver_later
-    end
-
-    OwnersMailer.ownership_request_approved(@ownership_request.id).deliver_later
-  end
-
-  def status_params
-    params.permit(:status).require(:status)
+  def redirect_try_again(_exception = nil)
+    redirect_to rubygem_adoptions_path(@rubygem.slug), alert: t("try_again")
   end
 end

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -31,8 +31,7 @@ class Ownership < ApplicationRecord
   end
 
   def self.create_confirmed(rubygem, user, approver)
-    ownership = rubygem.ownerships.create(user: user, authorizer: approver)
-    ownership.confirm!
+    rubygem.ownerships.create!(user: user, authorizer: approver).tap(&:confirm!)
   end
 
   def self.update_notifier(to_enable, to_disable, notifer_attr)
@@ -62,7 +61,7 @@ class Ownership < ApplicationRecord
   end
 
   def confirm!
-    update(confirmed_at: Time.current, token: nil) if unconfirmed?
+    update!(confirmed_at: Time.current, token: nil) if unconfirmed?
   end
 
   def confirmed?

--- a/app/models/ownership_call.rb
+++ b/app/models/ownership_call.rb
@@ -12,8 +12,8 @@ class OwnershipCall < ApplicationRecord
 
   enum status: { opened: true, closed: false }
 
-  def close
-    ownership_requests.close_all
-    update(status: :closed)
+  def close!
+    ownership_requests.each(&:close!)
+    update!(status: :closed)
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -261,12 +261,6 @@ class Rubygem < ApplicationRecord
     ownership_calls.find_by(status: "opened")
   end
 
-  def ownership_requestable?
-    abandoned_release_threshold   = 1.year.ago
-    abandoned_downloads_threshold = 10_000
-    ownership_calls.any? || (latest_version && latest_version.created_at < abandoned_release_threshold && downloads < abandoned_downloads_threshold)
-  end
-
   def update_versions!(version, spec)
     version.update_attributes_from_gem_specification!(spec)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -260,10 +260,6 @@ uniqueness: { case_sensitive: false }
     end
   end
 
-  def can_request_ownership?(rubygem)
-    !rubygem.owned_by?(self) && rubygem.ownership_requestable?
-  end
-
   def owns_gem?(rubygem)
     rubygem.owned_by?(self)
   end

--- a/app/policies/ownership_request_policy.rb
+++ b/app/policies/ownership_request_policy.rb
@@ -1,0 +1,20 @@
+class OwnershipRequestPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.none
+    end
+  end
+
+  def create?
+    return false unless record.user == user
+    Pundit.policy!(user, record.rubygem).request_ownership?
+  end
+
+  def approve?
+    record.rubygem.owned_by?(user)
+  end
+
+  def close?
+    (user.present? && record.user == user) || record.rubygem.owned_by?(user)
+  end
+end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -5,6 +5,9 @@ class RubygemPolicy < ApplicationPolicy
     end
   end
 
+  ABANDONED_RELEASE_AGE = 1.year
+  ABANDONED_DOWNLOADS_MAX = 10_000
+
   def show?
     true
   end
@@ -21,7 +24,23 @@ class RubygemPolicy < ApplicationPolicy
     false
   end
 
+  def show_adoption?
+    record.owned_by?(user) || request_ownership?
+  end
+
   def show_events?
+    record.owned_by?(user)
+  end
+
+  def request_ownership?
+    return false if record.owned_by?(user)
+    return true if record.ownership_calls.any?
+    return false if record.downloads >= ABANDONED_DOWNLOADS_MAX
+    return false unless record.latest_version&.created_at&.before?(ABANDONED_RELEASE_AGE.ago)
+    true
+  end
+
+  def close_ownership_requests?
     record.owned_by?(user)
   end
 

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -70,7 +70,7 @@
     <%= rubygem_trusted_publishers_link(@rubygem) if @rubygem.owned_by?(current_user) %>
     <%= oidc_api_key_role_links(@rubygem) if @rubygem.owned_by?(current_user) %>
     <%= resend_owner_confirmation_link(@rubygem) if @rubygem.unconfirmed_ownership?(current_user) %>
-    <%= rubygem_adoptions_link(@rubygem) if @rubygem.owned_by?(current_user) || @rubygem.ownership_requestable?%>
+    <%= rubygem_adoptions_link(@rubygem) if policy(@rubygem).show_adoption? %>
     <%= rubygem_security_events_link(@rubygem) if @rubygem.owned_by?(current_user) %>
   </div>
 </div>

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -198,11 +198,8 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           request = create(:ownership_request, rubygem: @rubygem)
           patch :update, params: { rubygem_id: @rubygem.name, id: request.id, status: "close" }
         end
-        should redirect_to("adoptions index") { rubygem_adoptions_path(@rubygem.slug) }
 
-        should "set try again flash" do
-          assert_equal "Something went wrong. Please try again.", flash[:alert]
-        end
+        should respond_with :forbidden
       end
     end
 
@@ -234,7 +231,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
 
         context "with unsuccessful update" do
           setup do
-            OwnershipRequest.stubs(:update_all).returns(false)
+            OwnershipRequest.any_instance.stubs(:update!).raises(ActiveRecord::RecordNotSaved)
             patch :close_all, params: { rubygem_id: @rubygem.name }
           end
 

--- a/test/models/ownership_call_test.rb
+++ b/test/models/ownership_call_test.rb
@@ -62,7 +62,7 @@ class OwnershipCallTest < ActiveSupport::TestCase
 
     should "close all associated open requests and then call" do
       create_list(:ownership_request, 2, rubygem: @rubygem, ownership_call: @ownership_call)
-      @ownership_call.close
+      @ownership_call.close!
 
       assert_predicate @ownership_call, :closed?
       assert_empty @ownership_call.ownership_requests.opened
@@ -71,13 +71,13 @@ class OwnershipCallTest < ActiveSupport::TestCase
     should "not close approved request" do
       create_list(:ownership_request, 2, rubygem: @rubygem, ownership_call: @ownership_call)
       approved_request = create(:ownership_request, :approved, rubygem: @rubygem, ownership_call: @ownership_call)
-      @ownership_call.close
+      @ownership_call.close!
 
       assert_contains OwnershipRequest.where(ownership_call: @ownership_call, status: :approved), approved_request
     end
 
     should "close call if no requests exist" do
-      @ownership_call.close
+      @ownership_call.close!
 
       assert_predicate @ownership_call, :closed?
       assert_empty @ownership_call.ownership_requests.opened

--- a/test/policies/ownership_request_policy_test.rb
+++ b/test/policies/ownership_request_policy_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class OwnershipRequestPolicyTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user, handle: "user")
+    @owner = create(:user, handle: "owner")
+    @requester = create(:user, handle: "requester")
+
+    @rubygem = create(:rubygem, number: "1.0", owners: [@owner], created_at: 2.years.ago)
+    @rubygem.versions.last.update!(created_at: 2.years.ago)
+
+    # ensure it is possible to request ownership of the rubygem
+    assert_predicate Pundit.policy!(@requester, @rubygem), :request_ownership?
+    @ownership_request = create(:ownership_request, rubygem: @rubygem, user: @requester)
+  end
+
+  def test_scope
+    assert_empty Pundit.policy_scope!(@owner, OwnershipCall).to_a
+    assert_empty Pundit.policy_scope!(@owner, @rubygem.ownership_requests).to_a
+    assert_empty Pundit.policy_scope!(@requester, OwnershipCall).to_a
+    assert_empty Pundit.policy_scope!(@user, OwnershipCall).to_a
+  end
+
+  def test_create
+    assert_predicate Pundit.policy!(@requester, @ownership_request), :create?
+    refute_predicate Pundit.policy!(@owner, @ownership_request), :create?
+    refute_predicate Pundit.policy!(@user, @ownership_request), :create?
+
+    newgem = create(:rubygem, number: "1.0", owners: [@owner])
+    newgem_request = build(:ownership_request, rubygem: newgem, user: @requester)
+
+    refute_predicate Pundit.policy!(@requester, newgem_request), :create?
+    refute_predicate Pundit.policy!(@owner, newgem_request), :create?
+    refute_predicate Pundit.policy!(@user, newgem_request), :create?
+  end
+
+  def test_approve
+    refute_predicate Pundit.policy!(@requester, @ownership_request), :approve?
+    assert_predicate Pundit.policy!(@owner, @ownership_request), :approve?
+    refute_predicate Pundit.policy!(@user, @ownership_request), :approve?
+  end
+
+  def test_close
+    assert_predicate Pundit.policy!(@requester, @ownership_request), :close?
+    assert_predicate Pundit.policy!(@owner, @ownership_request), :close?
+    refute_predicate Pundit.policy!(@user, @ownership_request), :close?
+  end
+end


### PR DESCRIPTION
I delved more into utilizing policies in this one. I think we _could_ use OwnershipRequests to support changing ownership of gems from users into Orgs, but maybe most of the time it will be done by an existing owner that could already approve the request anyway.