### PR TITLE
Ensure verified session for adoption actions

### DIFF
--- a/app/controllers/ownership_calls_controller.rb
+++ b/app/controllers/ownership_calls_controller.rb
@@ -1,8 +1,11 @@
 class OwnershipCallsController < ApplicationController
+  include SessionVerifiable
+
   before_action :find_rubygem, except: :index
   before_action :redirect_to_signin, unless: :signed_in?, except: :index
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, except: :index
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, except: :index
+  before_action :redirect_to_verify, only: %i[create close], unless: :verified_session_active?
   before_action :find_ownership_call, only: :close
 
   rescue_from ActiveRecord::RecordInvalid, with: :redirect_try_again

--- a/app/controllers/ownership_requests_controller.rb
+++ b/app/controllers/ownership_requests_controller.rb
@@ -1,8 +1,11 @@
 class OwnershipRequestsController < ApplicationController
+  include SessionVerifiable
+
   before_action :find_rubygem
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
+  before_action :redirect_to_verify, only: %i[update close_all], if: -> { @rubygem.owned_by?(current_user) && !verified_session_active? }
 
   rescue_from ActiveRecord::RecordInvalid, with: :redirect_try_again
   rescue_from ActiveRecord::RecordNotSaved, with: :redirect_try_again


### PR DESCRIPTION
These actions are protected at the adpotions controller view, but the actual POST and PATCH actions were not protected by the verified session check.

This is based on #4826. I tried to commit this so it wouldn't make an unreadable mess of test indentation changes.