### PR TITLE
Make it possible to run migrations again

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -12,7 +12,7 @@ StrongMigrations.auto_analyze = true
 
 # Set the version of the production database
 # so the right checks are run in development
-StrongMigrations.target_version = "11.3"
+StrongMigrations.target_version = "13"
 
 # Add custom checks
 # StrongMigrations.add_check do |method, args|


### PR DESCRIPTION
Funny story, strong_migrations was [upgraded to 2.0.0 last week](https://github.com/rubygems/rubygems.org/commit/7505e0507496c60b2b1d22ee8a6d57422b58b069). It turns out that version 2.0.0 dropped support for Postgres 11, and requires a minimum of Postgres 12. Funnier story, we have hardcoded the strong_migrations initializer to always act as if we are running on Postgres 11.3, which means that all migrations error out:

```
bin/rails aborted!
   (1.7ms)  SELECT pg_advisory_unlock(4040961485751852690)
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PostgreSQL version (11.3) not supported in this version of Strong Migrations (2.0.0)
```

That error shows up regardless of the version of postgres you are actually using, and made me tear my hair out for about half an hour trying to figure out how Rails was talking to postgres 11 when I didn't even have it installed on my computer anymore.

Anyway, I have verified that production postgres has been upgraded to 13, and that is why I have changed the strong_migrations initializer to reflect that we want to check migrations as if we are using postgres 13, even if local development is happening against a different version.

In the future, we may want to add updating this file to our database upgrade runbook!
