### PR TITLE
Update all Github Actions workflows to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ permissions: # added using https://github.com/step-security/secure-workflows
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rubygems-org
       - name: Install and start services (needed for image test)
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Configure AWS credentials from Production account
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         if: github.secret_source != 'None'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     name: Docker build (and optional push)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       RUBYGEMS_VERSION: 3.5.14
       RUBY_VERSION: 3.3.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ruby/setup-ruby@97e35c5302afcf3f5ac1df3fca9343d32536b286 # v1.184.0
@@ -20,7 +20,7 @@ jobs:
         run: bundle exec rubocop
   brakeman:
     name: Brakeman
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ruby/setup-ruby@97e35c5302afcf3f5ac1df3fca9343d32536b286 # v1.184.0
@@ -30,7 +30,7 @@ jobs:
         run: bundle exec brakeman
   importmap:
     name: Importmap Verify
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ruby/setup-ruby@97e35c5302afcf3f5ac1df3fca9343d32536b286 # v1.184.0
@@ -40,7 +40,7 @@ jobs:
         run: bundle exec rake importmap:verify
   kubeconform:
     name: Kubeconform
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         kubernetes_version: ["1.29.1"]

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   status_check:
     name: All required tests passing check
     needs: [rails]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - run: /bin/${{ (needs.rails.result == 'success' || needs.rails.result == 'skipped') }}


### PR DESCRIPTION
Our Github Actions is using a mixture of Ubuntu 22 & 24 images. We want to:
1. Update our images to the latest version
2. Update our action workflows to fix the image to `ubuntu-24.04`, so we're not surprised if things break `apt install` when a new image version is released.