### PR TITLE
OpenSearch docker container Java options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
       - "9200:9200"
     healthcheck:
@@ -41,6 +42,7 @@ services:
     environment:
       - 'OPENSEARCH_HOSTS=["http://search:9200"]'
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
     healthcheck:
       test:
         [


### PR DESCRIPTION
I am currently unable to start the `search` and `search-console` containers on my development environment (MacOS & Orbstack) with the following error:

```
java.lang.IllegalArgumentException: Values less than -1 bytes are not supported: -30535680b
```

Reviewing the OpenSearch docker documentation, it seems setting the `OPENSEARCH_JAVA_OPTS` environment is the fix for this error.