### PR TITLE
Add no-op policies for API actions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -72,6 +72,7 @@ class Api::BaseController < ApplicationController
   end
 
   def authorize(record, query = nil)
+    return if record.nil? # not found is handled by the action
     super(Array.wrap(record).prepend(:api), query)
   end
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -9,6 +9,7 @@ class Api::V1::DeletionsController < Api::BaseController
   before_action :verify_mfa_requirement
 
   def create
+    authorize @rubygem, :yank?
     @deletion = @api_key.user.deletions.build(version: @version)
     if @deletion.save
       StatsD.increment "yank.success"

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -15,6 +15,7 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def create
+    authorize @rubygem, :add_owner?
     return render_forbidden(t(:api_key_forbidden)) unless @api_key.can_add_owner?
 
     owner = User.find_by_name(email_param)
@@ -34,6 +35,7 @@ class Api::V1::OwnersController < Api::BaseController
   end
 
   def destroy
+    authorize @rubygem, :remove_owner?
     return render_forbidden(t(:api_key_forbidden)) unless @api_key.can_remove_owner?
 
     owner = @rubygem.owners_including_unconfirmed.find_by_name(email_param)

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::RubygemsController < Api::BaseController
   after_action  :cors_set_access_control_headers, only: :show
 
   def index
+    authorize Rubygem, :index?
     return render_forbidden(t(:api_key_insufficient_scope)) unless @api_key.can_index_rubygems?
 
     @rubygems = @api_key.user.rubygems.with_versions
@@ -33,6 +34,7 @@ class Api::V1::RubygemsController < Api::BaseController
   end
 
   def create
+    authorize Rubygem, :create?
     return render_forbidden(t(:api_key_insufficient_scope)) unless @api_key.can_push_rubygem?
 
     gemcutter = Pusher.new(@api_key, request.body, request:)

--- a/app/policies/api/rubygem_policy.rb
+++ b/app/policies/api/rubygem_policy.rb
@@ -4,6 +4,26 @@ class Api::RubygemPolicy < Api::ApplicationPolicy
 
   alias rubygem record
 
+  def index?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def yank?
+    true
+  end
+
+  def add_owner?
+    true
+  end
+
+  def remove_owner?
+    true
+  end
+
   def show_trusted_publishers?
     api_key_scope?(:configure_trusted_publishers, rubygem) && user_policy!.show_trusted_publishers?
   end

--- a/app/policies/api/web_hook_policy.rb
+++ b/app/policies/api/web_hook_policy.rb
@@ -1,0 +1,20 @@
+class Api::WebHookPolicy < Api::ApplicationPolicy
+  class Scope < Api::ApplicationPolicy::Scope
+  end
+
+  def index?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def fire?
+    true
+  end
+
+  def remove?
+    true
+  end
+end


### PR DESCRIPTION
Rather than try to add full, comprehensive policies for each controller in the API (a vertical approach), I want to get all interactions passing through the policy code and then start to add checks one at a time (a horizontal approach). I'm hoping this will unstick my other more complicated branches.