### PR TITLE
Fix `<em>` tag in the gem search page

### DIFF
--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <%= link_to t("advanced_search"), advanced_search_path, class: "t-link--gray t-link--has-arrow" %>
 <% if @yanked_filter %>
-  <% @subtitle = t('.subtitle', :query => content_tag(:em, h(params[:query]))) %>
+  <% @subtitle = t('.subtitle_html', :query => params[:query]) %>
 
   <% if @yanked_gem.present? %>
     <%= link_to rubygem_path(@yanked_gem.slug), :class => 'gems__gem' do %>
@@ -22,7 +22,7 @@
   <% end %>
 <% else %>
   <% if @gems %>
-    <% @subtitle = t('.subtitle', :query => content_tag(:em, h(params[:query]))) %>
+    <% @subtitle = t('.subtitle_html', :query => params[:query]) %>
 
     <header class="gems__header push--s">
       <p class="gems__meter"><%= page_entries_info(@gems, :entry_name => 'gem') %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -793,7 +793,7 @@ de:
       updated:
       yanked:
     show:
-      subtitle: für %{query}
+      subtitle_html: für <em>%{query}</em>
       month_update:
       week_update:
       filter:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -706,7 +706,7 @@ en:
       updated: Updated
       yanked: Yanked
     show:
-      subtitle: for %{query}
+      subtitle_html: for <em>%{query}</em>
       month_update: Updated last month (%{count})
       week_update: Updated last week (%{count})
       filter: "Filter:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -819,7 +819,7 @@ es:
       updated: Actualizada
       yanked: Borrada
     show:
-      subtitle: para %{query}
+      subtitle_html: para <em>%{query}</em>
       month_update: Actualizadas en el último mes (%{count})
       week_update: Actualizadas en la última semana (%{count})
       filter: 'Filtro:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -743,7 +743,7 @@ fr:
       updated: Mis à jour
       yanked:
     show:
-      subtitle: pour %{query}
+      subtitle_html: pour <em>%{query}</em>
       month_update:
       week_update:
       filter:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -704,7 +704,7 @@ ja:
       updated: 更新日
       yanked: ヤンク済み
     show:
-      subtitle: "%{query}の検索結果"
+      subtitle_html: "<em>%{query}</em>の検索結果"
       month_update: 先月更新（%{count}件）
       week_update: 先週更新（%{count}件）
       filter: 絞り込み：

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -698,7 +698,7 @@ nl:
       updated:
       yanked:
     show:
-      subtitle: voor %{query}
+      subtitle_html: voor <em>%{query}</em>
       month_update:
       week_update:
       filter:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -721,7 +721,7 @@ pt-BR:
       updated:
       yanked:
     show:
-      subtitle: para %{query}
+      subtitle_html: para <em>%{query}</em>
       month_update:
       week_update:
       filter:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -710,7 +710,7 @@ zh-CN:
       updated: 更新
       yanked: 撤回
     show:
-      subtitle: "%{query}"
+      subtitle_html: "<em>%{query}</em>"
       month_update: 上个月更新 (%{count})
       week_update: 上周更新 (%{count})
       filter: 过滤：

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -700,7 +700,7 @@ zh-TW:
       updated: 更新於
       yanked: 移除於
     show:
-      subtitle: "%{query}"
+      subtitle_html: "<em>%{query}</em>"
       month_update: 於最近一個月更新 (%{count})
       week_update: 於最近一週更新 (%{count})
       filter:


### PR DESCRIPTION
Caused by https://github.com/rubygems/rubygems.org/pull/4860
Fixes https://github.com/rubygems/rubygems.org/issues/4877

I checked and there don't appear to be other instances where this would happen.

![grafik](https://github.com/user-attachments/assets/009d0b52-aebf-4ec4-aec8-70ae75debf22)

I'm not sure if this change warrants a test. I guess I could check against some css selector but I don't think there's much value in that.