### PR TITLE
Add deny reason to pundit policies

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,7 +2,9 @@ class Api::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
   after_action :skip_session
 
-  rescue_from(Pundit::NotAuthorizedError) { |_| render_forbidden(t(:api_key_forbidden)) }
+  rescue_from(Pundit::NotAuthorizedError) do |e|
+    render_forbidden(e.policy.error)
+  end
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,9 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from ActionController::InvalidAuthenticityToken, with: :render_forbidden
   rescue_from ActionController::UnpermittedParameters, with: :render_bad_request
-  rescue_from(Pundit::NotAuthorizedError) { |_| render_forbidden } # don't pass pundit error message
+  rescue_from(Pundit::NotAuthorizedError) do |e|
+    render_forbidden(e.policy.error)
+  end
 
   before_action :set_locale
   before_action :reject_null_char_param
@@ -138,7 +140,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def render_forbidden(error = "forbidden")
+  def render_forbidden(error = nil)
+    error ||= t(:forbidden)
     render plain: error, status: :forbidden
   end
 

--- a/app/policies/api/oidc/rubygem_trusted_publisher_policy.rb
+++ b/app/policies/api/oidc/rubygem_trusted_publisher_policy.rb
@@ -5,15 +5,15 @@ class Api::OIDC::RubygemTrustedPublisherPolicy < Api::ApplicationPolicy
   delegate :rubygem, to: :record
 
   def show?
-    can_configure_trusted_publishers? && user_policy!.show?
+    can_configure_trusted_publishers? && user_authorized?(record, :show?)
   end
 
   def create?
-    can_configure_trusted_publishers? && user_policy!.create?
+    can_configure_trusted_publishers? && user_authorized?(record, :create?)
   end
 
   def destroy?
-    can_configure_trusted_publishers? && user_policy!.destroy?
+    can_configure_trusted_publishers? && user_authorized?(record, :destroy?)
   end
 
   private

--- a/app/policies/api/rubygem_policy.rb
+++ b/app/policies/api/rubygem_policy.rb
@@ -25,6 +25,6 @@ class Api::RubygemPolicy < Api::ApplicationPolicy
   end
 
   def show_trusted_publishers?
-    api_key_scope?(:configure_trusted_publishers, rubygem) && user_policy!.show_trusted_publishers?
+    api_key_scope?(:configure_trusted_publishers, rubygem) && user_authorized?(record, :show_trusted_publishers?)
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -18,11 +18,12 @@ class ApplicationPolicy
     attr_reader :user, :scope
   end
 
-  attr_reader :user, :record
+  attr_reader :user, :record, :error
 
   def initialize(user, record)
     @user = user
     @record = record
+    @error = nil
   end
 
   def index?
@@ -59,7 +60,19 @@ class ApplicationPolicy
 
   private
 
+  delegate :t, to: I18n
+
+  def deny(error)
+    @error = error
+    false
+  end
+
   def current_user?(record_user)
     user && user == record_user
+  end
+
+  def rubygem_owned_by?(user)
+    return true if rubygem.owned_by?(user)
+    deny(t(:forbidden))
   end
 end

--- a/app/policies/oidc/rubygem_trusted_publisher_policy.rb
+++ b/app/policies/oidc/rubygem_trusted_publisher_policy.rb
@@ -5,14 +5,14 @@ class OIDC::RubygemTrustedPublisherPolicy < ApplicationPolicy
   delegate :rubygem, to: :record
 
   def show?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def create?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def destroy?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 end

--- a/app/policies/ownership_call_policy.rb
+++ b/app/policies/ownership_call_policy.rb
@@ -5,10 +5,10 @@ class OwnershipCallPolicy < ApplicationPolicy
   delegate :rubygem, to: :record
 
   def create?
-    rubygem.owned_by?(user) && current_user?(record.user)
+    rubygem_owned_by?(user) && current_user?(record.user)
   end
 
   def close?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 end

--- a/app/policies/ownership_policy.rb
+++ b/app/policies/ownership_policy.rb
@@ -5,10 +5,10 @@ class OwnershipPolicy < ApplicationPolicy
   delegate :rubygem, to: :record
 
   def create?
-    rubygem.owned_by?(user) && current_user?(record.authorizer)
+    rubygem_owned_by?(user) && current_user?(record.authorizer)
   end
 
   def destroy?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 end

--- a/app/policies/ownership_request_policy.rb
+++ b/app/policies/ownership_request_policy.rb
@@ -9,10 +9,10 @@ class OwnershipRequestPolicy < ApplicationPolicy
   end
 
   def approve?
-    rubygem.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def close?
-    current_user?(record.user) || rubygem.owned_by?(user)
+    current_user?(record.user) || rubygem_owned_by?(user)
   end
 end

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -5,6 +5,8 @@ class RubygemPolicy < ApplicationPolicy
   ABANDONED_RELEASE_AGE = 1.year
   ABANDONED_DOWNLOADS_MAX = 10_000
 
+  alias rubygem record
+
   def show?
     true
   end
@@ -22,30 +24,30 @@ class RubygemPolicy < ApplicationPolicy
   end
 
   def show_adoption?
-    record.owned_by?(user) || request_ownership?
+    rubygem_owned_by?(user) || request_ownership?
   end
 
   def show_events?
-    record.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def request_ownership?
-    return false if record.owned_by?(user)
-    return true if record.ownership_calls.any?
-    return false if record.downloads >= ABANDONED_DOWNLOADS_MAX
-    return false unless record.latest_version&.created_at&.before?(ABANDONED_RELEASE_AGE.ago)
+    return false if rubygem_owned_by?(user)
+    return true if rubygem.ownership_calls.any?
+    return deny("above maximum downloads to be considered abandoned") if rubygem.downloads >= ABANDONED_DOWNLOADS_MAX
+    return false unless rubygem.latest_version&.created_at&.before?(ABANDONED_RELEASE_AGE.ago)
     true
   end
 
   def close_ownership_requests?
-    record.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def show_trusted_publishers?
-    record.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 
   def show_unconfirmed_ownerships?
-    record.owned_by?(user)
+    rubygem_owned_by?(user)
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -26,6 +26,7 @@ de:
   locale_name: Deutsch
   none: None
   not_found: Nicht gefunden
+  forbidden:
   api_gem_not_found:
   api_key_forbidden:
   api_key_soft_deleted:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
   locale_name: English
   none: None
   not_found: Not Found
+  forbidden: Forbidden
   api_gem_not_found: This gem could not be found
   api_key_forbidden: The API key doesn't have access
   api_key_soft_deleted: An invalid API key cannot be used. Please delete it and create a new one.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -26,6 +26,7 @@ es:
   locale_name: Español
   none: Ninguno
   not_found: No encontrado
+  forbidden:
   api_gem_not_found:
   api_key_forbidden: La clave API no tiene acceso
   api_key_soft_deleted:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,6 +27,7 @@ fr:
   locale_name: Français
   none:
   not_found: Introuvable
+  forbidden:
   api_gem_not_found:
   api_key_forbidden:
   api_key_soft_deleted:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,7 @@ ja:
   locale_name: 日本語
   none: なし
   not_found: 見つかりませんでした
+  forbidden:
   api_gem_not_found:
   api_key_forbidden: APIキーにアクセス権がありません
   api_key_soft_deleted:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -19,6 +19,7 @@ nl:
   locale_name: Nederlands
   none: Geen
   not_found: Niet gevonden
+  forbidden:
   api_gem_not_found:
   api_key_forbidden:
   api_key_soft_deleted:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -25,6 +25,7 @@ pt-BR:
   locale_name: Português do Brasil
   none: Nenhum
   not_found: Não encontrado
+  forbidden:
   api_gem_not_found:
   api_key_forbidden:
   api_key_soft_deleted:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -21,6 +21,7 @@ zh-CN:
   locale_name: 简体中文
   none: 无
   not_found: 未找到
+  forbidden:
   api_gem_not_found:
   api_key_forbidden: API 密钥没有访问权限
   api_key_soft_deleted:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -20,6 +20,7 @@ zh-TW:
   locale_name: 正體中文
   none: 無
   not_found: 沒有找到
+  forbidden:
   api_gem_not_found:
   api_key_forbidden: API 金鑰沒有存取權限
   api_key_soft_deleted:

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -42,7 +42,7 @@ class OwnersControllerTest < ActionController::TestCase
         should respond_with :forbidden
 
         should "render forbidden message" do
-          assert page.has_content?("forbidden")
+          assert page.has_content?("Forbidden")
         end
       end
     end

--- a/test/integration/api/v1/oidc/rubygem_trusted_publishers_controller_test.rb
+++ b/test/integration/api/v1/oidc/rubygem_trusted_publishers_controller_test.rb
@@ -62,7 +62,7 @@ class Api::V1::OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::In
 
     should "deny access" do
       assert_response :forbidden
-      assert_match "The API key doesn't have access", @response.body
+      assert_includes @response.body, "This API key cannot perform the specified action on this gem."
     end
   end
 

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -227,7 +227,7 @@ class OIDCTest < ApplicationSystemTestCase
     visit new_rubygem_trusted_publisher_path(rubygem.slug)
     verify_session
 
-    assert_text "forbidden"
+    assert_text "Forbidden"
 
     create(:ownership, rubygem: rubygem, user: @user)
 


### PR DESCRIPTION
This is necessary for the api policies, since they offer specific feedback when a policy denies a request.