### PR TITLE
Refactor Api::Policy tests to allow more than one policy

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -62,9 +62,14 @@ class ApplicationPolicy
 
   delegate :t, to: I18n
 
-  def deny(error)
+  def deny(error = t(:forbidden))
     @error = error
     false
+  end
+
+  def allow
+    @error = nil
+    true
   end
 
   def current_user?(record_user)
@@ -75,7 +80,11 @@ class ApplicationPolicy
     rubygem.owned_by?(user) || deny(t(:forbidden))
   end
 
-  def policy!(user, record)
-    Pundit.policy!(user, record)
+  def policy!(user, record) = Pundit.policy!(user, record)
+  def user_policy!(record) = policy!(user, record)
+
+  def user_authorized?(record, action)
+    policy = user_policy!(record)
+    policy.send(action) || deny(policy.error)
   end
 end

--- a/app/policies/ownership_request_policy.rb
+++ b/app/policies/ownership_request_policy.rb
@@ -5,7 +5,7 @@ class OwnershipRequestPolicy < ApplicationPolicy
   delegate :rubygem, to: :record
 
   def create?
-    current_user?(record.user) && Pundit.policy!(user, rubygem).request_ownership?
+    current_user?(record.user) && user_authorized?(rubygem, :request_ownership?)
   end
 
   def approve?

--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -33,10 +33,10 @@ class RubygemPolicy < ApplicationPolicy
 
   def request_ownership?
     return false if rubygem_owned_by?(user)
-    return true if rubygem.ownership_calls.any?
+    return allow if rubygem.ownership_calls.any?
     return false if rubygem.downloads >= ABANDONED_DOWNLOADS_MAX
-    return false unless rubygem.latest_version&.created_at&.before?(ABANDONED_RELEASE_AGE.ago)
-    true
+    return false if rubygem.latest_version.nil? || rubygem.latest_version.created_at.after?(ABANDONED_RELEASE_AGE.ago)
+    allow
   end
 
   def close_ownership_requests?

--- a/test/helpers/api_policy_helpers.rb
+++ b/test/helpers/api_policy_helpers.rb
@@ -1,0 +1,109 @@
+require_relative "policy_helpers"
+
+module ApiPolicyHelpers
+  extend ActiveSupport::Concern
+  include PolicyHelpers
+
+  class_methods do
+    def should_require_scope(scope, action)
+      context "requires #{scope} scope" do
+        should "deny ApiKey without scope" do
+          refute_authorized key_without_scope(scope), action
+        end
+
+        should "allow ApiKey with scope" do
+          assert_authorized key_with_scope(scope), action
+        end
+      end
+    end
+
+    def should_require_rubygem_scope(scope, action)
+      context "requires #{scope} and matching rubygem" do
+        should "deny ApiKey with rubygem without scope" do
+          refute_authorized key_without_scope(scope, rubygem: @rubygem), action
+        end
+
+        should "deny ApiKey with scope but wrong rubygem" do
+          refute_authorized key_with_scope(scope, rubygem: create(:rubygem, owners: [@owner])), action
+        end
+
+        should "allow ApiKey with scope and rubygem" do
+          assert_authorized key_with_scope(scope, rubygem: @rubygem), action
+        end
+      end
+    end
+
+    def should_require_user_key(scope, action)
+      context "requires ApiKey owned by a user" do
+        should "deny ApiKey not owned by a user" do
+          refute_authorized trusted_publisher_key(scope), action, I18n.t(:api_key_forbidden)
+        end
+
+        should "allow ApiKey owned by a user" do
+          assert_authorized key_with_scope(scope), action
+        end
+      end
+    end
+
+    def should_require_mfa(scope, action)
+      context "mfa required" do
+        setup do
+          GemDownload.increment(Rubygem::MFA_REQUIRED_THRESHOLD + 1, rubygem_id: @rubygem.id)
+          @rubygem.reload
+        end
+
+        should "deny ApiKey with owner.mfa_required_not_yet_enabled?" do
+          assert_predicate @owner, :mfa_required_not_yet_enabled?
+          refute_authorized key_with_scope(scope), action, I18n.t("multifactor_auths.api.mfa_required_not_yet_enabled")
+        end
+
+        should "deny ApiKey with owner.mfa_required_weak_level_enabled?" do
+          @owner.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+
+          assert_predicate @owner, :mfa_required_weak_level_enabled?
+          refute_authorized key_with_scope(scope), action, I18n.t("multifactor_auths.api.mfa_required_weak_level_enabled")
+        end
+
+        should "allow ApiKey with strong level mfa" do
+          @owner.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
+
+          assert_predicate @owner, :strong_mfa_level?
+          assert_authorized key_with_scope(scope), action
+        end
+      end
+    end
+
+    def should_delegate_to_policy(scope, action, policy_class)
+      context "delegates to #{policy_class}##{action}" do
+        should "allow if the #{policy_class} allows #{action}" do
+          policy_class.any_instance.stubs(action => true)
+
+          assert_authorized key_with_scope(scope), action
+        end
+
+        should "deny if the #{policy_class} denies #{action}" do
+          policy_class.any_instance.stubs(action => false, :error => "error")
+
+          refute_authorized key_with_scope(scope), action, "error"
+        end
+      end
+    end
+  end
+
+  def trusted_publisher_key(scope)
+    create(:api_key, :trusted_publisher, scopes: [scope])
+  end
+
+  def key_without_scope(scopes, **)
+    scopes = (ApiKey::APPLICABLE_GEM_API_SCOPES - Array.wrap(scopes)).sample(2)
+    key_with_scope(scopes, **)
+  end
+
+  def key_with_scope(scopes, owner: @owner, **)
+    create(:api_key, owner:, scopes: Array.wrap(scopes), **)
+  end
+
+  def refute_authorized(actor, action, message = I18n.t(:api_key_insufficient_scope))
+    super
+  end
+end

--- a/test/helpers/policy_helpers.rb
+++ b/test/helpers/policy_helpers.rb
@@ -1,0 +1,17 @@
+module PolicyHelpers
+  extend ActiveSupport::Concern
+
+  def assert_authorized(actor, action)
+    policy = policy!(actor)
+
+    assert_predicate policy, action
+    assert_nil policy.error
+  end
+
+  def refute_authorized(actor, action, message = nil)
+    policy = policy!(actor)
+
+    refute_predicate policy, action
+    assert_equal message.chomp, policy.error&.chomp if message
+  end
+end

--- a/test/policies/api/rubygem_policy_test.rb
+++ b/test/policies/api/rubygem_policy_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class Api::RubygemPolicyTest < ApiPolicyTestCase
   setup do
-    @user = create(:user, handle: "user")
     @owner = create(:user, handle: "owner")
     @rubygem = create(:rubygem, owners: [@owner])
 
@@ -13,95 +12,21 @@ class Api::RubygemPolicyTest < ApiPolicyTestCase
     )
   end
 
-  def record = @rubygem
-
-  def trusted_publisher_key(scope)
-    create(:api_key, :trusted_publisher, key: "tp", scopes: [scope])
-  end
-
-  def key_without_scope(scope, rubygem = nil)
-    scopes = (ApiKey::APPLICABLE_GEM_API_SCOPES - [scope]).sample(2)
-    create(:api_key, owner: @owner, scopes: scopes, rubygem:)
-  end
-
-  def key_with_scope(scope, rubygem = nil)
-    create(:api_key, owner: @owner, scopes: [scope], rubygem:)
-  end
-
-  def self.should_require_scope(scope, action)
-    should "deny ApiKey without scope" do
-      refute_authorized key_without_scope(scope), action
-    end
-
-    should "allow ApiKey with scope" do
-      assert_authorized key_with_scope(scope), action
-    end
-  end
-
-  def self.should_require_rubygem_scope(scope, action)
-    should "deny ApiKey with rubygem without scope" do
-      refute_authorized key_without_scope(scope, @rubygem), action
-    end
-
-    should "deny ApiKey with scope but wrong rubygem" do
-      refute_authorized key_with_scope(scope, create(:rubygem, owners: [@owner])), action
-    end
-
-    should "allow ApiKey with scope and rubygem" do
-      assert_authorized key_with_scope(scope, @rubygem), action
-    end
-  end
-
-  def self.should_require_user_key(scope, action)
-    should "deny ApiKey not owned by a user" do
-      refute_authorized trusted_publisher_key(scope), action, I18n.t(:api_key_forbidden)
-    end
-  end
-
-  def self.should_require_mfa(scope, action)
-    context "mfa required" do
-      setup do
-        GemDownload.increment(Rubygem::MFA_REQUIRED_THRESHOLD + 1, rubygem_id: @rubygem.id)
-        @rubygem.reload
-      end
-
-      should "deny ApiKey with owner.mfa_required_not_yet_enabled?" do
-        assert_predicate @owner, :mfa_required_not_yet_enabled?
-        refute_authorized key_with_scope(scope), action, I18n.t("multifactor_auths.api.mfa_required_not_yet_enabled")
-      end
-
-      should "deny ApiKey with owner.mfa_required_weak_level_enabled?" do
-        @owner.enable_totp!(ROTP::Base32.random_base32, :ui_only)
-
-        assert_predicate @owner, :mfa_required_weak_level_enabled?
-        refute_authorized key_with_scope(scope), action, I18n.t("multifactor_auths.api.mfa_required_weak_level_enabled")
-      end
-
-      should "allow ApiKey with strong level mfa" do
-        @owner.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
-
-        assert_predicate @owner, :strong_mfa_level?
-        assert_authorized key_with_scope(scope), action
-      end
-    end
-  end
-
-  def self.should_delegate_to_user_policy(scope, action)
-    should "be true if the base RubygemPolicy for the gem allows add_owner?" do
-      RubygemPolicy.any_instance.stubs(action => true)
-
-      assert_authorized key_with_scope(scope), action
-    end
-
-    should "be false if the base RubygemPolicy for the gem does not allow add_owner?" do
-      RubygemPolicy.any_instance.stubs(action => false, :error => "error")
-
-      refute_authorized key_with_scope(scope), action, "error"
-    end
+  def policy!(api_key)
+    Pundit.policy!(api_key, [:api, @rubygem])
   end
 
   context "#index?" do
-    should_require_scope :index_rubygems, :index?
+    scope = :index_rubygems
+    action = :index?
+
+    should_require_scope scope, action
+
+    should "allow ApiKey with scope and any rubygem" do
+      api_key = key_with_scope([:push_rubygem, scope], rubygem: create(:rubygem, owners: [@owner]))
+
+      assert_authorized api_key, action
+    end
   end
 
   context "#create?" do
@@ -111,8 +36,8 @@ class Api::RubygemPolicyTest < ApiPolicyTestCase
     should_require_scope scope, action
     should_require_mfa scope, action
 
-    should "deny ApiKey with rubygem without scope" do
-      refute_authorized key_without_scope(:push_rubygem, @rubygem), :create?
+    should "deny ApiKey without scope but with rubygem" do
+      refute_authorized key_without_scope(:push_rubygem, rubygem: @rubygem), :create?
     end
   end
 
@@ -133,7 +58,7 @@ class Api::RubygemPolicyTest < ApiPolicyTestCase
     should_require_mfa scope, action
     should_require_scope scope, action
     should_require_rubygem_scope scope, action
-    should_delegate_to_user_policy scope, action
+    should_delegate_to_policy scope, action, RubygemPolicy
   end
 
   context "#add_owner" do
@@ -144,7 +69,7 @@ class Api::RubygemPolicyTest < ApiPolicyTestCase
     should_require_mfa scope, action
     should_require_scope scope, action
     should_require_rubygem_scope scope, action
-    should_delegate_to_user_policy scope, action
+    should_delegate_to_policy scope, action, RubygemPolicy
   end
 
   context "#remove_owner" do
@@ -155,6 +80,6 @@ class Api::RubygemPolicyTest < ApiPolicyTestCase
     should_require_mfa scope, action
     should_require_scope scope, action
     should_require_rubygem_scope scope, action
-    should_delegate_to_user_policy scope, action
+    should_delegate_to_policy scope, action, RubygemPolicy
   end
 end

--- a/test/policies/ownership_call_policy_test.rb
+++ b/test/policies/ownership_call_policy_test.rb
@@ -1,21 +1,25 @@
 require "test_helper"
 
-class OwnershipCallPolicyTest < ActiveSupport::TestCase
+class OwnershipCallPolicyTest < PolicyTestCase
   setup do
-    @owner = FactoryBot.create(:user)
-    @rubygem = FactoryBot.create(:rubygem, owners: [@owner])
+    @owner = create(:user)
+    @rubygem = create(:rubygem, owners: [@owner])
     @ownership_call = @rubygem.ownership_calls.create(user: @owner, note: "valid note")
 
-    @user = FactoryBot.create(:user)
+    @user = create(:user)
+  end
+
+  def policy!(user)
+    Pundit.policy!(user, @ownership_call)
   end
 
   def test_create
-    assert_predicate Pundit.policy!(@owner, @ownership_call), :create?
-    refute_predicate Pundit.policy!(@user, @ownership_call), :create?
+    assert_authorized @owner, :create?
+    refute_authorized @user, :create?
   end
 
   def test_destroy
-    assert_predicate Pundit.policy!(@owner, @ownership_call), :close?
-    refute_predicate Pundit.policy!(@user, @ownership_call), :close?
+    assert_authorized @owner, :close?
+    refute_authorized @user, :close?
   end
 end

--- a/test/policies/rubygem_policy_test.rb
+++ b/test/policies/rubygem_policy_test.rb
@@ -1,21 +1,25 @@
 require "test_helper"
 
-class RubygemPolicyTest < ActiveSupport::TestCase
+class RubygemPolicyTest < PolicyTestCase
   setup do
     @owner = create(:user, handle: "owner")
     @rubygem = create(:rubygem, owners: [@owner])
     @user = create(:user, handle: "user")
   end
 
+  def policy!(user)
+    Pundit.policy!(user, @rubygem)
+  end
+
   context "#request_ownership?" do
     should "be false if the gem is owned by the user" do
-      refute_predicate Pundit.policy!(@owner, @rubygem), :request_ownership?
+      refute_authorized @owner, :request_ownership?
     end
 
     should "be true if the gem has ownership calls" do
       create(:ownership_call, rubygem: @rubygem, user: @owner)
 
-      assert_predicate Pundit.policy!(@user, @rubygem), :request_ownership?
+      assert_authorized @user, :request_ownership?
     end
 
     should "be false if the gem has more than 10,000 downloads" do
@@ -23,60 +27,60 @@ class RubygemPolicyTest < ActiveSupport::TestCase
       create(:version, rubygem: @rubygem, created_at: 2.years.ago)
 
       assert_operator @rubygem.downloads, :>, RubygemPolicy::ABANDONED_DOWNLOADS_MAX
-      refute_predicate Pundit.policy!(@user, @rubygem), :request_ownership?
+      refute_authorized @user, :request_ownership?
     end
 
     should "be false if the gem has no versions" do
       assert_empty @rubygem.versions
-      refute_predicate Pundit.policy!(@user, @rubygem), :request_ownership?
+      refute_authorized @user, :request_ownership?
     end
 
     should "be false if the gem has a version newer than 1 year" do
       create(:version, rubygem: @rubygem, created_at: 11.months.ago)
 
-      refute_predicate Pundit.policy!(@user, @rubygem), :request_ownership?
+      refute_authorized @user, :request_ownership?
     end
 
     should "be true if the gem's latest version is older than 1 year and less than 10,000 downloads" do
       create(:version, rubygem: @rubygem, created_at: 2.years.ago)
 
-      assert_predicate Pundit.policy!(@user, @rubygem), :request_ownership?
+      assert_authorized @user, :request_ownership?
     end
   end
 
   context "#show_adoption?" do
     should "be true if the gem is owned by the user" do
-      assert_predicate Pundit.policy!(@owner, @rubygem), :show_adoption?
+      assert_authorized @owner, :show_adoption?
     end
 
     should "be true if the rubygem is adoptable" do
       create(:version, rubygem: @rubygem, created_at: 2.years.ago)
 
-      assert_predicate Pundit.policy!(@owner, @rubygem), :show_adoption?
+      assert_authorized @owner, :show_adoption?
     end
   end
 
   context "#show_events?" do
     should "only allow the owner" do
-      assert_predicate Pundit.policy!(@owner, @rubygem), :show_events?
-      refute_predicate Pundit.policy!(@user, @rubygem), :show_events?
-      refute_predicate Pundit.policy!(nil, @rubygem), :show_events?
+      assert_authorized @owner, :show_events?
+      refute_authorized @user, :show_events?
+      refute_authorized nil, :show_events?
     end
   end
 
   context "#configure_trusted_publishers?" do
     should "only allow the owner" do
-      assert_predicate Pundit.policy!(@owner, @rubygem), :configure_trusted_publishers?
-      refute_predicate Pundit.policy!(@user, @rubygem), :configure_trusted_publishers?
-      refute_predicate Pundit.policy!(nil, @rubygem), :configure_trusted_publishers?
+      assert_authorized @owner, :configure_trusted_publishers?
+      refute_authorized @user, :configure_trusted_publishers?
+      refute_authorized nil, :configure_trusted_publishers?
     end
   end
 
   context "#show_unconfirmed_ownerships?" do
     should "only allow the owner" do
-      assert_predicate Pundit.policy!(@owner, @rubygem), :show_unconfirmed_ownerships?
-      refute_predicate Pundit.policy!(@user, @rubygem), :show_unconfirmed_ownerships?
-      refute_predicate Pundit.policy!(nil, @rubygem), :show_unconfirmed_ownerships?
+      assert_authorized @owner, :show_unconfirmed_ownerships?
+      refute_authorized @user, :show_unconfirmed_ownerships?
+      refute_authorized nil, :show_unconfirmed_ownerships?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,10 +25,12 @@ require "webauthn/fake_client"
 require "shoulda/context"
 require "shoulda/matchers"
 require "helpers/admin_helpers"
+require "helpers/api_policy_helpers"
 require "helpers/gem_helpers"
 require "helpers/email_helpers"
 require "helpers/es_helper"
 require "helpers/password_helpers"
+require "helpers/policy_helpers"
 require "helpers/webauthn_helpers"
 require "helpers/oauth_helpers"
 require "webmock/minitest"
@@ -274,28 +276,11 @@ class AdminPolicyTestCase < ActiveSupport::TestCase
 end
 
 class ApiPolicyTestCase < ActiveSupport::TestCase
-  def policy!(api_key, rec = nil)
-    rec ||= record
-    Pundit.policy!(api_key, [:api, rec])
-  end
+  include ApiPolicyHelpers
+end
 
-  def record
-    raise NotImplementedError, "You must define #record in #{self.class}"
-  end
-
-  def assert_authorized(actor, action)
-    policy = policy!(actor)
-
-    assert_predicate policy, action
-    assert_nil policy.error
-  end
-
-  def refute_authorized(actor, action, message = I18n.t(:api_key_insufficient_scope))
-    policy = policy!(actor)
-
-    refute_predicate policy, action
-    assert_equal message.chomp, policy.error&.chomp if message
-  end
+class PolicyTestCase < ActiveSupport::TestCase
+  include PolicyHelpers
 end
 
 class ComponentTest < ActiveSupport::TestCase


### PR DESCRIPTION
When adding `Api::VersionPolicy`, it became clear I needed to abstract better to remove a ton of duplication.