### PR TITLE
OwnershipRequest by existing owner should be invalid

### DIFF
--- a/app/policies/rubygem_policy.rb
+++ b/app/policies/rubygem_policy.rb
@@ -32,7 +32,6 @@ class RubygemPolicy < ApplicationPolicy
   end
 
   def request_ownership?
-    return false if rubygem_owned_by?(user)
     return allow if rubygem.ownership_calls.any?
     return false if rubygem.downloads >= ABANDONED_DOWNLOADS_MAX
     return false if rubygem.latest_version.nil? || rubygem.latest_version.created_at.after?(ABANDONED_RELEASE_AGE.ago)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -104,6 +104,11 @@ de:
             user_id:
               already_confirmed: ist bereits Eigentümer dieses Gems
               already_invited: wurde bereits zu diesem Gem eingeladen
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,11 @@ en:
             user_id:
               already_confirmed: "is already an owner of this gem"
               already_invited: "is already invited to this gem"
+        ownership_request:
+          attributes:
+            user_id:
+              taken: "has already requested ownership"
+              existing: "is already an owner"
         user:
           attributes:
             handle:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -102,6 +102,11 @@ es:
             user_id:
               already_confirmed: ya es propietario de esta gema
               already_invited: ya ha sido invitado a esta gema
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -100,6 +100,11 @@ fr:
             user_id:
               already_confirmed:
               already_invited:
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -93,6 +93,11 @@ ja:
             user_id:
               already_confirmed: は既にこのgemの所有者です
               already_invited: は既にこのgemに招待されています
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -92,6 +92,11 @@ nl:
             user_id:
               already_confirmed:
               already_invited:
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -99,6 +99,11 @@ pt-BR:
             user_id:
               already_confirmed:
               already_invited:
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -94,6 +94,11 @@ zh-CN:
             user_id:
               already_confirmed:
               already_invited:
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -93,6 +93,11 @@ zh-TW:
             user_id:
               already_confirmed: 已是此 Gem 的擁有者
               already_invited: 已獲邀加入此 Gem
+        ownership_request:
+          attributes:
+            user_id:
+              taken:
+              existing:
         user:
           attributes:
             handle:

--- a/test/functional/ownership_requests_controller_test.rb
+++ b/test/functional/ownership_requests_controller_test.rb
@@ -59,14 +59,17 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
           @rubygem = create(:rubygem, downloads: 2_000)
           create(:version, rubygem: @rubygem, created_at: 2.years.ago, number: "1.0.0")
         end
+
         context "when user is owner" do
           setup do
             create(:ownership, user: @user, rubygem: @rubygem)
             post :create, params: { rubygem_id: @rubygem.name, note: "small note" }
           end
-          should respond_with :forbidden
 
-          should "not create ownership request" do
+          should redirect_to("adoptions index") { rubygem_adoptions_path(@rubygem.slug) }
+          should set_flash[:alert].to("User is already an owner")
+
+          should "not create ownership call" do
             assert_nil @rubygem.ownership_requests.find_by(user: @user)
           end
         end
@@ -77,11 +80,8 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
               post :create, params: { rubygem_id: @rubygem.name, note: "small note" }
             end
             should redirect_to("adoptions index") { rubygem_adoptions_path(@rubygem.slug) }
-            should "set success notice flash" do
-              expected_notice = "Your ownership request was submitted."
+            should set_flash[:notice].to("Your ownership request was submitted.")
 
-              assert_equal expected_notice, flash[:notice]
-            end
             should "create ownership request" do
               assert_not_nil @rubygem.ownership_requests.find_by(user: @user)
             end
@@ -91,11 +91,8 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
               post :create, params: { rubygem_id: @rubygem.name }
             end
             should redirect_to("adoptions index") { rubygem_adoptions_path(@rubygem.slug) }
-            should "set error alert flash" do
-              expected_notice = "Note can't be blank"
+            should set_flash[:alert].to("Note can't be blank")
 
-              assert_equal expected_notice, flash[:alert]
-            end
             should "not create ownership call" do
               assert_nil @rubygem.ownership_requests.find_by(user: @user)
             end
@@ -106,11 +103,7 @@ class OwnershipRequestsControllerTest < ActionController::TestCase
               post :create, params: { rubygem_id: @rubygem.name, note: "new note" }
             end
             should redirect_to("adoptions index") { rubygem_adoptions_path(@rubygem.slug) }
-            should "set error alert flash" do
-              expected_notice = "User has already been taken"
-
-              assert_equal expected_notice, flash[:alert]
-            end
+            should set_flash[:alert].to("User has already requested ownership")
           end
         end
       end

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -166,8 +166,9 @@ class ProfileTest < SystemTest
 
   test "seeing ownership calls and requests" do
     rubygem = create(:rubygem, owners: [@user], number: "1.0.0")
+    requested_gem = create(:rubygem, number: "2.0.0")
     create(:ownership_call, rubygem: rubygem, user: @user, note: "special note")
-    create(:ownership_request, rubygem: rubygem, user: @user, note: "request note")
+    create(:ownership_request, rubygem: requested_gem, user: @user, note: "request note")
 
     sign_in
     visit profile_path("nick1")

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -134,9 +134,9 @@ class DeleteUserJobTest < ActiveJob::TestCase
     open_call = create(:ownership_call, rubygem: rubygem, user: user)
 
     other_call = create(:ownership_call, rubygem: other_rubygem, user: other_user)
-    closed_request = create(:ownership_request, ownership_call: other_call, rubygem: rubygem, user: user, status: :closed)
-    approved_request = create(:ownership_request, ownership_call: other_call, rubygem: rubygem, user: user, status: :approved)
-    open_request = create(:ownership_request, ownership_call: other_call, rubygem: rubygem, user: user)
+    closed_request = create(:ownership_request, ownership_call: other_call, rubygem: other_rubygem, user: user, status: :closed)
+    approved_request = create(:ownership_request, ownership_call: other_call, rubygem: other_rubygem, user: user, status: :approved)
+    open_request = create(:ownership_request, ownership_call: other_call, rubygem: other_rubygem, user: user)
     other_request = create(:ownership_request, ownership_call: open_call, rubygem: rubygem, user: other_user)
 
     assert_delete user

--- a/test/models/ownership_request_test.rb
+++ b/test/models/ownership_request_test.rb
@@ -57,7 +57,16 @@ class OwnershipRequestTest < ActiveSupport::TestCase
       ownership_request = build(:ownership_request, user: @user, rubygem: @rubygem)
 
       refute_predicate ownership_request, :valid?
-      assert_contains ownership_request.errors[:user_id], "has already been taken"
+      assert_contains ownership_request.errors[:user_id], "has already requested ownership"
+    end
+
+    should "not create a call when already an owner" do
+      owner = create(:user, handle: "owner")
+      create(:ownership, rubygem: @rubygem, user: owner)
+      ownership_request = build(:ownership_request, user: owner, rubygem: @rubygem)
+
+      refute_predicate ownership_request, :valid?
+      assert_contains ownership_request.errors[:user_id], "is already an owner"
     end
   end
 

--- a/test/policies/rubygem_policy_test.rb
+++ b/test/policies/rubygem_policy_test.rb
@@ -12,10 +12,6 @@ class RubygemPolicyTest < PolicyTestCase
   end
 
   context "#request_ownership?" do
-    should "be false if the gem is owned by the user" do
-      refute_authorized @owner, :request_ownership?
-    end
-
     should "be true if the gem has ownership calls" do
       create(:ownership_call, rubygem: @rubygem, user: @owner)
 
@@ -56,7 +52,7 @@ class RubygemPolicyTest < PolicyTestCase
     should "be true if the rubygem is adoptable" do
       create(:version, rubygem: @rubygem, created_at: 2.years.ago)
 
-      assert_authorized @owner, :show_adoption?
+      assert_authorized @user, :show_adoption?
     end
   end
 


### PR DESCRIPTION
The principal we use to decide if something should be a validation or a policy is whether or not an admin could override the choice. In this case, it never makes sense to allow an ownership request by an existing owner, so I'm moving the check to validations.