### PR TITLE
Don't report error on bad encoding in normalize_email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,8 +146,7 @@ uniqueness: { case_sensitive: false }
 
   def self.normalize_email(email)
     email.to_s.gsub(/\s+/, "")
-  rescue ArgumentError => e
-    Rails.error.report(e, handled: true)
+  rescue ArgumentError
     ""
   end
 


### PR DESCRIPTION
Exceptions were being raised to Honeybadger, which was a little annoying. Simply stop reporting it.

Adds tests so that the behavior is more clear, as I did not fully understand the original behavior until this discussion.