### PR TITLE
Remove unused `owner?` method in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,10 +107,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def owner?
-    @rubygem.owned_by?(current_user)
-  end
-
   def find_versioned_links
     @versioned_links = @rubygem.links(@latest_version)
   end


### PR DESCRIPTION
The policy refactor has entailed slowly removing hooks in the controller that relied on `owner?`.

There are none left.