### PR TITLE
Fix destroying rubygem with indexed versions and security events

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -1,7 +1,6 @@
 class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
-  include Events::Recordable
 
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :rubygem
   has_many :ownerships_including_unconfirmed, dependent: :destroy, class_name: "Ownership"
@@ -26,6 +25,10 @@ class Rubygem < ApplicationRecord
   has_many :reverse_dependencies, through: :incoming_dependencies, source: :version_rubygem
   has_many :reverse_development_dependencies, -> { merge(Dependency.development) }, through: :incoming_dependencies, source: :version_rubygem
   has_many :reverse_runtime_dependencies, -> { merge(Dependency.runtime) }, through: :incoming_dependencies, source: :version_rubygem
+
+  # needs to come last so its dependent: :destroy works, since yanking a version
+  # will create an event
+  include Events::Recordable
 
   has_one :most_recent_version,
     lambda {

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -265,6 +265,18 @@ class RubygemTest < ActiveSupport::TestCase
       assert_nil dependency.rubygem_id
       assert_equal dependency.unresolved_name, @rubygem.name
     end
+
+    should "allow destroying a gem with versions" do
+      @rubygem.save!
+      create(:ownership, rubygem: @rubygem)
+      create(:version, rubygem: @rubygem)
+      v2 = create(:version, rubygem: @rubygem)
+      create(:deletion, version: v2)
+
+      @rubygem.destroy!
+
+      assert_predicate Rubygem.where(id: @rubygem.id), :none?
+    end
   end
 
   context "with reverse dependencies" do


### PR DESCRIPTION
Not used in prod, but makes development much more pleasant
