### PR TITLE
Forbid gem name/version number&platform from ending in punctuation or common extension

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -47,6 +47,11 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
 
+  validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
+    name_format: { requires_letter: false },
+    if: -> { validation_context == :create || number_changed? || platform_changed? },
+    presence: true
+
   validate :unique_canonical_number, on: :create
   validate :platform_and_number_are_unique, on: :create
   validate :gem_platform_and_number_are_unique, on: :create

--- a/lib/name_format_validator.rb
+++ b/lib/name_format_validator.rb
@@ -2,14 +2,18 @@
 
 class NameFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value.class != String
-      record.errors.add attribute, "must be a String"
-    elsif !Patterns::LETTER_REGEXP.match?(value)
-      record.errors.add attribute, "must include at least one letter"
-    elsif !Patterns::NAME_PATTERN.match?(value)
-      record.errors.add attribute, "can only include letters, numbers, dashes, and underscores"
-    elsif Patterns::SPECIAL_CHAR_PREFIX_REGEXP.match?(value)
-      record.errors.add attribute, "can not begin with a period, dash, or underscore"
-    end
+    return record.errors.add attribute, "must be a String" if value.class != String
+
+    record.errors.add attribute, "must include at least one letter" if requires_letter? && !Patterns::LETTER_REGEXP.match?(value)
+    record.errors.add attribute, "can only include letters, numbers, dashes, and underscores" unless Patterns::NAME_PATTERN.match?(value)
+    record.errors.add attribute, "can not begin with a period, dash, or underscore" if Patterns::SPECIAL_CHAR_PREFIX_REGEXP.match?(value)
+    record.errors.add attribute, "can not end with a period, dash, or underscore" if Patterns::SPECIAL_CHAR_SUFFIX_REGEXP.match?(value)
+    record.errors.add attribute, "can not end with a common file extension" if Patterns::BANNED_EXTENSION_REGEXP.match?(value)
+  end
+
+  private
+
+  def requires_letter?
+    options.fetch(:requires_letter, true)
   end
 end

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -8,10 +8,13 @@ module Patterns
   LAZY_ROUTE_PATTERN    = /#{ALLOWED_CHARACTERS}?/
   NAME_PATTERN          = /\A#{ALLOWED_CHARACTERS}\z/
   LETTER_REGEXP         = /[a-zA-Z]+/
-  SPECIAL_CHAR_PREFIX_REGEXP = /\A[#{Regexp.escape(SPECIAL_CHARACTERS)}]/o
   URL_VALIDATION_REGEXP = %r{\Ahttps?://([^\s:@]+:[^\s:@]*@)?[A-Za-z\d-]+(\.[A-Za-z\d-]+)+\.?(:\d{1,5})?([/?]\S*)?\z}
   VERSION_PATTERN       = /\A#{Gem::Version::VERSION_PATTERN}\z/o
   REQUIREMENT_PATTERN   = Gem::Requirement::PATTERN
   BASE64_SHA256_PATTERN = %r{\A[0-9a-zA-Z_+/-]{43}={0,2}\z}
   HANDLE_PATTERN        = /\A[A-Za-z][A-Za-z_\-0-9]*\z/
+  SPECIAL_CHAR_PREFIX_REGEXP = /\A[#{Regexp.escape(SPECIAL_CHARACTERS)}]/o
+  SPECIAL_CHAR_SUFFIX_REGEXP = /[#{Regexp.escape(SPECIAL_CHARACTERS)}]\z/o
+  BANNED_EXTENSIONS          = %w[gem json html gemspec].freeze
+  BANNED_EXTENSION_REGEXP    = /\.(?:#{Regexp.union(BANNED_EXTENSIONS)})\z/i
 end

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -21,11 +21,15 @@ class RubygemTest < ActiveSupport::TestCase
     should allow_value("factory_girl").for(:name)
     should allow_value("rack-test").for(:name)
     should allow_value("perftools.rb").for(:name)
+    should allow_value("s3-4-2").for(:name)
+    should allow_value("its.a.gem.ok").for(:name)
     should_not allow_value("\342\230\203").for(:name)
     should_not allow_value("2.2").for(:name)
     should_not allow_value(".omghi").for(:name)
     should_not allow_value("-omghi").for(:name)
     should_not allow_value("_omghi").for(:name)
+    should_not allow_value("omg-").for(:name)
+    should_not allow_value("omg.gem").for(:name)
 
     context "with reserved Ruby gem" do
       setup do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -406,16 +406,21 @@ class VersionTest < ActiveSupport::TestCase
     end
     subject { @version }
 
+    should allow_value("1.2.3.pre").for(:number)
     should_not allow_value("#YAML<CEREALIZATION-FAIL>").for(:number)
     should_not allow_value("1.2.3-\"[javalol]\"").for(:number)
     should_not allow_value("0.8.45::Gem::PLATFORM::FAILBOAT").for(:number)
     should_not allow_value("1.2.3\n<bad>").for(:number)
     should_not allow_value("1.2.3-bad").for(:number)
+    should_not allow_value("1.2.3.").for(:number)
+    should_not allow_value("1.2.3.gem").for(:number)
 
     should allow_value("ruby").for(:platform)
     should allow_value("mswin32").for(:platform)
     should allow_value("x86_64-linux").for(:platform)
+    should allow_value("it.is.fine").for(:platform)
     should_not allow_value("Gem::Platform::Ruby").for(:platform)
+    should_not allow_value("ruby.gem").for(:platform)
 
     should "be invalid with platform longer than maximum field length" do
       @version.platform = "r" * (Gemcutter::MAX_FIELD_LENGTH + 1)


### PR DESCRIPTION
This helps insure that all gems can be navigated to via the rails app HTML pages
