### PR TITLE
Disallow TOTP reuse

### DIFF
--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -46,9 +46,10 @@ module UserTotpMethods
     return false if seed.blank?
 
     totp = ROTP::TOTP.new(seed)
-    return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30, after: last_totp_at)
+    totp_at = totp.verify(otp, drift_behind: 30, drift_ahead: 30, after: last_totp_at)
+    return false if totp_at.blank?
 
-    self.last_totp_at = Time.now.utc
+    self.last_totp_at = Time.at(totp_at).utc
     save!(validate: false)
   end
 end

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -46,8 +46,9 @@ module UserTotpMethods
     return false if seed.blank?
 
     totp = ROTP::TOTP.new(seed)
-    return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30)
+    return false unless totp.verify(otp, drift_behind: 30, drift_ahead: 30, after: last_totp_at)
 
+    self.last_totp_at = Time.now.utc
     save!(validate: false)
   end
 end

--- a/db/migrate/20240720201622_add_last_totp_at_to_users.rb
+++ b/db/migrate/20240720201622_add_last_totp_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastTotpAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :last_totp_at, :timestamp, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -519,6 +519,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_182907) do
     t.string "mfa_hashed_recovery_codes", default: [], array: true
     t.boolean "public_email", default: false, null: false
     t.datetime "deleted_at"
+    t.datetime "last_totp_at", precision: nil
     t.index "lower((email)::text) varchar_pattern_ops", name: "index_users_on_lower_email"
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -328,6 +328,8 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
 
           should "not include mfa warnings" do
             @gems.each_value do |gem|
+              travel_to 30.seconds.from_now
+
               @request.env["HTTP_OTP"] = ROTP::TOTP.new(@user.totp_seed).now
               delete :create, params: { gem_name: gem[:name], version: gem[:version] }
 

--- a/test/functional/multifactor_auths_controller_test.rb
+++ b/test/functional/multifactor_auths_controller_test.rb
@@ -672,6 +672,8 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         should "redirect user back to mfa_redirect_uri after successful mfa setup" do
           @redirect_paths.each do |path|
+            travel_to 30.seconds.from_now
+
             session[:mfa_redirect_uri] = path
             put :update, params: { level: "ui_and_api" }
             put :otp_update, params: { otp: ROTP::TOTP.new(@seed).now, level: "ui_and_api" }
@@ -694,6 +696,8 @@ class MultifactorAuthsControllerTest < ActionController::TestCase
 
         should "redirect user back to mfa_redirect_uri after a failed setup + successful setup" do
           @redirect_paths.each do |path|
+            travel_to 30.seconds.from_now
+
             session[:mfa_redirect_uri] = path
             put :update, params: { level: "ui_and_api" }
             put :otp_update, params: { otp: "12345", level: "ui_and_api" }


### PR DESCRIPTION
See https://rubydoc.info/github/mdp/rotp/#preventing-reuse-of-time-based-otps

See https://www.rfc-editor.org/rfc/rfc6238#section-5.2
