### PR TITLE
Add a mailer for one-off messages from admins

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -30,6 +30,17 @@ class Mailer < ApplicationMailer
     end
   end
 
+  def admin_manual(user, subject, body)
+    @user = user
+    @body = body
+    @sub_title = subject
+    mail to: @user.email,
+         subject: subject do |format|
+           format.html
+           format.text
+         end
+  end
+
   def deletion_complete(email)
     mail to: email,
          subject: I18n.t("mailer.deletion_complete.subject")

--- a/app/views/mailer/admin_manual.html.erb
+++ b/app/views/mailer/admin_manual.html.erb
@@ -1,0 +1,20 @@
+<% @title = t(".title") %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        <%= simple_format @body %><br />
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/admin_manual.text.erb
+++ b/app/views/mailer/admin_manual.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @user.handle %>
+
+<%= strip_tags @body %>

--- a/config/initializers/better_html.rb
+++ b/config/initializers/better_html.rb
@@ -1,5 +1,5 @@
 BetterHtml.configure do |config|
   config.template_exclusion_filter = proc { |filename|
-    filename.include?("avo")
+    filename.include?("avo") || filename.include?("/railties-")
   }
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -427,6 +427,8 @@ de:
         gepusht wurde.
     gem_trusted_publisher_added:
       title: VERTRAUENSWÜRDIGER PUBLISHER HINZUGEFÜGT
+    admin_manual:
+      title:
   news:
     show:
       title: Neue Veröffentlichungen — Alle Gems

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,6 +377,8 @@ en:
       gem_html: This webhook was previously called when <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> was pushed.
     gem_trusted_publisher_added:
       title: TRUSTED PUBLISHER ADDED
+    admin_manual:
+      title: MESSAGE FROM RUBYGEMS.ORG ADMINS
   news:
     show:
       title: New Releases — All Gems

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -418,6 +418,8 @@ es:
       gem_html: Este webhook se ejecutaba antes cuando se subía <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>.
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title: Nuevos lanzamientos — Todas las Gemas

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -383,6 +383,8 @@ fr:
       gem_html:
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title: Nouvelles Versions - Toutes les Gems

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -377,6 +377,8 @@ ja:
       gem_html: このwebhookは以前<strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong>がプッシュされたときに呼ばれました。
     gem_trusted_publisher_added:
       title: 信頼できる発行元が追加されました
+    admin_manual:
+      title:
   news:
     show:
       title: 新しいリリース - 全てのgem

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -368,6 +368,8 @@ nl:
       gem_html:
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -380,6 +380,8 @@ pt-BR:
       gem_html:
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title: Novos Releases - Todas as Gems

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -382,6 +382,8 @@ zh-CN:
         被推送时被调用。
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title: 新的发布 — 所有 Gem

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -374,6 +374,8 @@ zh-TW:
         被推送的時候被呼叫。
     gem_trusted_publisher_added:
       title:
+    admin_manual:
+      title:
   news:
     show:
       title: 最新發佈

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -215,4 +215,14 @@ class MailerPreview < ActionMailer::Preview
 
     Mailer.totp_disabled(user_id, Time.now.utc)
   end
+
+  def admin_manual
+    Mailer.admin_manual(User.last, "A subject", <<~TEXT)
+      A body
+      with multiple lines
+      and a link to https://example.com
+      and an emoji 🎉
+      and a p tag <p foo="bar" style="color: yellow;">with html</p> and a <a href="https://example.com">link</a>
+    TEXT
+  end
 end


### PR DESCRIPTION
Useful when we want to reach out to users after taking a manual admin action such as force-resetting passwords

![image](https://github.com/user-attachments/assets/341b8c68-fca6-4c5e-8819-ec445e694bf1)

![image](https://github.com/user-attachments/assets/4bee3f50-f994-454a-8c51-46b4bca1576b)
