### PR TITLE
Resolve recovery code acceptance tests not working

### DIFF
--- a/app/javascript/src/multifactor_auths.js
+++ b/app/javascript/src/multifactor_auths.js
@@ -16,7 +16,7 @@ function confirmNoRecoveryCopy (e, from) {
   }
 }
 
-if($("#recovery-code-list").length){
+if (document.getElementById("recovery-code-list")) {
   new ClipboardJS(".recovery__copy__icon");
 
   $(".recovery__copy__icon").on("click", function(e){

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -145,18 +145,17 @@ class SettingsTest < ApplicationSystemTestCase
     click_button "Enable"
 
     check "ack"
-    confirm_text = dismiss_confirm do
-      visit root_path
+    dismiss_confirm("Leave without copying recovery codes?") do
+      click_on "Continue"
     end
 
-    assert_equal("", confirm_text)
     assert_equal recovery_multifactor_auth_path, page.current_path
 
-    accept_confirm do
-      visit root_path
+    accept_confirm("Leave without copying recovery codes?") do
+      click_on "Continue"
     end
 
-    assert_equal root_path, page.current_path
+    assert_equal edit_settings_path, page.current_path
   end
 
   test "shows 'ui only' if user's level is ui_only" do


### PR DESCRIPTION
This Pull Request resolves a couple breaking tests in the Recovery Codes section that was causing our CI to stop passing. 

The issue seems to be in 2 parts:
* The first issue was that the `$("#recovery-code-list").length` no longer returns a valid object for the If condition to ever be valid.
* The second was that changing the current path was no longer triggering the confirm dialog in our tests