### PR TITLE
Rename #search_field to avoid Rails name conflict

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,7 +75,7 @@ module ApplicationHelper
     msg
   end
 
-  def search_field(home: false)
+  def rubygem_search_field(home: false)
     data = {
       autocomplete_target: "query",
       action: %w[

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,7 +1,7 @@
 <% home = current_page?(root_path) || current_page?(advanced_search_path) %>
 <div class="<%= home ? "home__search-wrap" : "header__search-wrap" %>" role="search">
   <%= form_tag search_path, method: :get, data: { controller: "autocomplete", autocomplete_selected_class: "selected", } do %>
-    <%= search_field(home: home) %>
+    <%= rubygem_search_field(home: home) %>
 
     <ul class="suggest-list" role="listbox" data-autocomplete-target="suggestions"></ul>
 


### PR DESCRIPTION
# What's this about?

Currently, a conflict in the name of a helper method is present which is causing the Rails index page, `/rails/info/routes`  to raise an error.

<img width="1624" alt="Screenshot 2024-08-14 at 3 33 31 PM" src="https://github.com/user-attachments/assets/e7d7ccd6-3674-4e54-8312-273c16b81e5e">

I've renamed the conflicting helper method to resolve this error.