### PR TITLE
Ensure AWS secrets never get printed out

### DIFF
--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -66,6 +66,7 @@ fi
 pusher_arn="arn:aws:iam::048268392960:role/rubygems-ecr-pusher"
 caller_arn="$(aws sts get-caller-identity --output text --query Arn || true)"
 
+set +x
 [[ "$caller_arn" == "$pusher_arn" ]] ||
   [[ "$caller_arn" == "arn:aws:sts::048268392960:assumed-role/rubygems-ecr-pusher/GitHubActions" ]] ||
   export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" \
@@ -75,6 +76,7 @@ caller_arn="$(aws sts get-caller-identity --output text --query Arn || true)"
       --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
       --output text)) ||
   true
+set -x
 
 if [[ -z "${AWS_SESSION_TOKEN}" ]]; then
   echo "Skipping push since no AWS session token was found"


### PR DESCRIPTION
This is not happening on CI anyways, but be robust against future changes
