### PR TITLE
Only expire unexpired API keys

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -40,7 +40,7 @@ class ApiKey < ApplicationRecord
 
   def self.expire_all!
     transaction do
-      find_each.all?(&:expire!)
+      unexpired.find_each.all?(&:expire!)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -310,7 +310,7 @@ uniqueness: { case_sensitive: false }
   end
 
   def expire_all_api_keys
-    api_keys.unexpired.expire_all!
+    api_keys.expire_all!
   end
 
   def destroy_associations_for_discard


### PR DESCRIPTION
Avoids looping over already expired keys
