### PR TITLE
Move to new Rails enum syntax.

### DIFF
--- a/app/models/ownership_call.rb
+++ b/app/models/ownership_call.rb
@@ -10,7 +10,7 @@ class OwnershipCall < ApplicationRecord
   delegate :name, to: :rubygem, prefix: true
   delegate :display_handle, to: :user, prefix: true
 
-  enum status: { opened: true, closed: false }
+  enum :status, { opened: true, closed: false }
 
   def close!
     ownership_requests.each(&:close!)

--- a/app/models/ownership_request.rb
+++ b/app/models/ownership_request.rb
@@ -12,7 +12,7 @@ class OwnershipRequest < ApplicationRecord
   delegate :name, to: :user, prefix: true
   delegate :name, to: :rubygem, prefix: true
 
-  enum status: { opened: 0, approved: 1, closed: 2 }
+  enum :status, { opened: 0, approved: 1, closed: 2 }
 
   def approve!(approver)
     return unless Pundit.policy!(approver, self).approve?


### PR DESCRIPTION
:information_source: old syntax is deprecated in Rails 7.2 and will be removed in Rails 8.0.