### PR TITLE
Fix false passing stats test.

### DIFF
--- a/test/functional/stats_controller_test.rb
+++ b/test/functional/stats_controller_test.rb
@@ -58,12 +58,13 @@ class StatsControllerTest < ActionController::TestCase
     end
 
     should "not have width greater than 100%" do
-      assert_select ".stats__graph__gem__meter" do |element|
-        element.pluck(:style).each do |width|
-          width =~ /width: (\d+[,.]\d+)%/
+      assert page.has_selector?(".stats__graph__gem__meter")
 
-          assert_operator Regexp.last_match(1).to_f, :<=, 100, "#{Regexp.last_match(1)} is greater than 100"
-        end
+      page.find_all(".stats__graph__gem__meter").each do |element|
+        assert element["data-bar-width"]
+        width = element["data-bar-width"].to_f
+
+        assert_operator width, :<=, 100, "#{width} is greater than 100"
       end
     end
   end


### PR DESCRIPTION
:information_source: located by Rails 7.2 warnings. Currently this tests is passing, even testing nothing. Related HTML attribute logic got changed at https://github.com/rubygems/rubygems.org/commit/4b98369d81b150d2dd1543d6282f87760b3177e2#diff-58ace09d8e2535d5b7a94dbdb4df1be0eafa84c833fb928dad808b2210b700db, but test is not failing, even testing old behaviour.