### PR TITLE
Missing assertions

### DIFF
--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -223,7 +223,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         end
 
         should "show error to user" do
-          page.assert_text "Show dashboard scope must be enabled exclusively"
+          assert page.has_content? "Show dashboard scope must be enabled exclusively"
         end
 
         should "not update scope of test key" do

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -223,7 +223,7 @@ class ApiKeysControllerTest < ActionController::TestCase
         end
 
         should "show error to user" do
-          assert page.has_content? "Show dashboard scope must be enabled exclusively"
+          assert_text "Show dashboard scope must be enabled exclusively"
         end
 
         should "not update scope of test key" do

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -58,8 +58,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          assert page.has_text?("Reset password")
-          assert page.has_selector?("input[type=password][autocomplete=new-password]")
+          assert_text "Reset password"
+          assert_selector "input[type=password][autocomplete=new-password]"
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -85,8 +85,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          assert page.has_text?("Reset password")
-          assert page.has_selector?("input[type=password][autocomplete=new-password]")
+          assert_text "Reset password"
+          assert_selector "input[type=password][autocomplete=new-password]"
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -113,8 +113,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          assert page.has_text?("Reset password")
-          assert page.has_selector?("input[type=password][autocomplete=new-password]")
+          assert_text "Reset password"
+          assert_selector "input[type=password][autocomplete=new-password]"
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -250,7 +250,7 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          assert page.has_text?("Reset password")
+          assert_text "Reset password"
         end
 
         should "clear mfa_expires_at" do
@@ -334,7 +334,7 @@ class PasswordsControllerTest < ActionController::TestCase
       end
 
       should "display edit form" do
-        assert page.has_text?("Reset password")
+        assert_text "Reset password"
       end
 
       should "clear mfa_expires_at" do

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -58,8 +58,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          page.assert_text("Reset password")
-          page.assert_selector("input[type=password][autocomplete=new-password]")
+          assert page.has_text?("Reset password")
+          assert page.has_selector?("input[type=password][autocomplete=new-password]")
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -85,8 +85,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          page.assert_text("Reset password")
-          page.assert_selector("input[type=password][autocomplete=new-password]")
+          assert page.has_text?("Reset password")
+          assert page.has_selector?("input[type=password][autocomplete=new-password]")
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -113,8 +113,8 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          page.assert_text("Reset password")
-          page.assert_selector("input[type=password][autocomplete=new-password]")
+          assert page.has_text?("Reset password")
+          assert page.has_selector?("input[type=password][autocomplete=new-password]")
         end
 
         should "instruct the browser not to send referrer that contains the token" do
@@ -250,7 +250,7 @@ class PasswordsControllerTest < ActionController::TestCase
         end
 
         should "display edit form" do
-          page.assert_text("Reset password")
+          assert page.has_text?("Reset password")
         end
 
         should "clear mfa_expires_at" do
@@ -334,7 +334,7 @@ class PasswordsControllerTest < ActionController::TestCase
       end
 
       should "display edit form" do
-        page.assert_text("Reset password")
+        assert page.has_text?("Reset password")
       end
 
       should "clear mfa_expires_at" do

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -106,8 +106,8 @@ class ProfilesControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "render user delete page" do
-        assert page.has_text? "Delete profile"
-        assert page.has_selector? "input[type=password][autocomplete=current-password]"
+        assert_text "Delete profile"
+        assert_selector "input[type=password][autocomplete=current-password]"
       end
     end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -106,8 +106,8 @@ class ProfilesControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "render user delete page" do
-        page.assert_text "Delete profile"
-        page.assert_selector "input[type=password][autocomplete=current-password]"
+        assert page.has_text? "Delete profile"
+        assert page.has_selector? "input[type=password][autocomplete=current-password]"
       end
     end
 

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -86,9 +86,9 @@ class RubygemsControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "include the security events" do
-        page.assert_text "Owner Added"
-        page.assert_text "Owner Confirmed"
-        page.assert_text "Owner Removed"
+        assert page.has_text? "Owner Added"
+        assert page.has_text? "Owner Confirmed"
+        assert page.has_text? "Owner Removed"
       end
     end
   end

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -86,9 +86,9 @@ class RubygemsControllerTest < ActionController::TestCase
       should respond_with :success
 
       should "include the security events" do
-        assert page.has_text? "Owner Added"
-        assert page.has_text? "Owner Confirmed"
-        assert page.has_text? "Owner Removed"
+        assert_text "Owner Added"
+        assert_text "Owner Confirmed"
+        assert_text "Owner Removed"
       end
     end
   end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -70,19 +70,19 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the results" do
-      assert page.has_text?(@sinatra.name)
-      assert page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
+      assert_text @sinatra.name
+      assert_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
     end
     should "not see brando on the page in the results" do
-      refute page.has_text?(@brando.name)
-      refute page.has_selector?("a[href='#{rubygem_path(@brando.slug)}']")
+      refute_text @brando.name
+      refute_selector "a[href='#{rubygem_path(@brando.slug)}']"
     end
     should "display pagination summary" do
       assert page.has_text?("all 2 gems")
     end
     should "not see suggestions" do
-      refute page.has_text?("Did you mean")
-      refute page.has_selector?(".search-suggestions")
+      refute_text "Did you mean"
+      refute_selector ".search-suggestions"
     end
   end
 
@@ -112,19 +112,19 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the suggestions" do
-      assert page.has_text?("Did you mean")
-      assert page.find(".search__suggestions").has_content?(@sinatra.name)
-      assert page.has_selector?("a[href='#{search_path(query: @sinatra.name)}']")
+      assert_text "Did you mean"
+      assert_text @sinatra.name, page.find(".search__suggestions")
+      assert_selector "a[href='#{search_path(query: @sinatra.name)}']"
     end
     should "not see sinatra on the page in the results" do
-      refute page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
+      refute_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
     end
     should "not see brando on the page in the results" do
-      refute page.has_text?(@brando.name)
-      refute page.has_selector?("a[href='#{rubygem_path(@brando.slug)}']")
+      refute_text @brando.name
+      refute_selector "a[href='#{rubygem_path(@brando.slug)}']"
     end
     should "not see filters" do
-      refute page.has_text?("Filter")
+      refute_text "Filter"
     end
   end
 
@@ -141,10 +141,10 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "see sinatra_redux on the page in the results" do
-      assert page.has_selector?("a[href='#{rubygem_path(@sinatra_redux.slug)}']")
+      assert_selector "a[href='#{rubygem_path(@sinatra_redux.slug)}']"
     end
     should "not see sinatra on the page in the results" do
-      refute page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
+      refute_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
     end
   end
 

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -70,19 +70,19 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the results" do
-      page.assert_text(@sinatra.name)
-      page.assert_selector("a[href='#{rubygem_path(@sinatra.slug)}']")
+      assert page.has_text?(@sinatra.name)
+      assert page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
     end
     should "not see brando on the page in the results" do
-      page.assert_no_text(@brando.name)
-      page.assert_no_selector("a[href='#{rubygem_path(@brando.slug)}']")
+      refute page.has_text?(@brando.name)
+      refute page.has_selector?("a[href='#{rubygem_path(@brando.slug)}']")
     end
     should "display pagination summary" do
-      page.assert_text("all 2 gems")
+      assert page.has_text?("all 2 gems")
     end
     should "not see suggestions" do
-      page.assert_no_text("Did you mean")
-      page.assert_no_selector(".search-suggestions")
+      refute page.has_text?("Did you mean")
+      refute page.has_selector?(".search-suggestions")
     end
   end
 
@@ -112,19 +112,19 @@ class SearchesControllerTest < ActionController::TestCase
 
     should respond_with :success
     should "see sinatra on the page in the suggestions" do
-      page.assert_text("Did you mean")
+      assert page.has_text?("Did you mean")
       assert page.find(".search__suggestions").has_content?(@sinatra.name)
       assert page.has_selector?("a[href='#{search_path(query: @sinatra.name)}']")
     end
     should "not see sinatra on the page in the results" do
-      page.assert_no_selector("a[href='#{rubygem_path(@sinatra.slug)}']")
+      refute page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
     end
     should "not see brando on the page in the results" do
-      page.assert_no_text(@brando.name)
-      page.assert_no_selector("a[href='#{rubygem_path(@brando.slug)}']")
+      refute page.has_text?(@brando.name)
+      refute page.has_selector?("a[href='#{rubygem_path(@brando.slug)}']")
     end
     should "not see filters" do
-      page.assert_no_text("Filter")
+      refute page.has_text?("Filter")
     end
   end
 
@@ -141,10 +141,10 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "see sinatra_redux on the page in the results" do
-      page.assert_selector("a[href='#{rubygem_path(@sinatra_redux.slug)}']")
+      assert page.has_selector?("a[href='#{rubygem_path(@sinatra_redux.slug)}']")
     end
     should "not see sinatra on the page in the results" do
-      page.assert_no_selector("a[href='#{rubygem_path(@sinatra.slug)}']")
+      refute page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
     end
   end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -474,8 +474,8 @@ class SessionsControllerTest < ActionController::TestCase
     end
 
     should "render sign-in form" do
-      page.assert_text("Sign in")
-      page.assert_selector("input[type=password][autocomplete=current-password]")
+      assert page.has_text?("Sign in")
+      assert page.has_selector?("input[type=password][autocomplete=current-password]")
     end
   end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -474,8 +474,8 @@ class SessionsControllerTest < ActionController::TestCase
     end
 
     should "render sign-in form" do
-      assert page.has_text?("Sign in")
-      assert page.has_selector?("input[type=password][autocomplete=current-password]")
+      assert_text "Sign in"
+      assert_selector "input[type=password][autocomplete=current-password]"
     end
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -11,8 +11,8 @@ class UsersControllerTest < ActionController::TestCase
     should render_template(:new)
 
     should "render the new user form" do
-      page.assert_text "Sign up"
-      page.assert_selector "input[type=password][autocomplete=new-password]"
+      assert page.has_text? "Sign up"
+      assert page.has_selector? "input[type=password][autocomplete=new-password]"
     end
 
     context "when logged in" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -11,8 +11,8 @@ class UsersControllerTest < ActionController::TestCase
     should render_template(:new)
 
     should "render the new user form" do
-      assert page.has_text? "Sign up"
-      assert page.has_selector? "input[type=password][autocomplete=new-password]"
+      assert_text "Sign up"
+      assert_selector "input[type=password][autocomplete=new-password]"
     end
 
     context "when logged in" do

--- a/test/integration/api/v2/version_information_test.rb
+++ b/test/integration/api/v2/version_information_test.rb
@@ -29,9 +29,10 @@ class VersionInformationTest < ActionDispatch::IntegrationTest
   test "has required fields" do
     request_endpoint(@rubygem, "2.0.0")
     json_response = JSON.load(@response.body)
-    json_response["sha"]
-    json_response["platform"]
-    json_response["ruby_version"]
+
+    assert json_response.key?("sha")
+    assert json_response.key?("platform")
+    assert json_response.key?("ruby_version")
   end
 
   test "version does not exist" do

--- a/test/integration/null_char_param_test.rb
+++ b/test/integration/null_char_param_test.rb
@@ -15,9 +15,13 @@ class NullCharParamTest < ActionDispatch::IntegrationTest
 
   test "cookie with null character responds with bad request for sign in" do
     get "/users/new", headers: { "HTTP_COOKIE" => "remember_token=php://input%00.;rubygems_session=php://input%00." }
+
+    assert_response :bad_request
   end
 
   test "cookie with null character responds with bad request for releases page" do
     get "/releases/popular", headers: { "HTTP_COOKIE" => "rubygems_session=php://input%00." }
+
+    assert_response :bad_request
   end
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -297,8 +297,8 @@ class SignInTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
-    page.assert_text "Sign in"
-    page.assert_text "Bad email or password."
+    assert page.has_content? "Sign in"
+    assert page.has_content? "Bad email or password."
   end
 
   teardown do

--- a/test/models/gem_name_reservation_test.rb
+++ b/test/models/gem_name_reservation_test.rb
@@ -19,16 +19,18 @@ class GemNameReservationTest < ActiveSupport::TestCase
   context "#reserved?" do
     should "recognize reserved gem name" do
       create(:gem_name_reservation, name: "reserved-gem-name")
-      GemNameReservation.reserved?("reserved-gem-name")
+
+      assert GemNameReservation.reserved?("reserved-gem-name")
     end
 
     should "recognize reserved case insensitive gem name" do
       create(:gem_name_reservation, name: "reserved-gem-name")
-      GemNameReservation.reserved?("RESERVED-gem-name")
+
+      assert GemNameReservation.reserved?("RESERVED-gem-name")
     end
 
     should "recognize not reserved gem name" do
-      GemNameReservation.reserved?("totally-random-gem-name")
+      refute GemNameReservation.reserved?("totally-random-gem-name")
     end
   end
 end

--- a/test/models/log_ticket_test.rb
+++ b/test/models/log_ticket_test.rb
@@ -12,8 +12,10 @@ class LogTicketTest < ActiveSupport::TestCase
   end
 
   should "allow different keys for the same directory" do
-    LogTicket.create!(directory: "test", key: "bar")
-    LogTicket.create!(directory: "test", key: "baz")
+    assert_nothing_raised do
+      LogTicket.create!(directory: "test", key: "bar")
+      LogTicket.create!(directory: "test", key: "baz")
+    end
   end
 
   context "#pop" do

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -48,9 +48,9 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:verify_mfa_requirement).returns true
         @cutter.stubs(:verify_gem_scope).returns true
         @cutter.stubs(:validate).returns true
-        @cutter.stubs(:save)
+        @cutter.stubs(:save).returns true
 
-        @cutter.process
+        assert @cutter.process
       end
 
       should "not attempt to find rubygem if spec can't be pulled" do

--- a/test/models/rubygem_contents_entry_test.rb
+++ b/test/models/rubygem_contents_entry_test.rb
@@ -226,7 +226,7 @@ class RubygemContentsEntryTest < ActiveSupport::TestCase
     end
 
     should "not evaluate the reader when setting the body with a block" do
-      create_persisted_entry(file_entry.metadata) { raise }
+      assert_nothing_raised { create_persisted_entry(file_entry.metadata) { raise } }
     end
   end
 

--- a/test/models/version_manifest_test.rb
+++ b/test/models/version_manifest_test.rb
@@ -287,9 +287,9 @@ class VersionsManifestTest < ActiveSupport::TestCase
     end
 
     should "gracefully no-op when there's nothing to delete" do
-      @manifest.yank
+      assert @manifest.yank
 
-      @manifest.yank
+      assert @manifest.yank
     end
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -637,29 +637,31 @@ class VersionTest < ActiveSupport::TestCase
 
   context "with a very long authors string." do
     should "create without error" do
-      create(:version,
-        authors: [
-          "Fbdoorman: David Pelaez",
-          "MiniFB:Appoxy",
-          "Dan Croak",
-          "Mike Burns",
-          "Jason Morrison",
-          "Joe Ferris",
-          "Eugene Bolshakov",
-          "Nick Quaranto",
-          "Josh Nichols",
-          "Mike Breen",
-          "Marcel G\303\266rner",
-          "Bence Nagy",
-          "Ben Mabey",
-          "Eloy Duran",
-          "Tim Pope",
-          "Mihai Anca",
-          "Mark Cornick",
-          "Shay Arnett",
-          "Jon Yurek",
-          "Chad Pytel"
-        ])
+      assert_nothing_raised do
+        create(:version,
+          authors: [
+            "Fbdoorman: David Pelaez",
+            "MiniFB:Appoxy",
+            "Dan Croak",
+            "Mike Burns",
+            "Jason Morrison",
+            "Joe Ferris",
+            "Eugene Bolshakov",
+            "Nick Quaranto",
+            "Josh Nichols",
+            "Mike Breen",
+            "Marcel G\303\266rner",
+            "Bence Nagy",
+            "Ben Mabey",
+            "Eloy Duran",
+            "Tim Pope",
+            "Mihai Anca",
+            "Mark Cornick",
+            "Shay Arnett",
+            "Jon Yurek",
+            "Chad Pytel"
+          ])
+      end
     end
   end
 

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -276,8 +276,8 @@ class OIDCTest < ApplicationSystemTestCase
 
     click_button "Delete"
 
-    page.assert_text "Trusted Publisher deleted"
-    page.assert_text "NO RUBYGEM TRUSTED PUBLISHERS FOUND"
+    assert_content "Trusted Publisher deleted"
+    assert_content "NO RUBYGEM TRUSTED PUBLISHERS FOUND"
   end
 
   test "creating pending trusted publishers" do
@@ -349,7 +349,7 @@ class OIDCTest < ApplicationSystemTestCase
 
     click_button "Delete"
 
-    page.assert_text "Pending Trusted Publisher deleted"
-    page.assert_text "NO PENDING TRUSTED PUBLISHERS FOUND"
+    assert_content "Pending Trusted Publisher deleted"
+    assert_content "NO PENDING TRUSTED PUBLISHERS FOUND"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -219,6 +219,22 @@ class ActionController::TestCase
     session[:verification] = 10.minutes.from_now
     session[:verified_user] = user.id
   end
+
+  def assert_text(text, context = page)
+    assert context.has_content?(text), "page is missing content #{text}"
+  end
+
+  def refute_text(text)
+    refute page.has_content?(text), "page has unexpected content #{text}"
+  end
+
+  def assert_selector(selector)
+    assert page.has_selector?(selector), "page is missing selector #{selector}"
+  end
+
+  def refute_selector(selector)
+    refute page.has_selector?(selector), "page has unexpected selector #{selector}"
+  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/unit/factories_test.rb
+++ b/test/unit/factories_test.rb
@@ -2,6 +2,6 @@ require "test_helper"
 
 class FactoriesTest < ActiveSupport::TestCase
   test "can create factories including traits" do
-    FactoryBot.lint(traits: true)
+    assert_nothing_raised { FactoryBot.lint(traits: true) }
   end
 end

--- a/test/unit/fastly_test.rb
+++ b/test/unit/fastly_test.rb
@@ -21,7 +21,8 @@ class FastlyTest < ActiveSupport::TestCase
       stub_request(:purge, "https://domain2.example.com/some-url")
         .with(headers: { "Fastly-Key" => "api-key" })
         .to_return(status: 200, body: "{}")
-      Fastly.purge(path: "some-url")
+
+      assert Fastly.purge(path: "some-url")
     end
 
     should "soft purge for each domain" do
@@ -31,7 +32,8 @@ class FastlyTest < ActiveSupport::TestCase
       stub_request(:purge, "https://domain2.example.com/some-url")
         .with(headers: { "Fastly-Key" => "api-key", "Fastly-Soft-Purge" => "1" })
         .to_return(status: 200, body: "{}")
-      Fastly.purge(path: "some-url", soft: true)
+
+      assert Fastly.purge(path: "some-url", soft: true)
     end
   end
 
@@ -40,13 +42,15 @@ class FastlyTest < ActiveSupport::TestCase
       stub_request(:post, "https://api.fastly.com/service/service-id/purge/some-key")
         .with(headers: { "Fastly-Key" => "api-key" })
         .to_return(status: 200, body: "{}")
-      Fastly.purge_key("some-key")
+
+      assert Fastly.purge_key("some-key")
     end
     should "send a post request for soft purges" do
       stub_request(:post, "https://api.fastly.com/service/service-id/purge/some-key")
         .with(headers: { "Fastly-Key" => "api-key", "Fastly-Soft-Purge" => "1" })
         .to_return(status: 200, body: "{}")
-      Fastly.purge_key("some-key", soft: true)
+
+      assert Fastly.purge_key("some-key", soft: true)
     end
   end
 end

--- a/test/views/events/table_component_test.rb
+++ b/test/views/events/table_component_test.rb
@@ -1,9 +1,7 @@
 require "test_helper"
 require "phlex/testing/rails/view_helper"
 
-class Events::TableComponentTest < ActiveSupport::TestCase
-  include Phlex::Testing::Rails::ViewHelper
-
+class Events::TableComponentTest < ComponentTest
   class TestEvent
     include ActiveModel::Model
     include ActiveModel::Attributes
@@ -47,14 +45,14 @@ class Events::TableComponentTest < ActiveSupport::TestCase
   test "renders an empty view" do
     page = render table
 
-    page.assert_text "No entries found"
+    assert_text page, "No entries found"
   end
 
   test "renders an unknown event" do
     page = render table(page([TestEvent.new(tag: "unknown:other")]))
 
-    page.assert_text "Displaying 1 entry"
-    page.assert_text "unknown:other"
+    assert_text page, "Displaying 1 entry"
+    assert_text page, "unknown:other"
   end
 
   test "renders redacted additional info when user_id does not match" do
@@ -68,11 +66,11 @@ class Events::TableComponentTest < ActiveSupport::TestCase
                                                  })
                              ]), stubs: { current_user: user })
 
-    page.assert_text "Displaying 1 entry"
-    page.assert_text "user2:created"
-    page.assert_text "Redacted"
-    page.assert_no_text "Buffalo, NY, US"
-    page.assert_no_text "installer (implementation on system)"
+    assert_text page, "Displaying 1 entry"
+    assert_text page, "user2:created"
+    assert_text page, "Redacted"
+    assert_no_text page, "Buffalo, NY, US"
+    assert_no_text page, "installer (implementation on system)"
   end
 
   test "renders additional info when user_id matches" do
@@ -86,9 +84,9 @@ class Events::TableComponentTest < ActiveSupport::TestCase
                                                  })
                              ]), stubs: { current_user: user })
 
-    page.assert_text "Displaying 1 entry"
-    page.assert_text "user:created"
-    page.assert_text "Buffalo, NY, US"
-    page.assert_text "installer (implementation on system)"
+    assert_text page, "Displaying 1 entry"
+    assert_text page, "user:created"
+    assert_text page, "Buffalo, NY, US"
+    assert_text page, "installer (implementation on system)"
   end
 end


### PR DESCRIPTION
One step closer to warning-less Rails 7.2. I was pretty skeptic to this new feature first, but it helped to reveal few broken places doing no assertions and testing nothing. Also it reveals quite strange mix of some test responsibilities like functional tests testing template outputs using Capybara (that's what system/integration test should do IMHO) and vice versa. I did the smallest change for now to eliminate all warnings.