### PR TITLE
Ensure SMTP connections use TLS

### DIFF
--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -6,7 +6,7 @@ unless Rails.env.local?
     password:             ENV['SENDGRID_PASSWORD'],
     domain:               'mailer.rubygems.org',
     authentication:       :plain,
-    enable_starttls_auto: true
+    enable_starttls:      true
   }
   ActionMailer::Base.delivery_method = :smtp
 end


### PR DESCRIPTION
enable_starttls: true will fail if StartTLS fails, where enable_starttls_auto would fallback to plain text

Fixes TOB-RGM-5
