### PR TITLE
Unblock User Avo Action

### DIFF
--- a/app/avo/actions/unblock_user.rb
+++ b/app/avo/actions/unblock_user.rb
@@ -1,7 +1,7 @@
 class UnblockUser < BaseAction
-  self.name = "Block User"
+  self.name = "Unblock User"
   self.visible = lambda {
-    current_user.team_member?("rubygems-org") && view == :show
+    current_user.team_member?("rubygems-org") && view == :show && record.blocked?
   }
 
   self.message = lambda {

--- a/app/avo/actions/unblock_user.rb
+++ b/app/avo/actions/unblock_user.rb
@@ -1,0 +1,18 @@
+class UnblockUser < BaseAction
+  self.name = "Block User"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+
+  self.message = lambda {
+    "Are you sure you would like to unblock user #{record.handle} with #{record.blocked_email}?"
+  }
+
+  self.confirm_button_label = "Unblock User"
+
+  class ActionHandler < ActionHandler
+    def handle_model(user)
+      user.unblock!
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -265,6 +265,8 @@ uniqueness: { case_sensitive: false }
   end
 
   def unblock!
+    raise ArgumentError, "User is not blocked" unless blocked?
+
     update!(
       email: blocked_email,
       blocked_email: nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,6 +264,17 @@ uniqueness: { case_sensitive: false }
     end
   end
 
+  def unblock!
+    update!(
+      email: blocked_email,
+      blocked_email: nil
+    )
+  end
+
+  def blocked?
+    blocked_email.present?
+  end
+
   def owns_gem?(rubygem)
     rubygem.owned_by?(self)
   end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -47,5 +47,10 @@ FactoryBot.define do
       mfa_level { User.mfa_levels["ui_and_gem_signin"] }
       mfa_recovery_codes { %w[aaa bbb ccc] }
     end
+
+    trait :blocked do
+      email { "security+locked-#{SecureRandom.hex(4)}@rubygems.org" }
+      blocked_email { "test@example.com" }
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -924,6 +924,37 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "#unblock!" do
+    setup do
+      @user = create(:user, :blocked)
+      @original_email = @user.blocked_email
+      @user.unblock!
+    end
+
+    should "restore the email field" do
+      assert_equal @original_email, @user.email
+    end
+
+    should "make the blocked email field nil" do
+      assert_nil @user.blocked_email
+    end
+  end
+
+  context "#blocked?" do
+    setup do
+      @blocked_user = build(:user, :blocked)
+      @unblocked_user = build(:user)
+    end
+
+    should "be true when the user has a blocked email" do
+      assert_predicate @blocked_user, :blocked?
+    end
+
+    should "be false when the user does not have a blocked email" do
+      refute_predicate @unblocked_user, :blocked?
+    end
+  end
+
   context ".normalize_email" do
     should "return the normalized email" do
       assert_equal "UsEr@example.COM", User.normalize_email(:"UsEr@\texample . COM")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -938,6 +938,18 @@ class UserTest < ActiveSupport::TestCase
     should "make the blocked email field nil" do
       assert_nil @user.blocked_email
     end
+
+    context "when the user is not currently blocked" do
+      setup do
+        @user = create(:user)
+      end
+
+      should "raise an error" do
+        assert_raises(ArgumentError) do
+          @user.unblock!
+        end
+      end
+    end
   end
 
   context "#blocked?" do

--- a/test/unit/avo/actions/unblock_user_test.rb
+++ b/test/unit/avo/actions/unblock_user_test.rb
@@ -3,11 +3,12 @@ require "test_helper"
 class UnblockUserTest < ActiveSupport::TestCase
   setup do
     @user = create(:user, :blocked)
-    @current_user = create(:admin_github_user)
+    @current_user = create(:admin_github_user, :is_admin)
     @resource = UserResource.new.hydrate(model: @user)
+    @action = UnblockUser.new(model: @user, resource: @resource, user: @current_user, view: :edit)
   end
 
-  test "unblock user" do
+  should "unblock user" do
     args = {
       current_user: @current_user,
       resource: @resource,
@@ -17,9 +18,35 @@ class UnblockUserTest < ActiveSupport::TestCase
       }
     }
 
-    action = UnblockUser.new(model: @user, resource: @resource, user: @current_user, view: :edit)
-    action.handle(**args)
+    @action.handle(**args)
 
     refute_predicate @user.reload, :blocked?
+  end
+
+  # Avo does not have an easy and direct way to test the message & visible class attributes.
+  # calling the lambda directly will raise an error because Avo requires the entire app to be loaded.
+
+  should "ask for confirmation" do
+    action_mock = Data.define(:record).new(record: @user)
+
+    assert_not_nil action_mock.instance_exec(&UnblockUser.message)
+  end
+
+  should "be visible" do
+    action_mock = Data.define(:current_user, :view, :record).new(current_user: @current_user, view: :show, record: @user)
+
+    assert action_mock.instance_exec(&UnblockUser.visible)
+  end
+
+  context "when the user is not blocked" do
+    setup do
+      @user = create(:user)
+    end
+
+    should "not be visible" do
+      action_mock = Data.define(:current_user, :view, :record).new(current_user: @current_user, view: :show, record: @user)
+
+      refute action_mock.instance_exec(&UnblockUser.visible)
+    end
   end
 end

--- a/test/unit/avo/actions/unblock_user_test.rb
+++ b/test/unit/avo/actions/unblock_user_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class UnblockUserTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user, :blocked)
+    @current_user = create(:admin_github_user)
+    @resource = UserResource.new.hydrate(model: @user)
+  end
+
+  test "unblock user" do
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      models: [@user],
+      fields: {
+        comment: "Unblocking incorrectly flagged user"
+      }
+    }
+
+    action = UnblockUser.new(model: @user, resource: @resource, user: @current_user, view: :edit)
+    action.handle(**args)
+
+    refute_predicate @user.reload, :blocked?
+  end
+end


### PR DESCRIPTION
# What's this about?

We often get support tickets from users who use an expired domain for the email, which results In their account getting blocked to prevent takeover attacks. 

Getting these users unblocked is a bit of a pain because we have to manually open a rails console and set the `blocked_email` and `email` fields to their correct values for the User to become active again.

This Pull Request adds a new Avo action, called `UnblockUser` which performs the described steps above to unblock a user.