### PR TITLE
Disable Honeybadger & Datadog in local environments

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,5 +1,7 @@
 require "app_revision"
 
+return if Rails.env.local? # Don't enable Honeybadger in local Development & Test environments
+
 Datadog.configure do |c|
   # unified service tagging
 
@@ -9,7 +11,7 @@ Datadog.configure do |c|
 
   # Enabling datadog functionality
 
-  enabled = !Rails.env.local? && ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
+  enabled = ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
   c.runtime_metrics.enabled = enabled
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,3 +1,5 @@
+return if Rails.env.local? # Don't enable Honeybadger in local Development & Test environments
+
 Rails.logger.silence(:error) do
   require "honeybadger"
 
@@ -7,10 +9,5 @@ Rails.logger.silence(:error) do
     end
 
     config.logger = SemanticLogger[Honeybadger]
-
-    if Rails.env.development?
-      config.report_data = false
-      config.logger.level = :error
-    end
   end
 end


### PR DESCRIPTION
# What's this about?

We use Honeybadger and Datadog to help maintain our service in production. Currently, these gems are enabled in production even though local development environment's are not setup/authenticated to these services.

# What does this Pull Request change?

This Pull Request disables Honeybadger and Datadog (and more?) from being initialized in local environments