### PR TITLE
Use long for downloads count in OpenSearch index.

### DIFF
--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -88,12 +88,16 @@ module RubygemSearchable
       {
         suggest: {
           input: name,
-          weight: downloads,
+          weight: suggest_weight_scale(downloads),
           contexts: {
             yanked: versions.none?(&:indexed?)
           }
         }
       }
+    end
+
+    def suggest_weight_scale(downloads)
+      Math.log10(downloads + 1).to_i
     end
   end
 end

--- a/app/models/concerns/rubygem_searchable.rb
+++ b/app/models/concerns/rubygem_searchable.rb
@@ -24,7 +24,7 @@ module RubygemSearchable
           description: { type: "text", analyzer: "english", fields: { raw: { analyzer: "simple", type: "text" } } },
           suggest: { type: "completion", contexts: { name: "yanked", type: "category" } },
           yanked: { type: "boolean" },
-          downloads: { type: "integer" },
+          downloads: { type: "long" },
           updated: { type: "date" }
         }
       }


### PR DESCRIPTION
fixes failing indexing of bundler

```
Searchkick::ImportError: {"type"=>"mapper_parsing_exception", "reason"=>"failed to parse field [downloads] of type [integer] in document with id 'xyz'. Preview of field's value: '2300514366'", "caused_by"=>{"type"=>"input_coercion_exception", "reason"=>"Numeric value (2300514366) out of range of int (-2147483648 - 2147483647)\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 41]"}} on item with id 'xyz'
```

Don't merge. Index needs to be migrated and rebuilt first.