### PR TITLE
Add new RSTUF state `PRE_RUN` to check job

### DIFF
--- a/app/jobs/rstuf/check_job.rb
+++ b/app/jobs/rstuf/check_job.rb
@@ -14,7 +14,7 @@ class Rstuf::CheckJob < Rstuf::ApplicationJob
       raise FailureException, "RSTUF job failed, please check payload and retry"
     when "ERRORED", "REVOKED", "REJECTED"
       raise ErrorException, "RSTUF internal problem, please check RSTUF health"
-    when "PENDING", "RUNNING", "RECEIVED", "STARTED"
+    when "PENDING", "PRE_RUN", "RUNNING", "RECEIVED", "STARTED"
       raise RetryException
     else
       Rails.logger.info "RSTUF job returned unexpected state #{status}"


### PR DESCRIPTION
Add a new RSTUF state `PRE_RUN` to check the job.
This state is right after being received by the RSTUF Worker and should retry.