### PR TITLE
Remove dry-initializer dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ gem "view_component", "~> 3.14.0"
 gem "pundit", "~> 2.4"
 gem "chartkick", "~> 5.1"
 gem "groupdate", "~> 6.5"
-gem "dry-initializer", "~> 3.1"
 
 group :avo, optional: true do
   source "https://packager.dev/avo-hq/" do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,6 @@ GEM
       dotenv (= 3.1.4)
       railties (>= 6.1)
     drb (2.2.1)
-    dry-initializer (3.1.1)
     email_validator (2.2.4)
       activemodel
     erubi (1.13.0)
@@ -919,7 +918,6 @@ DEPENDENCIES
   discard (~> 1.3)
   dogstatsd-ruby (~> 5.6)
   dotenv-rails (~> 3.1)
-  dry-initializer (~> 3.1)
   factory_bot_rails (~> 6.4)
   faraday (~> 2.12)
   faraday-multipart (~> 1.0)
@@ -1094,7 +1092,6 @@ CHECKSUMS
   dotenv (3.1.4) sha256=6dc502e718ea0d3542673345da05c7a69039840898e251757adb3405d2b35629
   dotenv-rails (3.1.4) sha256=a7d75f6ab3cc7f1b28e7deb0462efb155878e4e87ce3cc6e42ce35bea61c6fe4
   drb (2.2.1) sha256=e9d472bf785f558b96b25358bae115646da0dbfd45107ad858b0bc0d935cb340
-  dry-initializer (3.1.1) sha256=4d267dea367ccabe498b259c62b909b99d577d6db547d9510561999403546dec
   email_validator (2.2.4) sha256=5ab238095bec7aef9389f230e9e0c64c5081cdf91f19d6c5cecee0a93af20604
   erubi (1.13.0) sha256=fca61b47daefd865d0fb50d168634f27ad40181867445badf6427c459c33cd62
   et-orbi (1.2.11) sha256=d26e868cc21db88280a9ec1a50aa3da5d267eb9b2037ba7b831d6c2731f5df64

--- a/app/views/components/events/table_component.rb
+++ b/app/views/components/events/table_component.rb
@@ -12,9 +12,9 @@ class Events::TableComponent < ApplicationComponent
   register_value_helper :page_entries_info
   register_value_helper :paginate
 
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :security_events
+  prop :security_events, _Union(ActiveRecord::Relation, Array), reader: :private
 
   def view_template
     header(class: "gems__header push--s") do

--- a/app/views/components/events/table_details_component.rb
+++ b/app/views/components/events/table_details_component.rb
@@ -1,7 +1,7 @@
 class Events::TableDetailsComponent < ApplicationComponent
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :event
+  prop :event, _Any, reader: :private
   delegate :additional, :rubygem, to: :event
 
   def view_template

--- a/app/views/components/oidc/api_key_role/table_component.rb
+++ b/app/views/components/oidc/api_key_role/table_component.rb
@@ -2,9 +2,9 @@
 
 class OIDC::ApiKeyRole::TableComponent < ApplicationComponent
   include Phlex::Rails::Helpers::LinkTo
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :api_key_roles
+  prop :api_key_roles, _Any, reader: :private
 
   def view_template
     table(class: "t-body") do

--- a/app/views/components/oidc/id_token/key_value_pairs_component.rb
+++ b/app/views/components/oidc/id_token/key_value_pairs_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class OIDC::IdToken::KeyValuePairsComponent < ApplicationComponent
-  extend Dry::Initializer
-  option :pairs
+  extend Literal::Properties
+  prop :pairs, _Any, reader: :private
 
   def view_template
     dl(class: "t-body provider_attributes full-width overflow-wrap") do

--- a/app/views/components/oidc/id_token/table_component.rb
+++ b/app/views/components/oidc/id_token/table_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class OIDC::IdToken::TableComponent < ApplicationComponent
-  extend Dry::Initializer
-  option :id_tokens
+  extend Literal::Properties
+  prop :id_tokens, _Any, reader: :private
 
   include Phlex::Rails::Helpers::TimeTag
   include Phlex::Rails::Helpers::LinkToUnlessCurrent

--- a/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class OIDC::TrustedPublisher::GitHubAction::FormComponent < ApplicationComponent
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :github_action_form
+  prop :github_action_form, _Any, reader: :private
 
   def view_template
     github_action_form.fields_for :trusted_publisher do |trusted_publisher_form|

--- a/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
@@ -1,7 +1,7 @@
 class OIDC::TrustedPublisher::GitHubAction::TableComponent < ApplicationComponent
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :github_action
+  prop :github_action, _Any, reader: :private
 
   def view_template
     dl(class: "tw-flex tw-flex-col sm:tw-grid sm:tw-grid-cols-2 tw-items-baseline tw-gap-4 full-width overflow-wrap") do

--- a/app/views/oidc/id_tokens/show_view.rb
+++ b/app/views/oidc/id_tokens/show_view.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class OIDC::IdTokens::ShowView < ApplicationView
-  extend Dry::Initializer
+  extend Literal::Properties
   include Phlex::Rails::Helpers::TimeTag
   include Phlex::Rails::Helpers::LinkTo
 
-  option :id_token
+  prop :id_token, OIDC::IdToken, reader: :private
 
   def view_template # rubocop:disable Metrics/AbcSize
     self.title = t(".title")

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -5,9 +5,9 @@ class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
   include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::DistanceOfTimeInWordsToNow
   include Phlex::Rails::Helpers::LinkTo
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :trusted_publishers
+  prop :trusted_publishers, _Any, reader: :private
 
   def view_template
     title_content

--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -6,9 +6,9 @@ class OIDC::PendingTrustedPublishers::NewView < ApplicationView
   include Phlex::Rails::Helpers::OptionsForSelect
   include Phlex::Rails::Helpers::FormWith
 
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :pending_trusted_publisher
+  prop :pending_trusted_publisher, OIDC::PendingTrustedPublisher, reader: :private
 
   def view_template
     self.title = t(".title")

--- a/app/views/oidc/rubygem_trusted_publishers/index_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/index_view.rb
@@ -5,10 +5,10 @@ class OIDC::RubygemTrustedPublishers::IndexView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::ContentFor
   include OIDC::RubygemTrustedPublishers::Concerns::Title
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :rubygem
-  option :trusted_publishers
+  prop :rubygem, Rubygem, reader: :private
+  prop :trusted_publishers, _Any, reader: :private
 
   def view_template
     title_content

--- a/app/views/oidc/rubygem_trusted_publishers/new_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/new_view.rb
@@ -8,9 +8,9 @@ class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
   include Phlex::Rails::Helpers::SelectTag
   include OIDC::RubygemTrustedPublishers::Concerns::Title
 
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :rubygem_trusted_publisher
+  prop :rubygem_trusted_publisher, OIDC::RubygemTrustedPublisher, reader: :private
 
   def view_template
     title_content

--- a/app/views/profiles/security_events_view.rb
+++ b/app/views/profiles/security_events_view.rb
@@ -6,9 +6,9 @@ class Profiles::SecurityEventsView < ApplicationView
   include Phlex::Rails::Helpers::DistanceOfTimeInWordsToNow
   include Phlex::Rails::Helpers::TimeTag
   include Phlex::Rails::Helpers::LinkTo
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :security_events
+  prop :security_events, _Any, reader: :private
 
   def view_template
     title_content

--- a/app/views/rubygems/security_events_view.rb
+++ b/app/views/rubygems/security_events_view.rb
@@ -4,10 +4,10 @@ class Rubygems::SecurityEventsView < ApplicationView
   include Phlex::Rails::Helpers::ButtonTo
   include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::LinkTo
-  extend Dry::Initializer
+  extend Literal::Properties
 
-  option :rubygem
-  option :security_events
+  prop :rubygem, Rubygem, reader: :private
+  prop :security_events, _Any, reader: :private
 
   def view_template
     title_content

--- a/test/components/previews/oidc/trusted_publisher/github_action/form_component_preview.rb
+++ b/test/components/previews/oidc/trusted_publisher/github_action/form_component_preview.rb
@@ -9,11 +9,11 @@ class OIDC::TrustedPublisher::GitHubAction::FormComponentPreview < Lookbook::Pre
   class Wrapper < Phlex::HTML
     include Phlex::Rails::Helpers::FormWith
 
-    extend Dry::Initializer
-    option :form_object
+    extend Literal::Properties
+    prop :form_object, _Any
 
     def view_template
-      form_with(model: form_object, url: "/") do |github_action_form|
+      form_with(model: @form_object, url: "/") do |github_action_form|
         render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(github_action_form:)
         github_action_form.submit class: "form__submit", disabled: true
       end


### PR DESCRIPTION
Switch fully to literal, which avo is now using

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
