### PR TITLE
Update the Avo license for v3

### DIFF
--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -22,7 +22,7 @@
         "client_id": "EJ[1:YVJ0VwGrcSYWmu7lQOJPUdkXYI5VBgGXLla1+Fo1eA8=:jnplUfdfAMq/te3PyIN3SejasXCukW/g:0LsAhlffVl+6W4k5sRLWpew4D8ohT5ym3Ou+O1CsZgd/fvu16YWRpgvX345ewip0]",
         "github_key": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3ZtgHbbvis6EJ5UymIZBWPwc+Zvf722/:gcsPiEVuVZIitCZ3t2216Jn5re2vBTyN7FElhowCKpQUglwU]",
         "github_secret": "EJ[1:dz+xczzzSxiEdCK5nfz6u2RkBOEeeOTlMD2eWIHTAg8=:3bGij9eYVzE6mJ4XmIT/QBBRmnCi9nMs:8jcKV1Hl8TYTMQaQ8SV+agQ6c9UA9lb1DHKy2J/W//gdlJ2r/r4qlKeI/zoWMX2e461aB1Dx7XQ=]",
-        "avo_license_key": "EJ[1:6oWEkRT4PhQJLxAVEt3F66gOvAd2bB/J7cF+DpFv4Gk=:atX3EOd7BdoSBqJFPaqASO6/u6R2MLlR:G4TyGlkc1EZWpUJ0mQTS9Bw1O5V9Hww3DZtV+MQuDg9pzw8n7frV+GQek4wDqI29QLk0Kg==]",
+        "avo_license_key": "EJ[1:vHG/UgXm5H2xr/ExsZdTi7Lep9NzpQkKXFUlNb9FOVU=:dRDXtqaYSBhiY5cuHJutRa8R2ZUUE8h3:+xyDjGvAJmtwxHdMcGQ21GDRnVagGG009JSw]",
         "datadog_csp_api_key": "EJ[1:MJLOVnheQZD8mqT8Q5xlN8u6Qd9eH4sbO1kcsg/TTR4=:0eAj1g7msiS86qexeMNsWU+1vy3pXSKK:4YT1qDTiBirwkNsbNdhN90lPlF51qiMNChue7uMpEYuAiKTI3TnwOWJd7sk0PmARVsIn]",
         "hook_relay_account_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:JsT1PTsSpMaxE0FV7ODyJ5E1FQAzv9v/:tMUgIFIUJH+WhT+kHS5pne5Uw9qvdLqLd2aAfJ9EehzIYpH6Bl6EQg==]",
         "hook_relay_hook_id": "EJ[1:Px+UVqbFzeNGqkAlgQ9Vz00tXWKza1XmLLHD/iQT5wM=:Vt1tMd8/9ZhSHL80yrWIWUy2wMOh8Iqt:MUwOcVrjWl7i8RRNg68Sb/Fa+RYsLL54yc+adRK84i5jWWa9fmSgRg==]",

--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -22,7 +22,7 @@
         "client_id": "EJ[1:G3QtTGP/Pf0HRv8+b6zf3xI3TmNiOPmidA24ZSgQgjU=:AZtoluRkpeCK96i3FxPgamAkAlwRuTKq:NrpTfXVR1rAA0UyJzYVmCvJvQ5lr/VLyAoHDz0IY0cmC0aJLO8HWKsAYWq3T4w2D]",
         "github_key": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:XX+D9g9OUcALhAK1aRB5uK4hmUOhmq+a:kEEf22rN2vnyXE2I5me5Fc+2rCu070VA8IpcsbeJ8Xh/3261]",
         "github_secret": "EJ[1:w54WPX1mXZxgJoUu4zPMVMd5zCWl0rbbfuyqcvJOP1o=:0aEWndKlt5UpeGXSNfX8jWtc5UqnKk1g:MmBDQQEzb9tUaxVIL7bUUBbg2/UvhyvbnHcvlfqWztdSVHAFuvGe+tVtHjEdCdMzrJzG5d6UVBo=]",
-        "avo_license_key": "EJ[1:TD6sa+BG2xSLyZddF8CUdq8egeXQfz1oeMaSD/DV/z8=:iXP5X+kGqtPPjluF93iyxTRiwA4sq5ch:My9uCrd+KqROpd1l3x8HgQYvi/gRs+FBQ41IdmqouwbVJBRipuHotXYGHBcqOtvFwpk1/w==]",
+        "avo_license_key": "EJ[1:xcimfAiJn0jrCDMpC+0kpX0WGUO3QxTcjfZSV8/zMBg=:Kkeih5DzMjlewV8GjD+iBOhQHinGXswy:hDpP9A4MhyRLAAoAmekw9soIdVHWso4TClPK]",
         "datadog_csp_api_key": "EJ[1:M1xidXJHz2i/vKthLOnwYbEnkFjYneq+d6Ryj6TXdFQ=:fxMZfI3MptOYF/hXcrnrWK/SDTU1SzZC:Gn807pB1wSTTNIyTJ5cpGCvN5+vplIZUxi/a8/s+UFDJE52zeM5KyhvmK6f0J8mDa2vh]",
         "hook_relay_account_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:OUkdjS28VFFsXWnK0c2zBubgen83JLIZ:r9s3A3e3UuNrYRelD3HzIKsNvEGlGhvKmZayZt7wZGHrxB+yTb8gQQ==]",
         "hook_relay_hook_id": "EJ[1:JT93bSSDxXR0tIyvuhE4hVVEav3DdVDYtCuhLTlwwUw=:n1YqUGXM5FdcwoAJjIXXgHxWqiF/voeL:sj7Gbn405v2hw4CKkU6N7Fhgb3J/5RnrAZpp+Xcn61ZTNJq0qFXBiA==]",


### PR DESCRIPTION
# What's this about?

In #4342 we updated Avo to v3 but forgot to update the license after the change had been applied, this is causing errors and preventing logins to the backend dashboard. 