### PR TITLE
Unconfirmed email profile should return 404

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,15 @@ class ProfilesController < ApplicationController
 
   def show
     @user = User.find_by_slug!(params[:id])
-    @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading
+    return @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading if @user.email_confirmed?
+    respond_to do |format|
+      format.any do
+        render plain: t(:this_rubygem_could_not_be_found), status: :not_found
+      end
+      format.html do
+        render file: Rails.public_path.join("404.html"), status: :not_found, layout: false, formats: [:html]
+      end
+    end
   end
 
   def me

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,15 +9,8 @@ class ProfilesController < ApplicationController
 
   def show
     @user = User.find_by_slug!(params[:id])
-    return @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading if @user.email_confirmed?
-    respond_to do |format|
-      format.any do
-        render plain: t(:this_rubygem_could_not_be_found), status: :not_found
-      end
-      format.html do
-        render file: Rails.public_path.join("404.html"), status: :not_found, layout: false, formats: [:html]
-      end
-    end
+    return render_not_found unless @user.email_confirmed?
+    @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading
   end
 
   def me

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,8 +8,8 @@ class ProfilesController < ApplicationController
   before_action :disable_cache, only: :edit
 
   def show
-    @user = User.find_by_slug!(params[:id])
-    return render_not_found unless @user.email_confirmed?
+    @user = User.confirmed.find_by_slug!(params[:id])
+    return render_not_found unless @user
     @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   scope :not_deleted, -> { kept }
   scope :deleted, -> { with_discarded.discarded }
   scope :with_deleted, -> { with_discarded }
+  scope :confirmed, -> { where(email_confirmed: true) }
 
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :user
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -12,6 +12,19 @@ class ProfilesControllerTest < ActionController::TestCase
     end
   end
 
+  context "for a user whose email is not confirmed" do
+    setup do
+      @user = create(:user)
+      @user.update(email_confirmed: false)
+    end
+
+    should "render not found page" do
+      get :show, params: { id: @user.handle }
+
+      assert_response :not_found
+    end
+  end
+
   context "when not logged in" do
     setup { @user = create(:user) }
 


### PR DESCRIPTION
It is possible to view the profile page of a user whose email has not been confirmed. To resolve #5079, this PR returns a 404 error page for the profile page when the email has not been confirmed.