### PR TITLE
Add bcrypt password validation

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -121,6 +121,8 @@ de:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
             handle:
               invalid: "must start with a letter and can only contain letters, numbers, underscores, and dashes"
             password:
-              bcrypt_length: cannot be longer than 72 bytes due to bcrypt limitations
+              bcrypt_length: is too long (maximum is 72 bytes because of bcrypt limitations)
         version:
           attributes:
             gem_full_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,8 @@ en:
           attributes:
             handle:
               invalid: "must start with a letter and can only contain letters, numbers, underscores, and dashes"
+            password:
+              bcrypt_length: cannot be longer than 72 bytes due to bcrypt limitations
         version:
           attributes:
             gem_full_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
             handle:
               invalid: "must start with a letter and can only contain letters, numbers, underscores, and dashes"
             password:
-              bcrypt_length: is too long (maximum is 72 bytes because of bcrypt limitations)
+              bcrypt_length: is too long (maximum is 72 bytes)
         version:
           attributes:
             gem_full_name:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,6 +119,8 @@ es:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,6 +117,8 @@ fr:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -110,6 +110,8 @@ ja:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -109,6 +109,8 @@ nl:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -116,6 +116,8 @@ pt-BR:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -111,6 +111,8 @@ zh-CN:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -110,6 +110,8 @@ zh-TW:
           attributes:
             handle:
               invalid:
+            password:
+              bcrypt_length:
         version:
           attributes:
             gem_full_name:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -173,7 +173,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     context "password" do
-      should "be between 10 and 200 characters" do
+      should "be between 10 characters and 72 bytes" do
         user = build(:user, password: "%5a&12ed/")
 
         refute_predicate user, :valid?
@@ -182,7 +182,7 @@ class UserTest < ActiveSupport::TestCase
         user.password = "#{'a8b5d2d451' * 20}a"
 
         refute_predicate user, :valid?
-        assert_contains user.errors[:password], "is too long (maximum is 200 characters)"
+        assert_contains user.errors[:password], "is too long (maximum is 72 bytes because of bcrypt limitations)"
 
         user.password = "633!cdf7b3426c9%f6dd1a0b62d4ce44c4f544e%"
         user.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -182,7 +182,7 @@ class UserTest < ActiveSupport::TestCase
         user.password = "#{'a8b5d2d451' * 20}a"
 
         refute_predicate user, :valid?
-        assert_contains user.errors[:password], "is too long (maximum is 72 bytes because of bcrypt limitations)"
+        assert_contains user.errors[:password], "is too long (maximum is 72 bytes)"
 
         user.password = "633!cdf7b3426c9%f6dd1a0b62d4ce44c4f544e%"
         user.valid?


### PR DESCRIPTION
Used byte size password validation to prevent passwords longer than 72 bytes from being created since bcrypt silently truncates them.

Error message comparison
- Before: "Password is too long (maximum is 200 characters)"
- After: "Password is too long (maximum is 72 bytes)"

Fixes #5093