### PR TITLE
Add RAILS_GROUPS=assets back to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ COPY --link config/database.yml.sample /app/config/database.yml
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN <<BASH
   set -ex
-  SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
+  RAILS_GROUPS=assets SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
   rm -fr /app/tmp/cache/assets/
 BASH
 


### PR DESCRIPTION
I missed that the tailwind gem was included in a group in the Gemfile on its own that included :assets as the group name.

I think this is the only fix needed to make propshaft work.