### PR TITLE
Fix verifying sigstore bundles for github trusted publishers

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -175,7 +175,7 @@ class Pusher
     return true if attestations.blank?
     return notify("Pushing with an attestation requires trusted publishing", 400) unless api_key.trusted_publisher?
 
-    policy = api_key.owner.to_sigstore_identity_policy(api_key.oidc_id_token.jwt.dig("claims", "ref"))
+    policy = api_key.owner.to_sigstore_identity_policy
 
     artifact = Sigstore::Verification::V1::Artifact.new
     artifact.artifact = body.string

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -25,8 +25,7 @@ class PushTest < ActionDispatch::IntegrationTest
     )
 
     @key = "543321"
-    api_key = create(:api_key, owner: rubygem_trusted_publisher.trusted_publisher, key: @key, scopes: %i[push_rubygem])
-    create(:oidc_id_token, api_key: api_key, jwt: { claims: { "ref" => "refs/heads/main" } })
+    create(:api_key, owner: rubygem_trusted_publisher.trusted_publisher, key: @key, scopes: %i[push_rubygem])
 
     signing_jwt = ["", {
       aud: "sigstore",


### PR DESCRIPTION
We dont have the original jwt around any more, so re-create the policy based on whats intrinsic to the trusted publisher itself

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
