### PR TITLE
Add homepage url to user profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -65,7 +65,7 @@ class ProfilesController < ApplicationController
     end
   end
 
-  PERMITTED_PROFILE_PARAMS = %i[handle twitter_username unconfirmed_email public_email full_name].freeze
+  PERMITTED_PROFILE_PARAMS = %i[handle twitter_username unconfirmed_email homepage_url public_email full_name].freeze
 
   def verify_password
     password = params.permit(user: :password).require(:user)[:password]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,7 @@ class UsersController < ApplicationController
     password
     website
     twitter_username
+    homepage_url
     full_name
   ].freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,7 +82,7 @@ class User < ApplicationRecord
     message: "can only contain letters, numbers, and underscores"
   }, allow_nil: true, length: { within: 0..20 }
 
-  validates_formatting_of :homepage_url, using: :url, allow_nil: true
+  validates_formatting_of :homepage_url, using: :url, allow_blank: true
 
   validates :password,
     length: { minimum: 10 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,11 @@ class User < ApplicationRecord
     message: "can only contain letters, numbers, and underscores"
   }, allow_nil: true, length: { within: 0..20 }
 
+  validates :homepage_url, format: {
+    with: /\A[a-zA-Z0-9_]*\z/,
+    message: "can only contain letters, numbers, and underscores"
+  }, allow_nil: true, length: { within: 0..20 }
+
   validates :password,
     length: { minimum: 10 },
     unpwn: true,
@@ -351,7 +356,7 @@ class User < ApplicationRecord
       handle: nil, email_confirmed: false,
       unconfirmed_email: nil, blocked_email: nil,
       api_key: nil, confirmation_token: nil, remember_token: nil,
-      twitter_username: nil, webauthn_id: nil, full_name: nil,
+      twitter_username: nil, webauthn_id: nil, full_name: nil, homepage_url: nil,
       totp_seed: nil, mfa_hashed_recovery_codes: nil,
       mfa_level: :disabled,
       password: SecureRandom.hex(20).encode("UTF-8")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,7 +82,7 @@ class User < ApplicationRecord
     message: "can only contain letters, numbers, and underscores"
   }, allow_nil: true, length: { within: 0..20 }
 
-  validates_formatting_of :homepage_url, using: :url, message: "does not appear to be a valid URL", allow_nil: true
+  validates_formatting_of :homepage_url, using: :url, allow_nil: true
 
   validates :password,
     length: { minimum: 10 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,10 +82,7 @@ class User < ApplicationRecord
     message: "can only contain letters, numbers, and underscores"
   }, allow_nil: true, length: { within: 0..20 }
 
-  validates :homepage_url, format: {
-    with: /\A[a-zA-Z0-9_]*\z/,
-    message: "can only contain letters, numbers, and underscores"
-  }, allow_nil: true, length: { within: 0..20 }
+  validates_formatting_of :homepage_url, using: :url, message: "does not appear to be a valid URL", allow_nil: true
 
   validates :password,
     length: { minimum: 10 },

--- a/app/views/dashboards/_subject.html.erb
+++ b/app/views/dashboards/_subject.html.erb
@@ -23,6 +23,17 @@
   </div>
 <% end %>
 
+<% if user.homepage_url.present? %>
+  <div class="flex items-center mb-4 text-b3 lg:text-b2">
+    <%= icon_tag("link", color: :primary, class: "w-6 text-orange mr-3") %>
+    <p class="text-neutral-800 dark:text-white"><%=
+      link_to(
+        user.homepage_url
+      )
+    %></p>
+  </div>
+<% end %>
+
 <% if user.twitter_username.present? %>
   <div class="flex items-center mb-4 text-b3 lg:text-b2">
     <%= icon_tag("x-twitter", color: :primary, class: "w-6 text-orange mr-3") %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -75,7 +75,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
   </div>
 
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -71,7 +71,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input'%>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
   </div>
 
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -21,12 +21,8 @@
   </div>
 
   <div class="text_field">
-   <%= form.label :homepage_url, class: 'form__label' do %>
-
-     <span class='form__label__text'><%= t('.homepage_url') %></span>
-   <% end %>
-
-     <%= form.text_field(:homepage_url, class: 'form__input') %>
+   <%= form.label :homepage_url, class: 'form__label' %>
+   <%= form.text_field(:homepage_url, class: 'form__input') %>
   </div>
 
   <div class="text_field">
@@ -75,7 +71,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
   </div>
 
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -71,7 +71,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input'%>
   </div>
 
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -21,7 +21,7 @@
   </div>
 
   <div class="text_field">
-   <%= form.label :homepage_url, class: 'form__label form__label__icon-container' do %>
+   <%= form.label :homepage_url, class: 'form__label' do %>
 
      <span class='form__label__text'><%= t('.homepage_url') %></span>
    <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -71,7 +71,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
   </div>
 
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -22,7 +22,7 @@
 
   <div class="text_field">
    <%= form.label :homepage_url, class: 'form__label form__label__icon-container' do %>
-    
+
      <span class='form__label__text'><%= t('.homepage_url') %></span>
    <% end %>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -21,6 +21,15 @@
   </div>
 
   <div class="text_field">
+   <%= form.label :homepage_url, class: 'form__label form__label__icon-container' do %>
+    
+     <span class='form__label__text'><%= t('.homepage_url') %></span>
+   <% end %>
+
+     <%= form.text_field(:homepage_url, class: 'form__input') %>
+  </div>
+
+  <div class="text_field">
     <%= form.label :twitter_username, class: 'form__label form__label__icon-container' do %>
       <%=
         image_tag("/images/x_icon.png", alt: 'X icon', class: 'form__label__icon')

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -94,6 +94,14 @@
             )
           %>
         <% end %>
+        <% if @user.homepage_url.present? %>
+          <%=
+            link_to(
+              @user.homepage_url,
+              class: "profile__header__attribute t-link--black"
+            )
+          %>
+        <% end %>
       <% end %>
     </div>
 

--- a/db/migrate/20241114211431_add_homepage_url_to_users.rb
+++ b/db/migrate/20241114211431_add_homepage_url_to_users.rb
@@ -1,0 +1,5 @@
+class AddHomepageUrlToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :homepage_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_04_065953) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_14_211431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -556,6 +556,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_065953) do
     t.string "mfa_hashed_recovery_codes", default: [], array: true
     t.boolean "public_email", default: false, null: false
     t.datetime "deleted_at"
+    t.string "homepage_url"
     t.index "lower((email)::text) varchar_pattern_ops", name: "index_users_on_lower_email"
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -133,19 +133,19 @@ class ProfileTest < SystemTest
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 
-    test "adding homepage url" do
+  test "adding homepage url" do
     sign_in
     visit profile_path("nick1")
 
     click_link "Edit Profile"
-    fill_in "user_homepage_url", with: "https://nickisawesome.com"
+    fill_in "user_homepage_url", with: "www.nickisawesome.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     click_link "Sign out"
     visit profile_path("nick1")
 
-    assert page.has_link?("https://nickisawesome.com")
+    assert page.has_link?("www.nickisawesome.com")
   end
 
   test "deleting profile" do

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -133,6 +133,21 @@ class ProfileTest < SystemTest
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 
+    test "adding homepage url" do
+    sign_in
+    visit profile_path("nick1")
+
+    click_link "Edit Profile"
+    fill_in "user_homepage_url", with: "https://nickisawesome.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Update"
+
+    click_link "Sign out"
+    visit profile_path("nick1")
+
+    assert page.has_link?("https://nickisawesome.com")
+  end
+
   test "deleting profile" do
     sign_in
     visit profile_path("nick1")

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -31,7 +31,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert page.has_content? "nick2"
+    assert_content "nick2"
   end
 
   test "changing to an existing handle" do
@@ -138,14 +138,14 @@ class ProfileTest < SystemTest
     visit profile_path("nick1")
 
     click_link "Edit Profile"
-    fill_in "user_homepage_url", with: "www.nickisawesome.com"
+    fill_in "user_homepage_url", with: "https://nickisawesome.com"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
     click_link "Sign out"
     visit profile_path("nick1")
 
-    assert page.has_link?("www.nickisawesome.com")
+    assert page.has_link?("https://nickisawesome.com")
   end
 
   test "deleting profile" do

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -130,7 +130,6 @@ class ProfileTest < SystemTest
     click_link "Sign out"
     visit profile_path("nick1")
 
-    assert_content("test")
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -31,7 +31,7 @@ class ProfileTest < SystemTest
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Update"
 
-    assert_content "nick2"
+    assert page.has_content? "nick2"
   end
 
   test "changing to an existing handle" do
@@ -130,6 +130,7 @@ class ProfileTest < SystemTest
     click_link "Sign out"
     visit profile_path("nick1")
 
+    assert_content("test")
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 


### PR DESCRIPTION
Objective: 
- Add a homepage url in the profile 

<img width="792" alt="Screenshot 2024-11-14 at 17 59 50" src="https://github.com/user-attachments/assets/43c6a10e-5f87-474c-8b09-f0acccd2550c">

According to the tests the twitter and the homepage URL should display here but I have not been able to display this on main (?): 
<img width="926" alt="Screenshot 2024-11-14 at 18 01 51" src="https://github.com/user-attachments/assets/770a872a-3418-4b9f-a72e-5806449409d5">

I was told that the icon will show on production: 
<img width="404" alt="Screenshot 2024-11-14 at 18 03 36" src="https://github.com/user-attachments/assets/3dfe72a0-ff50-429a-914e-b1aa14c3508d">
