### PR TITLE
Update linkset homepage from gemspec only after version gets indexed

### DIFF
--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -16,6 +16,7 @@ class AfterVersionWriteJob < ApplicationJob
       version.update!(indexed: true)
       checksum = GemInfo.new(rubygem.name, cached: false).info_checksum
       version.update_attribute :info_checksum, checksum
+      SetLinksetHomeJob.perform_later(version:)
     end
   end
 

--- a/app/jobs/set_linkset_home_job.rb
+++ b/app/jobs/set_linkset_home_job.rb
@@ -1,0 +1,14 @@
+class SetLinksetHomeJob < ApplicationJob
+  queue_as :default
+
+  def perform(version:)
+    return unless version.latest? && version.indexed?
+
+    gem = RubygemFs.instance.get("gems/#{version.gem_file_name}")
+    package = Gem::Package.new(StringIO.new(gem))
+    homepage = package.spec.homepage
+
+    version.rubygem.linkset ||= Linkset.new
+    version.rubygem.linkset.update!(home: homepage)
+  end
+end

--- a/app/models/linkset.rb
+++ b/app/models/linkset.rb
@@ -1,5 +1,5 @@
 class Linkset < ApplicationRecord
-  belongs_to :rubygem
+  belongs_to :rubygem, inverse_of: :linkset
 
   before_save :create_homepage_link_verification, if: :home_changed?
 
@@ -17,10 +17,6 @@ class Linkset < ApplicationRecord
 
   def empty?
     LINKS.map { |link| attributes[link] }.all?(&:blank?)
-  end
-
-  def update_attributes_from_gem_specification!(spec)
-    update!(home: spec.homepage)
   end
 
   def create_homepage_link_verification

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -246,7 +246,8 @@ class Pusher
     end
 
     true
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique => e
+    logger.info { { message: "Error updating rubygem", exception: e } }
     false
   end
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -13,7 +13,7 @@ class Rubygem < ApplicationRecord
   has_many :versions, dependent: :destroy, validate: false
   has_one :latest_version, -> { latest.order(:position) }, class_name: "Version", inverse_of: :rubygem
   has_many :web_hooks, dependent: :destroy
-  has_one :linkset, dependent: :destroy
+  has_one :linkset, dependent: :destroy, inverse_of: :rubygem
   has_one :gem_download, -> { where(version_id: 0) }, inverse_of: :rubygem
   has_many :audits, as: :auditable, inverse_of: :auditable
   has_many :link_verifications, as: :linkable, inverse_of: :linkable, dependent: :destroy
@@ -269,34 +269,11 @@ class Rubygem < ApplicationRecord
     Ownership.create_confirmed(self, user, user) if unowned?
   end
 
-  def update_versions!(version, spec)
-    version.update_attributes_from_gem_specification!(spec)
-  end
-
-  def update_dependencies!(version, spec)
-    spec.dependencies.each do |dependency|
-      version.dependencies.create!(gem_dependency: dependency)
-    rescue ActiveRecord::RecordInvalid => e
-      # ActiveRecord can't chain a nested error here, so we have to add and reraise
-      e.record.errors.errors.each do |error|
-        errors.import(error, attribute: "dependency.#{error.attribute}")
-      end
-      raise
-    end
-  end
-
-  def update_linkset!(spec)
-    self.linkset ||= Linkset.new
-    self.linkset.update_attributes_from_gem_specification!(spec)
-    self.linkset.save!
-  end
-
   def update_attributes_from_gem_specification!(version, spec)
     Rubygem.transaction do
       save!
-      update_versions! version, spec
-      update_dependencies! version, spec
-      update_linkset! spec if version.reload.latest?
+      version.update_attributes_from_gem_specification!(spec)
+      version.update_dependencies!(spec)
     end
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -494,7 +494,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def metadata_links_format
-    Linkset::LINKS.each do |link|
+    Links::LINKS.each_value do |link|
       url = metadata[link]
       next unless url
       next if Patterns::URL_VALIDATION_REGEXP.match?(url)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -292,6 +292,18 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     )
   end
 
+  def update_dependencies!(spec)
+    spec.dependencies.each do |dependency|
+      dependencies.create!(gem_dependency: dependency)
+    rescue ActiveRecord::RecordInvalid => e
+      # ActiveRecord can't chain a nested error here, so we have to add and reraise
+      e.record.errors.errors.each do |error|
+        errors.import(error, attribute: "dependency.#{error.attribute}")
+      end
+      raise
+    end
+  end
+
   def platform_as_number
     if platformed?
       0
@@ -312,7 +324,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def slug
-    full_name.remove(/^#{rubygem.name}-/)
+    full_name.delete_prefix("#{rubygem.name}-")
   end
 
   def downloads_count

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -76,6 +76,7 @@ class PushTest < ActionDispatch::IntegrationTest
     push_gem "sandworm-1.0.0.gem"
 
     assert_response :success
+    perform_enqueued_jobs
 
     get rubygem_path("sandworm")
 
@@ -83,6 +84,7 @@ class PushTest < ActionDispatch::IntegrationTest
     assert page.has_content?("sandworm")
     assert page.has_content?("1.0.0")
     assert page.has_content?("Pushed by")
+    assert page.has_link? "Homepage", href: "http://example.com/sandworm"
 
     css = %(div.gem__users a[alt=#{@user.handle}])
 

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -411,6 +411,16 @@ class PushTest < ActionDispatch::IntegrationTest
     assert_match(/You have added cert_chain in gemspec but signature was empty/, response.body)
   end
 
+  test "publishing a gem with an invalid homepage" do
+    build_gem "sandworm", "2.0.0" do |gemspec|
+      gemspec.homepage = "not a valid url"
+    end
+    push_gem "sandworm-2.0.0.gem"
+
+    assert_response :unprocessable_content
+    assert_match(/is not a valid HTTP URI/, response.body)
+  end
+
   setup do
     @act = ENV["HOOK_RELAY_ACCOUNT_ID"]
     @id = ENV["HOOK_RELAY_HOOK_ID"]

--- a/test/models/linkset_test.rb
+++ b/test/models/linkset_test.rb
@@ -25,18 +25,6 @@ class LinksetTest < ActiveSupport::TestCase
     end
   end
 
-  context "with a Gem::Specification" do
-    setup do
-      @spec    = gem_specification_from_gem_fixture("test-0.0.0")
-      @linkset = create(:linkset)
-      @linkset.update_attributes_from_gem_specification!(@spec)
-    end
-
-    should "have linkset home be set to the specificaton's homepage" do
-      assert_equal @spec.homepage, @linkset.home
-    end
-  end
-
   context "validations" do
     %w[home code docs wiki mail bugs].each do |link|
       should allow_value("http://example.com").for(link.to_sym)

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -376,7 +376,7 @@ class RubygemTest < ActiveSupport::TestCase
       @specification.authors = [3]
 
       assert_raise ActiveRecord::RecordInvalid do
-        @rubygem.update_versions!(@version, @specification)
+        @version.update_attributes_from_gem_specification!(@specification)
       end
 
       assert_equal "Authors must be an Array of Strings", @rubygem.all_errors(@version)

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -359,17 +359,6 @@ class RubygemTest < ActiveSupport::TestCase
       refute_predicate @rubygem, :valid?
     end
 
-    should "return linkset errors in #all_errors" do
-      @specification = gem_specification_from_gem_fixture("test-0.0.0")
-      @specification.homepage = "badurl.com"
-
-      assert_raise ActiveRecord::RecordInvalid do
-        @rubygem.update_linkset!(@specification)
-      end
-
-      assert_equal "Home does not appear to be a valid URL", @rubygem.all_errors
-    end
-
     should "return version errors in #all_errors" do
       @version = build(:version)
       @specification = gem_specification_from_gem_fixture("test-0.0.0")
@@ -394,9 +383,7 @@ class RubygemTest < ActiveSupport::TestCase
       @rubygem.name = "1337"
 
       refute_predicate @rubygem, :valid?
-      assert_raise ActiveRecord::RecordInvalid do
-        @rubygem.update_linkset!(@specification)
-      end
+      @rubygem.linkset.update(home: @specification.homepage)
 
       assert_match "Name must include at least one letter, Home does not appear to be a valid URL",
         @rubygem.all_errors
@@ -828,10 +815,6 @@ class RubygemTest < ActiveSupport::TestCase
         refute_predicate @rubygem, :new_record?
         assert_predicate @rubygem.versions, :present?
       end
-
-      should "have the homepage set properly" do
-        assert_equal @specification.homepage, @rubygem.linkset.home
-      end
     end
 
     context "from a Gem::Specification with metadata with links" do
@@ -839,14 +822,12 @@ class RubygemTest < ActiveSupport::TestCase
 
       setup do
         @specification = new_gemspec("test", "1.0.0", "A summary", "ruby") do |s|
-          s.homepage = "https://example.com/test"
           s.metadata = {
             "funding_uri" => "https://example.com/",
             "documentation_uri" => "https://example.com/docs",
-            "source_code_uri" => "::",
-            "bug_tracker_uri" => "",
             "mailing_list_uri" => "http://example.com/mailing_list",
-            "wiki_uri" => "https://example.com/"
+            "wiki_uri" => "https://example.com/",
+            "homepage_uri" => "https://example.com/test"
           }
         end
 
@@ -857,7 +838,7 @@ class RubygemTest < ActiveSupport::TestCase
       end
 
       should "create link verification records" do
-        assert_equal ["::", "http://example.com/mailing_list", "https://example.com/", "https://example.com/docs", "https://example.com/test"],
+        assert_equal ["http://example.com/mailing_list", "https://example.com/", "https://example.com/docs", "https://example.com/test"],
                      @rubygem.link_verifications.pluck(:uri).sort
       end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -880,21 +880,21 @@ class VersionTest < ActiveSupport::TestCase
 
     context "with metadata" do
       should "be invalid with empty string as link" do
-        @version.metadata = { "home" => "" }
+        @version.metadata = { "source_code_uri" => "" }
         @version.validate
 
-        assert_equal(["['home'] does not appear to be a valid URL"], @version.errors.messages[:metadata])
+        assert_equal(["['source_code_uri'] does not appear to be a valid URL"], @version.errors.messages[:metadata])
       end
 
       should "be invalid with invalid link" do
-        @version.metadata = { "home" => "http:/github.com/bestgemever" }
+        @version.metadata = { "source_code_uri" => "http:/github.com/bestgemever" }
         @version.validate
 
-        assert_equal(["['home'] does not appear to be a valid URL"], @version.errors.messages[:metadata])
+        assert_equal(["['source_code_uri'] does not appear to be a valid URL"], @version.errors.messages[:metadata])
       end
 
       should "be valid with valid link" do
-        @version.metadata = { "home" => "http://github.com/bestgemever" }
+        @version.metadata = { "source_code_uri" => "http://github.com/bestgemever" }
 
         assert @version.validate
         assert_empty(@version.errors.messages[:metadata])


### PR DESCRIPTION
In current implementation, version.reload.indexed? is always false, so gems that only use spec.homepage to specify a homepage will never have a linkset created/updated

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
