### PR TITLE
prevent submission if password is not included

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -66,7 +66,7 @@
     <p class='form__field__instructions'>
       <%= t('.enter_password') %>
     </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
+    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
   </div>
 
 

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -133,19 +133,6 @@ class ProfileTest < SystemTest
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 
-  test "adding X(formerly Twitter) username without filling in your password" do
-    sign_in
-    visit profile_path("nick1")
-
-    click_link "Edit Profile"
-    fill_in "user_twitter_username", with: "nick1twitter"
-    click_button "Update"
-        puts page.html
-
-
-    assert_content("please fill in your password")
-  end
-
   test "deleting profile" do
     sign_in
     visit profile_path("nick1")

--- a/test/integration/profile_test.rb
+++ b/test/integration/profile_test.rb
@@ -133,6 +133,19 @@ class ProfileTest < SystemTest
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
 
+  test "adding X(formerly Twitter) username without filling in your password" do
+    sign_in
+    visit profile_path("nick1")
+
+    click_link "Edit Profile"
+    fill_in "user_twitter_username", with: "nick1twitter"
+    click_button "Update"
+        puts page.html
+
+
+    assert_content("please fill in your password")
+  end
+
   test "deleting profile" do
     sign_in
     visit profile_path("nick1")

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -13,18 +13,25 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "adding X(formerly Twitter) username without filling in your password" do
+    twitter_username = "nick1twitter"
+
     sign_in
     visit profile_path("nick1")
 
     click_link "Edit Profile"
+    fill_in "user_twitter_username", with: twitter_username
 
-    fill_in "user_twitter_username", with: "nick1twitter"
-
-    assert_equal "nick1twitter", page.find_by_id("user_twitter_username").value
+    assert_equal twitter_username, page.find_by_id("user_twitter_username").value
 
     click_button "Update"
 
     # Verify that the newly added Twitter username is still on the form so that the user does not need to re-enter it
-    assert_equal "nick1twitter", page.find_by_id("user_twitter_username").value
+    assert_equal twitter_username, page.find_by_id("user_twitter_username").value
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Update"
+
+    assert page.has_content? "Your profile was updated."
+    assert_equal twitter_username, page.find_by_id("user_twitter_username").value
   end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -17,10 +17,14 @@ class ProfileTest < ApplicationSystemTestCase
     visit profile_path("nick1")
 
     click_link "Edit Profile"
+
     fill_in "user_twitter_username", with: "nick1twitter"
+
+    assert_equal "nick1twitter", page.find_by_id("user_twitter_username").value
+
     click_button "Update"
 
-    # assert_content("please fill in your password")
-    assert page.has_content?("nick1twitter")
+    # Verify that the newly added Twitter username is still on the form so that the user does not need to re-enter it
+    assert_equal "nick1twitter", page.find_by_id("user_twitter_username").value
   end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -12,6 +12,11 @@ class ProfileTest < ApplicationSystemTestCase
     click_button "Sign in"
   end
 
+  def sign_out
+    page.driver.browser.clear_cookies # rack-test specific
+    visit "/"
+  end
+
   test "adding X(formerly Twitter) username without filling in your password" do
     twitter_username = "nick1twitter"
 
@@ -32,6 +37,12 @@ class ProfileTest < ApplicationSystemTestCase
     click_button "Update"
 
     assert page.has_content? "Your profile was updated."
+    assert_equal twitter_username, page.find_by_id("user_twitter_username").value
+
+    sign_out
+
+    visit profile_path("nick1")
+
     assert_equal twitter_username, page.find_by_id("user_twitter_username").value
   end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class ProfileTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
+  end
+
+  def sign_in
+    visit sign_in_path
+    fill_in "Email or Username", with: @user.reload.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+  end
+
+  test "adding X(formerly Twitter) username without filling in your password" do
+    sign_in
+    visit profile_path("nick1")
+
+    click_link "Edit Profile"
+    fill_in "user_twitter_username", with: "nick1twitter"
+    click_button "Update"
+
+    # assert_content("please fill in your password")
+    assert page.has_content?("nick1twitter")
+  end
+end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -1,4 +1,5 @@
 require "application_system_test_case"
+require "test_helper"
 
 class ProfileTest < ApplicationSystemTestCase
   setup do
@@ -10,11 +11,6 @@ class ProfileTest < ApplicationSystemTestCase
     fill_in "Email or Username", with: @user.reload.email
     fill_in "Password", with: @user.password
     click_button "Sign in"
-  end
-
-  def sign_out
-    page.driver.browser.clear_cookies # rack-test specific
-    visit "/"
   end
 
   test "adding X(formerly Twitter) username without filling in your password" do
@@ -37,12 +33,6 @@ class ProfileTest < ApplicationSystemTestCase
     click_button "Update"
 
     assert page.has_content? "Your profile was updated."
-    assert_equal twitter_username, page.find_by_id("user_twitter_username").value
-
-    sign_out
-
-    visit profile_path("nick1")
-
     assert_equal twitter_username, page.find_by_id("user_twitter_username").value
   end
 end


### PR DESCRIPTION
### PR is ready for review
Objective: Prevent the profile update form from submitting if the user forgets to add their password so they do not have to fill the form out again. 

Old behavior: 
- User updates their email 
- User either clicks enter or clicks on "Update" button 
- Page reloads and gets the below error message 
- User needs to re-enter their email 

New Behavior: 
- User updates their email 
- User either clicks enter or clicks on "Update" button 
- The page focuses on the password field and user sees this: 
<img width="353" alt="Screenshot 2024-11-18 at 11 10 59" src="https://github.com/user-attachments/assets/8c652d19-c907-45b4-8c64-e2c318c5240e">

- User types in passwords and DOES NOT need to re-enter email 
- User clicks "Update" button 🥳 

More context: This PR opened during the Ruby Conf Hack day. Thanks  @martinemde for suggesting this fix :). 