### PR TITLE
Allow access to some sidebar controls for owners of fully yanked gems

### DIFF
--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -56,7 +56,7 @@ module RubygemsHelper
 
     link_to t("rubygems.aside.links.unsubscribe"), rubygem_subscription_path(rubygem.slug),
       class: [:toggler, "gem__link", "t-list__item", style], id: "unsubscribe",
-      method: :delete, remote: true
+      method: :delete
   end
 
   def change_diff_link(rubygem, latest_version)

--- a/app/views/rubygems/_aside_yanked.html.erb
+++ b/app/views/rubygems/_aside_yanked.html.erb
@@ -1,0 +1,23 @@
+<div class="gem__aside l-col--r--pad">
+  <% if @adoption %>
+    <%= link_to "adoption", rubygem_adoptions_path(@rubygem.slug), class: "adoption__tag" %>
+  <% end %>
+
+  <% if @rubygem.metadata_mfa_required? %>
+    <h2 class="gem__ruby-version__heading t-list__heading">
+      <%= t('.requires_mfa') %>:
+      <span class="gem__ruby-version">
+        true
+      </span>
+    </h2>
+  <% end %>
+  <div class="t-list__items">
+    <%= unsubscribe_link(@rubygem) %>
+    <%= ownership_link(@rubygem) if policy(@rubygem).show_unconfirmed_ownerships? %>
+    <%= rubygem_trusted_publishers_link(@rubygem) if policy(@rubygem).configure_trusted_publishers? %>
+    <%= oidc_api_key_role_links(@rubygem) if policy(@rubygem).configure_oidc? %>
+    <%= resend_owner_confirmation_link(@rubygem) if @rubygem.unconfirmed_ownership?(current_user) %>
+    <%= rubygem_adoptions_link(@rubygem) if policy(@rubygem).show_adoption? %>
+    <%= rubygem_security_events_link(@rubygem) if policy(@rubygem).show_events? %>
+  </div>
+</div>

--- a/app/views/rubygems/show_yanked.html.erb
+++ b/app/views/rubygems/show_yanked.html.erb
@@ -19,4 +19,6 @@
       <%= render partial: "rubygems/gem_members", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
     <% end %>
   </div>
+
+  <%= render "rubygems/aside_yanked" %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -739,8 +739,8 @@ en:
     show_yanked:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org. Yanked versions of this gem may already exist.
       reserved_namespace_html:
-        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
-        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command. You can also create new versions of this gem using gem push.
+        one: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for 1 more day. After that time is up, anyone will be able to claim this gem name using gem push. <br/><br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command or create new versions of this gem using gem push.
+        other: This gem previously existed, but has been removed by its owner. The RubyGems.org team has reserved this gem name for %{count} more days. After that time is up, anyone will be able to claim this gem name using gem push. <br/><br/> If you are the previous owner of this gem, you can change ownership of this gem using the gem owner command or create new versions of this gem using gem push.
     security_events:
       title: Security Events
       description_html: "This page shows the security events that have occurred on %{gem}. If you see any suspicious activity, please <a href='mailto:support@rubygems.org'>contact support</a>."


### PR DESCRIPTION
Access to control ownerships, trusted publishers, etc is still important when all versions have been yanked so that new versions of the gem can be pushed.

Adds a limited sidebar view to yanked gems that is mostly only visible to owners. The only exception is if adoption, which will show on the page for non-owners if currently active.

<img width="971" alt="Screenshot 2024-11-20 at 12 11 06 PM" src="https://github.com/user-attachments/assets/1bb9c183-e50e-4843-be19-821176122171">
