### PR TITLE
Fix locales that require a 'host' variable

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -43,12 +43,12 @@ class Mailer < ApplicationMailer
 
   def deletion_complete(email)
     mail to: email,
-         subject: I18n.t("mailer.deletion_complete.subject")
+         subject: I18n.t("mailer.deletion_complete.subject", host: Gemcutter::HOST_DISPLAY)
   end
 
   def deletion_failed(email)
     mail to: email,
-         subject: I18n.t("mailer.deletion_failed.subject")
+         subject: I18n.t("mailer.deletion_failed.subject", host: Gemcutter::HOST_DISPLAY)
   end
 
   def notifiers_changed(user_id)
@@ -56,7 +56,7 @@ class Mailer < ApplicationMailer
     @ownerships = @user.ownerships.by_indexed_gem_name
 
     mail to: @user.email,
-         subject: I18n.t("mailer.notifiers_changed.subject",
+         subject: I18n.t("mailer.notifiers_changed.subject", host: Gemcutter::HOST_DISPLAY,
            default: "You changed your RubyGems.org email notification settings")
   end
 

--- a/app/mailers/web_hooks_mailer.rb
+++ b/app/mailers/web_hooks_mailer.rb
@@ -6,7 +6,7 @@ class WebHooksMailer < ApplicationMailer
     @failure_count = failure_count
 
     mail to: @user.email,
-         subject: t("mailer.web_hook_deleted.subject") do |format|
+         subject: t("mailer.web_hook_deleted.subject", host: Gemcutter::HOST_DISPLAY) do |format|
            format.html
            format.text
          end
@@ -17,7 +17,7 @@ class WebHooksMailer < ApplicationMailer
     @delete_command = "gem install gemcutter && gem webhook#{" #{web_hook.rubygem.name}" unless web_hook.global?} --remove '#{web_hook.url}'"
 
     mail to: web_hook.user.email,
-         subject: t("mailer.web_hook_disabled.subject") do |format|
+         subject: t("mailer.web_hook_disabled.subject", host: Gemcutter::HOST_DISPLAY) do |format|
            format.html
            format.text
          end

--- a/app/views/mailer/email_confirmation.text.erb
+++ b/app/views/mailer/email_confirmation.text.erb
@@ -1,4 +1,4 @@
 Hi <%= @user.handle %>
 
-<%= t("mailer.email_confirmation.welcome_message") %>
+<%= t("mailer.email_confirmation.welcome_message", host: Gemcutter::HOST_DISPLAY) %>
 <%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %>

--- a/test/integration/notification_settings_test.rb
+++ b/test/integration/notification_settings_test.rb
@@ -42,7 +42,7 @@ class NotificationSettingsTest < SystemTest
 
     assert_emails 1
 
-    assert_equal I18n.t("mailer.notifiers_changed.subject"), last_email.subject
+    assert_equal I18n.t("mailer.notifiers_changed.subject", host: Gemcutter::HOST_DISPLAY), last_email.subject
 
     assert_selector "#flash_notice", text: I18n.t("notifiers.update.success")
 

--- a/test/system/avo/web_hooks_test.rb
+++ b/test/system/avo/web_hooks_test.rb
@@ -65,6 +65,6 @@ class Avo::WebHooksSystemTest < ApplicationSystemTestCase
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
-    assert_equal I18n.t("mailer.web_hook_deleted.subject"), last_email.subject
+    assert_equal I18n.t("mailer.web_hook_deleted.subject", host: Gemcutter::HOST_DISPLAY), last_email.subject
   end
 end


### PR DESCRIPTION
#5266 Some locales require a `host` variable, which was missed during translation. So, these parts are fixed. 

I have only checked locales having a `host` variable to avoid expanding the scope of this PR.

![image](https://github.com/user-attachments/assets/d46697a8-f296-4a8c-8f43-4ce3de04ef3b)
