### PR TITLE
Fix deprecated tailwind not being linked in css

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,4 @@
+@import url("tailwind.deprecated.css");
 @import url("base.css");
 @import url("layout.css");
 @import url("suggest-list.css");


### PR DESCRIPTION
I verified that pending_trusted_publishers does render with the `tw-` classes correctly in dev.