### PR TITLE
Fix links for archives on a /pages/dump page

### DIFF
--- a/app/javascript/controllers/dump_controller.js
+++ b/app/javascript/controllers/dump_controller.js
@@ -46,8 +46,9 @@ export default class extends Controller {
 
   appendItem(text, uri) {
     const clone = this.templateTarget.content.cloneNode(true);
-    const a = clone.querySelector('a > span')
-    a.textContent = text;
+    const span = clone.querySelector("a > span");
+    const a = clone.querySelector("a");
+    span.textContent = text;
     a.href = uri;
     this.element.appendChild(clone)
   }


### PR DESCRIPTION
pages/data is missing correct links to pg dumps. See here:

https://rubygems.org/pages/data

This fix resolves that by ensuring that href attribute is added to a element. Previously href attribute was added to span, hence why it wasn't working.

If I'm not mistaken, this issue was introduced in this PR:
https://github.com/rubygems/rubygems.org/pull/5080