### PR TITLE
Fix not found error for attestation build summary URL

### DIFF
--- a/app/models/attestation.rb
+++ b/app/models/attestation.rb
@@ -40,7 +40,7 @@ class Attestation < ApplicationRecord
         source_commit_string: "#{repo}@#{commit[0, 7]}",
         source_commit_url: "https://github.com/#{repo}/tree/#{commit}",
         build_file_string:, build_file_url:,
-        build_summary_url: "https://github.com/#{repo}/actions/runs/#{build_file_string}"
+        build_summary_url: "https://github.com/#{repo}/actions/#{build_file_string.delete_prefix('.github/')}"
       }
     else
       raise "Unhandled issuer: #{issuer.inspect}"

--- a/app/models/attestation.rb
+++ b/app/models/attestation.rb
@@ -29,7 +29,8 @@ class Attestation < ApplicationRecord
     commit = extensions["1.3.6.1.4.1.57264.1.3"]
     ref  =  extensions["1.3.6.1.4.1.57264.1.14"]
     san  =  extensions["subjectAltName"]
-    build_file_url = extensions["1.3.6.1.4.1.57264.1.21"]
+    build_summary_url = extensions["1.3.6.1.4.1.57264.1.21"]
+    build_file_url = build_summary_url.sub(%r{attempts/\d+\z}, "workflow")
 
     case issuer
     when "https://token.actions.githubusercontent.com"
@@ -38,9 +39,9 @@ class Attestation < ApplicationRecord
       {
         ci_platform: "GitHub Actions",
         source_commit_string: "#{repo}@#{commit[0, 7]}",
-        source_commit_url: "https://github.com/#{repo}/tree/#{commit}",
+        source_commit_url: "https://github.com/#{repo}/commit/#{commit}",
         build_file_string:, build_file_url:,
-        build_summary_url: "https://github.com/#{repo}/actions/#{build_file_string.delete_prefix('.github/')}"
+        build_summary_url:
       }
     else
       raise "Unhandled issuer: #{issuer.inspect}"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/40a23d25-bb24-4191-ad3e-728cf4a0e925)

![image](https://github.com/user-attachments/assets/2bf3708a-009d-4661-87b3-b2b321872478)

![image](https://github.com/user-attachments/assets/fcd66a62-fd98-4f8b-aa04-2e9fd427f40e)


When I used the https://github.com/rubygems/release-gem action with `.github/workflows/release.yml`, it displays the `Build summary`.

However it links to `https://github.com/OWNER/REPO/actions/runs/.github/workflows/release.yml` and displays `Not Found` error.
As far as I know, GitHub provides a list of workflow runs as https://github.com/OWNER/REPO/actions/workflows/release.yml.
Is this just a typo? Or github provides the runs link with several patterns?

---

@segiddins ref: #5330

I'm posting this PR instead of creating an issue, for sharing the related code. I'm okay for this closed anytime. 🙇‍♂️ 