### PR TITLE
Successfully able to run tests locally

### DIFF
--- a/test/system/authorizing_profile_update_test.rb
+++ b/test/system/authorizing_profile_update_test.rb
@@ -1,7 +1,7 @@
 require "application_system_test_case"
 require "test_helper"
 
-class ProfileTest < ApplicationSystemTestCase
+class AuthorizingProfileUpdateTest < ApplicationSystemTestCase
   setup do
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
   end
@@ -29,7 +29,7 @@ class ProfileTest < ApplicationSystemTestCase
     # Verify that the newly added Twitter username is still on the form so that the user does not need to re-enter it
     assert_equal twitter_username, page.find_by_id("user_twitter_username").value
 
-    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    fill_in "Password", with: @user.password
     click_button "Update"
 
     assert page.has_content? "Your profile was updated."


### PR DESCRIPTION
How to replicate bug: 
- Run `bin/rails test:all` locally 
- You will see the below error message 
<img width="1120" alt="Screenshot 2024-12-26 at 15 34 23" src="https://github.com/user-attachments/assets/2978186e-18d3-4c64-8b4a-dc16f3a3fd9c" />
 
I introduce this bug accidentally   in this PR https://github.com/rubygems/rubygems.org/pull/5250/files 