### PR TITLE
Add groups for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,13 @@ updates:
     interval: daily
   open-pull-requests-limit: 99
   versioning-strategy: increase
-  ignore:
-  - dependency-name: "rubocop*"
+  groups:
+    avo:
+      patterns: ["avo", "avo-*"]
+    rubocop:
+      patterns: ["rubocop", "rubocop-*"]
+    rails:
+      patterns: ["rails", "active*", "action*", "railties"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
My hope is this will help surface better changelog links in the dependabot PRs when the linked gems update

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
