### PR TITLE
Fix endless 5xx responses leading to pages

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -10,6 +10,10 @@ data:
       worker_connections  5120;
     }
     http {
+      # Ensure buffer is large enough to contend with a redirect to a URL that is at the request line length limit
+      proxy_buffers   4 16k;
+      proxy_buffer_size 16k;
+
       server {
           listen       80;
           server_name  _;


### PR DESCRIPTION
The root cause here is that rails was returning
responses to the reverse proxy where the total
size of all the headers was greater than 4k. This
would lead to an
`upstream sent too big header while reading response header from upstream`
error in nginx, resulting in a default 502 bad
gateway response.

It took us dozens of hours of searching to find
the root cause because our nginx log parsing was
throwing away all of the error logs, and I only
saw it when directly tailing the logs from the
container in k8s. I have since fixed the log pipeline so the errors will show up as errors, with the error message.

As to how the rails app was returning so many
header bytes:
The `Redirector` middleware generates a 301
whenever it sees a host that does not match a
predefined list. Notably, `api.rubygems.org`
points to prod, but is _not_ in that list.
The 301 includes a `Location` header with the
correct host, while maintaining the rest of the
path and query string. This means that the `Location`
header could contain up to the nginx limit of almost
8k bytes. In combination with the other headers returned
by the rails app, this was sufficient to exceed the
default limit of 4k bytes.

Verified that this fixes the 502s on staging by manually applying.

Tested via `curl http://localhost:8080/versions/$(printf 'HelloWorld%.0s' {1..395})/abcdef -H 'X-Forwarded-Proto: https' -H 'X-Edge-Proto: https' -H 'Host: indexs.rubygems.org' -H 'Accept: sam/test' -v`

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
