### PR TITLE
Add integration test for assuming an API Key Role using a Buildkite OIDC token

### DIFF
--- a/test/factories/oidc/api_key_role.rb
+++ b/test/factories/oidc/api_key_role.rb
@@ -19,5 +19,23 @@ FactoryBot.define do
         ]
       }
     end
+
+    trait :buildkite do
+      provider factory: :oidc_provider_buildkite
+      sequence(:name) { |n| "Buildkite Pusher #{n}" }
+      access_policy do
+        {
+          statements: [
+            { effect: "allow",
+              principal: { oidc: provider.issuer },
+              conditions: [
+                { operator: "string_equals", claim: "organization_slug", value: "example-org" }
+              ] }
+          ]
+        }
+      end
+    end
+
+    factory :oidc_api_key_role_buildkite, traits: [:buildkite]
   end
 end

--- a/test/factories/oidc/provider.rb
+++ b/test/factories/oidc/provider.rb
@@ -63,5 +63,56 @@ FactoryBot.define do
     transient do
       pkey { OpenSSL::PKey::RSA.generate(2048) }
     end
+
+    trait :buildkite do
+      sequence(:issuer) { |n| "https://#{n}.agent.buildkite.com" }
+      configuration do
+        {
+          issuer: issuer,
+          jwks_uri: "#{issuer}/.well-known/jwks",
+          id_token_signing_alg_values_supported: [
+            "RS256"
+          ],
+          response_types_supported: [
+            "id_token"
+          ],
+          scopes_supported: [
+            "openid"
+          ],
+          subject_types_supported: %w[
+            public
+            pairwise
+          ],
+          claims_supported: %w[
+            sub
+            aud
+            exp
+            iat
+            iss
+            nbf
+            jti
+            organization_id
+            organization_slug
+            pipeline_id
+            pipeline_slug
+            build_number
+            build_branch
+            build_tag
+            build_commit
+            build_source
+            step_key
+            job_id
+            agent_id
+            cluster_id
+            cluster_name
+            queue_id
+            queue_key
+            runner_environment
+          ]
+        }
+      end
+    end
+
+    factory :oidc_provider_buildkite, traits: [:buildkite]
   end
 end


### PR DESCRIPTION
Until recently, Buildkite OIDC tokens did not contain a `jti` claim. At some point in early 2024 it was possible to assume an API Key Role using Buildkite OIDC tokens, but when testing in January 2025 we found the assume role request was failing with an error:

> Missing/invalid jti

Buildkite has addressed that by adding a `jti` claim to tokens - it's a good claim to include. However, to reduce the risk of regressions in the future, this PR proposes adding an integration test with a Buildkite-shaped OIDC token.

The trait added to the OIDC::Provider factory is based on a real token that I generated then anonymized. I only test the happy path with this token - there's a buncha existing tests for various unhappy paths (expired token, etc) using the Github Actions shaped OIDC token and there's little value in replicating them.

Most of the added test is copy-pasted from the happy-path Github Actions test further up the file.

Fixes #5412