### PR TITLE
Fix frozen string Ruby 3.4 warnings.

### DIFF
--- a/app/helpers/dynamic_errors_helper.rb
+++ b/app/helpers/dynamic_errors_helper.rb
@@ -46,7 +46,7 @@ module DynamicErrorsHelper
           end
         end.join.html_safe
 
-        contents = ''
+        contents = +''
         contents << content_tag(options[:header_tag] || :h2, header_message) unless header_message.blank?
         contents << content_tag(:p, message) unless message.blank?
         contents << content_tag(:ul, error_messages)

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -127,11 +127,11 @@ module RubygemsHelper
   end
 
   def links_to_owners(rubygem)
-    rubygem.owners.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
+    rubygem.owners.sort_by(&:id).inject(+"") { |link, owner| link << link_to_user(owner) }.html_safe
   end
 
   def links_to_owners_without_mfa(rubygem)
-    rubygem.owners.without_mfa.sort_by(&:id).inject("") { |link, owner| link << link_to_user(owner) }.html_safe
+    rubygem.owners.without_mfa.sort_by(&:id).inject(+"") { |link, owner| link << link_to_user(owner) }.html_safe
   end
 
   def link_to_user(user)

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -210,7 +210,7 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
     context "with credentials with invalid encoding" do
       setup do
         @user = create(:user)
-        authorize_with("\x12\xff\x12:creds".force_encoding(Encoding::UTF_8))
+        authorize_with(String.new("\x12\xff\x12:creds", encoding: Encoding::UTF_8))
         get :show
       end
       should_deny_access

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -981,20 +981,20 @@ class UserTest < ActiveSupport::TestCase
 
     should "preserve valid characters so that the format error can be returned" do
       # UTF-8 "香" character, which is valid UTF-8, but we reject utf-8 in email addresses
-      assert_equal "香@example.com", User.normalize_email("\u9999@example.com".force_encoding("utf-8"))
+      assert_equal "香@example.com", User.normalize_email(String.new("\u9999@example.com", encoding: "utf-8"))
 
       # ISO-8859-1 "Å" character (valid in ISO-8859-1)
-      encoded_email = "myem\xC5il@example.com".force_encoding("ISO-8859-1")
+      encoded_email = String.new("myem\xC5il@example.com", encoding: "ISO-8859-1")
 
       assert_equal encoded_email, User.normalize_email(encoded_email)
     end
 
     should "return an empty string on invalid inputs" do
       # bad encoding when sent as ASCII-8BIT
-      assert_equal "", User.normalize_email("\u9999@example.com".force_encoding("ascii"))
+      assert_equal "", User.normalize_email(String.new("\u9999@example.com", encoding: "ascii"))
 
       # ISO-8859-1 "Å" character (invalid in UTF-8, which uses \xC385 for this character)
-      assert_equal "", User.normalize_email("myem\xC5il@example.com".force_encoding("UTF-8"))
+      assert_equal "", User.normalize_email(String.new("myem\xC5il@example.com", encoding: "UTF-8"))
     end
 
     should "return an empty string for nil" do


### PR DESCRIPTION
This should cover all warnings related to codebase. There are still warnings from rack-sanitizer I tried to fix at https://github.com/Shopify/rack-sanitizer/pull/4.