### PR TITLE
Move to native maintenance_tasks error handler.

### DIFF
--- a/config/initializers/maintenance_tasks.rb
+++ b/config/initializers/maintenance_tasks.rb
@@ -1,17 +1,3 @@
-MaintenanceTasks.error_handler = lambda { |error, task_context, errored_element|
-  errored_element =
-    case errored_element
-    when ActiveRecord::Base
-      errored_element.to_gid
-    end
-
-  Rails.error.report(
-    error,
-    context: { task_context:, errored_element: },
-    handled: false
-  )
-}
-
 Rails.autoloaders.main.on_load("MaintenanceTasks::ApplicationController") do
   MaintenanceTasks::ApplicationController.include GitHubOAuthable
   MaintenanceTasks::ApplicationController.prepend MaintenanceTasksAuditable


### PR DESCRIPTION
fixes following warning

```
DEPRECATION WARNING: MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribeto the error reporter instead. (called from <main> at /home/retro/code/oss/rubygems.org/config/initializers/maintenance_tasks.rb:1)
```

It will be [reported as following](https://github.com/Shopify/maintenance_tasks/blob/7505b9c64942cab305b5bec91ec2a5bb73546915/app/jobs/concerns/maintenance_tasks/task_job_concern.rb#L194).

```
Rails.error.report(error, context: task_context, source: "maintenance-tasks")
```