### PR TITLE
Update Rubocop to use prism.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - !ruby/regexp /(vendor|bundle|bin|db/(migrate/|schema\.rb|downloads_schema\.rb)|tmp|server)($|\/.*)/
   DisplayCopNames: true
   DisplayStyleGuide: true
+  ParserEngine: parser_prism
   TargetRubyVersion: 3.4
   NewCops: enable
 


### PR DESCRIPTION
Per https://github.com/whitequark/parser/issues/1056#issuecomment-2605628509 parser gem isn't compatible with Ruby 3.4. Rubocop Prism parser is "quite experimental", but seems working well with no troubles.