### PR TITLE
New system test creating an API Key Role for Buildkite

### DIFF
--- a/app/controllers/oidc/api_key_roles_controller.rb
+++ b/app/controllers/oidc/api_key_roles_controller.rb
@@ -136,8 +136,6 @@ class OIDC::ApiKeyRolesController < ApplicationController
     return unless (gh = helpers.link_to_github(rubygem)).presence
     return unless (@api_key_role.provider = OIDC::Provider.github_actions)
 
-    statement.principal = { oidc: @api_key_role.provider.issuer }
-
     repo_condition = OIDC::AccessPolicy::Statement::Condition.new(
       claim: "repository",
       operator: "string_equals",


### PR DESCRIPTION
~Note: depends on https://github.com/rubygems/rubygems.org/pull/5416. Once that merges, I can rebase this and the first commit will fall away~

At the moment creating an API Key Role for Buildkite on rubygems.org results in an Access Policy that requires a GitHub Actions principal: `https://token.actions.githubusercontent.com`. To fix it, I have to inspect the DOM on the new form and make the principal input visible, then change it to `https://agent.buildkite.com`.

This PR has two commits:

1. Add a failing system test that demonstrates the issue
2. The fix

When a gem has a source doe URI for GitHub, `add_default_params` defaults the form to common settings for GitHub OIDC tokens.

That's a reasonable thing to do. However, that includes setting the principal to a Github Actions shaped value. That value is rendered on the form in hidden elements so the user doesn't have a chance to edit it. After saving the created role has a provider of Buildkite with an expected principal for GitHub Actions.

Its safe to remove the statement.principal assignment completely. It's not required - when the form is submitted the
OIDC::ApiKeyRole#set_statement_principals callback will set the correct principal for both GitHub Actions *and* Buildkite.

Fixes #5376 