### PR TITLE
Set Cross-Origin-Opener-Policy: same-origin on all pages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,10 @@ module Gemcutter
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    # Insert the middleware to apply COOP to all responses
+    require_relative "../lib/gemcutter/middleware/security_headers_middleware"
+    config.middleware.insert_before 0, SecurityHeadersMiddleware
+
     ###
     # TODO: This is a 8.0 framework default, but load order requires it to be here to avoid deprecation warnings.
     #
@@ -84,10 +88,6 @@ module Gemcutter
     config.active_support.cache_format_version = 7.1
 
     config.action_dispatch.rescue_responses["Rack::Multipart::EmptyContentError"] = :bad_request
-
-    config.action_dispatch.default_headers.merge!(
-      "Cross-Origin-Opener-Policy" => "same-origin"
-    )
   end
 
   def self.config

--- a/lib/gemcutter/middleware/security_headers_middleware.rb
+++ b/lib/gemcutter/middleware/security_headers_middleware.rb
@@ -1,0 +1,14 @@
+class SecurityHeadersMiddleware
+    def initialize(app)
+      @app = app
+    end
+  
+    def call(env)
+      status, headers, response = @app.call(env)
+  
+      # Ensure COOP is set for all responses (HTML, APIs, static files, errors)
+      headers["Cross-Origin-Opener-Policy"] = "same-origin"
+  
+      [status, headers, response]
+    end
+  end

--- a/test/unit/gemcutter/middleware/security_headers_middleware_test.rb
+++ b/test/unit/gemcutter/middleware/security_headers_middleware_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require_relative "../../../../lib/gemcutter/middleware/security_headers_middleware.rb"
+
+
+class SecurityHeadersMiddlewareTest < ActiveSupport::TestCase
+  def setup
+    @app = ->(_env) { [200, { "Content-Type" => "text/html" }, ["OK"]] }
+    @middleware = SecurityHeadersMiddleware.new(@app)
+  end
+
+  test "adds Cross-Origin-Opener-Policy header to responses" do
+    env = Rack::MockRequest.env_for("/")
+    status, headers, _body = @middleware.call(env)
+
+    assert_equal 200, status
+    assert_equal "same-origin", headers["Cross-Origin-Opener-Policy"]
+  end
+
+  test "preserves other existing headers" do
+    env = Rack::MockRequest.env_for("/")
+    _, headers, _ = @middleware.call(env)
+
+    assert headers.key?("Content-Type")
+  end
+
+  test "works with non-HTML responses" do
+    @app = ->(_env) { [200, { "Content-Type" => "application/json" }, ["{}"]] }
+    @middleware = SecurityHeadersMiddleware.new(@app)
+
+    env = Rack::MockRequest.env_for("/api/test")
+    status, headers, _body = @middleware.call(env)
+
+    assert_equal 200, status
+    assert_equal "same-origin", headers["Cross-Origin-Opener-Policy"]
+  end
+
+  test "applies header to error pages" do
+    @app = ->(_env) { [404, { "Content-Type" => "text/html" }, ["Not Found"]] }
+    @middleware = SecurityHeadersMiddleware.new(@app)
+
+    env = Rack::MockRequest.env_for("/nonexistent")
+    status, headers, _body = @middleware.call(env)
+
+    assert_equal 404, status
+    assert_equal "same-origin", headers["Cross-Origin-Opener-Policy"]
+  end
+end


### PR DESCRIPTION
Hello Team,

This PR fixes HackerOne Report [2681420](https://hackerone.com/reports/2681420). In the previous fix #4910, @segiddins add the header to all standard pages (not errors). However, the fix did not cover the cases of non-existing paths (errors). This PR fixes the issue by ensuring all pages, even errors, have the header correctly set. I tested this locally, and it should work fine on all paths. Can you kindly review and merge this PR and then close the H1 report so that I can claim the bounty?

Best,
Ali 