### PR TITLE
oidc system tests: wait for sign in to finish before continuing

### DIFF
--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -8,11 +8,14 @@ class OIDCTest < ApplicationSystemTestCase
     @id_token = create(:oidc_id_token, user: @user, api_key_role: @api_key_role)
   end
 
-  def sign_in
+  def sign_in # rubocop:disable Minitest/TestMethodName
     visit sign_in_path
     fill_in "Email or Username", with: @user.reload.email
     fill_in "Password", with: @user.password
     click_button "Sign in"
+
+    # Wait for the reload and confirm the sign in worked
+    page.assert_selector "h1", text: "Dashboard"
   end
 
   def verify_session # rubocop:disable Minitest/TestMethodName
@@ -227,7 +230,6 @@ class OIDCTest < ApplicationSystemTestCase
 
     sign_in
 
-    page.assert_selector "h1", text: "Dashboard"
     visit rubygem_path(rubygem.slug)
     click_link "OIDC: Create"
     verify_session


### PR DESCRIPTION
While working on #5434 I found the other system tests in this file were flakey on my local laptop.

Adding this assertion to force the test to wait for the sign in to finish before proceeding makes them pass reliabily.