### PR TITLE
Add dependabot group for aws-*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       patterns: ["rubocop", "rubocop-*"]
     rails:
       patterns: ["rails", "active*", "action*", "railties"]
+    aws:
+      patterns: ["aws-*"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
To cut down on daily number of AWS update PRs

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
