### PR TITLE
Fix broken provider id for edit api key roles form

### DIFF
--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="form__group">
     <%= f.label :oidc_provider_id, class: "form__label" %>
     <p/>
-    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, selected: :provider_id, class: "form__input form__select" %>
+    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, class: "form__input form__select" %>
   </div>
   <div class="form__group">
     <%= f.label :api_key_permissions, class: "form__label" %>

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -221,7 +221,7 @@ class OIDCTest < ApplicationSystemTestCase
     assert_equal_hash(expected, role.reload.as_json.slice(*expected.keys))
   end
 
-  test "creating an api key role for a provider who isn't GitHub" do
+  test "creating and updating an api key role for a provider who isn't GitHub" do
     provider_two = create(:oidc_provider_buildkite, issuer: "https://agent.buildkite.com")
     rubygem = create(:rubygem, owners: [@user])
 
@@ -307,6 +307,18 @@ class OIDCTest < ApplicationSystemTestCase
     }
 
     assert_equal_hash(expected, role.as_json.slice(*expected.keys))
+
+    click_button "Edit API Key Role"
+
+    page.assert_selector "h1", text: "Edit API Key Role"
+
+    assert_select "OIDC provider", options: ["https://token.actions.githubusercontent.com", "https://agent.buildkite.com"], selected: "https://agent.buildkite.com"
+
+    page.fill_in "Name", with: "Another Name"
+
+    click_button "Update Api key role"
+
+    page.assert_selector "h1", text: "API Key Role Another Name"
   end
 
   test "creating rubygem trusted publishers" do


### PR DESCRIPTION
I noticed when I was updating one of our OIDC API key roles that the OIDC provider wasn't being taken from the existing object due to the use of `selected: :provider_id` [here](https://github.com/rubygems/rubygems.org/compare/master...wooly:rubygems.org:master?expand=1#diff-27cfeaf651f6fa877e0132eac4e7536c660c25ddd269f19edace505ae62c30f2L9).

I've removed this as I don't think it's necessary and updated the system test to ensure that the correct issuer is selected in the OIDC provider dropdown when editing.