### PR TITLE
Fix showing security event details in admin

### DIFF
--- a/app/avo/fields/event_additional_field.rb
+++ b/app/avo/fields/event_additional_field.rb
@@ -9,15 +9,16 @@ class Avo::Fields::EventAdditionalField < Avo::Fields::BaseField
 
     Avo::Fields::NestedField.new(id, **@args) do
       additional_type.attribute_types.each do |attribute_name, type|
+        attribute_name = attribute_name.to_sym
         case type
         when Types::GlobalId
-          field attribute_name.to_sym, as: :global_id, show_on: :index
+          field attribute_name, as: :global_id, show_on: :index
         when ActiveModel::Type::String
-          field attribute_name.to_sym, as: :text, show_on: :index
+          field attribute_name, as: :text, show_on: :index
         when ActiveModel::Type::Boolean
-          field attribute_name.to_sym, as: :boolean, show_on: :index
+          field attribute_name, as: :boolean, show_on: :index
         else
-          field attribute_name.to_sym, as: :json_viewer, hide_on: :index
+          field attribute_name, as: :text, hide_on: :index
         end
       end
     end.hydrate(record:, resource:, action:, view:, panel_name:, user:)

--- a/app/components/avo/fields/nested_field/edit_component.html.erb
+++ b/app/components/avo/fields/nested_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper **field_wrapper_args, class: "nested-form-wrapper", data: {} do %>
   <% form.fields_for field.id, field.value do |form| %>
     <% field.get_fields.each do |f| %>
-      <%= render f.hydrate(view:, model: field.value, resource:).component_for_view(view).new(field: f, form:, view:) %>
+      <%= render f.hydrate(view:, record: field.value, resource:).component_for_view(view).new(field: f, form:, view:) %>
       <% if field.value && field.value.errors.include?(f.id) %>
         <div class="text-red-600 mt-2 text-sm"><%= field.value.errors.messages_for(f.id).to_sentence %></div>
       <% end %>

--- a/app/components/avo/fields/nested_field/index_component.html.erb
+++ b/app/components/avo/fields/nested_field/index_component.html.erb
@@ -5,7 +5,7 @@
     <% field.get_fields.each do |f| %>
       <tr class="!tw-py-0" >
         <td><%= f.name %></td>
-        <%= render f.hydrate(view:, model: field.value, resource:).component_for_view(view).new(field: f, resource:, flush: true) %>
+        <%= render f.hydrate(view:, record: field.value, resource:).component_for_view(view).new(field: f, resource:, flush: true) %>
       </tr>
     <% end %>
     </tbody></table>

--- a/app/components/avo/fields/nested_field/show_component.html.erb
+++ b/app/components/avo/fields/nested_field/show_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper **field_wrapper_args, data: {} do %>
   <div class="divide-y">
     <% field.get_fields.each do |f| %>
-      <%= render f.hydrate(view:, model: field.value, resource:).component_for_view(view).new(field: f, resource:) %>
+      <%= render f.hydrate(view:, record: field.value, resource:).component_for_view(view).new(field: f, resource:) %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Before:
<img width="174" alt="image" src="https://github.com/user-attachments/assets/381bb7e3-e973-42a6-af8b-3aff2e7b37a0" />


After:
<img width="734" alt="image" src="https://github.com/user-attachments/assets/509b953c-7d00-416e-a12d-c1cad16e2f8d" />


Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
