### PR TITLE
Add "the" before gem references in owner notification emails

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
       edit_api_key: "Edit API key"
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
     all_gems: All Gems
-    gem_ownership_removed: Ownership of %{rubygem_name} has been removed after being scoped to this key.
+    gem_ownership_removed: Ownership of the %{rubygem_name} gem has been removed after being scoped to this key.
   dashboards:
     show:
       creating_link_text: creating
@@ -343,30 +343,30 @@ en:
       subject: You have requested email address update on %{host}
       title: EMAIL UPDATE REQUESTED
     ownership_confirmation:
-      subject: Please confirm the ownership of %{gem} gem on %{host}
+      subject: Please confirm the ownership of the %{gem} gem on %{host}
       title: OWNERSHIP CONFIRMATION
       subtitle: Hi %{handle}!
-      body_text: You were added as an owner to %{gem} gem by %{authorizer}. Please visit link below to confirm your ownership.
-      body_html: You were added as an owner to <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem by <strong>%{authorizer}</strong>. Please click on the link below to confirm your ownership.
-      link_expiration_explanation_html: Please note that this link is valid for only %{expiry_hours}. You can resend confirmation mail from the  <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem page after sign in.
+      body_text: You were added as an owner to the %{gem} gem by %{authorizer}. Please visit link below to confirm your ownership.
+      body_html: You were added as an owner to the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem by <strong>%{authorizer}</strong>. Please click on the link below to confirm your ownership.
+      link_expiration_explanation_html: Please note that this link is valid for only %{expiry_hours}. You can resend confirmation mail from the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem page after sign in.
     owner_added:
-      subject_self: You were added as an owner to %{gem} gem
-      subject_others: User %{owner_handle} was added as an owner to %{gem} gem
+      subject_self: You were added as an owner to the %{gem} gem
+      subject_others: User %{owner_handle} was added as an owner to the %{gem} gem
       title: OWNER ADDED
       subtitle: Hi %{user_handle}!
-      body_self_html: <b>You</b> were added as an owner to <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem on %{host}.
-      body_others_html: <b>%{owner_handle}</b> was added as an owner to <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem by <b>%{authorizer}</b>. You are receiving this notification because you are an owner of %{gem}.
+      body_self_html: <b>You</b> were added as an owner to the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem on %{host}.
+      body_others_html: <b>%{owner_handle}</b> was added as an owner to the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem by <b>%{authorizer}</b>. You are receiving this notification because you are an owner of %{gem}.
     owner_removed:
-      subject: You were removed as an owner from %{gem} gem
+      subject: You were removed as an owner from the %{gem} gem
       title: OWNER REMOVED
       subtitle: Hi %{user_handle}!
-      body_html: <b>You</b> were removed as an owner for <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem on %{host} by <b>%{remover}</b>.
+      body_html: <b>You</b> were removed as an owner from the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem on %{host} by <b>%{remover}</b>.
     owner_updated:
-      subject: Your role was updated for %{gem} gem
+      subject: Your role was updated for the %{gem} gem
       title: OWNER ROLE UPDATED
       subtitle: Hi %{user_handle}!
-      body_html: Your role was updated to %{role} for <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem.
-      body_text: Your role was updated to %{role} for %{gem} gem.
+      body_html: Your role was updated to %{role} for the <strong><a href="https://rubygems.org/gems/%{gem}">%{gem}</a></strong> gem.
+      body_text: Your role was updated to %{role} for the %{gem} gem.
     web_hook_deleted:
       title: WEBHOOK DELETED
       subject: Your %{host} webhook was deleted
@@ -573,7 +573,7 @@ en:
       role: Role
       title: Edit Owner
     confirm:
-      confirmed_email: You were added as an owner to %{gem} gem
+      confirmed_email: You were added as an owner to the %{gem} gem
       token_expired: The confirmation token has expired. Please try resending the token from the gem page.
     index:
       add_owner: ADD OWNER

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -235,7 +235,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           end
 
           should "send confirmation mail to second user" do
-            assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
+            assert_equal "Please confirm the ownership of the #{@rubygem.name} gem on RubyGems.org", last_email.subject
             assert_equal [@second_user.email], last_email.to
           end
         end
@@ -671,7 +671,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
           end
 
           should "send email notification to user being removed" do
-            assert_equal "You were removed as an owner from #{@rubygem.name} gem", last_email.subject
+            assert_equal "You were removed as an owner from the #{@rubygem.name} gem", last_email.subject
             assert_equal [@second_user.email], last_email.to
           end
         end

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -88,7 +88,7 @@ class OwnersControllerTest < ActionController::TestCase
             perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
             assert_emails 1
-            assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
+            assert_equal "Please confirm the ownership of the #{@rubygem.name} gem on RubyGems.org", last_email.subject
             assert_equal [@new_owner.email], last_email.to
           end
 
@@ -198,7 +198,7 @@ class OwnersControllerTest < ActionController::TestCase
           end
           should "send email notifications about owner removal" do
             assert_emails 1
-            assert_contains last_email.subject, "You were removed as an owner from #{@rubygem.name} gem"
+            assert_contains last_email.subject, "You were removed as an owner from the #{@rubygem.name} gem"
             assert_equal [@second_user.email], last_email.to
           end
         end
@@ -218,7 +218,7 @@ class OwnersControllerTest < ActionController::TestCase
           end
           should "send email notifications about owner removal" do
             assert_emails 1
-            assert_contains last_email.subject, "You were removed as an owner from #{@rubygem.name} gem"
+            assert_contains last_email.subject, "You were removed as an owner from the #{@rubygem.name} gem"
             assert_equal [@second_user.email], last_email.to
           end
         end
@@ -317,7 +317,7 @@ class OwnersControllerTest < ActionController::TestCase
         end
         should "resend confirmation email" do
           assert_emails 1
-          assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
+          assert_equal "Please confirm the ownership of the #{@rubygem.name} gem on RubyGems.org", last_email.subject
           assert_equal [@new_owner.email], last_email.to
         end
       end
@@ -551,7 +551,7 @@ class OwnersControllerTest < ActionController::TestCase
         should "confirm ownership" do
           assert_predicate @ownership, :confirmed?
           assert redirect_to("rubygem show") { rubygem_path(@rubygem.slug) }
-          assert_equal "You were added as an owner to #{@rubygem.name} gem", flash[:notice]
+          assert_equal "You were added as an owner to the #{@rubygem.name} gem", flash[:notice]
         end
 
         should "not sign in the user" do
@@ -561,8 +561,8 @@ class OwnersControllerTest < ActionController::TestCase
         should "send email notifications about new owner" do
           owner_added_email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
-          assert_contains owner_added_email_subjects, "You were added as an owner to #{@rubygem.name} gem"
-          assert_contains owner_added_email_subjects, "User #{@user.handle} was added as an owner to #{@rubygem.name} gem"
+          assert_contains owner_added_email_subjects, "You were added as an owner to the #{@rubygem.name} gem"
+          assert_contains owner_added_email_subjects, "User #{@user.handle} was added as an owner to the #{@rubygem.name} gem"
 
           owner_added_email_to = ActionMailer::Base.deliveries.map(&:to).flatten
 

--- a/test/integration/owner_test.rb
+++ b/test/integration/owner_test.rb
@@ -35,7 +35,7 @@ class OwnerTest < SystemTest
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
     assert_emails 1
-    assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
+    assert_equal "Please confirm the ownership of the #{@rubygem.name} gem on RubyGems.org", last_email.subject
   end
 
   test "adding owner via UI with handle" do
@@ -53,7 +53,7 @@ class OwnerTest < SystemTest
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
     assert_emails 1
-    assert_equal "Please confirm the ownership of #{@rubygem.name} gem on RubyGems.org", last_email.subject
+    assert_equal "Please confirm the ownership of the #{@rubygem.name} gem on RubyGems.org", last_email.subject
   end
 
   test "owners data is correctly represented" do
@@ -95,7 +95,7 @@ class OwnerTest < SystemTest
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
     assert_emails 1
-    assert_contains last_email.subject, "You were removed as an owner from #{@rubygem.name} gem"
+    assert_contains last_email.subject, "You were removed as an owner from the #{@rubygem.name} gem"
     assert_equal [@other_user.email], last_email.to
   end
 
@@ -198,14 +198,14 @@ class OwnerTest < SystemTest
     end
 
     assert_equal page.current_path, rubygem_path(@rubygem.slug)
-    assert page.has_selector? "#flash_notice", text: "You were added as an owner to #{@rubygem.name} gem"
+    assert page.has_selector? "#flash_notice", text: "You were added as an owner to the #{@rubygem.name} gem"
 
     assert_emails 2
 
     owner_added_email_subjects = ActionMailer::Base.deliveries.map(&:subject)
 
-    assert_contains owner_added_email_subjects, "You were added as an owner to #{@rubygem.name} gem"
-    assert_contains owner_added_email_subjects, "User #{@unconfirmed_ownership.user.handle} was added as an owner to #{@rubygem.name} gem"
+    assert_contains owner_added_email_subjects, "You were added as an owner to the #{@rubygem.name} gem"
+    assert_contains owner_added_email_subjects, "User #{@unconfirmed_ownership.user.handle} was added as an owner to the #{@rubygem.name} gem"
   end
 
   test "clicking on incorrect link shows error" do

--- a/test/mailers/owners_test.rb
+++ b/test/mailers/owners_test.rb
@@ -14,7 +14,7 @@ class OwnersMailerTest < ActionMailer::TestCase
       email = OwnersMailer.with(ownership: @maintainer_ownership).owner_updated
 
       assert_emails(1) { email.deliver_now }
-      assert_equal email.subject, "Your role was updated for #{@rubygem.name} gem"
+      assert_equal email.subject, "Your role was updated for the #{@rubygem.name} gem"
     end
   end
 end

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -22,7 +22,7 @@ class ApiKeysHelperTest < ActionView::TestCase
       expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
         <span
           class="tooltip__text"
-          data-tooltip="Ownership of #{rubygem_name} has been removed after being scoped to this key."\
+          data-tooltip="Ownership of the #{rubygem_name} gem has been removed after being scoped to this key."\
         >#{rubygem_name} [?]</span>
       HTML
 


### PR DESCRIPTION
While receiving notifications about gem ownership, I noticed the wording felt a bit unnatural without the definite article "the" before references to gems. This small pull request improves readability by adding "the" where appropriate in the owner-related email notifications.

Just a small grammar improvement that, I think, makes the notifications sound more natural. Feel free to close this pull request if you disagree 🙈 