### PR TITLE
Add more assertions to tests to let previous requests finish.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,7 +629,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-sanitizer (2.0.3)
+    rack-sanitizer (2.0.4)
       rack (>= 1.0, < 4.0)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
@@ -1261,7 +1261,7 @@ CHECKSUMS
   rack-attack (6.7.0) sha256=3ca47e8f66cd33b2c96af53ea4754525cd928ed3fa8da10ee6dad0277791d77c
   rack-oauth2 (2.2.1) sha256=c73aa87c508043e2258f02b4fb110cacba9b37d2ccf884e22487d014a120d1a5
   rack-protection (4.1.1) sha256=51a254a5d574a7f0ca4f0672025ce2a5ef7c8c3bd09c431349d683e825d7d16a
-  rack-sanitizer (2.0.3) sha256=3e492e1b56b0005fb1b56d77dff996821059aad4321634883ae3c42c865f9af0
+  rack-sanitizer (2.0.4) sha256=782ff5efb53177f6d2ab3a80ce07dbfecef8123a1e5c613160a38731e49e846c
   rack-session (2.1.0) sha256=437c3916535b58ef71c816ce4a2dee0a01c8a52ae6077dc2b6cd19085760a290
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.2.1) sha256=f737191fd5c5b348b7f0a4412a3b86383f88c43e13b8217b63d4c8d90b9e798d

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,11 +1,11 @@
 WebAuthn.configure do |config|
-  config.origin = [if Rails.env.development?
-                     ENV.fetch("WEBAUTHN_ORIGIN", "http://localhost:3000")
-                   elsif Rails.env.test?
-                     "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}:31337"
-                   else
-                     "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
-                   end]
+  config.allowed_origins = [if Rails.env.development?
+                              ENV.fetch("WEBAUTHN_ORIGIN", "http://localhost:3000")
+                            elsif Rails.env.test?
+                              "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}:31337"
+                            else
+                              "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}"
+                            end]
   config.rp_name = Gemcutter::HOST_DISPLAY
   # config.rp_id = Gemcutter::HOST
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -14,4 +14,20 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   end
+
+  def sign_in
+    visit sign_in_path
+    fill_in "Email or Username", with: @user.reload.email
+    fill_in "Password", with: @user.password
+    click_button "Sign in"
+
+    assert page.has_content?("Dashboard")
+  end
+
+  def sign_out
+    reset_session!
+    visit "/"
+
+    assert page.has_content?("Sign in".upcase)
+  end
 end

--- a/test/integration/api/v1/search_test.rb
+++ b/test/integration/api/v1/search_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class Api::V1::Search < ActionDispatch::IntegrationTest
+  include SearchKickHelper
+
   test "request with non-string query shows bad request" do
+    import_and_refresh
+
     get "/api/v1/search.json?query[]="
 
     assert_response :bad_request

--- a/test/integration/email_confirmation_test.rb
+++ b/test/integration/email_confirmation_test.rb
@@ -14,6 +14,8 @@ class EmailConfirmationTest < SystemTest
     click_link "Didn't receive confirmation mail?"
     fill_in "Email address", with: email
     click_button "Resend Confirmation"
+
+    assert page.has_content? "We will email you confirmation link to activate your account if one exists."
   end
 
   test "requesting confirmation mail does not tell if a user exists" do

--- a/test/integration/encoding_test.rb
+++ b/test/integration/encoding_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class EncodingTest < ActionDispatch::IntegrationTest
+  include SearchKickHelper
+
   test "invalid utf-8 characters should be sanitized" do
+    import_and_refresh
+
     get "/api/v1/search.json?query=vagrant%ADvbguest"
 
     assert_response :success

--- a/test/integration/password_reset_test.rb
+++ b/test/integration/password_reset_test.rb
@@ -18,7 +18,11 @@ class PasswordResetTest < SystemTest
 
     click_link "Forgot password?"
     fill_in "Email address", with: email
-    perform_enqueued_jobs { click_button "Reset password" }
+    perform_enqueued_jobs do
+      click_button "Reset password"
+
+      assert page.has_content? "You will receive an email within the next few minutes."
+    end
   end
 
   test "reset password form does not tell if a user exists" do

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -9,6 +9,8 @@ class ApiKeysTest < ApplicationSystemTestCase
     fill_in "Email or Username", with: @user.email
     fill_in "Password", with: @user.password
     click_button "Sign in"
+
+    assert page.has_content?("Dashboard")
   end
 
   test "creating new api key" do
@@ -40,6 +42,8 @@ class ApiKeysTest < ApplicationSystemTestCase
 
     visit_profile_api_keys_path
     click_button "New API key"
+
+    assert page.has_content?("New API key")
 
     assert_empty URI.parse(page.current_url).query
 
@@ -194,6 +198,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     refute page.has_content? "Enable MFA"
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_predicate api_key.reload, :can_add_owner?
   end
 
@@ -208,6 +213,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     page.select "All Gems"
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_equal "All Gems", page.find('.owners__cell[data-title="Gem"]').text
     assert_nil api_key.reload.rubygem
   end
@@ -225,6 +231,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     assert page.has_select? "api_key_rubygem_id", selected: "All Gems", disabled: true
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_nil api_key.reload.rubygem
   end
 
@@ -243,6 +250,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     page.select @ownership.rubygem.name
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_equal api_key.reload.rubygem, @ownership.rubygem
   end
 
@@ -278,6 +286,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     check "mfa"
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_predicate api_key.reload, :can_add_owner?
     assert_predicate @user.api_keys.last, :mfa_enabled?
   end
@@ -296,6 +305,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     refute page.has_content? "Enable MFA"
     click_button "Update API Key"
 
+    assert page.has_content?("Successfully updated API key")
     assert_predicate api_key.reload, :can_add_owner?
     assert_predicate @user.api_keys.last, :mfa_enabled?
   end

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -8,16 +8,6 @@ class OIDCTest < ApplicationSystemTestCase
     @id_token = create(:oidc_id_token, user: @user, api_key_role: @api_key_role)
   end
 
-  def sign_in # rubocop:disable Minitest/TestMethodName
-    visit sign_in_path
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
-
-    # Wait for the reload and confirm the sign in worked
-    page.assert_selector "h1", text: "Dashboard"
-  end
-
   def verify_session # rubocop:disable Minitest/TestMethodName
     page.assert_title(/^Confirm Password/)
     fill_in "Password", with: @user.password

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -8,18 +8,6 @@ class ProfileTest < ApplicationSystemTestCase
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
   end
 
-  def sign_in
-    visit sign_in_path
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
-  end
-
-  def sign_out
-    reset_session!
-    visit "/"
-  end
-
   test "changing handle" do
     sign_in
 
@@ -180,6 +168,8 @@ class ProfileTest < ApplicationSystemTestCase
       fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
       click_button "Confirm"
     end
+
+    assert page.has_content?("Your account deletion request has been enqueued.")
 
     sign_in
     visit delete_profile_path

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -5,13 +5,6 @@ class SettingsTest < ApplicationSystemTestCase
     @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
   end
 
-  def sign_in
-    visit sign_in_path
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
-  end
-
   def enable_otp
     key = ROTP::Base32.random_base32
     @user.enable_totp!(key, :ui_only)

--- a/test/system/webauthn_credentials_test.rb
+++ b/test/system/webauthn_credentials_test.rb
@@ -7,13 +7,6 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
     @user = create(:user)
   end
 
-  def sign_in
-    visit sign_in_path
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
-  end
-
   should "have security device form" do
     sign_in
     visit edit_settings_path

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -12,8 +12,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   test "when verifying webauthn credential" do
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert_match "Authenticate with Security Device", page.html
-    assert_match "Authenticating as #{@user.handle}", page.html
+    assert page.has_content?("Authenticate with Security Device")
+    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
     click_on "Authenticate"
 
@@ -28,8 +28,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     assert_poll_status("pending")
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert_match "Authenticate with Security Device", page.html
-    assert_match "Authenticating as #{@user.handle}", page.html
+    assert page.has_content?("Authenticate with Security Device")
+    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
     click_on "Authenticate"
 
@@ -46,8 +46,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   test "when client closes connection during verification" do
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert_match "Authenticate with Security Device", page.html
-    assert_match "Authenticating as #{@user.handle}", page.html
+    assert page.has_content?("Authenticate with Security Device")
+    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
     @mock_client.kill_server
     click_on "Authenticate"
@@ -64,8 +64,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     wrong_port = 1111
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: wrong_port })
 
-    assert_match "Authenticate with Security Device", page.html
-    assert_match "Authenticating as #{@user.handle}", page.html
+    assert page.has_content?("Authenticate with Security Device")
+    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
     click_on "Authenticate"
 
@@ -81,8 +81,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     @mock_client.response = @mock_client.bad_request_response
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert_match "Authenticate with Security Device", page.html
-    assert_match "Authenticating as #{@user.handle}", page.html
+    assert page.has_content?("Authenticate with Security Device")
+    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
     click_on "Authenticate"
 
@@ -97,8 +97,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     travel 3.minutes do
-      assert_match "Authenticate with Security Device", page.html
-      assert_match "Authenticating as #{@user.handle}", page.html
+      assert page.has_content?("Authenticate with Security Device")
+      assert page.has_content?("Authenticating as #{@user.handle}".upcase)
 
       click_on "Authenticate"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -189,10 +189,14 @@ class ActiveSupport::TestCase
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
+    assert page.has_content? "Dashboard"
+
     @authenticator = create_webauthn_credential_while_signed_in
 
     find(:css, ".header__popup-link").click
     click_on "Sign out"
+
+    assert page.has_content?("Sign in".upcase)
 
     @authenticator
   end


### PR DESCRIPTION
- seems Chrome 134 changed behavior 
- those tests were never stable for me locally, with this fix I was able to re-run 20 times without fail
- my guess is: asking Chrome for new action now can also now stop the previous one if not finished yet
- adding assertion to problematic places seems fixing the CI since it enforces test to wait for previous action to finish first
- no idea this change was intended, but since I have seen it sporadically in previous Chrome versions locally, it seems our tests are wrong, not the Chrome headless :thinking: 
- I have added also fixes for 2 most annoying warnings in test suite in separate commits.

_potentially closes https://github.com/rubygems/rubygems.org/pull/5536_