### PR TITLE
Assert URL once page is fully loaded in API keys test.

### DIFF
--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -191,8 +191,8 @@ class ApiKeysTest < ApplicationSystemTestCase
     visit_profile_api_keys_path
     click_button "Edit"
 
-    assert_empty URI.parse(page.current_url).query
     assert page.has_content? "Edit API key"
+    assert_empty URI.parse(page.current_url).query
     check "api_key[add_owner]"
 
     refute page.has_content? "Enable MFA"


### PR DESCRIPTION
- fixes some recent CI failures
- verified locally it fixes the problem (I was able to reproduce)