### PR TITLE
Add an index to the versions for Dependencies#show

### DIFF
--- a/app/controllers/dependencies_controller.rb
+++ b/app/controllers/dependencies_controller.rb
@@ -6,7 +6,7 @@ class DependenciesController < ApplicationController
   def show
     @dependencies = Hash.new { |h, k| h[k] = [] }
     resolvable_dependencies = @latest_version.dependencies.where(unresolved_name: nil)
-      .strict_loading.preload(rubygem: :public_versions)
+      .strict_loading.preload(rubygem: :public_versions_for_dependencies)
 
     resolvable_dependencies.each do |dependency|
       gem_name = dependency.rubygem.name
@@ -27,7 +27,7 @@ class DependenciesController < ApplicationController
     requirements = dependency.clean_requirements
     reqs = Gem::Dependency.new(name, requirements.split(/\s*,\s*/))
 
-    matching_versions = dependency.rubygem.public_versions.select { |v| reqs.match?(name, v.number) }
+    matching_versions = dependency.rubygem.public_versions_for_dependencies.select { |v| reqs.match?(name, v.number) }
     match = matching_versions.detect { |v| match_platform(platform, v.platform) } || matching_versions.first
     match&.slug
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -138,6 +138,9 @@ class Rubygem < ApplicationRecord
   end
 
   has_many :public_versions, -> { by_position.published }, class_name: "Version", inverse_of: :rubygem
+  has_many :public_versions_for_dependencies, lambda {
+    order(:rubygem_id).by_position.published.select(:rubygem_id, :full_name, :number, :platform)
+  }, class_name: "Version", inverse_of: :rubygem
 
   def public_versions_with_extra_version(extra_version)
     versions = public_versions.limit(5).to_a

--- a/db/migrate/20250407201204_add_index_to_versions.rb
+++ b/db/migrate/20250407201204_add_index_to_versions.rb
@@ -1,0 +1,9 @@
+class AddIndexToVersions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+  def change
+    add_index :versions, %w[rubygem_id position created_at], order: { position: :asc, created_at: :desc },
+      where: "indexed = true",
+      include: %i[full_name number platform],
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_04_065953) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_201204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -612,6 +612,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_065953) do
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
+t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 
   create_table "web_hooks", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This adds an index to the versions table to speed up the query in
Dependencies#show. The index is on the rubygem_id, position, and created_at columns, and is ordered by position ascending and created_at descending.
The index is only applied to rows where indexed = true.

The `order by` clause is used to ensure that an index scan is all that is needed to
run the query.

Before:

```
Gather Merge  (cost=48301.05..49691.58 rows=11918 width=878) (actual time=27.670..32.615 rows=16297 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  ->  Sort  (cost=47301.02..47315.92 rows=5959 width=878) (actual time=17.273..17.662 rows=5432 loops=3)
        Sort Key: "position", created_at DESC
        Sort Method: external merge  Disk: 3624kB
        Worker 0:  Sort Method: quicksort  Memory: 2490kB
        Worker 1:  Sort Method: quicksort  Memory: 2431kB
        ->  Parallel Bitmap Heap Scan on versions  (cost=406.23..44624.37 rows=5959 width=878) (actual time=1.631..10.145 rows=5432 loops=3)
              Recheck Cond: (rubygem_id = ANY ('{15163,112014,26159,16914,15076,32035,173920,186981,183849,183850}'::integer[]))
              Filter: indexed
              Rows Removed by Filter: 17
              Heap Blocks: exact=3925
              ->  Bitmap Index Scan on index_versions_on_rubygem_id_and_number_and_platform  (cost=0.00..402.62 rows=15777 width=0) (actual time=3.251..3.251 rows=16347 loops=1)
                    Index Cond: (rubygem_id = ANY ('{15163,112014,26159,16914,15076,32035,173920,186981,183849,183850}'::integer[]))
Planning Time: 0.212 ms
Execution Time: 33.862 ms
```

After:

```
Index Only Scan using index_versions_on_rubygem_id_and_position_and_created_at on versions  (cost=0.43..613.35 rows=13564 width=28) (actual time=0.035..4.553 rows=16297 loops=1)
  Index Cond: (rubygem_id = ANY ('{15163,112014,26159,16914,15076,32035,173920,186981,183849,183850}'::integer[]))
  Heap Fetches: 0
Planning Time: 0.289 ms
Execution Time: 5.351 ms
```

This should help resolve the DOS issues we had last month!

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
