### PR TITLE
Support deps.dev API token scanning

### DIFF
--- a/app/controllers/api/v1/github_secret_scanning_controller.rb
+++ b/app/controllers/api/v1/github_secret_scanning_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::GitHubSecretScanningController < Api::BaseController
   include ApiKeyable
 
+  before_action :find_secret_scanning_key
+  before_action :validate_secret_scanning_key
+
   # API called by GitHub Secret Scanning tool
   # see docs https://docs.github.com/en/developers/overview/secret-scanning
   # Sample message:
@@ -16,14 +19,6 @@ class Api::V1::GitHubSecretScanningController < Api::BaseController
   # [{"token": "some_token", "type": "some_type", "url": "some_url"}]
   #
   def revoke
-    key_id = request.headers.fetch("GITHUB-PUBLIC-KEY-IDENTIFIER", "")
-    signature = request.headers.fetch("GITHUB-PUBLIC-KEY-SIGNATURE", "")
-
-    return render plain: "Missing GitHub Signature", status: :unauthorized if key_id.blank? || signature.blank?
-    key = secret_scanning_key(key_id)
-    return render plain: "Can't fetch public key from GitHub", status: :unauthorized if key.empty_public_key?
-    return render plain: "Invalid GitHub Signature", status: :unauthorized unless key.valid_github_signature?(signature, request.body.read.chomp)
-
     tokens = params.expect(_json: [%i[token type url]]).index_by { |t| hashed_key(t.require(:token)) }
     api_keys = ApiKey.where(hashed_key: tokens.keys).index_by(&:hashed_key)
     resp = tokens.map do |hashed_key, t|
@@ -49,12 +44,25 @@ class Api::V1::GitHubSecretScanningController < Api::BaseController
 
   private
 
+  def find_secret_scanning_key
+    if (key_id = request.headers.fetch("GITHUB-PUBLIC-KEY-IDENTIFIER", "").presence) &&
+        (@signature = request.headers.fetch("GITHUB-PUBLIC-KEY-SIGNATURE", "").presence)
+      @key = GitHubSecretScanning.new(key_id)
+    elsif (key_id = request.headers.fetch("DepsDev-Public-Key-Identifier", "").presence) &&
+        (@signature = request.headers.fetch("DepsDevPublic-Key-Signature", "").presence)
+      @key = GitHubSecretScanning::DepsDev.new(key_id)
+    else
+      render plain: "Missing GitHub Signature", status: :unauthorized
+    end
+  end
+
+  def validate_secret_scanning_key
+    return render plain: "Can't fetch public key from GitHub", status: :unauthorized if @key.empty_public_key?
+    render plain: "Invalid GitHub Signature", status: :unauthorized unless @key.valid_github_signature?(@signature, request.body.read.chomp)
+  end
+
   def schedule_revoke_email(api_key, url)
     return unless api_key.user?
     Mailer.api_key_revoked(api_key.owner_id, api_key.name, api_key.scopes.join(", "), url).deliver_later
-  end
-
-  def secret_scanning_key(key_id)
-    GitHubSecretScanning.new(key_id)
   end
 end

--- a/lib/github_secret_scanning.rb
+++ b/lib/github_secret_scanning.rb
@@ -16,7 +16,7 @@ class GitHubSecretScanning
   end
 
   def self.public_key(id)
-    cache_key = ["GitHubSecretScanning", "public_keys", id]
+    cache_key = [name, "public_keys", id]
     Rails.cache.fetch(cache_key) do
       public_keys = secret_scanning_keys.public_keys
       public_keys&.find { |v| v.key_identifier == id }&.key
@@ -25,5 +25,13 @@ class GitHubSecretScanning
 
   def self.secret_scanning_keys
     Octokit.client.get(KEYS_URI)
+  end
+
+  class DepsDev < GitHubSecretScanning
+    KEYS_URI = "https://storage.googleapis.com/depsdev-gcp-public-keys/secret_scanning".freeze
+
+    def self.secret_scanning_keys
+      Octokit.client.get(KEYS_URI)
+    end
   end
 end

--- a/test/integration/api/v1/github_secret_scanning_test.rb
+++ b/test/integration/api/v1/github_secret_scanning_test.rb
@@ -4,6 +4,9 @@ class Api::V1::GitHubSecretScanningTest < ActionDispatch::IntegrationTest
   HEADER_KEYID = "GITHUB-PUBLIC-KEY-IDENTIFIER".freeze
   HEADER_SIGNATURE = "GITHUB-PUBLIC-KEY-SIGNATURE".freeze
 
+  DEPS_DEV_HEADER_KEYID = "DepsDev-Public-Key-Identifier".freeze
+  DEPS_DEV_HEADER_SIGNATURE = "DepsDevPublic-Key-Signature".freeze
+
   KEYS_RESPONSE_BODY =
     { "public_keys" => [
       {
@@ -12,135 +15,142 @@ class Api::V1::GitHubSecretScanningTest < ActionDispatch::IntegrationTest
       }
     ] }.freeze
 
-  context "on POST to revoke" do
-    setup do
-      key = OpenSSL::PKey::EC.generate("secp256k1")
-      @private_key_pem = key.to_pem
-      @public_key_pem = key.public_to_pem
+  [
+    [:github, HEADER_KEYID, HEADER_SIGNATURE, GitHubSecretScanning::KEYS_URI],
+    [:deps_dev, DEPS_DEV_HEADER_KEYID, DEPS_DEV_HEADER_SIGNATURE, GitHubSecretScanning::DepsDev::KEYS_URI]
+  ].each do |name, header_keyid, header_signature, keys_uri|
+    context "from #{name}" do
+      context "on POST to revoke" do
+        setup do
+          key = OpenSSL::PKey::EC.generate("secp256k1")
+          @private_key_pem = key.to_pem
+          @public_key_pem = key.public_to_pem
 
-      h = KEYS_RESPONSE_BODY.dup
-      h["public_keys"][0]["key"] = @public_key_pem
+          h = KEYS_RESPONSE_BODY.dup
+          h["public_keys"][0]["key"] = @public_key_pem
 
-      stub_request(:get, GitHubSecretScanning::KEYS_URI)
-        .to_return(
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: h.to_json
-        )
+          stub_request(:get, keys_uri)
+            .to_return(
+              status: 200,
+              headers: { "Content-Type" => "application/json" },
+              body: h.to_json
+            )
 
-      @tokens = [
-        { "token" => "some_token", "type" => "some_type", "url" => "some_url" }
-      ]
+          @tokens = [
+            { "token" => "some_token", "type" => "some_type", "url" => "some_url" }
+          ]
 
-      @user = create(:user)
-    end
-
-    context "with no key_id" do
-      setup do
-        post revoke_api_v1_api_key_path(@rubygem),
-          params: {},
-          headers: { HEADER_SIGNATURE => "bar" }
-      end
-
-      should "deny access" do
-        assert_response :unauthorized
-        assert_match "Missing GitHub Signature", @response.body
-      end
-    end
-
-    context "with no signature" do
-      setup do
-        post revoke_api_v1_api_key_path(@rubygem),
-          params: {},
-          headers: { HEADER_KEYID => "foo" }
-      end
-
-      should "deny access" do
-        assert_response :unauthorized
-        assert_match "Missing GitHub Signature", @response.body
-      end
-    end
-
-    context "with invalid key_id" do
-      setup do
-        post revoke_api_v1_api_key_path(@rubygem),
-          params: {},
-          headers: { HEADER_KEYID => "foo", HEADER_SIGNATURE => "bar" }
-      end
-
-      should "deny access" do
-        assert_response :unauthorized
-        assert_match "Can't fetch public key from GitHub", @response.body
-      end
-    end
-
-    context "with invalid signature" do
-      setup do
-        signature = sign_body("Hello world!")
-        post revoke_api_v1_api_key_path(@rubygem),
-          params: {},
-          headers: { HEADER_KEYID => "test_key_id", HEADER_SIGNATURE => Base64.encode64(signature) }
-      end
-
-      should "deny access" do
-        assert_response :unauthorized
-        assert_match "Invalid GitHub Signature", @response.body
-      end
-    end
-
-    context "without a valid token" do
-      setup do
-        signature = sign_body(JSON.dump(@tokens))
-        post revoke_api_v1_api_key_path(@rubygem),
-          params: @tokens,
-          headers: { HEADER_KEYID => "test_key_id", HEADER_SIGNATURE => Base64.encode64(signature) },
-          as: :json
-      end
-
-      should "returns success" do
-        assert_response :success
-        json = JSON.parse(@response.body)[0]
-
-        assert_equal "false_positive", json["label"]
-        assert_equal @tokens[0]["type"], json["token_type"]
-        assert_equal @tokens[0]["token"], json["token_raw"]
-      end
-    end
-
-    context "with a valid token" do
-      setup do
-        key = "rubygems_#{SecureRandom.hex(24)}"
-        @api_key = create(:api_key, key: key)
-        @tokens << { "token" => key, "type" => "rubygems", "url" => "some_url" }
-        signature = sign_body(JSON.dump(@tokens))
-
-        perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-          post revoke_api_v1_api_key_path(@rubygem),
-            params: @tokens,
-            headers: { HEADER_KEYID => "test_key_id", HEADER_SIGNATURE => Base64.encode64(signature) },
-            as: :json
+          @user = create(:user)
         end
-      end
 
-      should "returns success and remove the token" do
-        assert_response :success
+        context "with no key_id" do
+          setup do
+            post revoke_api_v1_api_key_path(@rubygem),
+              params: {},
+              headers: { header_signature => "bar" }
+          end
 
-        json = JSON.parse(@response.body)
+          should "deny access" do
+            assert_response :unauthorized
+            assert_match "Missing GitHub Signature", @response.body
+          end
+        end
 
-        assert_equal "true_positive", json.last["label"]
-        assert_equal @tokens.last["token"], json.last["token_raw"]
+        context "with no signature" do
+          setup do
+            post revoke_api_v1_api_key_path(@rubygem),
+              params: {},
+              headers: { header_keyid => "foo" }
+          end
 
-        assert_predicate @api_key.reload, :expired?
-      end
+          should "deny access" do
+            assert_response :unauthorized
+            assert_match "Missing GitHub Signature", @response.body
+          end
+        end
 
-      should "delivers an email" do
-        refute_empty ActionMailer::Base.deliveries
-        email = ActionMailer::Base.deliveries.last
+        context "with invalid key_id" do
+          setup do
+            post revoke_api_v1_api_key_path(@rubygem),
+              params: {},
+              headers: { header_keyid => "foo", header_signature => "bar" }
+          end
 
-        assert_equal [@api_key.user.email], email.to
-        assert_equal ["no-reply@mailer.rubygems.org"], email.from
-        assert_equal "One of your API keys was revoked on rubygems.org", email.subject
-        assert_match "some_url", email.body.to_s
+          should "deny access" do
+            assert_response :unauthorized
+            assert_match "Can't fetch public key from GitHub", @response.body
+          end
+        end
+
+        context "with invalid signature" do
+          setup do
+            signature = sign_body("Hello world!")
+            post revoke_api_v1_api_key_path(@rubygem),
+              params: {},
+              headers: { header_keyid => "test_key_id", header_signature => Base64.encode64(signature) }
+          end
+
+          should "deny access" do
+            assert_response :unauthorized
+            assert_match "Invalid GitHub Signature", @response.body
+          end
+        end
+
+        context "without a valid token" do
+          setup do
+            signature = sign_body(JSON.dump(@tokens))
+            post revoke_api_v1_api_key_path(@rubygem),
+              params: @tokens,
+              headers: { header_keyid => "test_key_id", header_signature => Base64.encode64(signature) },
+              as: :json
+          end
+
+          should "returns success" do
+            assert_response :success
+            json = JSON.parse(@response.body)[0]
+
+            assert_equal "false_positive", json["label"]
+            assert_equal @tokens[0]["type"], json["token_type"]
+            assert_equal @tokens[0]["token"], json["token_raw"]
+          end
+        end
+
+        context "with a valid token" do
+          setup do
+            key = "rubygems_#{SecureRandom.hex(24)}"
+            @api_key = create(:api_key, key: key)
+            @tokens << { "token" => key, "type" => "rubygems", "url" => "some_url" }
+            signature = sign_body(JSON.dump(@tokens))
+
+            perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+              post revoke_api_v1_api_key_path(@rubygem),
+                params: @tokens,
+                headers: { header_keyid => "test_key_id", header_signature => Base64.encode64(signature) },
+                as: :json
+            end
+          end
+
+          should "returns success and remove the token" do
+            assert_response :success
+
+            json = JSON.parse(@response.body)
+
+            assert_equal "true_positive", json.last["label"]
+            assert_equal @tokens.last["token"], json.last["token_raw"]
+
+            assert_predicate @api_key.reload, :expired?
+          end
+
+          should "delivers an email" do
+            refute_empty ActionMailer::Base.deliveries
+            email = ActionMailer::Base.deliveries.last
+
+            assert_equal [@api_key.user.email], email.to
+            assert_equal ["no-reply@mailer.rubygems.org"], email.from
+            assert_equal "One of your API keys was revoked on rubygems.org", email.subject
+            assert_match "some_url", email.body.to_s
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Now that deps.dev supports rubygems (yay!), they have offered to do API token scanning for us.

The scanning is identical to GitHub's revocation API, with the slight difference of different header names (and a different endpoint to fetch valid keys from)

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
