### PR TITLE
Reduce memory usage in StoreVersionContentsJob

### DIFF
--- a/app/models/rubygem_contents/entry.rb
+++ b/app/models/rubygem_contents/entry.rb
@@ -4,7 +4,16 @@ class RubygemContents::Entry
   class InvalidMetadata < RuntimeError; end
 
   SIZE_LIMIT = 500.megabytes
-  MIME_TEXTUAL_SUBTYPES = %w[json ld+json x-csh x-sh x-httpd-php xhtml+xml xml].freeze
+  MIME_TEXTUAL_SUBTYPES = %w[
+    text/
+    application/json
+    application/ld\+json
+    application/x-csh
+    application/x-sh
+    application/x-httpd-php
+    application/xhtml\+xml
+    application/xml
+  ].freeze
 
   class << self
     # Passing in an existing Magic instance is very important for memory usage.
@@ -96,10 +105,7 @@ class RubygemContents::Entry
     return false unless mime
     return true if empty?
     return false if mime.end_with?("charset=binary")
-    media_type, sub_type = mime.split(";").first.split("/")
-    return true if media_type == "text"
-    return false if media_type != "application"
-    true if MIME_TEXTUAL_SUBTYPES.include?(sub_type)
+    MIME_TEXTUAL_SUBTYPES.any? { |subtype| mime.start_with?(subtype) }
   end
 
   def body

--- a/app/models/rubygem_contents/entry.rb
+++ b/app/models/rubygem_contents/entry.rb
@@ -64,7 +64,7 @@ class RubygemContents::Entry
     else
       @body_persisted = sha256.present? && !large? && text?
       @body = attrs[:body] if @body_persisted
-      @lines = @body&.lines&.count unless symlink?
+      @lines = @body.count("\n") + (@body.end_with?("\n") || @body.empty? ? 0 : 1) if @body && !symlink?
     end
   end
 

--- a/app/models/rubygem_contents/entry.rb
+++ b/app/models/rubygem_contents/entry.rb
@@ -60,7 +60,7 @@ class RubygemContents::Entry
   alias content_length size
   alias bytesize size
 
-  def initialize(path:, size:, persisted: false, **attrs, &reader)
+  def initialize(path:, size:, persisted: false, **attrs, &reader) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     @path = path
     @size = size.to_i
     @persisted = persisted

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -51,13 +51,16 @@ class VersionManifest
 
   # @param [Gem::Package] package
   def store_package(package)
+    magic = Magic.open(Magic::MIME)
     entries = GemPackageEnumerator.new(package).filter_map do |tar_entry|
       Rails.error.handle(context: { gem: package.spec.full_name, entry: tar_entry.full_name }) do
-        RubygemContents::Entry.from_tar_entry(tar_entry)
+        RubygemContents::Entry.from_tar_entry(tar_entry, magic:)
       end
     end
     store_entries entries
     store_spec package.spec
+  ensure
+    magic.close
   end
 
   # Writing version contents is done in one pass, collecting all the checksums

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -53,7 +53,7 @@ class VersionManifest
   def store_package(package)
     magic = Magic.open(Magic::MIME)
     entries = GemPackageEnumerator.new(package).filter_map do |tar_entry|
-      Rails.error.handle(context: { gem: package.spec.full_name, entry: tar_entry.full_name }) do
+      Rails.error.handle(context: { gem:, version:, entry: tar_entry.full_name }) do
         RubygemContents::Entry.from_tar_entry(tar_entry, magic:)
       end
     end

--- a/lib/gem_package_enumerator.rb
+++ b/lib/gem_package_enumerator.rb
@@ -10,6 +10,11 @@ class GemPackageEnumerator
     raise ArgumentError, "package must be a Gem::Package"
   end
 
+  # NOTE: For efficiency sake we do not verify the gem before reading the
+  # contents. This means that if you try to access anything on the package
+  # before IO.rewind is called, it will crash trying to read from the wrong
+  # position. This saves as much memory allocation as the unpacked size of
+  # the gem.
   def each(&blk)
     return enum_for(__method__).lazy unless blk
     open_data_tar { |data_tar| data_tar.each(&blk) }
@@ -26,7 +31,6 @@ class GemPackageEnumerator
   private
 
   def open_data_tar(&)
-    @package.verify
     @package.gem.with_read_io do |io|
       Gem::Package::TarReader.new(io).seek("data.tar.gz") do |gem_entry|
         @package.open_tar_gz(gem_entry, &)


### PR DESCRIPTION
The primary culprit here is Magic. When opening a new instance every iteration, we cause a massive memory bloat that doesn't get cleaned up right away.

With these improvements, memory profiler reports an improvement of `2.03GB` -> `800MB` for our pathological gem test.

These changes also make a significant speed improvement, from "I couldn't stand to wait for it to finish while it exceeded 11GB memory usage before I killed it" -> `51sec (with magic disabled)` -> `7.23sec` now.