### PR TITLE
Limit storing version contents

### DIFF
--- a/app/models/rubygem_contents/entry.rb
+++ b/app/models/rubygem_contents/entry.rb
@@ -3,7 +3,9 @@
 class RubygemContents::Entry
   class InvalidMetadata < RuntimeError; end
 
-  SIZE_LIMIT = 500.megabytes
+  # Reading 262 bytes is (supposedly) enough to determine the mime type of the entry.
+  BYTES_FOR_MAGIC_DETECTION = 262
+  SIZE_LIMIT = 100.megabytes
   MIME_TEXTUAL_SUBTYPES = %w[
     text/
     application/json
@@ -27,9 +29,8 @@ class RubygemContents::Entry
       }
 
       if entry.size > SIZE_LIMIT
-        head = entry.read(4096)
-        mime = magic.buffer(head)
-        return new(mime: mime, **attrs)
+        mime = magic.buffer(entry.read(BYTES_FOR_MAGIC_DETECTION))
+        return new(mime:, **attrs)
       end
 
       # Using the linkname as the body, like git, makes it easier to show and diff symlinks. Thanks git!

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -2,6 +2,7 @@
 
 class VersionManifest
   DEFAULT_DIGEST = "sha256"
+  MAX_ENTRIES = 1000
 
   attr_reader :version, :contents
 
@@ -51,14 +52,23 @@ class VersionManifest
 
   # @param [Gem::Package] package
   def store_package(package)
+    read_and_store_entries(package)
+    store_spec package.spec
+  end
+
+  def read_and_store_entries(package)
     magic = Magic.open(Magic::MIME)
+    count = 0
     entries = GemPackageEnumerator.new(package).filter_map do |tar_entry|
-      Rails.error.handle(context: { gem:, version:, entry: tar_entry.full_name }) do
-        RubygemContents::Entry.from_tar_entry(tar_entry, magic:)
-      end
+      count += 1
+      # bail completely if the gem is too large.
+      # this is better than producting a partial manifest,
+      # because that could trick someone into thinking they
+      # are seeing the entire gem when they are not.
+      return if count > MAX_ENTRIES # rubocop:disable Lint/NonLocalExitFromIterator
+      RubygemContents::Entry.from_tar_entry(tar_entry, magic:)
     end
     store_entries entries
-    store_spec package.spec
   ensure
     magic.close
   end

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -62,7 +62,7 @@ class VersionManifest
     entries = GemPackageEnumerator.new(package).filter_map do |tar_entry|
       count += 1
       # bail completely if the gem is too large.
-      # this is better than producting a partial manifest,
+      # this is better than producing a partial manifest,
       # because that could trick someone into thinking they
       # are seeing the entire gem when they are not.
       return if count > MAX_ENTRIES # rubocop:disable Lint/NonLocalExitFromIterator

--- a/test/models/rubygem_contents_entry_test.rb
+++ b/test/models/rubygem_contents_entry_test.rb
@@ -50,7 +50,7 @@ class RubygemContentsEntryTest < ActiveSupport::TestCase
       size: RubygemContents::Entry::SIZE_LIMIT + 1,
       symlink?: false
     )
-    tar_entry.stubs(:read).with(4096).returns("a" * 4096)
+    tar_entry.stubs(:read).with(262).returns("a" * 262)
     RubygemContents::Entry.from_tar_entry(tar_entry)
   end
 
@@ -123,7 +123,7 @@ class RubygemContentsEntryTest < ActiveSupport::TestCase
       tar_entry.expects(:full_name).returns(large_entry.path)
       tar_entry.expects(:header).returns(mock(mode: 0o644))
       tar_entry.expects(:size).at_least_once.returns(RubygemContents::Entry::SIZE_LIMIT + 1)
-      tar_entry.expects(:read).with(4096).returns("a" * 4096)
+      tar_entry.expects(:read).with(262).returns("a" * 262)
       entry = RubygemContents::Entry.from_tar_entry(tar_entry)
 
       assert_equal large_entry, entry


### PR DESCRIPTION
Bailing out completely when uploading files means we either have an accurate view of all files, or no files, rather than a misleading partial extraction.

Still upload the spec so we have that info available.