### PR TITLE
Enable datadog pg comment propagation

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -43,7 +43,7 @@ Datadog.configure do |c|
   c.tracing.instrument :faraday, split_by_domain: true, service_name: c.service
   c.tracing.instrument :http, split_by_domain: true, service_name: c.service
   c.tracing.instrument :opensearch, service_name: c.service
-  c.tracing.instrument :pg
+  c.tracing.instrument :pg, comment_propagation: 'full'
   c.tracing.instrument :rails, request_queuing: true
   c.tracing.instrument :shoryuken if defined?(Shoryuken)
 end


### PR DESCRIPTION
This will allow linking database monitoring traces to their parent spans in the application

Following https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm/?tab=ruby

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
