### PR TITLE
Stop chomping the payload for sig validation in secret scanning

### DIFF
--- a/app/controllers/api/v1/github_secret_scanning_controller.rb
+++ b/app/controllers/api/v1/github_secret_scanning_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::GitHubSecretScanningController < Api::BaseController
 
   def validate_secret_scanning_key
     return render plain: "Can't fetch public key from GitHub", status: :unauthorized if @key.empty_public_key?
-    render plain: "Invalid GitHub Signature", status: :unauthorized unless @key.valid_github_signature?(@signature, request.body.read.chomp)
+    render plain: "Invalid GitHub Signature", status: :unauthorized unless @key.valid_github_signature?(@signature, request.body.read)
   end
 
   def schedule_revoke_email(api_key, url)

--- a/lib/github_secret_scanning.rb
+++ b/lib/github_secret_scanning.rb
@@ -1,4 +1,6 @@
 class GitHubSecretScanning
+  include SemanticLogger::Loggable
+
   KEYS_URI = "https://api.github.com/meta/public_keys/secret_scanning".freeze
 
   def initialize(key_identifier)


### PR DESCRIPTION
It is only necessary for testing when input payload has a trailing newline from heredoc strings