### PR TITLE
Fix position of gem count in stats graph

### DIFF
--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -188,7 +188,7 @@
 
 .stats__graph__gem__count {
   position: absolute;
-  right: 12px; }
+  left: 12px; }
   @media (max-width: 419px) {
     .stats__graph__gem__count {
       font-size: 12px; } }


### PR DESCRIPTION
On smaller devices, the gem count value could overlap the gem name. This overlap prevented users from clicking the link associated with the gem name.

Using the `left` property for positioning the count ensures that the gem name remains clickable, resolving the usability issue on small screens.

| Before | After |
|--------|--------|
| ![rubygems org_stats_page=5(Pixel 7)](https://github.com/user-attachments/assets/0d1135d2-6660-4e4f-802b-b8b73e9c8d4e) | ![rubygems org_stats_page=5(Pixel 7) (1)](https://github.com/user-attachments/assets/ea2f227c-8233-4c57-bdda-a99107383f93) |