### PR TITLE
[DevContainer] Use apt feature to install pkg-config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,7 @@
-# syntax = docker/dockerfile:1.4
-
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=3.4.3
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends pkg-config \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Ensure binding is always 0.0.0.0
+# Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
+ENV BINDING="0.0.0.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,12 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     // "ghcr.io/rails/devcontainer/features/activestorage": {},
-    "ghcr.io/rails/devcontainer/features/postgres-client": {}
+    "ghcr.io/rails/devcontainer/features/postgres-client": {},
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": [
+        "pkg-config"
+      ]
+    }
   },
   // Configure tool-specific properties.
   "containerEnv": {


### PR DESCRIPTION
Features makes it much easier to manage dependencies inside the devcontainer than relying on the Dockerfile.