### PR TITLE
Add ClickHouse usage to Privacy Notice

### DIFF
--- a/app/views/policies/privacy.md
+++ b/app/views/policies/privacy.md
@@ -1,6 +1,6 @@
 # RubyGems.org Privacy Notice
 
-Last updated Mar 18, 2025
+Last updated May 7, 2025
 
 **This policy is in community review. It will take effect at the end of this period estimated on May 20th, 2025\.**
 
@@ -20,7 +20,7 @@ You may register security devices and/or authentication apps in order to secure 
 
 #### Web traffic Information
 
-We collect information related to web traffic such as IP addresses and geolocation data for security-relevant events.
+We collect information related to web traffic such as IP addresses and geolocation data for security-relevant events and to analyze how and where RubyGems is used.
 
 #### Gem Data and Metadata
 
@@ -43,7 +43,8 @@ We collect this information to perform our contract with you (e.g. to provide th
 In addition to the purposes described in the Ruby Central Privacy Policy, we disclose personal information related to your use of RubyGems as set forth below:
 
 * To publish information about RubyGems packages and authors via the service  
-* To enable users of the service, including mirror operators, to view and download RubyGems packages
+* To enable users of the service, including mirror operators, to view and download RubyGems packages  
+* To analyze usage of the RubyGems service
 
 ### Third Party Services We Share Information With
 
@@ -51,10 +52,11 @@ Ruby Central uses some third party services to assist with operating online serv
 
 Specifically, we use:
 
-* Amazon Web Services (AWS) to host the RubyGems.org website and services. We store your information on AWS servers. Their use of this information is subject to the [AWS GDPR Data Processing Addendum](https://aws.amazon.com/blogs/security/aws-gdpr-data-processing-addendum/) between AWS and Ruby Central and the [AWS Privacy Notice](https://aws.amazon.com/privacy/).  
+* Amazon Web Services (AWS) to host the RubyGems.org website and services. We store your information on AWS servers. Their use of this information is subject to the [AWS GDPR Data Processing Addendum](https://aws.amazon.com/blogs/security/aws-gdpr-data-processing-addendum/) between AWS and Ruby Central.  
 * Fastly to provide CDN services for the RubyGems website and services. Your information transits their servers. Their use of this information is subject to the [Data Processing Terms](https://www.fastly.com/data-processing) between Fastly and Ruby Central and the Fastly [Privacy Policy](https://www.fastly.com/privacy/).  
-* Datadog to aggregate metrics and application performance data. Some personal information may be stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.datadoghq.com/legal/data-processing-addendum/) between Datadog and Ruby Central and the Datadog [Privacy Policy](https://www.datadoghq.com/legal/privacy/).  
-* Honeycomb.io to aggregate metrics and application performance data. Only information related to web traffic is stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.honeycomb.io/dpa) between Honeycomb and Ruby Central and the Honeycomb [Privacy Notice](https://www.honeycomb.io/privacy).    
-* Honeybadger to monitor, track, and resolve application errors.  Their use of this information is subject to the [Data Processing Addendum](https://www.honeybadger.io/terms/data-processing-addendum/) between Honeybadger and Ruby Central and the Honeybadger [Privacy Statement](https://www.honeybadger.io/privacy/).  
-* Twilio to send emails through the SendGrid product. Their use of this information is subject to the [Data Protection Addendum](https://www.twilio.com/en-us/legal/data-protection-addendum) between Twilio and Ruby Central and the Twilio [Privacy Notice](https://www.twilio.com/en-us/legal/privacy).
+* Datadog to aggregate metrics and application performance data. Some personal information may be stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.datadoghq.com/legal/data-processing-addendum/) between Datadog and Ruby Central.  
+* Honeycomb.io to aggregate metrics and application performance data. Only information related to web traffic is stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.honeycomb.io/dpa) between Honeycomb and Ruby Central.    
+* Honeybadger to monitor, track, and resolve application errors.  Their use of this information is subject to the [Data Processing Addendum](https://www.honeybadger.io/terms/data-processing-addendum/) between Honeybadger and Ruby Central.  
+* Twilio to send emails through the SendGrid product. Their use of this information is subject to the [Data Protection Addendum](https://www.twilio.com/en-us/legal/data-protection-addendum) between Twilio and Ruby Central.
 
+We also have a partnership with ClickHouse to enable retrieval and analysis of historic RubyGems download log data, and to make some log data publicly available to the Ruby community. The data we share with ClickHouse includes geolocation data, which we use for internal analysis of RubyGems usage, but the only location data we make publicly available is continent and country from which downloads originate. ClickHouse’s use of private geolocation data is subject to the [Data Processing Addendum](https://clickhouse.com/legal/agreements/data-processing-addendum) between ClickHouse and Ruby Central.

--- a/app/views/policies/privacy.md
+++ b/app/views/policies/privacy.md
@@ -1,6 +1,6 @@
 # RubyGems.org Privacy Notice
 
-Last updated May 7, 2025
+Last updated May 9, 2025
 
 **This policy is in community review. It will take effect at the end of this period estimated on May 20th, 2025\.**
 
@@ -12,23 +12,23 @@ Ruby Central collects the following information from users of RubyGems.org:
 
 #### Registration Information
 
-When you register for RubyGems, we collect your username, email address and password. You may optionally provide your full name or your organization’s name, if you use that feature.
+When you register for RubyGems.org, we collect your username, email address and password. You may optionally provide your full name or your organization’s name, if you use that feature.
 
 #### Multi-Factor Authentication Information
 
-You may register security devices and/or authentication apps in order to secure your RubyGems account with multi-factor authentication. When you do, we collect information uniquely identifying your security device.
+You may register security devices and/or authentication apps in order to secure your RubyGems.org account with multi-factor authentication. When you do, we collect information uniquely identifying your security device.
 
 #### Web traffic Information
 
-We collect information related to web traffic such as IP addresses and geolocation data for security-relevant events and to analyze how and where RubyGems is used.
+We collect information related to web traffic such as IP addresses and geolocation data for security-relevant events and to analyze how and where RubyGems.org is used.
 
 #### Gem Data and Metadata
 
-When you upload a gem software package to RubyGems, we collect any data and metadata contained in the package. This includes gem specification (gem spec) data, including gem author names and email addresses. It also includes any personal information included in the gem files, such as open source author attributions in source code files.
+When you upload a gem software package to RubyGems.org, we collect any data and metadata contained in the package. This includes gem specification (gem spec) data, including gem author names and email addresses. It also includes any personal information included in the gem files, such as open source author attributions in source code files.
 
 ## Purposes and Legal Bases for Our Use of Your Personal Information
 
-Ruby Central collects personal information related to your use of RubyGems for the following purposes:
+Ruby Central collects personal information related to your use of RubyGems.org for the following purposes:
 
 * To provide the RubyGems service including incident response purposes  
 * To publish information about RubyGems packages and authors on the RubyGems service  
@@ -53,10 +53,10 @@ Ruby Central uses some third party services to assist with operating online serv
 Specifically, we use:
 
 * Amazon Web Services (AWS) to host the RubyGems.org website and services. We store your information on AWS servers. Their use of this information is subject to the [AWS GDPR Data Processing Addendum](https://aws.amazon.com/blogs/security/aws-gdpr-data-processing-addendum/) between AWS and Ruby Central.  
-* Fastly to provide CDN services for the RubyGems website and services. Your information transits their servers. Their use of this information is subject to the [Data Processing Terms](https://www.fastly.com/data-processing) between Fastly and Ruby Central and the Fastly [Privacy Policy](https://www.fastly.com/privacy/).  
+* Fastly to provide CDN services for the RubyGems.org website and services. Your information transits their servers. Their use of this information is subject to the [Data Processing Terms](https://www.fastly.com/data-processing) between Fastly and Ruby Central and the Fastly [Privacy Policy](https://www.fastly.com/privacy/).  
 * Datadog to aggregate metrics and application performance data. Some personal information may be stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.datadoghq.com/legal/data-processing-addendum/) between Datadog and Ruby Central.  
 * Honeycomb.io to aggregate metrics and application performance data. Only information related to web traffic is stored on their servers. Their use of this information is subject to the [Data Processing Addendum](https://www.honeycomb.io/dpa) between Honeycomb and Ruby Central.    
 * Honeybadger to monitor, track, and resolve application errors.  Their use of this information is subject to the [Data Processing Addendum](https://www.honeybadger.io/terms/data-processing-addendum/) between Honeybadger and Ruby Central.  
 * Twilio to send emails through the SendGrid product. Their use of this information is subject to the [Data Protection Addendum](https://www.twilio.com/en-us/legal/data-protection-addendum) between Twilio and Ruby Central.
 
-We also have a partnership with ClickHouse to enable retrieval and analysis of historic RubyGems download log data, and to make some log data publicly available to the Ruby community. The data we share with ClickHouse includes geolocation data, which we use for internal analysis of RubyGems usage, but the only location data we make publicly available is continent and country from which downloads originate. ClickHouse’s use of private geolocation data is subject to the [Data Processing Addendum](https://clickhouse.com/legal/agreements/data-processing-addendum) between ClickHouse and Ruby Central.
+We also have a partnership with ClickHouse to enable retrieval and analysis of historic RubyGems.org download log data, and to make some log data publicly available to the Ruby community. The data we share with ClickHouse includes geolocation data, which we use for internal analysis of RubyGems.org usage, but the only location data we make publicly available is continent and country from which downloads originate. ClickHouse’s use of private geolocation data is subject to the [Data Processing Addendum](https://clickhouse.com/legal/agreements/data-processing-addendum) between ClickHouse and Ruby Central.


### PR DESCRIPTION
Update the privacy notice for Rubygems.org to include data processing by ClickHouse. 