### PR TITLE
Add k8s deployment for Within 24 Hours job queue

### DIFF
--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: good-job
         image: 048268392960.dkr.ecr.us-west-2.amazonaws.com/rubygems/rubygems.org:<%= current_sha %>
-        args: ["good_job", "start", "--queues", "default,mailers,searchkick"]
+        args: ["good_job", "start", "--queues", "default,mailers,searchkick,stats,version_contents"]
         resources:
           <% if environment == 'production' %>
           requests:

--- a/config/deploy/jobs_within_24_hours.yaml.erb
+++ b/config/deploy/jobs_within_24_hours.yaml.erb
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jobs
+  name: jobs-within-24-hours
   annotations:
     shipit.shopify.io/restart: 'true'
 spec:
@@ -12,13 +12,13 @@ spec:
       maxUnavailable: 50%
   selector:
     matchLabels:
-      name: jobs
+      name: jobs-within-24-hours
   template:
     metadata:
       annotations:
         ad.datadoghq.com/good-job.logs: '[{"source":"rails","service":"rubygems.org","version": <%= current_sha.dump %>}]'
       labels:
-        name: jobs
+        name: jobs-within-24-hours
         tags.datadoghq.com/env: "<%= environment %>"
         tags.datadoghq.com/service: rubygems.org
         tags.datadoghq.com/version: <%= current_sha %>
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: good-job
         image: 048268392960.dkr.ecr.us-west-2.amazonaws.com/rubygems/rubygems.org:<%= current_sha %>
-        args: ["good_job", "start", "--queues", "default,mailers,searchkick"]
+        args: ["good_job", "start", "--queues", "within_24_hours"]
         resources:
           <% if environment == 'production' %>
           requests:

--- a/config/deploy/jobs_within_24_hours.yaml.erb
+++ b/config/deploy/jobs_within_24_hours.yaml.erb
@@ -28,21 +28,12 @@ spec:
         image: 048268392960.dkr.ecr.us-west-2.amazonaws.com/rubygems/rubygems.org:<%= current_sha %>
         args: ["good_job", "start", "--queues", "within_24_hours"]
         resources:
-          <% if environment == 'production' %>
           requests:
-            cpu: 500m
-            memory: 1.4Gi
-          limits:
-            cpu: 1000m
-            memory: 2.0Gi
-          <% else %>
-          requests:
-            cpu: 200m
-            memory: 250Mi
+            cpu: 100m
+            memory: 400Mi
           limits:
             cpu: 500m
-            memory: 1.2Gi
-          <% end %>
+            memory: 600Mi
         ports:
           - name: probe-port
             containerPort: 7001


### PR DESCRIPTION
We need to send roughly 200K emails to users informing them of the newly introduced rubygems.org policies in #5581. The announcement emails don't need to be delivered straight away, and infact, should not get in the way of other background tasks of being processed.

In #5581, I placed the announcement emails in a queue called `within_24_hours`, similar to the naming proposed in https://engineering.gusto.com/scaling-sidekiq-at-gusto-3f9e3279e63 to surface this signal. This PR makes the changes to the Kubernetes Resources to run the `within_24_hours` queue in a separate worker.