### PR TITLE
Remove Order by clause in email policy maintenance task 

### DIFF
--- a/app/tasks/maintenance/policy_announcement_email_task.rb
+++ b/app/tasks/maintenance/policy_announcement_email_task.rb
@@ -2,7 +2,7 @@
 
 class Maintenance::PolicyAnnouncementEmailTask < MaintenanceTasks::Task
   def collection
-    User.order(id: :asc)
+    User.all
   end
 
   def process(user)


### PR DESCRIPTION
Maintenance Tasks does not want us setting our own Order by in ActiveRecord, and infact already orders the AR relation by ID. 

```
Ran for less than 5 seconds until an error happened less than a minute ago.

JobIteration::ActiveRecordCursor::ConditionNotSupportedError

The relation cannot use ORDER BY or LIMIT due to the way how iteration with a cursor is designed. You can use other ways to limit the number of rows, e.g. a WHERE condition on the primary key column.
```