### PR TITLE
Change logic displaying remove ownership button

### DIFF
--- a/app/helpers/owners_helper.rb
+++ b/app/helpers/owners_helper.rb
@@ -18,4 +18,8 @@ module OwnersHelper
       image_tag("/images/check.svg")
     end
   end
+
+  def can_delete_ownership?(ownership, user)
+    ownership&.user_id != user.id
+  end
 end

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -50,12 +50,14 @@
         <%= ownership.confirmed_at.strftime("%Y-%m-%d %H:%M %Z") if ownership.confirmed? %>
       </td>
       <td class="owners__cell" data-title="Action">
-        <%= button_to t("remove"),
-          rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
-          method: "delete",
-          data: { confirm: t("owners.index.confirm_remove") },
-          class: "form__submit form__submit--small" %>
-        <br>
+        <% if can_delete_ownership?(ownership, current_user) %>
+          <%= button_to t("remove"),
+            rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
+            method: "delete",
+            data: { confirm: t("owners.index.confirm_remove") },
+            class: "form__submit form__submit--small" %>
+          <br>
+        <% end %>
         <%= button_to t("edit"),
           edit_rubygem_owner_path(@rubygem.name, ownership.user.display_id),
           disabled: ownership.user == current_user,


### PR DESCRIPTION
### Issue
There is an [open issue](https://github.com/rubygems/rubygems.org/issues/5666) reported as a bug.

The problem is that the `Remove` button is displayed even when a gem has only one owner. Although this case is handled gracefully - when the sole owner attempts to remove themselves, a flash error is shown with a descriptive [message](https://github.com/MaxSukhanov/rubygems.org/blob/6d5cfb924bbb1bc0d285688cff8432cb4ff63356/config/locales/en.yml#L612) (see screenshot) - the presence of the button could be misleading and confusing.

<img width="1288" alt="Screenshot 2025-06-01 at 02 09 03" src="https://github.com/user-attachments/assets/e038623f-2cc4-4231-94a9-4eb29322a937" />

This is currently enforced in code by [this condition](https://github.com/MaxSukhanov/rubygems.org/blob/6d5cfb924bbb1bc0d285688cff8432cb4ff63356/app/models/ownership.rb#L80).

### Solution
The `Remove` button is now hidden for owners when they are viewing their own ownership, regardless of whether other owners exist or not.

Note: This change assumes that owners should not be able to remove their own ownership under any circumstances. If this assumption is incorrect, please let me know.

