### PR TITLE
Ensure audit page is rendered before clicking.

### DIFF
--- a/test/system/avo/manual_changes_test.rb
+++ b/test/system/avo/manual_changes_test.rb
@@ -60,6 +60,7 @@ class Avo::ManualChangesSystemTest < ApplicationSystemTestCase
 
     find('div[data-field-id="auditable"]').click_on log_ticket.to_param
 
+    page.assert_text "pending"
     page.assert_title(/^#{log_ticket.to_param}/)
 
     click_on "Edit"


### PR DESCRIPTION
- makes it more stable

fixes random failures like https://github.com/rubygems/rubygems.org/actions/runs/15277486529/job/42977107810?pr=5698