### PR TITLE
set GOOD_JOB_QUEUE_SELECT_LIMIT env var

### DIFF
--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -65,6 +65,8 @@ spec:
             value: "<%= environment %>"
           - name: GOOD_JOB_PROBE_PORT
             value: "7001"
+          - name: GOOD_JOB_QUEUE_SELECT_LIMIT
+            value: "1000"
           <% if environment != "production" %>
           - name: GOOD_JOB_MAX_THREADS
             value: "2"

--- a/config/deploy/jobs_within_24_hours.yaml.erb
+++ b/config/deploy/jobs_within_24_hours.yaml.erb
@@ -56,6 +56,8 @@ spec:
             value: "<%= environment %>"
           - name: GOOD_JOB_PROBE_PORT
             value: "7001"
+          - name: GOOD_JOB_QUEUE_SELECT_LIMIT
+            value: "1000"
           <% if environment != "production" %>
           - name: GOOD_JOB_MAX_THREADS
             value: "2"


### PR DESCRIPTION
Last Friday, I attempted to send an email to every user (~230,000) on rubygems.org regarding the new policies being introduced in #5581. I used a mixture of Maintenance Tasks and background tasks to schedule the background tasks so that they wouldn't suddenly go from 0 to 100% instantly. However, after 2 hours of sending emails, the database server was locked at 100%, and the background jobs came to a grinding halt.

Here is a screenshot of Datadog showing a significant load on the database server caused by a large number of scheduled background jobs.

<img width="1169" alt="Screenshot 2025-06-03 at 12 10 25 pm" src="https://github.com/user-attachments/assets/e6ae3265-f836-45e8-9167-ce99bbf447da" />

The query that was identified as causing this load is:

```SQL
SELECT good_jobs . * 
FROM 
good_jobs
 
WHERE good_jobs.id IN ( WITH rows AS MATERIALIZED ( 
    SELECT good_jobs.id, good_jobs.active_job_id 
    FROM 
good_jobs
 
    WHERE good_jobs.queue_name IN ( ? ) AND good_jobs.finished_at IS ? AND ( good_jobs.scheduled_at <= ? OR good_jobs.scheduled_at IS ? ) 
    ORDER BY priority ASC NULLS LAST, good_jobs.created_at ASC 
) 
SELECT rows.id 
FROM rows 
WHERE pg_try_advisory_lock ( ( ? || substr ( md5 ( ? || ? || rows.active_job_id :: text ), ?, ? ) ) :: bit ( ? ) :: bigint ) 
LIMIT ? ) 
ORDER BY priority ASC NULLS LAST, good_jobs.created_at ASC
```

This query is from an internal mechanism inside the Good Job RubyGem that is used to process scheduled background jobs.

# Solution

Thankfully, Good job has a mechanism to reduce the load of this operation

> GoodJob’s advisory locking strategy uses a materialized CTE (Common Table Expression). This strategy can be non-performant when querying a very large queue of executable jobs (100,000+) because the database query must materialize all executable jobs before acquiring an advisory lock.

> GoodJob offers an optional optimization to limit the number of jobs that are queried: Queue Select Limit.

https://github.com/bensheldon/good_job?tab=readme-ov-file#queue-performance-with-queue-select-limit