### PR TITLE
Resume Policy Announcement Email from last known position

### DIFF
--- a/app/tasks/maintenance/policy_announcement_email_task.rb
+++ b/app/tasks/maintenance/policy_announcement_email_task.rb
@@ -2,7 +2,7 @@
 
 class Maintenance::PolicyAnnouncementEmailTask < MaintenanceTasks::Task
   def collection
-    User.all
+    User.where("id > ?", 10_333)
   end
 
   def process(user)

--- a/test/tasks/maintenance/policy_announcement_email_task_test.rb
+++ b/test/tasks/maintenance/policy_announcement_email_task_test.rb
@@ -7,12 +7,13 @@ class Maintenance::PolicyAnnouncementEmailTaskTest < ActiveSupport::TestCase
 
   setup do
     @user = create(:user)
+    @another_user = create(:user, id: 10_334)
   end
 
   test "scoping the task to all users" do
     task = Maintenance::PolicyAnnouncementEmailTask.new
 
-    assert_equal User.all, task.collection
+    assert_equal [@another_user], task.collection
   end
 
   test "places the background task in the correct queue" do


### PR DESCRIPTION
We encountered an issue sending the policy announcement email to rubygems.org users in #5715, which forced me to delete all the remaining scheduled background jobs in order to restore the database server back to normal operations.

I've applied a fix and are ready to resume sending out the policy email to users. We've already emailed about 10K users, and I don't want to resend the same email again, so I am updating the Maintenance task to resume from the last user that was sent the policy email.

After the announcement email has been completed, I will be deleting this maintenance task.