### PR TITLE
Link to Organization in gem show page

### DIFF
--- a/app/assets/stylesheets/modules/gem.css
+++ b/app/assets/stylesheets/modules/gem.css
@@ -411,3 +411,10 @@
     width: 100%;
   }
 }
+
+.gem__organization-name {
+    padding: 16px 0;
+    display: block;
+    color: #141c22;
+    transition-duration: 0.25s;
+    transition-property: color; }

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -354,6 +354,10 @@ class Rubygem < ApplicationRecord
     URI.join("https://rubygems.org/gems/", name)
   end
 
+  def owned_by_organization?
+    organization.present?
+  end
+
   private
 
   # a gem namespace is not protected if it is
@@ -404,10 +408,6 @@ class Rubygem < ApplicationRecord
 
     sanitized_query = ActiveRecord::Base.send(:sanitize_sql_array, update_query)
     ActiveRecord::Base.connection.execute(sanitized_query)
-  end
-
-  def owned_by_organization?
-    organization.present?
   end
 
   def user_authorized_for_organization?(user)

--- a/app/views/rubygems/_release_info.html.erb
+++ b/app/views/rubygems/_release_info.html.erb
@@ -1,5 +1,13 @@
 <div class="gem__members">
-  <% if rubygem.owners.present? %>
+
+  <% if rubygem.owned_by_organization? %>
+    <div class="gem__organization-header">
+      <h3 class="t-list__heading"><%= t '.managed_by' %>:</h3>
+      <div class="gem__organization-info">
+        <h4 class="gem__organization-header"><%= link_to rubygem.organization.name, organization_path(rubygem.organization), class: "gem__organization-name" %></h4>
+      </div>
+    </div>
+  <% elsif rubygem.owners.present? %>
     <h3 class="t-list__heading"><%= t '.owners_header' %>:</h3>
     <div class="gem__users">
       <%= links_to_owners(rubygem) %>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -79,7 +79,7 @@
       </div>
     <% end %>
 
-    <%= render partial: "rubygems/gem_members", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
+    <%= render partial: "rubygems/release_info", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
     <%= render partial: "rubygems/version_navigation", locals: { rubygem: @rubygem, latest_version: @latest_version } %>
   </div>
 

--- a/app/views/rubygems/show_yanked.html.erb
+++ b/app/views/rubygems/show_yanked.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <% unless @rubygem.pushable? %>
-      <%= render partial: "rubygems/gem_members", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
+      <%= render partial: "rubygems/release_info", locals: { latest_version: @latest_version, rubygem: @rubygem } %>
     <% end %>
   </div>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -798,7 +798,8 @@ de:
       reserved_namespace:
     dependencies:
       header: "%{title} Abhängigkeiten"
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: Autoren
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -719,7 +719,8 @@ en:
       reserved_namespace: This namespace is reserved by rubygems.org.
     dependencies:
       header: "%{title} Dependencies"
-    gem_members:
+    release_info:
+      managed_by: Managed By
       authors_header: Authors
       self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling multi-factor authentication (MFA)</a> to keep your account secure.
       not_using_mfa_warning_show: "* Some owners are not using multi-factor authentication (MFA). Click for the complete list."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -810,7 +810,8 @@ es:
       reserved_namespace: Este namespace está reservado por rubygems.org.
     dependencies:
       header: dependencias de %{title}
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: Autores
       self_no_mfa_warning_html: Considera por favor <a href="/settings/edit">activar
         la autenticación de múltiples factores (AMF)</a> para mantener tu cuenta segura.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -743,7 +743,8 @@ fr:
       reserved_namespace: Ce nom est réservé par rubygems.org.
     dependencies:
       header: Dépendances de %{title}
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: Auteurs
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -723,7 +723,8 @@ ja:
       reserved_namespace: この名前空間はrubygems.orgにより予約されています。
     dependencies:
       header: "%{title}依存関係"
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: 作者
       self_no_mfa_warning_html: アカウントをセキュアに保つため、<a href="/settings/edit">多要素認証（MFA）
         の有効化</a>をご検討ください。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -710,7 +710,8 @@ nl:
       reserved_namespace:
     dependencies:
       header: "%{title} afhankelijkheden"
-    gem_members:
+    release_info:
+      managed_by:
       authors_header:
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -722,7 +722,8 @@ pt-BR:
       reserved_namespace: This namespace is reserved by rubygems.org.
     dependencies:
       header:
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: Autores
       self_no_mfa_warning_html:
       not_using_mfa_warning_show: "* Alguns donos não estão usando MFA. Clique para

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -720,7 +720,8 @@ zh-CN:
       reserved_namespace: 该命名空间由 RubyGems.org 保留。
     dependencies:
       header: "%{title} 依赖"
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: 作者
       self_no_mfa_warning_html: 请考虑 <a href="/settings/edit">启用多因素身份验证（MFA）</a> 来保障您的帐户安全。
       not_using_mfa_warning_show: "* 某些所有者当前还没有启用多因素验证（MFA）。请点击查看完整列表。"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -712,7 +712,8 @@ zh-TW:
       reserved_namespace: 此命名空間被 rubygems.org 保留。
     dependencies:
       header: "%{title} 相依性套件"
-    gem_members:
+    release_info:
+      managed_by:
       authors_header: 作者
       self_no_mfa_warning_html:
       not_using_mfa_warning_show: "* 某些擁有者未使用多重要素驗證 (MFA)。點擊此處以顯示完整名單。"

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -442,4 +442,19 @@ class RubygemsControllerTest < ActionController::TestCase
       should respond_with :redirect
     end
   end
+
+  context "when gem is owned by an organization" do
+    setup do
+      @owner = create(:user)
+      @rubygem = create(:rubygem)
+      @version = create(:version, rubygem: @rubygem)
+      @organization = create(:organization, name: "Test Org", handle: "test-org", rubygems: [@rubygem], owners: [@owner])
+    end
+
+    should "link the organization profile page" do
+      get :show, params: { id: @rubygem.slug }
+
+      assert page.has_link?(@organization.name, href: organization_path(@organization))
+    end
+  end
 end


### PR DESCRIPTION
This Pull Request is updating the gem show page (https://rubygems.org/gems/rails) to show an "managed by this organisation" banner instead of the gem owners list. 

This is important because when a gem is owned by an organisation, the gem will not have any owners anymore, except for outside collaborators, so we want to link the user to the Organization instead.

#### Gem Page with link to Organization

<img width="1624" alt="Screenshot 2025-06-12 at 1 58 43 pm" src="https://github.com/user-attachments/assets/4c7b66fa-b292-4671-87b8-4e02c55d5fcf" />
