### PR TITLE
Resolve FromAsCasing warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.4
 ARG ALPINE_VERSION=3.20
-FROM ruby:$RUBY_VERSION-alpine${ALPINE_VERSION} as base
+FROM ruby:$RUBY_VERSION-alpine${ALPINE_VERSION} AS base
 
 # Install packages
 RUN --mount=type=cache,id=dev-apk-cache,sharing=locked,target=/var/cache/apk \
@@ -28,7 +28,7 @@ ARG RUBYGEMS_VERSION
 RUN gem update --system ${RUBYGEMS_VERSION} --no-document
 
 # Throw-away build stage to reduce size of final image
-FROM base as build
+FROM base AS build
 
 # Install packages
 RUN \


### PR DESCRIPTION
The following warnings were being emitted when building an image. There's not a great amount of immediate value in fixing them, but the less that is ignored, the greater the signal.

```plaintext
 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 31)
 ```