### PR TITLE
Fix for burger menu in mobile browsers

### DIFF
--- a/app/javascript/controllers/nav_controller.js
+++ b/app/javascript/controllers/nav_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
   ]
   static classes = ["expanded"]
 
-  connect() { this.skipSandwichIcon = true }
+  connect(){this.mousedown = false}
 
   toggle(e) {
     e.preventDefault();
@@ -21,16 +21,24 @@ export default class extends Controller {
     }
   }
 
-  focus() {
-    if (this.skipSandwichIcon) { // skip sandwich icon when you tab from "gem" icon
-      this.enter();
-      this.hasSearchTarget && this.searchTarget.focus();
-      this.skipSandwichIcon = false;
-    } else {
-      this.leave();
-      this.logoTarget.focus();
-      this.skipSandwichIcon = true;
+  // This event is used to open the menu when user presses "TAB" and focuses on the burger menu
+  focus(event) {
+    // Ignore click events on the burger menu, we are only interested in tab events
+    if (this.mousedown){
+      this.mousedown = false
+      return;
     }
+    // Open the menu
+    this.enter();
+    // Wait 50ms before focusing on the search input - necessary for Firefox mobile
+    setTimeout(() => {
+      this.hasSearchTarget && this.searchTarget.focus();
+    }, 50);
+  }
+
+  // Register if last event was a mousedown
+  mouseDown(e){
+    this.mousedown = true
   }
 
   hide(e) { !this.headerTarget.contains(e.target) && this.leave() }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
           <span class="header__logo" data-icon="⬡">⬢</span>
           <span class="t-hidden">RubyGems</span>
         <% end %>
-        <a class="header__club-sandwich" href="#" data-action="nav#toggle focusin->nav#focus click@window->nav#hide">
+        <a class="header__club-sandwich" href="#" data-action="nav#toggle focusin->nav#focus mousedown->nav#mouseDown click@window->nav#hide">
           <span class="t-hidden">Navigation menu</span>
         </a>
 


### PR DESCRIPTION
- Firefox Android: burger menu did not open when clicking it in the home screen
- Firefox Android: burger menu opened halfway when clicking it in other pages (like /gems)
- Chrome Android: burger menu required two clicks to open it in the home page

We have kept the existing functionality when focusing on the burger menu using TAB (only useful for computers with small screens).

Thanks to the help of @olleolleolle @QODHDPDM @RZhyvitskyi

## Before the changes

https://github.com/user-attachments/assets/f4c9cfac-862e-4d00-815a-c97990947bd6

https://github.com/user-attachments/assets/9102769b-9d85-49fe-8e87-f3d2b7d4568f

## After the changes

https://github.com/user-attachments/assets/62712ace-06d2-47e8-acb5-36f511e1f09c

https://github.com/user-attachments/assets/b1227173-af9c-448b-9c1c-f4145b483785

