### PR TITLE
Resolve tailwindcss not compiling core tailwind classes

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,7 +1,5 @@
 @config "../../../config/tailwind.config.js";
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/aspect-ratio";


### PR DESCRIPTION
With #5652, TailwindCSS is not being correctly rendered in staging. This is due to Tailwind changing that directive that imports the core classes https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives