### PR TITLE
Use `persist-credentials: false` in workflow

### DIFF
--- a/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
+++ b/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
@@ -64,7 +64,7 @@ class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
           steps: [
             { uses: "rubygems/configure-rubygems-credentials@main",
               with: { "role-to-assume": api_key_role.token, audience: configured_audience, "gem-server": gem_server_url }.compact },
-            { uses: "actions/checkout@v4" },
+            { uses: "actions/checkout@v4", with: { "persists-credentials": false } },
             { name: "Set remote URL", run: set_remote_url_run },
             { name: "Set up Ruby", uses: "ruby/setup-ruby@v1", with: { "bundler-cache": true, "ruby-version": "ruby" } },
             { name: "Release", run: "bundle exec rake release" },


### PR DESCRIPTION
This is the last of the uses of `actions/checkout` which lacked `persist-credentials: false`. Using that value prevents secrets from being written to `.git/config`