### PR TITLE
Gate "Invite" button rendering by policy

### DIFF
--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -93,8 +93,10 @@
       <% end %>
     <% end %>
 
-    <div class="pt-6 flex flex-row justify-end">
-      <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
-    </div>
+    <% if policy(@organization).invite_member? %>
+      <div class="pt-6 flex flex-row justify-end">
+        <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -76,4 +76,20 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
 
     refute page.has_content? "#{owner.handle} owner", normalize_ws: true
   end
+
+  test "should render an invite button for admins+" do
+    organization = create(:organization, owners: [@user])
+
+    get organization_path(organization)
+
+    assert page.has_content? "Invite", normalize_ws: true
+  end
+
+  test "should not render the invite button for users with less access than admins" do
+    organization = create(:organization, maintainers: [@user])
+
+    get organization_path(organization)
+
+    refute page.has_content? "Invite", normalize_ws: true
+  end
 end

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -82,7 +82,7 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
 
     get organization_path(organization)
 
-    assert page.has_content? "Invite", normalize_ws: true
+    assert page.has_content? "Invite"
   end
 
   test "should not render the invite button for users with less access than admins" do
@@ -90,6 +90,6 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
 
     get organization_path(organization)
 
-    refute page.has_content? "Invite", normalize_ws: true
+    refute page.has_content? "Invite"
   end
 end


### PR DESCRIPTION
Non-admins (i.e. maintainers) cannot invite users, so the "Invite" button was leading to a
404. This change prevents rendering the button so the workflow can't be attempted.

| Before | After |
|--------|--------|
| <img width="992" alt="image" src="https://github.com/user-attachments/assets/31b96a8c-a2c0-4c6d-aa56-25e4afcec237" /> | <img width="1005" alt="image" src="https://github.com/user-attachments/assets/a30e239e-cf65-4669-865c-38f514fe2ec8" /> |
