### PR TITLE
Disable Datadog when running locally

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,7 +1,5 @@
 require "app_revision"
 
-return if Rails.env.local? # Don't enable Datadog in local Development & Test environments
-
 Datadog.configure do |c|
   # unified service tagging
 
@@ -11,7 +9,8 @@ Datadog.configure do |c|
 
   # Enabling datadog functionality
 
-  enabled = ENV["DD_AGENT_HOST"].present? && !defined?(Rails::Console)
+  running_locally = Rails.env.local? || defined?(Rails::Console)
+  enabled = !running_locally || ENV["DD_AGENT_HOST"].present?
   c.runtime_metrics.enabled = enabled
   c.profiling.enabled = enabled
   c.tracing.enabled = enabled


### PR DESCRIPTION
By returning before the Datadog client was configured, we prevent Datadog's agent from being disabled. This was resulting in errors showing up in test output, like so:

```plaintext

E, [2025-06-20T15:19:31.131599 #50864] ERROR -- datadog: [datadog] (/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/datadog-2.17.0/lib/datadog/tracing/transport/http/client.rb:43:in 'Datadog::Tracing::Transport::HTTP::Client#send_request') Internal error during Datadog::Tracing::Transport::HTTP::Client request. Cause: Errno::ECONNREFUSED Failed to open TCP connection to 127.0.0.1:8126 (Connection refused - connect(2) for "127.0.0.1" port 8126) Location: /Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/net-http-0.6.0/lib/net/http.rb:1665:in 'TCPSocket#initialize'
.....................................................................
```

The disabling logic has been moved into the configuration block so that the agent is disabled and test output now looks like:

```plaintext

.....................................................................
```