### PR TITLE
Remove redefined constant warnings

### DIFF
--- a/test/helpers/rake_task_helper.rb
+++ b/test/helpers/rake_task_helper.rb
@@ -1,0 +1,11 @@
+require "rake"
+
+# Run Rake tasks without loading them and introducing constant redefinition warnings
+module RakeTaskHelper
+  def setup_rake_tasks(task_file)
+    Rake::Task.clear
+    # :environment is already loaded when running tests, so stub it
+    Rake::Task.define_task(:environment)
+    load Rails.root.join("lib", "tasks", task_file)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,11 +31,13 @@ require "helpers/email_helpers"
 require "helpers/es_helper"
 require "helpers/password_helpers"
 require "helpers/policy_helpers"
+require "helpers/rake_task_helper"
 require "helpers/webauthn_helpers"
 require "helpers/oauth_helpers"
 require "helpers/avo_helpers"
 require "webmock/minitest"
 require "phlex/testing/rails/view_helper"
+require "rake"
 
 # setup license early since some tests are testing Avo outside of requests
 # and license is set with first request
@@ -298,8 +300,6 @@ class ActionDispatch::IntegrationTest
     assert_nil request.env[:clearance].current_user
   end
 end
-
-Gemcutter::Application.load_tasks
 
 # Force loading of ActionDispatch::SystemTesting::* helpers
 _ = ActionDispatch::SystemTestCase

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -1,11 +1,15 @@
 require "test_helper"
 
 class MailerTest < ActionMailer::TestCase
+  include RakeTaskHelper
+
   MIN_DOWNLOADS_FOR_MFA_RECOMMENDATION_POLICY = 165_000_000
   MIN_DOWNLOADS_FOR_MFA_REQUIRED_POLICY = 180_000_000
 
   setup do
     TOPLEVEL_BINDING.receiver.stubs(:mx_exists?).returns(true)
+
+    setup_rake_tasks("mfa_policy.rake")
   end
 
   context "sending mail for mfa recommendation announcement" do

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -1,10 +1,14 @@
 require "test_helper"
 
 class UpdateVersionsFileTest < ActiveSupport::TestCase
+  include RakeTaskHelper
+
   setup do
     @tmp_versions_file = Tempfile.new("tmp_versions_file")
     tmp_path = @tmp_versions_file.path
     Rails.application.config.rubygems.stubs(:[]).with("versions_file_location").returns(tmp_path)
+
+    setup_rake_tasks("compact_index.rake")
   end
 
   def update_versions_file
@@ -15,7 +19,6 @@ class UpdateVersionsFileTest < ActiveSupport::TestCase
   end
 
   teardown do
-    Rake::Task["compact_index:update_versions_file"].reenable
     @tmp_versions_file.unlink
   end
 


### PR DESCRIPTION
Because `Gemcutter::Application.load_tasks` was being called multiple times, we were getting warnings about constants being defined (and redefined) multiple times. By removing the task loading invokation from the test helper (and loading tasks as close to the call sites as possible), we can remove the noise and prevent confusion.

**Before:**

```plaintext
 ~/ruby-central/rubygems.org $ bin/rails test:units --seed 7369
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/multi_json-1.15.0/lib/multi_json/adapters/json_common.rb:18: warning: JSON::PRETTY_STATE_PROTOTYPE is deprecated and will be removed in json 3.0.0, just use JSON.pretty_generate
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/avo-3.17.9/lib/tasks/tailwindcss_rails.rake:9: warning: already initialized constant GEM_PATH
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/avo-3.17.9/lib/tasks/tailwindcss_rails.rake:9: warning: previous definition of GEM_PATH was here
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/avo-3.17.9/lib/tasks/tailwindcss_rails.rake:11: warning: already initialized constant AVO_TAILWIND_COMPILE_COMMAND
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/avo-3.17.9/lib/tasks/tailwindcss_rails.rake:11: warning: previous definition of AVO_TAILWIND_COMPILE_COMMAND was here
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/railties-8.0.2/lib/rails/tasks/statistics.rake:4: warning: already initialized constant STATS_DIRECTORIES
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/railties-8.0.2/lib/rails/tasks/statistics.rake:4: warning: previous definition of STATS_DIRECTORIES was here
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.4.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Run options: --seed 7369

 # Running:

.....................................................................................................................................................................................................................
```

**After:**

```plaintext
 ~/ruby-central/rubygems.org $ bin/rails test:units --seed 7369
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/multi_json-1.15.0/lib/multi_json/adapters/json_common.rb:18: warning: JSON::PRETTY_STATE_PROTOTYPE is deprecated and will be removed in json 3.0.0, just use JSON.pretty_generate
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.4.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Run options: --seed 7369

 # Running:

......................................................................................................................................................................................................................
```