### PR TITLE
📲 Align gem counts to the left on small devices 

### DIFF
--- a/app/assets/stylesheets/modules/stats.css
+++ b/app/assets/stylesheets/modules/stats.css
@@ -187,19 +187,21 @@
   color: #b6aa51; }
 
 .stats__graph__gem__count {
-  position: absolute;
-  right: 12px; }
+  position: absolute; }
+  @media (max-width: 709px) {
+    .stats__graph__gem__count {
+      left: 12px;
+      top: 7px; } }
   @media (max-width: 419px) {
     .stats__graph__gem__count {
       font-size: 12px; } }
   @media (min-width: 420px) and (max-width: 709px) {
     .stats__graph__gem__count {
       font-size: 13px; } }
-  @media (max-width: 709px) {
-    .stats__graph__gem__count {
-      top: 7px; } }
   @media (min-width: 710px) {
     .stats__graph__gem__count {
+      right: 12px;
+      left: 12px;
       top: 5px;
       font-size: 15px; } }
   @-moz-document url-prefix() {


### PR DESCRIPTION
This is following up on a layout bug which `yykamei` reported and began fixing. The fix was initially to align the gem count on the left for all devices, but I've pared that down to only be done on smaller screens.

| Mobile Before | Mobile After |
|--------|--------|
| <img width="411" alt="image" src="https://github.com/user-attachments/assets/0ee0d443-c139-41df-9064-f0fdebcf8eb2" /> | <img width="411" alt="image" src="https://github.com/user-attachments/assets/a932049d-71b8-4359-bdb3-f58d993898c1" /> | 

| Desktop Before | Desktop After |
|--------|--------|
| <img width="507" alt="image" src="https://github.com/user-attachments/assets/1ed7731d-cff1-4c6e-92bd-a460906d1c88" /> | <img width="520" alt="image" src="https://github.com/user-attachments/assets/e54fb54d-8402-4c95-9d37-560a50b7b9ae" /> | 