### PR TITLE
Resolve no assertion warning

### DIFF
--- a/test/system/avo/sendgrid_events_test.rb
+++ b/test/system/avo/sendgrid_events_test.rb
@@ -13,23 +13,23 @@ class Avo::SendgridEventsSystemTest < ApplicationSystemTestCase
 
     visit avo.resources_sendgrid_events_path
 
-    page.assert_text event.email
+    assert_text event.email
 
     click_on "Filters"
     fill_in id: "avo_filters_email_filter", with: "nope"
     click_on "Filter by email"
 
-    page.assert_no_text event.email
-    page.assert_text "No record found"
+    assert_no_text event.email
+    assert_text "No record found"
 
     click_on "Filters"
     fill_in id: "avo_filters_email_filter", with: ".+e@gmail.*"
     click_on "Filter by email"
 
-    page.assert_text event.email
+    assert_text event.email
 
     visit avo.resources_sendgrid_event_path(event)
 
-    page.assert_text event.sendgrid_id
+    assert_text event.sendgrid_id
   end
 end


### PR DESCRIPTION
There _are_ assertions, but they're not at the top-level of the test. This is leading to the following warning:

```plaintext
Test is missing assertions: `test_search_for_event` /home/runner/work/rubygems.org/rubygems.org/test/system/avo/sendgrid_events_test.rb:6
```

This `page.assert` pattern is relatively common and could be updated, but I'm going to leave that until there's a need to make a larger change.