### PR TITLE
Disable DD trace attempts when running locally

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,13 +2,11 @@ require "app_revision"
 
 Datadog.configure do |c|
   # unified service tagging
-
   c.service = "rubygems.org"
   c.version = AppRevision.version
   c.env = Rails.env
 
   # Enabling datadog functionality
-
   running_locally = Rails.env.local? || defined?(Rails::Console)
   enabled = !running_locally || ENV["DD_AGENT_HOST"].present?
   c.runtime_metrics.enabled = enabled
@@ -30,26 +28,29 @@ Datadog.configure do |c|
   }
 
   # Configuring the datadog library
-
   c.logger.instance = SemanticLogger[Datadog]
 
-  # Configuring tracing
+  # Configuring tracing (when enabled)
+  if enabled
+    c.tracing.report_hostname = true
 
-  c.tracing.report_hostname = true
-
-  c.tracing.instrument :aws
-  c.tracing.instrument :dalli
-  c.tracing.instrument :faraday, split_by_domain: true, service_name: c.service
-  c.tracing.instrument :http, split_by_domain: true, service_name: c.service
-  c.tracing.instrument :opensearch, service_name: c.service
-  c.tracing.instrument :pg, comment_propagation: 'full'
-  c.tracing.instrument :rails, request_queuing: true
-  c.tracing.instrument :shoryuken if defined?(Shoryuken)
+    c.tracing.instrument :aws
+    c.tracing.instrument :dalli
+    c.tracing.instrument :faraday, split_by_domain: true, service_name: c.service
+    c.tracing.instrument :http, split_by_domain: true, service_name: c.service
+    c.tracing.instrument :opensearch, service_name: c.service
+    c.tracing.instrument :pg, comment_propagation: 'full'
+    c.tracing.instrument :rails, request_queuing: true
+    c.tracing.instrument :shoryuken if defined?(Shoryuken)
+  end
 end
 
-Datadog::Tracing.before_flush(
-  # Remove spans for the /internal/ping endpoint
-  Datadog::Tracing::Pipeline::SpanFilter.new { |span| span.resource == "Internal::PingController#index" }
-)
+# Only set up span filtering when tracing is enabled
+if Datadog.configuration.tracing.enabled
+  Datadog::Tracing.before_flush(
+    # Remove spans for the /internal/ping endpoint
+    Datadog::Tracing::Pipeline::SpanFilter.new { |span| span.resource == "Internal::PingController#index" }
+  )
+end
 
 require "datadog/auto_instrument"


### PR DESCRIPTION
I disabled traces, but didn't prevent further configuration of said traces. This caused a bunch of extraneous output to be printed when running the rails server:

```plaintext
Sql comment propagation with 'full' mode is aborted, because tracing is disabled. Please set 'Datadog.configuration.tracing.enabled = true' to continue
```

Fixes: https://github.com/rubygems/rubygems.org/issues/5763