### PR TITLE
UI for accepting new rubygems.org policies

### DIFF
--- a/app/assets/stylesheets/modules/org.css
+++ b/app/assets/stylesheets/modules/org.css
@@ -20,6 +20,84 @@
   text-decoration: underline;
   font-weight: bold;
 }
+
+/* Policy Banner */
+
+.policy-banner {
+  background-color: #fff6d2;
+  border-bottom: 1px solid #dcd3b1;
+  padding: 15px 0;
+  position: relative;
+}
+
+.policy-banner__wrap {
+  width: 90%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+}
+
+.policy-banner__content {
+  flex: 1;
+}
+
+.policy-banner__title {
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #141c22;
+}
+
+.policy-banner__body {
+  font-size: 14px;
+  margin-bottom: 15px;
+  color: #141c22;
+  line-height: 1.4;
+}
+
+.policy-banner__actions {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.policy-banner__link {
+  color: #141c22;
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+.policy-banner__link:hover {
+  color: #e9573f;
+}
+
+.policy-banner__form {
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .policy-banner__wrap {
+    padding: 0 15px;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .policy-banner__actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .policy-banner__close {
+    top: 8px;
+    right: 10px;
+  }
+}
+
 /* Announcement Styles */
 
 #announcement {
@@ -44,28 +122,42 @@
   margin-bottom: 60px;
   padding: 20px;
   border: 1px solid #e9573f;
-  border-radius: 3px; }
-  .errorExplanation h2 {
-    margin-bottom: 10px; }
-  .errorExplanation p {
-    font-style: italic; }
-  .errorExplanation ul {
-    margin-top: 18px; }
-  .errorExplanation ul li, .errorExplanation p {
-    font-weight: 300;
-    font-size: 16px;
-    line-height: 1.66; }
-  .errorExplanation ul li {
-    padding-left: 23px;
-    text-indent: -23px; }
-    .errorExplanation ul li:before {
-      content: "✘";
-      margin-right: 15px;
-      position: relative;
-      top: -2px;
-      font-family: "icomoon";
-      font-size: 10px;
-      color: #e9573f; }
+  border-radius: 3px;
+}
+
+.errorExplanation h2 {
+  margin-bottom: 10px;
+}
+
+.errorExplanation p {
+  font-style: italic;
+}
+
+.errorExplanation ul {
+  margin-top: 18px;
+}
+
+.errorExplanation ul li,
+.errorExplanation p {
+  font-weight: 300;
+  font-size: 16px;
+  line-height: 1.66;
+}
+
+.errorExplanation ul li {
+  padding-left: 23px;
+  text-indent: -23px;
+}
+
+.errorExplanation ul li:before {
+  content: "✘";
+  margin-right: 15px;
+  position: relative;
+  top: -2px;
+  font-family: "icomoon";
+  font-size: 10px;
+  color: #e9573f;
+}
 
 
 
@@ -75,7 +167,8 @@
   padding-top: 50px;
   font-weight: 300;
   font-size: 18px;
-  line-height: 1.66; }
+  line-height: 1.66;
+}
 
 
 
@@ -83,10 +176,12 @@
 
 .dashboard {
   width: 100%;
-  overflow: auto; }
+  overflow: auto;
+}
 
 .dashboard__gems {
-  margin-top: -30px; }
+  margin-top: -30px;
+}
 
 .dashboard__updates {
   margin-top: 3px;
@@ -94,35 +189,43 @@
   font-weight: 800;
   font-size: 12px;
   text-transform: uppercase;
-  color: #c1c4ca; }
+  color: #c1c4ca;
+}
 
 .dashboard__gem {
   padding-top: 20px;
   padding-bottom: 20px;
   display: block;
   border-bottom: 1px solid #c1c4ca;
-  color: #141c22; }
-  .dashboard__gem:hover .dashboard__gem__name {
-    color: #e9573f; }
+  color: #141c22;
+}
+
+.dashboard__gem:hover .dashboard__gem__name {
+  color: #e9573f;
+}
 
 .dashboard__gem__info {
-  margin-bottom: 6px; }
+  margin-bottom: 6px;
+}
 
 .dashboard__gem__name {
   font-weight: 800;
   font-size: 18px;
   transition-duration: 0.25s;
-  transition-property: color; }
+  transition-property: color;
+}
 
 .dashboard__gem__version {
   margin-left: 10px;
   font-weight: 300;
-  color: #a6aab2; }
+  color: #a6aab2;
+}
 
 .dashboard__gem__desc {
   font-weight: 300;
   font-size: 15px;
-  line-height: 1.66; }
+  line-height: 1.66;
+}
 
 
 
@@ -132,34 +235,54 @@
   padding-bottom: 40px;
   width: 100%;
   overflow: auto;
-  border-bottom: 1px solid #c1c4ca; }
-  @media (max-width: 779px) {
-    .profile__header {
-      padding-top: 18px; } }
-  @media (min-width: 780px) {
-    .profile__header {
-      padding-top: 60px; } }
+  border-bottom: 1px solid #c1c4ca;
+}
+
+@media (max-width: 779px) {
+  .profile__header {
+    padding-top: 18px;
+  }
+}
+
+@media (min-width: 780px) {
+  .profile__header {
+    padding-top: 60px;
+  }
+}
 
 @media (min-width: 600px) {
   .profile__header__name-wrap {
     float: left;
-    width: 70%; } }
+    width: 70%;
+  }
+}
 
 .profile__header__name {
-  overflow-x: auto; }
-  @media (min-width: 780px) {
-    .profile__header__name {
-      padding-top: 16px; } }
+  overflow-x: auto;
+}
+
+@media (min-width: 780px) {
+  .profile__header__name {
+    padding-top: 16px;
+  }
+}
 
 .profile__header__username {
-  overflow-x: auto; }
+  overflow-x: auto;
+}
+
 @media (min-width: 780px) {
   .profile__header__username {
-    padding-top: 4px; } }
+    padding-top: 4px;
+  }
+}
 
 @media (max-width: 779px) {
   .profile__header__avatar {
-    display: none; } }
+    display: none;
+  }
+}
+
 @media (min-width: 780px) {
   .profile__header__avatar {
     margin-right: 45px;
@@ -167,56 +290,77 @@
     width: 150px;
     float: left;
     border-radius: 50%;
-    margin-bottom: 21px; } }
+    margin-bottom: 21px;
+  }
+}
 
 .profile__header__attribute {
   padding-top: 10px;
-  display: inline-block; }
-  .profile__header__attribute:before {
-    margin-right: 9px;
-    position: relative;
-    top: 1px; }
+  display: inline-block;
+}
+
+.profile__header__attribute:before {
+  margin-right: 9px;
+  position: relative;
+  top: 1px;
+}
 
 .profile__header__icon {
   height: 14px;
   float: left;
   margin-top: 12px;
   margin-left: 1px;
-  padding-right: 7px; }
+  padding-right: 7px;
+}
 
 @media (max-width: 599px) {
   .profile__downloads-wrap {
     padding-top: 32px;
     width: 100%;
-    float: left; } }
+    float: left;
+  }
+}
+
 @media (min-width: 600px) {
   .profile__downloads-wrap {
     float: right;
-    text-align: right; } }
+    text-align: right;
+  }
+}
+
 @media (min-width: 780px) {
   .profile__downloads-wrap {
-    padding-top: 32px; } }
+    padding-top: 32px;
+  }
+}
 
 
 
 /* Dashboard Gems and Subscriptions */
 
 .mine h1 {
-  margin-bottom: 0 !important; }
+  margin-bottom: 0 !important;
+}
 
 .mine ul {
-  margin-top: 10px !important; }
+  margin-top: 10px !important;
+}
 
 .mine li {
   text-indent: 0 !important;
   overflow: auto;
-  font-size: 15px !important; }
-  .mine li:before {
-    margin-left: -23px;
-    float: left;
-    top: 9px !important; }
-  .mine li a {
-    word-break: break-all; }
+  font-size: 15px !important;
+}
+
+.mine li:before {
+  margin-left: -23px;
+  float: left;
+  top: 9px !important;
+}
+
+.mine li a {
+  word-break: break-all;
+}
 
 
 
@@ -224,18 +368,22 @@
 
 @media (max-width: 529px) {
   .hide-assets {
-    display: none; }}
+    display: none;
+  }
+}
 
 .about__assets__heading {
   text-transform: none !important;
-  margin-bottom: 18px !important; }
+  margin-bottom: 18px !important;
+}
 
 .about__assets-wrap {
   padding-left: 32px;
   height: 90px;
   max-width: 440px;
   background-color: #c1c4ca;
-  border-radius: 45px; }
+  border-radius: 45px;
+}
 
 .about__assets {
   padding-right: 26px;
@@ -243,10 +391,12 @@
   top: 16px;
   float: left;
   height: 60px;
-  border-right: 1px solid #8d9197; }
+  border-right: 1px solid #8d9197;
+}
 
 .about__asset {
-  width: 60px; }
+  width: 60px;
+}
 
 .about__assets__download {
   margin-left: 32px;
@@ -259,14 +409,23 @@
   background-color: #ffffff;
   font-size: 18px;
   font-weight: 800;
-  line-height: 44px; }
-  .about__assets__download:focus, .about__assets__download:hover {
-    color: #e9573f !important; }
-  .about__assets__download:before {
-    margin-left: 8px;
-    float: right; }
-  .about__assets__download:focus:before, .about__assets__download:hover:before {
-    animation: arrow .75s infinite; }
+  line-height: 44px;
+}
+
+.about__assets__download:focus,
+.about__assets__download:hover {
+  color: #e9573f !important;
+}
+
+.about__assets__download:before {
+  margin-left: 8px;
+  float: right;
+}
+
+.about__assets__download:focus:before,
+.about__assets__download:hover:before {
+  animation: arrow .75s infinite;
+}
 
 /* Banner */
 

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,5 +1,6 @@
 class PoliciesController < ApplicationController
   before_action :find_policy, only: :show
+  before_action :redirect_to_signin, unless: :signed_in?, only: %i[acknowledge]
 
   layout "hammy"
 
@@ -11,6 +12,11 @@ class PoliciesController < ApplicationController
     add_breadcrumb t("policies.index.title"), policies_path
     add_breadcrumb t("policies.#{@page}.title")
     render @page
+  end
+
+  def acknowledge
+    current_user.acknowledge_policies!
+    redirect_back_or_to root_path
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+    @user.policies_acknowledged_at = Time.zone.now
     if @user.save
       Mailer.email_confirmation(@user).deliver_later
       flash[:notice] = t(".email_sent")

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -6,4 +6,8 @@ module UsersHelper
   def twitter_url(user)
     "https://twitter.com/#{user.twitter_username}"
   end
+
+  def show_policies_acknowledge_banner?(user)
+    user.present? && !user.policies_acknowledged?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -388,8 +388,4 @@ class User < ApplicationRecord
   def record_policies_acknowledged_event
     record_event!(Events::UserEvent::POLICIES_ACKNOWLEDGED)
   end
-
-  def acknowledged_policies
-    errors.add(:policies_acknowledged_at, "must be acknowledged") if policies_acknowledged_at.blank?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,6 +288,10 @@ class User < ApplicationRecord
     update(policies_acknowledged_at: Time.zone.now)
   end
 
+  def policies_acknowledged?
+    policies_acknowledged_at.present?
+  end
+
   private
 
   def update_email
@@ -383,5 +387,9 @@ class User < ApplicationRecord
 
   def record_policies_acknowledged_event
     record_event!(Events::UserEvent::POLICIES_ACKNOWLEDGED)
+  end
+
+  def acknowledged_policies
+    errors.add(:policies_acknowledged_at, "must be acknowledged") if policies_acknowledged_at.blank?
   end
 end

--- a/app/views/layouts/_policies_acknowledgement.html.erb
+++ b/app/views/layouts/_policies_acknowledgement.html.erb
@@ -1,0 +1,19 @@
+<% if current_user.present? && !current_user.policies_acknowledged? %>
+  <div class="policy-banner" role="alert">
+    <div class="policy-banner__wrap">
+      <div class="policy-banner__content">
+          <h3 class="policy-banner__title">New Policies for RubyGems.org</h3>
+          <p class="policy-banner__body">
+              We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
+          </p>
+          <div class="policy-banner__actions">
+              <%= link_to "Review Policies", policies_path, class: "policy-banner__link" %>
+              <%= form_with url: acknowledge_policies_path, method: :patch, local: true, class: "policy-banner__form" do |form| %>
+              <%= form.submit "I Accept" %>
+              <% end %>
+          </div>
+          </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/_policies_acknowledgement.html.erb
+++ b/app/views/layouts/_policies_acknowledgement.html.erb
@@ -1,19 +1,17 @@
-<% if current_user.present? && !current_user.policies_acknowledged? %>
-  <div class="policy-banner" role="alert">
-    <div class="policy-banner__wrap">
-      <div class="policy-banner__content">
-          <h3 class="policy-banner__title">New Policies for RubyGems.org</h3>
-          <p class="policy-banner__body">
-              We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
-          </p>
-          <div class="policy-banner__actions">
-              <%= link_to "Review Policies", policies_path, class: "policy-banner__link" %>
-              <%= form_with url: acknowledge_policies_path, method: :patch, local: true, class: "policy-banner__form" do |form| %>
-              <%= form.submit "I Accept" %>
-              <% end %>
-          </div>
-          </div>
-      </div>
+<div class="policy-banner" role="alert">
+  <div class="policy-banner__wrap">
+    <div class="policy-banner__content">
+        <h3 class="policy-banner__title">New Policies for RubyGems.org</h3>
+        <p class="policy-banner__body">
+            We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
+        </p>
+        <div class="policy-banner__actions">
+            <%= link_to "Review Policies", policies_path, class: "policy-banner__link" %>
+            <%= form_with url: acknowledge_policies_path, method: :patch, local: true, class: "policy-banner__form" do |form| %>
+            <%= form.submit "I Accept" %>
+            <% end %>
+        </div>
+        </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/layouts/_policies_acknowledgement_hammy.html.erb
+++ b/app/views/layouts/_policies_acknowledgement_hammy.html.erb
@@ -1,29 +1,27 @@
-<% if current_user.present? && !current_user.policies_acknowledged? %>
-  <div class="bg-blue-50 dark:bg-blue-950 border-b border-blue-200 dark:border-blue-800" role="alert">
-    <div class="max-w-screen-xl mx-auto py-4">
-      <div class="flex items-start gap-4">
+<div class="bg-blue-50 dark:bg-blue-950 border-b border-blue-200 dark:border-blue-800" role="alert">
+  <div class="max-w-screen-xl mx-auto py-4">
+    <div class="flex items-start gap-4">
+      
+      <!-- Content -->
+      <div class="flex-1 min-w-0">
+        <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-1">
+          New Policies for RubyGems.org
+        </h3>
+        <p class="text-sm text-blue-700 dark:text-blue-200 mb-3 leading-relaxed">
+          We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
+        </p>
         
-        <!-- Content -->
-        <div class="flex-1 min-w-0">
-          <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-1">
-            New Policies for RubyGems.org
-          </h3>
-          <p class="text-sm text-blue-700 dark:text-blue-200 mb-3 leading-relaxed">
-            We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
-          </p>
-          
-          <!-- Actions -->
-          <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
-            <%= link_to "Review Policies", policies_path, 
-                class: "text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline" %>
-            <%= form_with url: acknowledge_policies_path, method: :patch, local: true, 
-                class: "inline-flex" do |form| %>
-              <%= form.submit "I Accept", 
-                  class: "px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-blue-900 transition-colors" %>
-            <% end %>
-          </div>
+        <!-- Actions -->
+        <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+          <%= link_to "Review Policies", policies_path, 
+              class: "text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline" %>
+          <%= form_with url: acknowledge_policies_path, method: :patch, local: true, 
+              class: "inline-flex" do |form| %>
+            <%= form.submit "I Accept", 
+                class: "px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-blue-900 transition-colors" %>
+          <% end %>
         </div>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/layouts/_policies_acknowledgement_hammy.html.erb
+++ b/app/views/layouts/_policies_acknowledgement_hammy.html.erb
@@ -1,0 +1,29 @@
+<% if current_user.present? && current_user.policies_acknowledged_at.blank? %>
+  <div class="bg-blue-50 dark:bg-blue-950 border-b border-blue-200 dark:border-blue-800" role="alert">
+    <div class="max-w-screen-xl mx-auto py-4">
+      <div class="flex items-start gap-4">
+        
+        <!-- Content -->
+        <div class="flex-1 min-w-0">
+          <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-1">
+            New Policies for RubyGems.org
+          </h3>
+          <p class="text-sm text-blue-700 dark:text-blue-200 mb-3 leading-relaxed">
+            We've introduced new Terms of Service, Privacy Notice, Acceptable Use Policy, and Copyright Policy to provide clarity and transparency regarding our operations and commitment to maintaining a safe environment for all users.
+          </p>
+          
+          <!-- Actions -->
+          <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+            <%= link_to "Review Policies", policies_path, 
+                class: "text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline" %>
+            <%= form_with url: acknowledge_policies_path, method: :patch, local: true, 
+                class: "inline-flex" do |form| %>
+              <%= form.submit "I Accept", 
+                  class: "px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-blue-900 transition-colors" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/_policies_acknowledgement_hammy.html.erb
+++ b/app/views/layouts/_policies_acknowledgement_hammy.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.present? && current_user.policies_acknowledged_at.blank? %>
+<% if current_user.present? && !current_user.policies_acknowledged? %>
   <div class="bg-blue-50 dark:bg-blue-950 border-b border-blue-200 dark:border-blue-800" role="alert">
     <div class="max-w-screen-xl mx-auto py-4">
       <div class="flex items-start gap-4">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,10 @@
         <%= yield :banner %>
       </div>
     <% end %>
+    
+    <!-- Policies acknowledgment banner -->
+    <%= render "layouts/policies_acknowledgement" %>
+    
     <header class="header <%= 'header--interior' if request.path_info != '/' %>" data-nav-target="header collapse">
       <div class="l-wrap--header">
         <%= link_to(root_path, title: 'RubyGems', class: 'header__logo-wrap', data: { nav_target: "logo" }) do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
     <% end %>
     
     <!-- Policies acknowledgment banner -->
-    <%= render "layouts/policies_acknowledgement" %>
+    <%= render "layouts/policies_acknowledgement" if show_policies_acknowledge_banner?(current_user) %>
     
     <header class="header <%= 'header--interior' if request.path_info != '/' %>" data-nav-target="header collapse">
       <div class="l-wrap--header">

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -174,7 +174,7 @@
       </div>
 
       <!-- Policies acknowledgment banner -->
-      <%= render "layouts/policies_acknowledgement_hammy" %>
+      <%= render "layouts/policies_acknowledgement_hammy" if show_policies_acknowledge_banner?(current_user) %>
 
       <!-- Breadcrumbs -->
       <%= render "layouts/breadcrumbs" %>

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -173,6 +173,9 @@
         </div>
       </div>
 
+      <!-- Policies acknowledgment banner -->
+      <%= render "layouts/policies_acknowledgement_hammy" %>
+
       <!-- Breadcrumbs -->
       <%= render "layouts/breadcrumbs" %>
     </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,7 +315,11 @@ Rails.application.routes.draw do
   get 'pages/*id' => 'pages#show', constraints: { format: :html, id: Regexp.union(Gemcutter::PAGES) }, as: :page
 
   resources :policies, only: %i[index show], constraints: { format: :html, policy: Regexp.union(Gemcutter::POLICY_PAGES) },
-    param: :policy
+    param: :policy do
+      collection do
+        patch :acknowledge
+      end
+    end
 
   ################################################################################
   # Internal Routes

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     password { PasswordHelpers::SECURE_TEST_PASSWORD }
     api_key { "secret123" }
     email_confirmed { true }
+    policies_acknowledged_at { Time.zone.now }
 
     transient do
       mfa_recovery_codes { [] }

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -24,4 +24,31 @@ class PoliciesControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "when acknowledge is requested" do
+    context "without authenticated user" do
+      should "redirect to sign in" do
+        patch :acknowledge, params: { accept: "1" }
+
+        assert_response :redirect
+        assert_redirected_to sign_in_path
+      end
+    end
+
+    context "with authenticated user" do
+      setup do
+        @user = create(:user, policies_acknowledged_at: nil)
+        sign_in_as(@user)
+      end
+
+      should "acknowledge policies and redirect" do
+        patch :acknowledge, params: { accept: "1" }
+
+        assert_response :redirect
+        @user.reload
+
+        assert_not_nil @user.policies_acknowledged_at
+      end
+    end
+  end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -34,6 +34,14 @@ class UsersControllerTest < ActionController::TestCase
 
         assert User.find_by(email: "foo@bar.com")
       end
+
+      should "acknowledge the rubygems.org policies" do
+        post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
+
+        user = User.find_by(email: "foo@bar.com")
+
+        assert_not_nil user.policies_acknowledged_at
+      end
     end
 
     context "when missing a parameter" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -36,11 +36,12 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       should "acknowledge the rubygems.org policies" do
-        post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
+        freeze_time do
+          post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
+          user = User.find_by(email: "foo@bar.com")
 
-        user = User.find_by(email: "foo@bar.com")
-
-        assert_not_nil user.policies_acknowledged_at
+          assert_equal Time.current, user.policies_acknowledged_at
+        end
       end
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1010,4 +1010,18 @@ class UserTest < ActiveSupport::TestCase
       assert_event Events::UserEvent::POLICIES_ACKNOWLEDGED, {}, user.reload.events.where(tag: Events::UserEvent::POLICIES_ACKNOWLEDGED).sole
     end
   end
+
+  context "#policies_acknowledged?" do
+    should "return true when policies_acknowledged_at is set" do
+      user = create(:user, policies_acknowledged_at: Time.current)
+
+      assert_predicate user, :policies_acknowledged?
+    end
+
+    should "return false when policies_acknowledged_at is not set" do
+      user = create(:user, policies_acknowledged_at: nil)
+
+      refute_predicate user, :policies_acknowledged?
+    end
+  end
 end

--- a/test/system/accept_new_policies_test.rb
+++ b/test/system/accept_new_policies_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+class AcceptNewPoliciesTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, policies_acknowledged_at: nil)
+  end
+  test "user accepts new policies on default rubygems.org layout" do
+    visit sign_in_path
+
+    click_link "login as #{@user[:handle]}"
+
+    visit root_path
+
+    assert_text "New Terms of Service and Privacy Policy"
+    click_button "Accept"
+
+    assert_current_path root_path
+    assert_no_text "New Terms of Service and Privacy Policy"
+  end
+
+  test "user accepts new policies on hammy layout" do
+    visit sign_in_path
+
+    click_link "login as #{@user[:handle]}"
+
+    visit dashboard_path
+
+    assert_text "New Terms of Service and Privacy Policy"
+    click_button "Accept"
+
+    assert_current_path dashboard_path
+    assert_no_text "New Terms of Service and Privacy Policy"
+  end
+end

--- a/test/system/accept_new_policies_test.rb
+++ b/test/system/accept_new_policies_test.rb
@@ -10,11 +10,11 @@ class AcceptNewPoliciesTest < ApplicationSystemTestCase
 
     visit root_path
 
-    assert_text "New Terms of Service and Privacy Policy"
+    assert_text "New Policies for RubyGems.org"
     click_button "Accept"
 
     assert_current_path root_path
-    assert_no_text "New Terms of Service and Privacy Policy"
+    assert_no_text "New Policies for RubyGems.org"
   end
 
   test "user accepts new policies on hammy layout" do
@@ -24,10 +24,10 @@ class AcceptNewPoliciesTest < ApplicationSystemTestCase
 
     visit dashboard_path
 
-    assert_text "New Terms of Service and Privacy Policy"
+    assert_text "New Policies for RubyGems.org"
     click_button "Accept"
 
     assert_current_path dashboard_path
-    assert_no_text "New Terms of Service and Privacy Policy"
+    assert_no_text "New Policies for RubyGems.org"
   end
 end


### PR DESCRIPTION
RubyGems.org has introduced a new set of policies (#5714), and we need to record user acceptance. We added a field in #5530 to capture this, and this Pull Request completes the process by adding the UI and logic to enable users to accept the policies.

### Screenshots
 
<img width="1440" alt="Screenshot 2025-07-01 at 10 26 24 am" src="https://github.com/user-attachments/assets/f1d7d949-d123-4071-95f5-f7c59fe31a21" />

<img width="1440" alt="Screenshot 2025-07-01 at 10 26 28 am" src="https://github.com/user-attachments/assets/42988476-76c8-4912-a1c0-229ad70fa1a3" />
