### PR TITLE
Modify Version#payload to include alias to number called version to match Rubygem attributes

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -353,6 +353,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
       "downloads_count"            => downloads_count,
       "metadata"                   => metadata,
       "number"                     => number,
+      "version"                    => number, # simple alias for number
       "summary"                    => summary,
       "platform"                   => platform,
       "rubygems_version"           => required_rubygems_version,


### PR DESCRIPTION
I found it incredibly awkward that 

https://rubygems.org/api/v1/gems/rubygems-update.json

returns an attribute called version, but

https://rubygems.org/api/v1/versions/rubygems-update.json

does not. This fixes that w/o breaking backwards compatibility.

I am pushing this PR to get the tests to run. They won't run on my branch on my fork. Please disregard until green.