### PR TITLE
Allowlist duplication for Avo resources

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,15 @@ exclude_patterns:
 - "**/vendor/"
 - "**/*.d.ts"
 - "app/models/user.rb"
+
 method-count:
     config:
       threshold: 25
+
+engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - "app/avo/actions/**/*"
+      - "app/avo/fields/**/*"
+      - "app/avo/resources/**/*"


### PR DESCRIPTION
CodeClimate has been flagging duplication in the `fields` methods. I believe it's preferable to have this explicit duplication rather than creating an abstraction which might obscure the resource declarations. Thus, I'm allowlisting duplication for Avo paths.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/25c431f7-44e1-4d4b-abf0-182aab426e5e" />
