### PR TITLE
Return accurate results for Activities API latest endpoint (fixes #5741)

### DIFF
--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::ActivitiesController < Api::BaseController
   def latest
     rubygems = Rubygem.includes(:linkset, :gem_download, latest_version: %i[dependencies gem_download])
+      .with_versions
       .order(created_at: :desc)
-      .where(indexed: true)
       .limit(50)
       .map { |rubygem| rubygem.payload(rubygem.latest_version) }
     render_rubygems(rubygems)

--- a/test/functional/api/v1/activities_controller_test.rb
+++ b/test/functional/api/v1/activities_controller_test.rb
@@ -20,18 +20,20 @@ class Api::V1::ActivitiesControllerTest < ActionController::TestCase
         get :latest, format: :json
         gems = JSON.load @response.body
 
-        assert_equal 2, gems.length
+        assert_equal 3, gems.length
         assert_equal "foobar", gems[0]["name"]
         assert_equal "sinatra", gems[1]["name"]
+        assert_equal "rails", gems[2]["name"]
       end
 
       should "return correct YAML for latest gems" do
         get :latest, format: :yaml
         gems = YAML.safe_load(@response.body)
 
-        assert_equal 2, gems.length
+        assert_equal 3, gems.length
         assert_equal "foobar", gems[0]["name"]
         assert_equal "sinatra", gems[1]["name"]
+        assert_equal "rails", gems[2]["name"]
       end
     end
 


### PR DESCRIPTION
This enables the Activity API's latest endpoint to return the 50 most recently created gems. Previously, the endpoint used the `new_pushed_versions` scope which returns new gems with only one release, preventing the endpoint from returning new gems that are updated recently after their release. 