### PR TITLE
📮 Respond to `POST policies/copyright`

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -19,6 +19,11 @@ class PoliciesController < ApplicationController
     redirect_back_or_to root_path
   end
 
+  def method_not_allowed
+    response.headers["Allow"] = "GET"
+    head :method_not_allowed
+  end
+
   private
 
   def find_policy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -321,6 +321,8 @@ Rails.application.routes.draw do
       end
     end
 
+  post 'policies/:policy', to: 'policies#method_not_allowed', constraints: { policy: Regexp.union(Gemcutter::POLICY_PAGES) }
+
   ################################################################################
   # Internal Routes
 

--- a/test/functional/policies_controller_test.rb
+++ b/test/functional/policies_controller_test.rb
@@ -51,4 +51,15 @@ class PoliciesControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "when POST request is made to policy pages" do
+    should "return method not allowed for any policy" do
+      Gemcutter::POLICY_PAGES.each do |policy|
+        post :method_not_allowed, params: { policy: policy }
+
+        assert_response :method_not_allowed
+        assert_equal "GET", response.headers["Allow"]
+      end
+    end
+  end
 end

--- a/test/integration/policies_test.rb
+++ b/test/integration/policies_test.rb
@@ -36,4 +36,17 @@ class PoliciesTest < SystemTest
 
     assert page.has_content?("Copyright Policy")
   end
+
+  test "POST to valid policy returns method not allowed" do
+    post "/policies/copyright"
+
+    assert_response :method_not_allowed
+    assert_equal "GET", response.headers["Allow"]
+  end
+
+  test "POST to invalid policy is disallowed" do
+    assert_raises(ActionController::RoutingError) do
+      post "/policies/nonexistent-policy"
+    end
+  end
 end


### PR DESCRIPTION
We've been getting POST requests at this endpoint, which is not supported. Assuming good faith, I'm opting to inform the requester that `POST` is not allowed, and that `GET` is.