### PR TITLE
updates the postgresql install command in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Follow the instructions below on how to install Bundler and setup the database.
 
   * Note that `-e "xpack.security.enabled=false"` disables authentication.
 
-* Install PostgreSQL (>= 13.x): `brew install postgres`
+* Install PostgreSQL (>= 13.x): `brew install postgresql`
   * Setup information: `brew info postgresql`
 * Install memcached: `brew install memcached`
   * Show all memcached options: `memcached -h`


### PR DESCRIPTION
The postgresql install command was missing part of the letter, which resulted in an error. This updates that command.