### PR TITLE
Updates the names of the clashing test names

### DIFF
--- a/test/system/organization_invite_test.rb
+++ b/test/system/organization_invite_test.rb
@@ -1,6 +1,6 @@
 require "application_system_test_case"
 
-class OrganizationInviteTest < ApplicationSystemTestCase
+class OrganizationInviteSystemTest < ApplicationSystemTestCase
   setup do
     @owner = create(:user)
     @member = create(:user)

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -1,6 +1,6 @@
 require "application_system_test_case"
 
-class RubygemTransferTest < ApplicationSystemTestCase
+class RubygemTransferSystemTest < ApplicationSystemTestCase
   def setup
     @owner = create(:user)
     @rubygem = create(:rubygem, owners: [@owner])


### PR DESCRIPTION
Fixes an issue that was causing `bin/rails test:all` to fail due to test name clashing.