### PR TITLE
⛳ Feature Flag Organizations

### DIFF
--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -11,7 +11,7 @@ class Organizations::BaseController < ApplicationController
   private
 
   def organizations_enabled?
-    FeatureFlag.enabled?(:organizations, current_user)
+    FeatureFlag.enabled?(FeatureFlag::ORGANIZATIONS, current_user)
   end
 
   def find_organization

--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -2,12 +2,17 @@ class Organizations::BaseController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
+  before_action :render_not_found, unless: :organizations_enabled?
 
   before_action :find_organization
 
   layout "subject"
 
   private
+
+  def organizations_enabled?
+    FeatureFlag.enabled?(:organizations, current_user)
+  end
 
   def find_organization
     @organization = Organization.find_by(handle: params[:organization_id])

--- a/app/controllers/organizations/onboarding/base_controller.rb
+++ b/app/controllers/organizations/onboarding/base_controller.rb
@@ -1,6 +1,7 @@
 class Organizations::Onboarding::BaseController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
+  before_action :render_not_found, unless: :organizations_enabled?
   before_action :find_or_initialize_onboarding
   before_action :set_breadcrumbs
 
@@ -27,4 +28,10 @@ class Organizations::Onboarding::BaseController < ApplicationController
     @approved_invites ||= @organization_onboarding.approved_invites
   end
   helper_method :approved_invites
+
+  private
+
+  def organizations_enabled?
+    FeatureFlag.enabled?(:organizations, current_user)
+  end
 end

--- a/app/controllers/organizations/onboarding/base_controller.rb
+++ b/app/controllers/organizations/onboarding/base_controller.rb
@@ -32,6 +32,6 @@ class Organizations::Onboarding::BaseController < ApplicationController
   private
 
   def organizations_enabled?
-    FeatureFlag.enabled?(:organizations, current_user)
+    FeatureFlag.enabled?(FeatureFlag::ORGANIZATIONS, current_user)
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,4 +1,4 @@
-class OrganizationsController < ApplicationController
+class OrganizationsController < Organizations::BaseController
   before_action :redirect_to_signin, only: :index, unless: :signed_in?
   before_action :redirect_to_new_mfa, only: :index, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, only: :index, if: :mfa_required_weak_level_enabled?

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,6 +3,8 @@ class OrganizationsController < Organizations::BaseController
   before_action :redirect_to_new_mfa, only: :index, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, only: :index, if: :mfa_required_weak_level_enabled?
 
+  skip_before_action :render_not_found, only: %i[show index]
+
   before_action :find_organization, only: %i[show edit update]
 
   layout "subject"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,4 +106,8 @@ module ApplicationHelper
       **kwargs
     )
   end
+
+  def organizations_enabled?(user)
+    FeatureFlag.enabled?(FeatureFlag::ORGANIZATIONS, user)
+  end
 end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,4 +1,6 @@
 class FeatureFlag
+  ORGANIZATIONS = :organizations
+
   class << self
     def enabled?(flag_name, actor = nil)
       Flipper.enabled?(flag_name, actor)

--- a/app/views/dashboards/_promo.html.erb
+++ b/app/views/dashboards/_promo.html.erb
@@ -1,3 +1,4 @@
+<% return unless organizations_enabled?(current_user) %>
 <% return unless current_user.memberships.any? %>
 <div class="flex flex-col px-4 py-6 md:p-10 mb-10 border border-orange rounded-lg bg-orange-050 dark:bg-orange-950">
   <h2 class="flex text-h3 mb-10">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -93,7 +93,7 @@
       <% end %>
     <% end %>
 
-    <% if policy(@organization).invite_member? %>
+    <% if policy(@organization).invite_member? && organizations_enabled?(current_user) %>
       <div class="pt-6 flex flex-row justify-end">
         <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
       </div>

--- a/test/functional/organizations/invitations_controller_test.rb
+++ b/test/functional/organizations/invitations_controller_test.rb
@@ -6,11 +6,11 @@ class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
     @organization = create(:organization)
     @membership = create(:membership, :pending, organization: @organization, user: @user)
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   test "requires feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organization_invitation_path(@organization, as: @user)
 
       assert_response :not_found

--- a/test/functional/organizations/invitations_controller_test.rb
+++ b/test/functional/organizations/invitations_controller_test.rb
@@ -5,6 +5,20 @@ class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
     @organization = create(:organization)
     @membership = create(:membership, :pending, organization: @organization, user: @user)
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  test "requires feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get organization_invitation_path(@organization, as: @user)
+
+      assert_response :not_found
+
+      patch organization_invitation_path(@organization, as: @user)
+
+      assert_response :not_found
+    end
   end
 
   test "GET /organizations/:organization_handle/invitation" do

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -6,12 +6,12 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
     @membership = create(:membership, organization: @organization, user: @user, role: :admin)
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
   end
 
   test "feature flag enablement is required" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organization_memberships_path(@organization)
 
       assert_response :not_found

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -6,7 +6,25 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
     @membership = create(:membership, organization: @organization, user: @user, role: :admin)
 
+    FeatureFlag.enable_for_actor(:organizations, @user)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+  end
+
+  test "feature flag enablement is required" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get organization_memberships_path(@organization)
+
+      assert_response :not_found
+
+      get new_organization_membership_path(@organization)
+
+      assert_response :not_found
+
+      new_user = create(:user)
+      post organization_memberships_path(@organization), params: { membership: { user: new_user.handle, role: :admin } }
+
+      assert_response :not_found
+    end
   end
 
   test "GET /organizations/:organization_handle/members" do

--- a/test/functional/organizations/onboarding/confirm_controller_test.rb
+++ b/test/functional/organizations/onboarding/confirm_controller_test.rb
@@ -15,10 +15,24 @@ class Organizations::Onboarding::ConfirmControllerTest < ActionDispatch::Integra
       namesake_rubygem: @rubygem,
       approved_invites: [{ user: @collaborator, role: "maintainer" }]
     )
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
   end
 
-  context "GET #show" do
-    should "to render the show template" do
+  should "require feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get "/organizations/onboarding/confirm"
+
+      assert_response :not_found
+
+      patch "/organizations/onboarding/confirm"
+
+      assert_response :not_found
+    end
+  end
+
+  context "GET #edit" do
+    should "to render the edit template" do
       get "/organizations/onboarding/confirm"
 
       assert_response :ok

--- a/test/functional/organizations/onboarding/confirm_controller_test.rb
+++ b/test/functional/organizations/onboarding/confirm_controller_test.rb
@@ -16,11 +16,11 @@ class Organizations::Onboarding::ConfirmControllerTest < ActionDispatch::Integra
       approved_invites: [{ user: @collaborator, role: "maintainer" }]
     )
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   should "require feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get "/organizations/onboarding/confirm"
 
       assert_response :not_found

--- a/test/functional/organizations/onboarding/gems_controller_test.rb
+++ b/test/functional/organizations/onboarding/gems_controller_test.rb
@@ -13,6 +13,20 @@ class Organizations::Onboarding::GemsControllerTest < ActionDispatch::Integratio
       organization_handle: @namesake_rubygem.name,
       organization_name: "Existing Name"
     )
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  should "require feature flat enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get organization_onboarding_gems_path(as: @user)
+
+      assert_response :not_found
+
+      patch organization_onboarding_gems_path(as: @user), params: { organization_onboarding: { rubygems: [@gem.id] } }
+
+      assert_response :not_found
+    end
   end
 
   context "PATCH update" do

--- a/test/functional/organizations/onboarding/gems_controller_test.rb
+++ b/test/functional/organizations/onboarding/gems_controller_test.rb
@@ -14,11 +14,11 @@ class Organizations::Onboarding::GemsControllerTest < ActionDispatch::Integratio
       organization_name: "Existing Name"
     )
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   should "require feature flat enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organization_onboarding_gems_path(as: @user)
 
       assert_response :not_found

--- a/test/functional/organizations/onboarding/name_controller_test.rb
+++ b/test/functional/organizations/onboarding/name_controller_test.rb
@@ -4,6 +4,22 @@ class Organizations::Onboarding::NameControllerTest < ActionDispatch::Integratio
   setup do
     @user = create(:user, :mfa_enabled)
     @gem = create(:rubygem, owners: [@user])
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  should "require feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get organization_onboarding_name_path(as: @user)
+
+      assert_response :not_found
+
+      post organization_onboarding_name_path(as: @user), params: { organization_onboarding: {
+        organization_name: "New Name", organization_handle: @gem.name, name_type: "gem"
+      } }
+
+      assert_response :not_found
+    end
   end
 
   context "GET new" do

--- a/test/functional/organizations/onboarding/name_controller_test.rb
+++ b/test/functional/organizations/onboarding/name_controller_test.rb
@@ -5,11 +5,11 @@ class Organizations::Onboarding::NameControllerTest < ActionDispatch::Integratio
     @user = create(:user, :mfa_enabled)
     @gem = create(:rubygem, owners: [@user])
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   should "require feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organization_onboarding_name_path(as: @user)
 
       assert_response :not_found

--- a/test/functional/organizations/onboarding/users_controller_test.rb
+++ b/test/functional/organizations/onboarding/users_controller_test.rb
@@ -14,11 +14,11 @@ class Organizations::Onboarding::UsersControllerTest < ActionDispatch::Integrati
 
     @invites = @organization_onboarding.invites.to_a
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   should "require feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organization_onboarding_users_path(as: @user)
 
       assert_response :not_found

--- a/test/functional/organizations/onboarding/users_controller_test.rb
+++ b/test/functional/organizations/onboarding/users_controller_test.rb
@@ -13,6 +13,27 @@ class Organizations::Onboarding::UsersControllerTest < ActionDispatch::Integrati
     )
 
     @invites = @organization_onboarding.invites.to_a
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  should "require feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      get organization_onboarding_users_path(as: @user)
+
+      assert_response :not_found
+
+      patch organization_onboarding_users_path(as: @user), params: {
+        organization_onboarding: {
+          invites_attributes: {
+            "0" => { id: @invites[0].id, role: "maintainer" },
+            "1" => { id: @invites[1].id, role: "admin" }
+          }
+        }
+      }
+
+      assert_response :not_found
+    end
   end
 
   context "on GET /organizations/onboarding/users" do

--- a/test/functional/organizations/onboarding_controller_test.rb
+++ b/test/functional/organizations/onboarding_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Organizations::OnboardingControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   context "GET /organizations/onboarding" do
@@ -15,7 +15,7 @@ class Organizations::OnboardingControllerTest < ActionDispatch::IntegrationTest
   end
 
   should "require feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       organization_onboarding = create(:organization_onboarding, :completed, created_by: @user)
 
       delete organization_onboarding_path(as: @user)

--- a/test/helpers/feature_flag_helpers.rb
+++ b/test/helpers/feature_flag_helpers.rb
@@ -8,7 +8,7 @@ module FeatureFlagHelpers
   end
 
   def disable_feature(flag_name)
-    FeatureFlag.disable(flag_name)
+    FeatureFlag.disable_globally(flag_name)
   end
 
   def with_feature(flag_name, enabled: true, actor: nil)

--- a/test/integration/organizations/gems_test.rb
+++ b/test/integration/organizations/gems_test.rb
@@ -5,11 +5,11 @@ class Organizations::GemsTest < ActionDispatch::IntegrationTest
     @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   test "should require feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       @organization = create(:organization, owners: [@user])
 
       get "/organizations/#{@organization.to_param}/gems"

--- a/test/integration/organizations/gems_test.rb
+++ b/test/integration/organizations/gems_test.rb
@@ -4,6 +4,18 @@ class Organizations::GemsTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  test "should require feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      @organization = create(:organization, owners: [@user])
+
+      get "/organizations/#{@organization.to_param}/gems"
+
+      assert_response :not_found
+    end
   end
 
   test "should get index" do

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -5,11 +5,11 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
     @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   test "requires feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       get organizations_path
 
       assert_response :not_found

--- a/test/system/invitation_test.rb
+++ b/test/system/invitation_test.rb
@@ -9,6 +9,19 @@ class InvitationTest < ApplicationSystemTestCase
     @membership = create(:membership, user: @user, organization: @organization, role: :admin)
 
     @outside_user = create(:user)
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(:organizations, @outside_user)
+  end
+
+  test "requires feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      sign_in
+
+      visit organization_path(@organization)
+
+      assert_no_text "Invite"
+    end
   end
 
   test "inviting a user to an organization" do

--- a/test/system/invitation_test.rb
+++ b/test/system/invitation_test.rb
@@ -10,12 +10,12 @@ class InvitationTest < ApplicationSystemTestCase
 
     @outside_user = create(:user)
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
-    FeatureFlag.enable_for_actor(:organizations, @outside_user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @outside_user)
   end
 
   test "requires feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       sign_in
 
       visit organization_path(@organization)

--- a/test/system/onboarding_test.rb
+++ b/test/system/onboarding_test.rb
@@ -8,6 +8,20 @@ class OnboardingTest < ApplicationSystemTestCase
     @maintainer = create(:user)
     @rubygem = create(:rubygem, owners: [@user, @other_user, @admin, @maintainer])
     @other_rubygem = create(:rubygem, owners: [@user, @other_user])
+
+    FeatureFlag.enable_for_actor(:organizations, @user)
+  end
+
+  test "requires feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @user) do
+      visit sign_in_path
+
+      click_link "login as #{@user[:handle]}"
+
+      visit organization_onboarding_path
+
+      assert_no_text "Create an Org"
+    end
   end
 
   test "onboarding an organization with a single gem and user" do

--- a/test/system/onboarding_test.rb
+++ b/test/system/onboarding_test.rb
@@ -9,11 +9,11 @@ class OnboardingTest < ApplicationSystemTestCase
     @rubygem = create(:rubygem, owners: [@user, @other_user, @admin, @maintainer])
     @other_rubygem = create(:rubygem, owners: [@user, @other_user])
 
-    FeatureFlag.enable_for_actor(:organizations, @user)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
   end
 
   test "requires feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @user) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
       visit sign_in_path
 
       click_link "login as #{@user[:handle]}"

--- a/test/system/organization_invite_test.rb
+++ b/test/system/organization_invite_test.rb
@@ -6,11 +6,11 @@ class OrganizationInviteSystemTest < ApplicationSystemTestCase
     @member = create(:user)
     @organization = create(:organization, owners: [@owner])
 
-    FeatureFlag.enable_for_actor(:organizations, @owner)
+    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @owner)
   end
 
   test "requires feature flag enablement" do
-    with_feature(:organizations, enabled: false, actor: @owner) do
+    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @owner) do
       sign_in(@owner)
 
       visit organization_path(@organization)

--- a/test/system/organization_invite_test.rb
+++ b/test/system/organization_invite_test.rb
@@ -5,6 +5,18 @@ class OrganizationInviteSystemTest < ApplicationSystemTestCase
     @owner = create(:user)
     @member = create(:user)
     @organization = create(:organization, owners: [@owner])
+
+    FeatureFlag.enable_for_actor(:organizations, @owner)
+  end
+
+  test "requires feature flag enablement" do
+    with_feature(:organizations, enabled: false, actor: @owner) do
+      sign_in(@owner)
+
+      visit organization_path(@organization)
+
+      assert_no_text "Invite"
+    end
   end
 
   test "invite user to organization" do


### PR DESCRIPTION
As we roll out the organizations beta, we want to ensure we've got fine-grained control over enrollment. This PR prevents access to organizations pages when the feature flag is not enabled for a user.

---

`organizations` flag (active in production) 👇

<img width="615" height="211" alt="image" src="https://github.com/user-attachments/assets/0ae2007d-551b-4ef1-aeaa-50ebaaee2268" />
