### PR TITLE
Disable preloading of features

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,8 @@ module Gemcutter
     config.action_dispatch.default_headers.merge!(
       "Cross-Origin-Opener-Policy" => "same-origin"
     )
+
+    config.flipper.preload = false
   end
 
   def self.config


### PR DESCRIPTION
We'll need to monitor performance as we add feature flags. Since we're currently not gating features, we can do without preloading for now.