### PR TITLE
Include role in owners api response

### DIFF
--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -6,9 +6,10 @@ class Api::V1::OwnersController < Api::BaseController
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def show
+    payload = @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) }
     respond_to do |format|
-      format.json { render json: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }
-      format.yaml { render yaml: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }
+      format.json { render json: payload }
+      format.yaml { render yaml: payload }
     end
   end
 

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -6,9 +6,12 @@ class Api::V1::OwnersController < Api::BaseController
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def show
+    # owners is a through relationship, where the through table is ownerships, connecting User and Rubygem.
+    # role lives in the ownership table, as a user could have a different role for different gems.
+    # so the role should correspond to this gem only
     respond_to do |format|
-      format.json { render json: @rubygem.owners }
-      format.yaml { render yaml: @rubygem.owners }
+      format.json { render json: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }
+      format.yaml { render yaml: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }
     end
   end
 

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -6,9 +6,6 @@ class Api::V1::OwnersController < Api::BaseController
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def show
-    # owners is a through relationship, where the through table is ownerships, connecting User and Rubygem.
-    # role lives in the ownership table, as a user could have a different role for different gems.
-    # so the role should correspond to this gem only
     respond_to do |format|
       format.json { render json: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }
       format.yaml { render yaml: @rubygem.owners.map { |owner| owner.payload.merge("role" => owner.ownerships.find_by(rubygem: @rubygem).role) } }

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -99,6 +99,21 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
     should respond_with :not_found
   end
 
+
+  context "GET /api/v1/gems/:gem/owners.json" do
+    setup do
+      @user = create(:user)
+      @rubygem = create(:rubygem, owners: [@user])
+      get :show, params: { rubygem_id: @rubygem.slug }, format: :json
+    end
+    should "include associated users id, handle, and role in response" do
+      user_payload = JSON.parse(@response.body).first
+      assert_equal "owner", user_payload["role"]
+      assert_equal @user.id, user_payload["id"]
+      assert_equal @user.handle, user_payload["handle"]
+    end
+  end
+
   should "route POST /api/v1/gems/rubygem/owners.json" do
     route = { controller: "api/v1/owners",
               action: "create",


### PR DESCRIPTION
Addresses https://github.com/rubygems/rubygems.org/issues/5816 by including the role of each member of a gem in the response to [/api/v1/gems/:gem_id/owners.json](https://guides.rubygems.org/rubygems-org-api/#get---apiv1gemsgem-nameownersjsonyaml)

Note: There could be a better solution to this, but I found it difficult to work around the User#payload method. It looks like using serializers was discussed in the past but rejected. https://github.com/rubygems/rubygems.org/issues/1027#issuecomment-292725824 As this is my first PR here, I am absolutely open to feedback or better approaches. 