### PR TITLE
More Organization improvements

### DIFF
--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -2,17 +2,11 @@ class Organizations::BaseController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
-  before_action :render_not_found, unless: :organizations_enabled?
-
   before_action :find_organization
 
   layout "subject"
 
   private
-
-  def organizations_enabled?
-    FeatureFlag.enabled?(FeatureFlag::ORGANIZATIONS, current_user)
-  end
 
   def find_organization
     @organization = Organization.find_by(handle: params[:organization_id])

--- a/app/controllers/organizations/gems_controller.rb
+++ b/app/controllers/organizations/gems_controller.rb
@@ -1,6 +1,8 @@
 class Organizations::GemsController < Organizations::BaseController
   before_action :find_organization, only: %i[index]
 
+  skip_before_action :redirect_to_signin, only: %i[index]
+
   layout "subject"
 
   def index

--- a/app/controllers/organizations/members_controller.rb
+++ b/app/controllers/organizations/members_controller.rb
@@ -1,13 +1,18 @@
 class Organizations::MembersController < Organizations::BaseController
   before_action :find_membership, only: %i[edit update destroy]
 
+  skip_before_action :redirect_to_signin, only: %i[index]
+
   rescue_from Pundit::NotAuthorizedError, with: :render_not_found
 
   def index
-    authorize @organization, :list_memberships?
-
-    @memberships = @organization.memberships_including_unconfirmed.includes(:user)
-    @memberships_count = @organization.memberships_including_unconfirmed.count
+    if OrganizationPolicy.new(current_user, @organization).list_memberships?
+      @memberships = @organization.memberships_including_unconfirmed.includes(:user)
+      @memberships_count = @organization.memberships_including_unconfirmed.count
+    else
+      @memberships = @organization.memberships.includes(:user)
+      @memberships_count = @organization.memberships.count
+    end
   end
 
   def new

--- a/app/controllers/organizations/onboarding/base_controller.rb
+++ b/app/controllers/organizations/onboarding/base_controller.rb
@@ -8,7 +8,10 @@ class Organizations::Onboarding::BaseController < ApplicationController
   layout "onboarding"
 
   def find_or_initialize_onboarding
-    @organization_onboarding = OrganizationOnboarding.includes(invites: :user).find_or_initialize_by(created_by: Current.user, status: :pending)
+    @organization_onboarding = OrganizationOnboarding
+      .includes(invites: :user)
+      .where.not(status: :completed)
+      .find_or_initialize_by(created_by: Current.user)
   end
 
   def set_breadcrumbs

--- a/app/controllers/organizations/onboarding_controller.rb
+++ b/app/controllers/organizations/onboarding_controller.rb
@@ -1,4 +1,4 @@
-class Organizations::OnboardingController < Organizations::BaseController
+class Organizations::OnboardingController < Organizations::Onboarding::BaseController
   def destroy
     OrganizationOnboarding.destroy_by(created_by: Current.user, status: %i[pending failed])
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,8 +3,6 @@ class OrganizationsController < Organizations::BaseController
   before_action :redirect_to_new_mfa, only: :index, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, only: :index, if: :mfa_required_weak_level_enabled?
 
-  skip_before_action :render_not_found, only: %i[show index]
-
   before_action :find_organization, only: %i[show edit update]
 
   layout "subject"

--- a/app/controllers/rubygems/transfer/base_controller.rb
+++ b/app/controllers/rubygems/transfer/base_controller.rb
@@ -8,7 +8,10 @@ class Rubygems::Transfer::BaseController < ApplicationController
 
   def find_or_initialize_transfer
     @rubygem = Rubygem.find_by(name: params[:rubygem_id])
-    @rubygem_transfer = RubygemTransfer.includes(invites: :user).find_or_initialize_by(created_by: Current.user, rubygem: @rubygem, status: :pending)
+    @rubygem_transfer = RubygemTransfer
+      .includes(invites: :user)
+      .where.not(status: :completed)
+      .find_or_initialize_by(created_by: Current.user, rubygem: @rubygem)
   end
 
   def set_breadcrumbs

--- a/app/models/organization_invite.rb
+++ b/app/models/organization_invite.rb
@@ -8,7 +8,7 @@ class OrganizationInvite < ApplicationRecord
     validate: { allow_nil: true }
 
   def to_membership(actor: nil)
-    return nil if outside_contributor?
+    return nil if role.blank? || outside_contributor?
 
     Membership.new(
       user: user,

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -19,15 +19,21 @@
 <!-- Organizations -->
 <%= render CardComponent.new do |c| %>
   <%= c.divided_list do %>
-    <% @memberships.each do |membership| %>
-      <%= c.list_item_to(organization_path(membership.organization.handle)) do %>
-        <div class="flex flex-row w-full justify-between items-center">
-          <div class="flex flex-col">
-            <p class="text-neutral-800 dark:text-white"><%= membership.organization.name %></p>
-            <p class="text-b3 text-neutral-600"><%= membership.organization.handle %></p>
+    <% if @memberships.size.zero? %>
+      <%= c.list_item do %>
+        <%= t(".no_organizations") %>
+      <% end %>
+    <% else %>
+      <% @memberships.each do |membership| %>
+        <%= c.list_item_to(organization_path(membership.organization.handle)) do %>
+          <div class="flex flex-row w-full justify-between items-center">
+            <div class="flex flex-col">
+              <p class="text-neutral-800 dark:text-white"><%= membership.organization.name %></p>
+              <p class="text-b3 text-neutral-600"><%= membership.organization.handle %></p>
+            </div>
+            <p class="text-neutral-500 capitalize"><%= membership.role %></p>
           </div>
-          <p class="text-neutral-500 capitalize"><%= membership.role %></p>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/organizations/members/index.html.erb
+++ b/app/views/organizations/members/index.html.erb
@@ -5,7 +5,7 @@
 %>
 
 <% content_for :subject do %>
-  <%= render "organizations/subject", organization: @organization, current: :users %>
+  <%= render "organizations/subject", organization: @organization, current: :members %>
 <% end %>
 
 <div class="flex flex-row items-center justify-between">
@@ -15,21 +15,25 @@
 <%= render CardComponent.new do |c| %>
   <%= c.head do %>
 		<%= c.title t("organizations.show.members"), icon: "organizations", count: @memberships_count %>
-    <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
+    <% if policy(@organization).invite_member? %>
+      <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
+    <% end %>
   <% end %>
     <%= c.divided_list do %>
 		<% @memberships.each do |membership| %>
 			<%= c.list_item_to(
-				edit_organization_membership_path(@organization, membership),
+				policy(@organization).list_memberships? ? edit_organization_membership_path(@organization, membership) : profile_path(membership.user),
 				title: membership.user.handle,
 			) do %>
 				<div class="flex flex-col w-full justify-between">
 					<div class="flex flex-row w-full items-center justify-between">
 						<p class="text-neutral-800 dark:text-white"><%= membership.user.handle %></p>
-						<% if membership.confirmed? %>
-						<p class="text-neutral-500 capitalize"><%= membership.role %></p>
-						<% else %>
-						<p class="text-neutral-500 capitalize"><%= t(".pending") %></p>
+						<% if policy(@organization).list_memberships? %>
+							<% if membership.confirmed? %>
+							<p class="text-neutral-500 capitalize"><%= membership.role %></p>
+							<% else %>
+							<p class="text-neutral-500 capitalize"><%= t(".pending") %></p>
+							<% end %>
 						<% end %>
 					</div>
 				</div>

--- a/app/views/organizations/members/new.html.erb
+++ b/app/views/organizations/members/new.html.erb
@@ -18,7 +18,7 @@
     <%= c.title "Invite Member", icon: "organizations" %>
   <% end %>
 
-  <%= form_with(model: @membership, url: organization_memberships_path(@organization), method: :post, html: { class: "bg-white dark:bg-gray-900 p-6" }) do |f| %>
+  <%= form_with(model: @membership, url: organization_memberships_path(@organization), method: :post, html: { class: "p-6" }) do |f| %>
     <% if @membership.errors.any? %>
       <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
         <div class="flex">

--- a/app/views/organizations/members/new.html.erb
+++ b/app/views/organizations/members/new.html.erb
@@ -18,7 +18,7 @@
     <%= c.title "Invite Member", icon: "organizations" %>
   <% end %>
 
-  <%= form_with(model: @membership, url: organization_memberships_path(@organization), method: :post, html: { class: "bg-white dark:bg-gray-900 p-6 rounded-lg shadow-md mb-6 border border-gray-200 dark:border-gray-700" }) do |f| %>
+  <%= form_with(model: @membership, url: organization_memberships_path(@organization), method: :post, html: { class: "bg-white dark:bg-gray-900 p-6" }) do |f| %>
     <% if @membership.errors.any? %>
       <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
         <div class="flex">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -93,7 +93,7 @@
       <% end %>
     <% end %>
 
-    <% if policy(@organization).invite_member? && organizations_enabled?(current_user) %>
+    <% if policy(@organization).invite_member? %>
       <div class="pt-6 flex flex-row justify-end">
         <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
       </div>

--- a/app/views/rubygems/_release_info.html.erb
+++ b/app/views/rubygems/_release_info.html.erb
@@ -6,6 +6,13 @@
       <div class="gem__organization-info">
         <h4 class="gem__organization-header"><%= link_to rubygem.organization.name, organization_path(rubygem.organization), class: "gem__organization-name" %></h4>
       </div>
+
+      <% if rubygem.owners.any? %>
+      <h3 class="t-list__heading"><%= t '.outside_contributors' %></h3>
+      <div class="gem__users">
+        <%= links_to_owners(rubygem) %>
+      </div>
+      <% end %>
     </div>
   <% elsif rubygem.owners.present? %>
     <h3 class="t-list__heading"><%= t '.owners_header' %>:</h3>

--- a/app/views/rubygems/transfer/organizations/new.html.erb
+++ b/app/views/rubygems/transfer/organizations/new.html.erb
@@ -18,8 +18,10 @@
   <label class="flex flex-col xl:flex-row items-center rounded-lg border border-neutral-400 dark:border-neutral-600 overflow-hidden">
     <%= f.select(
       :organization,
-      @organizations.map(&:handle),
-      { prompt: "select..." },
+      options_for_select(@organizations.collect { [it.name, it.handle]}, selected: @rubygem_transfer.organization&.handle),
+      { 
+        prompt: "select...",
+      },
       {
         required: true,
         class: "flex-1 w-full h-11 text-b2 px-4 xl:px-2 bg-white border-none dark:bg-neutral-950 rounded-b-lg xl:rounded-bl-none xl:rounded-r-lg outline-none appearance-none focus:ring-inset focus:ring-1 focus:ring-orange-500"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -114,6 +114,12 @@ de:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -830,6 +830,7 @@ de:
       header: "%{title} Abhängigkeiten"
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: Autoren
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -118,8 +118,12 @@ de:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -461,6 +461,7 @@ de:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,7 @@ en:
       header: "%{title} Dependencies"
     release_info:
       managed_by: Managed By
+      outside_contributors: Outside Contributors
       authors_header: Authors
       self_no_mfa_warning_html: Please consider <a href="/settings/edit">enabling multi-factor authentication (MFA)</a> to keep your account secure.
       not_using_mfa_warning_show: "* Some owners are not using multi-factor authentication (MFA). Click for the complete list."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,8 +113,12 @@ en:
           attributes:
             user:
               taken: has already been invited to this organization
+              blank: not found
+              required: not found
             user_id:
               taken: has already been invited to this organization
+              blank: not found
+              required: not found
         ownership:
           attributes:
             user_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,12 @@ en:
           attributes:
             handle:
               invalid: "must start with a letter and can only contain letters, numbers, underscores, and dashes"
+        membership:
+          attributes:
+            user:
+              taken: has already been invited to this organization
+            user_id:
+              taken: has already been invited to this organization
         ownership:
           attributes:
             user_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,6 +419,7 @@ en:
   organizations:
     index:
       title: Organizations
+      no_organizations: You are not a member of any organizations.
     show:
       organization: Organization
       gems: Gems

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -116,8 +116,12 @@ es:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -842,6 +842,7 @@ es:
       header: dependencias de %{title}
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: Autores
       self_no_mfa_warning_html: Considera por favor <a href="/settings/edit">activar
         la autenticación de múltiples factores (AMF)</a> para mantener tu cuenta segura.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -112,6 +112,12 @@ es:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -456,6 +456,7 @@ es:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,6 +110,12 @@ fr:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -425,6 +425,7 @@ fr:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -114,8 +114,12 @@ fr:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -775,6 +775,7 @@ fr:
       header: Dépendances de %{title}
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: Auteurs
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -107,8 +107,12 @@ ja:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -420,6 +420,7 @@ ja:
   organizations:
     index:
       title: 組織
+      no_organizations:
     show:
       organization: 組織
       gems: gem

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -755,6 +755,7 @@ ja:
       header: "%{title}依存関係"
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: 作者
       self_no_mfa_warning_html: アカウントをセキュアに保つため、<a href="/settings/edit">多要素認証（MFA）
         の有効化</a>をご検討ください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -103,6 +103,12 @@ ja:
           attributes:
             handle:
               invalid: は英字から始まり、英字、数字、アンダーバー、ハイフンのみが含まれていなければなりません
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -106,8 +106,12 @@ nl:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -742,6 +742,7 @@ nl:
       header: "%{title} afhankelijkheden"
     release_info:
       managed_by:
+      outside_contributors:
       authors_header:
       self_no_mfa_warning_html:
       not_using_mfa_warning_show:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -102,6 +102,12 @@ nl:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -409,6 +409,7 @@ nl:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -422,6 +422,7 @@ pt-BR:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -109,6 +109,12 @@ pt-BR:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -754,6 +754,7 @@ pt-BR:
       header:
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: Autores
       self_no_mfa_warning_html:
       not_using_mfa_warning_show: "* Alguns donos não estão usando MFA. Clique para

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -113,8 +113,12 @@ pt-BR:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -104,6 +104,12 @@ zh-CN:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -752,6 +752,7 @@ zh-CN:
       header: "%{title} 依赖"
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: 作者
       self_no_mfa_warning_html: 请考虑 <a href="/settings/edit">启用多因素身份验证（MFA）</a> 来保障您的帐户安全。
       not_using_mfa_warning_show: "* 某些所有者当前还没有启用多因素验证（MFA）。请点击查看完整列表。"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -108,8 +108,12 @@ zh-CN:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -424,6 +424,7 @@ zh-CN:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -415,6 +415,7 @@ zh-TW:
   organizations:
     index:
       title:
+      no_organizations:
     show:
       organization:
       gems:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -103,6 +103,12 @@ zh-TW:
           attributes:
             handle:
               invalid:
+        membership:
+          attributes:
+            user:
+              taken:
+            user_id:
+              taken:
         ownership:
           attributes:
             user_id:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -107,8 +107,12 @@ zh-TW:
           attributes:
             user:
               taken:
+              blank:
+              required:
             user_id:
               taken:
+              blank:
+              required:
         ownership:
           attributes:
             user_id:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -744,6 +744,7 @@ zh-TW:
       header: "%{title} 相依性套件"
     release_info:
       managed_by:
+      outside_contributors:
       authors_header: 作者
       self_no_mfa_warning_html:
       not_using_mfa_warning_show: "* 某些擁有者未使用多重要素驗證 (MFA)。點擊此處以顯示完整名單。"

--- a/test/factories/organizations.rb
+++ b/test/factories/organizations.rb
@@ -13,15 +13,15 @@ FactoryBot.define do
 
     after(:create) do |organization, evaluator|
       evaluator.owners.each do |user|
-        create(:membership, user: user, organization: organization, role: :owner)
+        create(:membership, user: user, organization: organization, role: :owner, confirmed_at: Time.zone.now)
       end
 
       evaluator.admins.each do |user|
-        create(:membership, user: user, organization: organization, role: :admin)
+        create(:membership, user: user, organization: organization, role: :admin, confirmed_at: Time.zone.now)
       end
 
       evaluator.maintainers.each do |user|
-        create(:membership, user: user, organization: organization, role: :maintainer)
+        create(:membership, user: user, organization: organization, role: :maintainer, confirmed_at: Time.zone.now)
       end
 
       evaluator.rubygems.each do |rubygem|

--- a/test/factories/rubygem_transfer.rb
+++ b/test/factories/rubygem_transfer.rb
@@ -5,18 +5,21 @@ FactoryBot.define do
     organization { association :organization }
 
     before(:create) do |rubygem_transfer|
-      rubygem_transfer.rubygem.ownerships.create!(
-        user: rubygem_transfer.created_by,
-        role: :owner,
+      rubygem_transfer.rubygem.ownerships.create_with(
         authorizer: rubygem_transfer.created_by,
         confirmed_at: Time.zone.now
+      ).find_or_create_by!(
+        user: rubygem_transfer.created_by,
+        role: :owner
       )
 
-      rubygem_transfer.organization.memberships.create!(
-        user: rubygem_transfer.created_by,
-        role: :owner,
-        confirmed_at: Time.zone.now
-      )
+      rubygem_transfer.organization.memberships
+        .create_with(
+          confirmed_at: Time.zone.now
+        ).find_or_create_by!(
+          user: rubygem_transfer.created_by,
+          role: :owner
+        )
     end
   end
 end

--- a/test/functional/organizations/invitations_controller_test.rb
+++ b/test/functional/organizations/invitations_controller_test.rb
@@ -5,20 +5,6 @@ class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
     @organization = create(:organization)
     @membership = create(:membership, :pending, organization: @organization, user: @user)
-
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
-  end
-
-  test "requires feature flag enablement" do
-    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
-      get organization_invitation_path(@organization, as: @user)
-
-      assert_response :not_found
-
-      patch organization_invitation_path(@organization, as: @user)
-
-      assert_response :not_found
-    end
   end
 
   test "GET /organizations/:organization_handle/invitation" do

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -6,25 +6,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     @user = create(:user)
     @membership = create(:membership, organization: @organization, user: @user, role: :admin)
 
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
-  end
-
-  test "feature flag enablement is required" do
-    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
-      get organization_memberships_path(@organization)
-
-      assert_response :not_found
-
-      get new_organization_membership_path(@organization)
-
-      assert_response :not_found
-
-      new_user = create(:user)
-      post organization_memberships_path(@organization), params: { membership: { user: new_user.handle, role: :admin } }
-
-      assert_response :not_found
-    end
   end
 
   test "GET /organizations/:organization_handle/members" do

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -22,7 +22,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
 
     get organization_memberships_path(@organization)
 
-    assert_response :not_found
+    assert_response :success
   end
 
   test "GET /organizations/:organization_handle/members as maintainer" do

--- a/test/functional/organizations/onboarding/name_controller_test.rb
+++ b/test/functional/organizations/onboarding/name_controller_test.rb
@@ -40,6 +40,23 @@ class Organizations::Onboarding::NameControllerTest < ActionDispatch::Integratio
         assert_select "input[name=?][value=?]", "organization_onboarding[organization_name]", @organization_onboarding.organization_name
       end
     end
+
+    context "when the user has an existing failed onboarding" do
+      setup do
+        @organization_onboarding = create(
+          :organization_onboarding,
+          :failed,
+          created_by: @user,
+          organization_name: "Failed Name"
+        )
+      end
+
+      should "render with the failed onboarding" do
+        get organization_onboarding_name_path(as: @user)
+
+        assert_select "input[name=?][value=?]", "organization_onboarding[organization_name]", @organization_onboarding.organization_name
+      end
+    end
   end
 
   context "POST create" do

--- a/test/functional/rubygems/transfer/organizations_controller_test.rb
+++ b/test/functional/rubygems/transfer/organizations_controller_test.rb
@@ -7,6 +7,21 @@ class Rubygems::Transfer::OrganizationsControllerTest < ActionDispatch::Integrat
     @rubygem = create(:rubygem, owners: [@user])
   end
 
+  test "GET /rubygems/:rubygem_id/transfer/organization" do
+    get rubygem_transfer_organization_path(@rubygem.slug, as: @user)
+
+    assert_response :success
+  end
+
+  test "GET /rubygems/:rubygem_id/transfer/organization with existing rubygems transfer" do
+    transfer = create(:rubygem_transfer, rubygem: @rubygem, organization: @organization, created_by: @user, status: :pending)
+
+    get rubygem_transfer_organization_path(@rubygem.slug, as: @user)
+
+    assert_response :success
+    assert_select "select[name=?] option[selected=selected][value=?]", "rubygem_transfer[organization]", transfer.organization.handle
+  end
+
   test "POST /rubygems/:rubygem_id/transfer/organization" do
     post rubygem_transfer_organization_path(@rubygem.slug, as: @user), params: { rubygem_transfer: { organization: @organization.handle } }
 

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -457,4 +457,21 @@ class RubygemsControllerTest < ActionController::TestCase
       assert page.has_link?(@organization.name, href: organization_path(@organization))
     end
   end
+
+  context "when a gem is owned by an organization and has outside contributors" do
+    setup do
+      @owner = create(:user)
+      @rubygem = create(:rubygem, owners: [@owner])
+      @version = create(:version, rubygem: @rubygem)
+      @organization = create(:organization, owners: [@owner])
+      @outside_contributor = create(:user)
+      create(:ownership, rubygem: @rubygem, user: @outside_contributor, role: :maintainer)
+    end
+
+    should "display outside contributors" do
+      get :show, params: { id: @rubygem.slug }
+
+      assert page.has_selector?("a[href='#{profile_path(@outside_contributor.display_id)}']")
+    end
+  end
 end

--- a/test/integration/organizations/gems_test.rb
+++ b/test/integration/organizations/gems_test.rb
@@ -4,18 +4,6 @@ class Organizations::GemsTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
-
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
-  end
-
-  test "should require feature flag enablement" do
-    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
-      @organization = create(:organization, owners: [@user])
-
-      get "/organizations/#{@organization.to_param}/gems"
-
-      assert_response :not_found
-    end
   end
 
   test "should get index" do

--- a/test/integration/organizations/members_test.rb
+++ b/test/integration/organizations/members_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Organizations::MembersTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    @maintainer = create(:user)
+    @organization = create(:organization)
+
+    @owner_membership = create(:membership, user: @owner, organization: @organization, role: "owner")
+    @maintainer_membership = create(:membership, user: @maintainer, organization: @organization, role: "maintainer")
+  end
+
+  should "get index as a guest user" do
+    get organization_memberships_path(@organization)
+
+    assert_response :success
+    assert_select "h1", text: "Members"
+    assert_select "a", text: "Invite", count: 0
+    assert_select "li a[href=?]", profile_path(@owner), text: @owner.handle
+    assert_select "li a[href=?]", profile_path(@maintainer), text: @maintainer.handle
+  end
+
+  should "get index as an owner" do
+    post session_path(session: { who: @owner.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    get organization_memberships_path(@organization)
+
+    assert_response :success
+    assert_select "h1", text: "Members"
+    assert_select "a", text: "Invite", count: 1
+    assert_select "li a[href=?]", edit_organization_membership_path(@organization, @owner_membership), text: "#{@owner.handle} owner"
+    assert_select "li a[href=?]", edit_organization_membership_path(@organization, @maintainer_membership), text: "#{@maintainer.handle} maintainer"
+  end
+end

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -26,6 +26,7 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
     get "/organizations"
 
     assert_response :success
+    assert page.has_content? "You are not a member of any organizations."
   end
 
   test "should list organizations for a user" do

--- a/test/models/organization_invite_test.rb
+++ b/test/models/organization_invite_test.rb
@@ -15,6 +15,12 @@ class OrganizationInviteTest < ActiveSupport::TestCase
     assert_nil invite.to_membership
   end
 
+  test "to_membership returns nil when role is empty" do
+    invite = create(:organization_invite, role: "")
+
+    assert_nil invite.to_membership
+  end
+
   test "to_membership sets invited_by to the actor" do
     user = create(:user)
     invite = create(:organization_invite, role: :owner)

--- a/test/system/invitation_test.rb
+++ b/test/system/invitation_test.rb
@@ -9,19 +9,6 @@ class InvitationTest < ApplicationSystemTestCase
     @membership = create(:membership, user: @user, organization: @organization, role: :admin)
 
     @outside_user = create(:user)
-
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @user)
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @outside_user)
-  end
-
-  test "requires feature flag enablement" do
-    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @user) do
-      sign_in
-
-      visit organization_path(@organization)
-
-      assert_no_text "Invite"
-    end
   end
 
   test "inviting a user to an organization" do

--- a/test/system/organization_invite_test.rb
+++ b/test/system/organization_invite_test.rb
@@ -5,18 +5,6 @@ class OrganizationInviteSystemTest < ApplicationSystemTestCase
     @owner = create(:user)
     @member = create(:user)
     @organization = create(:organization, owners: [@owner])
-
-    FeatureFlag.enable_for_actor(FeatureFlag::ORGANIZATIONS, @owner)
-  end
-
-  test "requires feature flag enablement" do
-    with_feature(FeatureFlag::ORGANIZATIONS, enabled: false, actor: @owner) do
-      sign_in(@owner)
-
-      visit organization_path(@organization)
-
-      assert_no_text "Invite"
-    end
   end
 
   test "invite user to organization" do

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -27,7 +27,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     assert_current_path rubygem_transfer_organization_path(@rubygem.slug)
 
-    select @organization.handle, from: "Organization"
+    select @organization.name, from: "Organization"
     click_on "Continue"
 
     assert_text "No owners to manage"
@@ -53,7 +53,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     assert_current_path rubygem_transfer_organization_path(@rubygem.slug)
 
-    select @organization.handle, from: "Organization"
+    select @organization.name, from: "Organization"
 
     click_on "Continue"
 
@@ -76,7 +76,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     assert_current_path rubygem_transfer_organization_path(@rubygem.slug)
 
-    select @organization.handle, from: "Organization"
+    select @organization.name, from: "Organization"
     click_on "Cancel"
 
     assert_current_path rubygem_path(@rubygem.slug)


### PR DESCRIPTION
We've finally launched Organizations into production and the first bit of feedback is coming through. This Pull Request resolves several reported bugs and issues that have been found so far.

> https://rubygems.org/organizations/redacted/memberships does not load
> I can't join an organization. The email is sent to me, I click the link and sign in, but the page doesn't exist (https://rubygems.org/organizations/redacted/invitation)

This is due to the Feature Flag being a bit too restrictive, I have pulled it back a bit and allowed the Organization Policy to take the reigns in figuring out what we do/don't show to the user.

> Gem page in the ownership section MUST show outside collaborators or else there is risk that outside collaborators "go rogue" and there's no way to do any baselining.

This has been added.

There's also some additional bug fixes that I've found myself, which I will refer to the commit messages.