### PR TITLE
🔒 Grant Outside Contributors `maintainer` Role

### DIFF
--- a/test/functional/organizations/onboarding/users_controller_test.rb
+++ b/test/functional/organizations/onboarding/users_controller_test.rb
@@ -121,6 +121,24 @@ class Organizations::Onboarding::UsersControllerTest < ActionDispatch::Integrati
       assert_equal "admin", @organization_onboarding.invites.find_by(user_id: @other_users[1].id).role
     end
 
+    should "update user to outside contributor role" do
+      patch organization_onboarding_users_path(as: @user), params: {
+        organization_onboarding: {
+          invites_attributes: {
+            "0" => { id: @invites[0].id, role: "outside_contributor" },
+            "1" => { id: @invites[1].id, role: "maintainer" }
+          }
+        }
+      }
+
+      assert_redirected_to organization_onboarding_confirm_path
+
+      @organization_onboarding.reload
+
+      assert_equal "outside_contributor", @organization_onboarding.invites.find_by(user_id: @other_users[0].id).role
+      assert_equal "maintainer", @organization_onboarding.invites.find_by(user_id: @other_users[1].id).role
+    end
+
     context "when already invited users" do
       should "update roles and/or uninvite" do
         @organization_onboarding.invites.create(user_id: @other_users[0].id, role: "admin")

--- a/test/functional/rubygems/transfer/users_controller_test.rb
+++ b/test/functional/rubygems/transfer/users_controller_test.rb
@@ -46,4 +46,21 @@ class Rubygems::Transfer::UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
   end
+
+  test "PATCH /rubygems/:rubygem_id/transfer/users with outside contributor role" do
+    patch rubygem_transfer_users_path(@rubygem.slug, as: @user), params: {
+      rubygem_transfer: {
+        invites_attributes: {
+          "0" => { id: @invites[0].id, role: "outside_contributor" },
+          "1" => { id: @invites[1].id, role: "maintainer" }
+        }
+      }
+    }
+
+    assert_equal "outside_contributor", @transfer.invites.find_by(user_id: @other_users[0].id).role
+    assert_equal "maintainer", @transfer.invites.find_by(user_id: @other_users[1].id).role
+
+    assert_response :redirect
+    assert_redirected_to rubygem_transfer_confirm_path(@rubygem.slug)
+  end
 end

--- a/test/system/onboarding_test.rb
+++ b/test/system/onboarding_test.rb
@@ -145,14 +145,15 @@ class OnboardingTest < ApplicationSystemTestCase
 
     click_button "Create Org"
 
-    ownership = Ownership.find_by(user: outside_contributor, rubygem: @rubygem)
+    visit rubygem_owners_path(@rubygem.slug)
 
-    assert_not_nil ownership
-    assert_equal "maintainer", ownership.role
+    assert_text "Please confirm your password to continue"
 
-    organization = Organization.find_by(handle: @rubygem.name)
-    membership = organization.memberships.find_by(user: outside_contributor)
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
 
-    assert_nil membership
+    click_button "Confirm"
+
+    # headers:               OWNER                STATUS     MFA                         ADDED BY                               ROLE
+    assert_text "#{outside_contributor.handle}\nConfirmed\nDisabled\n#{outside_contributor.ownerships.first.authorizer_name} Maintainer"
   end
 end

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -94,11 +94,16 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     assert_text "MANAGED BY: #{@organization.name}", normalize_ws: true
 
-    # Verify the outside contributor still has ownership but was demoted to maintainer
-    ownership = Ownership.find_by(user: maintainer, rubygem: @rubygem)
+    visit rubygem_owners_path(@rubygem.slug)
 
-    assert_not_nil ownership
-    assert_equal "maintainer", ownership.role
+    assert_text "Please confirm your password to continue"
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+
+    click_button "Confirm"
+
+    # headers:         OWNER             STATUS     MFA                         ADDED BY                      ROLE
+    assert_text "#{maintainer.handle}\nConfirmed\nDisabled\n#{maintainer.ownerships.first.authorizer_name} Maintainer"
   end
 
   test "cancelling a rubygem transfer" do


### PR DESCRIPTION
# 😬 Problem

When a gem transfers to an organization, former "owners" who choose to (or are assigned to) remain outside contributors retain their owner-level permissions. While this has the added benefit of providing continuity in the former owner's workflow, this creates a security and governance issue where external users can add/remove gem owners on organization-owned assets.

## ⨧ Rationale

Using the imperfect analogy of a startup acquisition, when `Company A` acquires a product from `Company B`, former `Company B` owners may join their new organization or stay on as contractors. The contractors retain operational access, but cannot hire/fire `Company A` employees or make executive decisions about `Company A`'s assets.

Similarly, outside contributors should maintain the ability to push/manage gems (operational access), but should not control who is granted access to organization-owned gems (administrative access).

## 🔧 Solution
By converting outside contributors from "owner" role to "maintainer" role during the onboarding process, we preserve operational access while removing administrative privileges.

## 🟰 Result

|   Ability | Org Owner | Org Admin | Org Maintainer | Maintainer (Outside Contributor) |
|--------|--------|--------|--------|--------|
| Add/remove gem to organization | ✅ | ❌ | ❌ | ❌ |
| Add/remove member to organization | ✅ | ❌ | ❌ | ❌ |
| Add/remove outside contributor to gem | ✅ | ✅ | ❌ | ❌ |
| Publish/manage _all_ organization's gems | ✅ | ✅ | ✅ | ❌ |
| Publish/manage individual gem | ✅ | ✅ | ✅ | ✅ | 