### PR TITLE
Remove outdated comment re: honeybadger dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "flipper-active_record", "~> 1.3"
 gem "flipper-ui", "~> 1.3"
 gem "good_job", "~> 3.99"
 gem "gravtastic", "~> 3.2"
-gem "honeybadger", "~> 6.0.2", require: false # see https://github.com/rubygems/rubygems.org/pull/4598
+gem "honeybadger", "~> 6.0.2", require: false
 gem "http_accept_language", "~> 2.1"
 gem "kaminari", "~> 1.2"
 gem "mail", "~> 2.8"


### PR DESCRIPTION
This was added while reverting from 5.8.0 to 5.5.1 over a year ago. The upstream bug has long been fixed.