### PR TITLE
Replace deprecated status: :unprocessable_content with :unprocessable_entity

### DIFF
--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::ApiKeysController < Api::BaseController
           respond_with "Scopes for the API key #{api_key.name} updated"
         else
           errors = api_key.errors.full_messages
-          respond_with "Failed to update scopes for the API key #{api_key.name}: #{errors}", status: :unprocessable_entity
+          respond_with "Failed to update scopes for the API key #{api_key.name}: #{errors}", status: :unprocessable_content
         end
       end
     end
@@ -69,7 +69,7 @@ class Api::V1::ApiKeysController < Api::BaseController
       Mailer.api_key_created(api_key.id).deliver_later
       respond_with key
     else
-      respond_with api_key.errors.full_messages.to_sentence, status: :unprocessable_entity
+      respond_with api_key.errors.full_messages.to_sentence, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::DeletionsController < Api::BaseController
     else
       StatsD.increment "yank.failure"
       render plain: response_with_mfa_warning(@deletion.errors.full_messages.to_sentence),
-             status: :unprocessable_entity
+             status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/v1/oidc/api_key_roles_controller.rb
+++ b/app/controllers/api/v1/oidc/api_key_roles_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::OIDC::ApiKeyRolesController < Api::BaseController
   rescue_from ActiveRecord::RecordInvalid do |err|
     render json: {
       errors: err.record.errors
-    }, status: :unprocessable_entity
+    }, status: :unprocessable_content
   end
 
   def index

--- a/app/controllers/api/v1/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/api/v1/oidc/rubygem_trusted_publishers_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::OIDC::RubygemTrustedPublishersController < Api::BaseController
     if trusted_publisher.save
       render json: trusted_publisher, status: :created
     else
-      render json: { errors: trusted_publisher.errors, status: :unprocessable_entity }, status: :unprocessable_entity
+      render json: { errors: trusted_publisher.errors, status: :unprocessable_entity }, status: :unprocessable_content
     end
   end
 
@@ -49,7 +49,7 @@ class Api::V1::OIDC::RubygemTrustedPublishersController < Api::BaseController
 
     return if @trusted_publisher_type
 
-    render json: { error: t("oidc.trusted_publisher.unsupported_type") }, status: :unprocessable_entity
+    render json: { error: t("oidc.trusted_publisher.unsupported_type") }, status: :unprocessable_content
   end
 
   def create_params

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::OwnersController < Api::BaseController
                                               "Ownership access will be enabled after the user clicks on the " \
                                               "confirmation mail sent to their email.")
     else
-      render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
+      render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_content
     end
   end
 
@@ -40,7 +40,7 @@ class Api::V1::OwnersController < Api::BaseController
     if ownership.update(ownership_params)
       render plain: response_with_mfa_warning("Owner updated successfully.")
     else
-      render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
+      render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
         format.json { render json: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }
       end
     else
-      render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_entity
+      render plain: t("settings.edit.no_webauthn_credentials"), status: :unprocessable_content
     end
   end
 

--- a/app/controllers/oidc/pending_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/pending_trusted_publishers_controller.rb
@@ -32,7 +32,7 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
       flash.now[:error] = trusted_publisher.errors.full_messages.to_sentence
       render OIDC::PendingTrustedPublishers::NewView.new(
         pending_trusted_publisher: trusted_publisher
-      ), status: :unprocessable_entity
+      ), status: :unprocessable_content
     end
   end
 

--- a/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
@@ -25,7 +25,7 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
       flash.now[:error] = trusted_publisher.errors.full_messages.to_sentence
       render OIDC::RubygemTrustedPublishers::NewView.new(
         rubygem_trusted_publisher: trusted_publisher
-      ), status: :unprocessable_entity
+      ), status: :unprocessable_content
     end
   end
 

--- a/app/controllers/organizations/members_controller.rb
+++ b/app/controllers/organizations/members_controller.rb
@@ -37,7 +37,7 @@ class Organizations::MembersController < Organizations::BaseController
       OrganizationMailer.user_invited(@membership).deliver_later
       redirect_to organization_memberships_path(@organization), notice: t(".member_invited")
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -46,7 +46,7 @@ class Organizations::MembersController < Organizations::BaseController
     if @membership.update(membership_params[:membership])
       redirect_to organization_memberships_path(@organization), notice: t(".member_updated")
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/organizations/onboarding/confirm_controller.rb
+++ b/app/controllers/organizations/onboarding/confirm_controller.rb
@@ -9,6 +9,6 @@ class Organizations::Onboarding::ConfirmController < Organizations::Onboarding::
     redirect_to organization_path(@organization_onboarding.organization)
   rescue ActiveRecord::ActiveRecordError
     flash.now[:error] = "Onboarding error: #{@organization_onboarding.error}"
-    render :edit, status: :unprocessable_entity
+    render :edit, status: :unprocessable_content
   end
 end

--- a/app/controllers/organizations/onboarding/gems_controller.rb
+++ b/app/controllers/organizations/onboarding/gems_controller.rb
@@ -6,7 +6,7 @@ class Organizations::Onboarding::GemsController < Organizations::Onboarding::Bas
     if @organization_onboarding.update(onboarding_gems_params)
       redirect_to organization_onboarding_users_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/organizations/onboarding/name_controller.rb
+++ b/app/controllers/organizations/onboarding/name_controller.rb
@@ -6,7 +6,7 @@ class Organizations::Onboarding::NameController < Organizations::Onboarding::Bas
     if @organization_onboarding.update(onboarding_name_params)
       redirect_to organization_onboarding_gems_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/organizations/onboarding/users_controller.rb
+++ b/app/controllers/organizations/onboarding/users_controller.rb
@@ -6,7 +6,7 @@ class Organizations::Onboarding::UsersController < Organizations::Onboarding::Ba
     if @organization_onboarding.update(onboarding_user_params)
       redirect_to organization_onboarding_confirm_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -49,7 +49,7 @@ class OwnersController < ApplicationController
       OwnersMailer.ownership_confirmation(ownership).deliver_later
       redirect_to rubygem_owners_path(@rubygem.slug), notice: t(".success_notice", handle: owner.name)
     else
-      index_with_error ownership.errors.full_messages.to_sentence, :unprocessable_entity
+      index_with_error ownership.errors.full_messages.to_sentence, :unprocessable_content
     end
   end
 
@@ -61,7 +61,7 @@ class OwnersController < ApplicationController
       OwnersMailer.with(ownership: @ownership, authorizer: current_user).owner_updated.deliver_later
       redirect_to rubygem_owners_path(@ownership.rubygem.slug), notice: t(".success_notice", handle: @ownership.user.name)
     else
-      index_with_error @ownership.errors.full_messages.to_sentence, :unprocessable_entity
+      index_with_error @ownership.errors.full_messages.to_sentence, :unprocessable_content
     end
   end
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -42,7 +42,7 @@ class PasswordsController < ApplicationController
       redirect_to signed_in? ? dashboard_path : sign_in_path
     else
       flash.now[:alert] = t(".failure")
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -61,7 +61,7 @@ class PasswordsController < ApplicationController
     return if @email.present?
 
     flash.now[:alert] = t(".failure_on_missing_email")
-    render template: "passwords/new", status: :unprocessable_entity
+    render template: "passwords/new", status: :unprocessable_content
   end
 
   def validate_confirmation_token

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -14,6 +14,6 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
     redirect_to rubygem_path(@rubygem.slug)
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "Onboarding error: #{@rubygem_transfer.error}"
-    render :edit, status: :unprocessable_entity
+    render :edit, status: :unprocessable_content
   end
 end

--- a/app/controllers/rubygems/transfer/organizations_controller.rb
+++ b/app/controllers/rubygems/transfer/organizations_controller.rb
@@ -18,7 +18,7 @@ class Rubygems::Transfer::OrganizationsController < Rubygems::Transfer::BaseCont
     if @rubygem_transfer.save
       redirect_to rubygem_transfer_users_path(@rubygem.slug)
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/rubygems/transfer/users_controller.rb
+++ b/app/controllers/rubygems/transfer/users_controller.rb
@@ -10,7 +10,7 @@ class Rubygems::Transfer::UsersController < Rubygems::Transfer::BaseController
     if @rubygem_transfer.update(rubygem_transfer_params)
       redirect_to rubygem_transfer_confirm_path(@rubygem.slug)
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/webauthn_credentials_controller.rb
+++ b/app/controllers/webauthn_credentials_controller.rb
@@ -17,10 +17,10 @@ class WebauthnCredentialsController < ApplicationController
       render_callback_redirect
     else
       message = webauthn_credential.errors.full_messages.to_sentence
-      render json: { message: message }, status: :unprocessable_entity
+      render json: { message: message }, status: :unprocessable_content
     end
   rescue WebAuthn::Error => e
-    render json: { message: e.message }, status: :unprocessable_entity
+    render json: { message: e.message }, status: :unprocessable_content
   ensure
     session.delete("webauthn_registration")
   end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -1008,7 +1008,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
 
         patch :update, params: { rubygem_id: @rubygem.slug, email: @maintainer.email, role: :invalid }
 
-        assert_response :unprocessable_entity
+        assert_response :unprocessable_content
         assert_equal "Role is not included in the list", @response.body
         assert_predicate ownership.reload, :maintainer?
       end

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -89,7 +89,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   test "POST /organizations/:organization_handle/members with invalid values" do
     post organization_memberships_path(@organization), params: { membership: { user: "invalid role", role: :invalid_role } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "POST /organizations/:organization_handle/members as a maintainer" do
@@ -122,7 +122,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   test "PATCH /organizations/:organization_handle/members/:id with invalid values" do
     patch organization_membership_path(@organization, @membership), params: { membership: { role: "invalid_role" } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "PATCH /organizations/:organization_handle/members/:id as a guest" do

--- a/test/functional/organizations/onboarding/gems_controller_test.rb
+++ b/test/functional/organizations/onboarding/gems_controller_test.rb
@@ -55,7 +55,7 @@ class Organizations::Onboarding::GemsControllerTest < ActionDispatch::Integratio
       notmygem = create(:rubygem)
       patch organization_onboarding_gems_path(as: @user), params: { organization_onboarding: { rubygems: [notmygem.id] } }
 
-      assert_response :unprocessable_entity
+      assert_response :unprocessable_content
       assert_equal [@namesake_rubygem.id], @organization_onboarding.reload.rubygems
     end
   end

--- a/test/functional/organizations/onboarding/name_controller_test.rb
+++ b/test/functional/organizations/onboarding/name_controller_test.rb
@@ -90,7 +90,7 @@ class Organizations::Onboarding::NameControllerTest < ActionDispatch::Integratio
           organization_name: ""
         } }
 
-        assert_response :unprocessable_entity
+        assert_response :unprocessable_content
       end
     end
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -374,7 +374,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
           password_reset: { reset_api_key: "true", password: "pass" }
         }
 
-        assert_response :unprocessable_entity
+        assert_response :unprocessable_content
         assert_select "#flash_alert", "Your password could not be changed. Please try again."
         assert_select "h1", "Reset password"
         assert_select "#errorExplanation", /Password is too short \(minimum is 10 characters\)/

--- a/test/functional/rubygems/transfer/confirmations_controller_test.rb
+++ b/test/functional/rubygems/transfer/confirmations_controller_test.rb
@@ -25,7 +25,7 @@ class Rubygems::Transfer::ConfirmationsControllerTest < ActionDispatch::Integrat
 
     patch rubygem_transfer_confirm_path(@rubygem.slug, as: @user)
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal flash[:error], "Onboarding error: #{error_message}"
   end
 

--- a/test/functional/rubygems/transfer/organizations_controller_test.rb
+++ b/test/functional/rubygems/transfer/organizations_controller_test.rb
@@ -41,6 +41,6 @@ class Rubygems::Transfer::OrganizationsControllerTest < ActionDispatch::Integrat
   test "POST /rubygems/:rubygem_id/transfer/organization with invalid organization" do
     post rubygem_transfer_organization_path(@rubygem.slug, as: @user), params: { rubygem_transfer: { organization: "invalid_handle" } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end

--- a/test/functional/rubygems/transfer/users_controller_test.rb
+++ b/test/functional/rubygems/transfer/users_controller_test.rb
@@ -44,6 +44,6 @@ class Rubygems::Transfer::UsersControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end


### PR DESCRIPTION
This removes deprecation warnings in `rails test`.

See rack/rack#2137 and rails/rails#52087 for details.

Note: [RubygemTrustedPublishersController](https://github.com/rubygems/rubygems.org/blob/af7fa39142b06c48dd6635daf4a743389b78d9d5/app/controllers/api/v1/oidc/rubygem_trusted_publishers_controller.rb#L26) responds with
```ruby
render json: { errors:, status: :unprocessable_entity }, status: :unprocessable_content
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
I've left that symbol in the JSON hash untouched to keep the API contract, even though it's not asserted [in the test](https://github.com/rubygems/rubygems.org/blob/f4e52e8c3632e6cbf3d3ff9f3bb4ff06bbe14b8d/test/integration/api/v1/oidc/rubygem_trusted_publishers_controller_test.rb#L185).

This looks to me like a possible copy/paste remnant.

As a total Rails newb, I'm not at all confident though! `grep -r 'render json:' app/controllers/ |grep status` shows other `status` keys in JSON responses.

I'd be happy to create a separate PR (or issue) to remove these (at least any untested). Let me know if that's desirable.