### PR TITLE
Fix dashboard dialog backdrop styling

### DIFF
--- a/app/assets/stylesheets/hammy.css
+++ b/app/assets/stylesheets/hammy.css
@@ -7,7 +7,18 @@
 
 /* Default browser style adds a max width that is hard to override with tailwind directly */
 dialog:modal {
+  background: none;
   max-width: 100vw;
+}
+
+dialog::backdrop {
+  background-color: rgb(255, 255, 255, 0.8);
+}
+
+@media (prefers-color-scheme: dark) {
+  dialog::backdrop {
+    background-color: rgb(0, 0, 0, 0.8);
+  }
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */


### PR DESCRIPTION
I did some quick diggin around and landed on this solution. As-is, the `dialog:modal` is inheriting a background color from _somewhere_ (apologies, I couldn't quite figure that out). A solution out of that is to set `background: none;` (`background-color: initial;` also worked).

Then, for each color scheme (default/light and dark), style the `dialog` element's `::backdrop` pseudo-element using a semi-transparent white or black. I kinda guessed at the opacity values, so if they aren't to anyone's taste, I'm more than happy to adjust those.

Thanks for considering this change!

Fixes #5866.

## References

- [MDN's `::backdrop` documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
- [MDN's `prefers-color-scheme` media query documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)

## Screenshots

<img width="1149" height="640" alt="image" src="https://github.com/user-attachments/assets/ac30bb9c-ec02-4aa7-b200-b5818b441a7d" />

<img width="1148" height="632" alt="image" src="https://github.com/user-attachments/assets/893faf89-3865-4cd5-9dae-460a057b7e94" />


