### PR TITLE
Allow users to transfer many RubyGems to an Organization in a single transaction

### DIFF
--- a/app/controllers/rubygems/transfer/base_controller.rb
+++ b/app/controllers/rubygems/transfer/base_controller.rb
@@ -4,7 +4,7 @@ class Rubygems::Transfer::BaseController < ApplicationController
   before_action :find_or_initialize_transfer
   before_action :set_breadcrumbs
 
-  rescue_from Pundit::NotAuthorizedError, Pundit::NotDefinedError, with: :render_not_found
+  rescue_from Pundit::NotAuthorizedError, with: :render_not_found
 
   def find_or_initialize_transfer
     @rubygem_transfer = RubygemTransfer

--- a/app/controllers/rubygems/transfer/base_controller.rb
+++ b/app/controllers/rubygems/transfer/base_controller.rb
@@ -4,19 +4,17 @@ class Rubygems::Transfer::BaseController < ApplicationController
   before_action :find_or_initialize_transfer
   before_action :set_breadcrumbs
 
-  rescue_from Pundit::NotAuthorizedError, with: :render_not_found
+  rescue_from Pundit::NotAuthorizedError, Pundit::NotDefinedError, with: :render_not_found
 
   def find_or_initialize_transfer
-    @rubygem = Rubygem.find_by(name: params[:rubygem_id])
     @rubygem_transfer = RubygemTransfer
       .includes(invites: :user)
       .where.not(status: :completed)
-      .find_or_initialize_by(created_by: Current.user, rubygem: @rubygem)
+      .find_or_initialize_by(created_by: Current.user)
   end
 
   def set_breadcrumbs
     add_breadcrumb t("breadcrumbs.gems"), rubygems_path
-    add_breadcrumb @rubygem.name, rubygem_path(@rubygem)
-    add_breadcrumb "Transfer Gem"
+    add_breadcrumb "Transfer"
   end
 end

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -11,7 +11,7 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
 
     @rubygem_transfer.transfer!
 
-    flash[:notice] = I18n.t("rubygems.transfer.confirm.success", 
+    flash[:notice] = I18n.t("rubygems.transfer.confirm.success",
                             organization: @rubygem_transfer.organization.name,
                             count: @rubygem_transfer.rubygems.size)
     redirect_to organization_path(@rubygem_transfer.organization.handle)
@@ -24,8 +24,8 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
 
   def ensure_valid_transfer
     # Redirect if organization is missing or no gems selected
-    return if @rubygem_transfer.organization.present? && 
-              (@rubygem_transfer.new_record? || @rubygem_transfer.rubygems.any?)
+    return if @rubygem_transfer.organization.present? &&
+      (@rubygem_transfer.new_record? || @rubygem_transfer.rubygems.any?)
 
     redirect_to organization_transfer_rubygems_path
   end

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -1,5 +1,6 @@
 class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseController
   layout "onboarding"
+  before_action :ensure_valid_transfer
 
   def edit
     authorize @rubygem_transfer.organization, :add_gem?
@@ -15,5 +16,15 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "Onboarding error: #{@rubygem_transfer.error}"
     render :edit, status: :unprocessable_content
+  end
+
+  private
+
+  def ensure_valid_transfer
+    # Redirect if organization is missing or no gems selected
+    return if @rubygem_transfer.organization.present? && 
+              (@rubygem_transfer.new_record? || @rubygem_transfer.rubygems.any?)
+
+    redirect_to organization_transfer_rubygems_path
   end
 end

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -2,16 +2,16 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
   layout "onboarding"
 
   def edit
-    authorize @rubygem, :transfer_gem?
+    authorize @rubygem_transfer.organization, :add_gem?
   end
 
   def update
-    authorize @rubygem, :transfer_gem?
+    authorize @rubygem_transfer.organization, :add_gem?
 
     @rubygem_transfer.transfer!
 
-    flash[:notice] = I18n.t("rubygems.transfer.confirm.success", gem: @rubygem.name, organization: @rubygem_transfer.organization.name)
-    redirect_to rubygem_path(@rubygem.slug)
+    flash[:notice] = I18n.t("rubygems.transfer.confirm.success", organization: @rubygem_transfer.organization.name)
+    redirect_to organization_path(@rubygem_transfer.organization.handle)
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "Onboarding error: #{@rubygem_transfer.error}"
     render :edit, status: :unprocessable_content

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -22,10 +22,11 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
 
   private
 
+  # This is a quick sanity check to ensure we have a ready RubygemTransfer. If the
+  # transfer doesn't have an associated Organization, check the user authorization
+  # would raise a Pundit::NilClassPolicy
   def ensure_valid_transfer
-    # Redirect if organization is missing or no gems selected
-    return if @rubygem_transfer.organization.present? &&
-      (@rubygem_transfer.new_record? || @rubygem_transfer.rubygems.any?)
+    return if @rubygem_transfer.organization.present? && @rubygem_transfer.rubygems.any?
 
     redirect_to organization_transfer_rubygems_path
   end

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -11,7 +11,9 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
 
     @rubygem_transfer.transfer!
 
-    flash[:notice] = I18n.t("rubygems.transfer.confirm.success", organization: @rubygem_transfer.organization.name)
+    flash[:notice] = I18n.t("rubygems.transfer.confirm.success", 
+                            organization: @rubygem_transfer.organization.name,
+                            count: @rubygem_transfer.rubygems.size)
     redirect_to organization_path(@rubygem_transfer.organization.handle)
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "Onboarding error: #{@rubygem_transfer.error}"

--- a/app/controllers/rubygems/transfer/organizations_controller.rb
+++ b/app/controllers/rubygems/transfer/organizations_controller.rb
@@ -4,19 +4,16 @@ class Rubygems::Transfer::OrganizationsController < Rubygems::Transfer::BaseCont
   layout "onboarding"
 
   def new
-    authorize @rubygem, :transfer_gem?
-    @organizations = Current.user.organizations
+    @organizations = current_user.organizations
   end
 
   def create
-    authorize @rubygem, :transfer_gem?
-
-    @organizations = Current.user.organizations
+    @organizations = current_user.organizations
     @organization = @organizations.find_by(handle: organization_params[:rubygem_transfer][:organization])
 
     @rubygem_transfer.organization = @organization
     if @rubygem_transfer.save
-      redirect_to rubygem_transfer_users_path(@rubygem.slug)
+      redirect_to rubygems_transfer_rubygems_path
     else
       render :new, status: :unprocessable_content
     end

--- a/app/controllers/rubygems/transfer/rubygems_controller.rb
+++ b/app/controllers/rubygems/transfer/rubygems_controller.rb
@@ -1,0 +1,20 @@
+class Rubygems::Transfer::RubygemsController < Rubygems::Transfer::BaseController
+  layout "onboarding"
+
+  def show
+  end
+
+  def update
+    if @rubygem_transfer.update(rubygem_transfer_params)
+      redirect_to users_transfer_rubygems_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def rubygem_transfer_params
+    params.permit(rubygem_transfer: { rubygems: [] }).fetch(:rubygem_transfer, {})
+  end
+end

--- a/app/controllers/rubygems/transfer/users_controller.rb
+++ b/app/controllers/rubygems/transfer/users_controller.rb
@@ -2,13 +2,11 @@ class Rubygems::Transfer::UsersController < Rubygems::Transfer::BaseController
   layout "onboarding"
 
   def edit
-    @users = @rubygem.owners
-    @organization = @rubygem_transfer.organization
   end
 
   def update
     if @rubygem_transfer.update(rubygem_transfer_params)
-      redirect_to rubygem_transfer_confirm_path(@rubygem.slug)
+      redirect_to confirm_transfer_rubygems_path
     else
       render :edit, status: :unprocessable_content
     end

--- a/app/controllers/rubygems/transfers_controller.rb
+++ b/app/controllers/rubygems/transfers_controller.rb
@@ -4,10 +4,10 @@ class Rubygems::TransfersController < ApplicationController
   before_action :find_rubygem
 
   def destroy
-    @rubygem_transfer = RubygemTransfer.find_by(created_by: Current.user, rubygem: @rubygem, status: :pending)
+    @rubygem_transfer = RubygemTransfer.find_by(created_by: Current.user, status: :pending)
     @rubygem_transfer&.destroy!
 
-    redirect_to rubygem_path(@rubygem.slug)
+    redirect_to dashboard_path, notice: t("rubygems.transfer.cancelled")
   end
 
   private

--- a/app/controllers/rubygems/transfers_controller.rb
+++ b/app/controllers/rubygems/transfers_controller.rb
@@ -4,7 +4,7 @@ class Rubygems::TransfersController < ApplicationController
   before_action :find_rubygem
 
   def destroy
-    @rubygem_transfer = RubygemTransfer.find_by(created_by: Current.user, status: :pending)
+    @rubygem_transfer = RubygemTransfer.find_by(created_by: Current.user, status: %i[pending failed])
     @rubygem_transfer&.destroy!
 
     redirect_to dashboard_path, notice: t("rubygems.transfer.cancelled")

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -126,11 +126,6 @@ module RubygemsHelper
       security_events_rubygem_path(rubygem.slug), class: "gem__link t-list__item"
   end
 
-  def rubygem_organization_transfer_link(rubygem)
-    link_to "Transfer to Organization",
-      rubygem_transfer_path(rubygem.slug), class: "gem__link t-list__item"
-  end
-
   def links_to_owners(rubygem)
     rubygem.owners.sort_by(&:id).inject(+"") { |link, owner| link << link_to_user(owner) }.html_safe
   end

--- a/app/models/rubygem_transfer.rb
+++ b/app/models/rubygem_transfer.rb
@@ -1,7 +1,6 @@
 class RubygemTransfer < ApplicationRecord
   enum :status, { pending: "pending", completed: "completed", failed: "failed" }, default: "pending"
 
-  belongs_to :rubygem
   belongs_to :organization
   belongs_to :created_by, class_name: "User"
 
@@ -10,9 +9,9 @@ class RubygemTransfer < ApplicationRecord
 
   accepts_nested_attributes_for :invites
 
-  validate :rubygem_ownership, :organization_ownership, :rubygem_existing_organization
+  validate :created_by_gem_ownerships, :created_by_organization_ownership, :rubygem_existing_organization
 
-  before_save :sync_invites, if: :organization_changed?
+  before_save :sync_invites, if: :rubygems_changed?
 
   def transfer!
     transaction do
@@ -24,7 +23,9 @@ class RubygemTransfer < ApplicationRecord
         completed_at: Time.zone.now
       )
 
-      rubygem.update!(organization_id: organization.id)
+      selected_rubygems.each do |rubygem|
+        rubygem.update!(organization_id: organization.id)
+      end
 
       remove_ownerships_for_joining_members
       demote_outside_contributors_to_maintainer
@@ -42,13 +43,27 @@ class RubygemTransfer < ApplicationRecord
     invites.includes(:user).select { |invite| invite.user.present? && invite.role.present? }
   end
 
+  def available_rubygems
+    return Rubygem.none if created_by.blank?
+    created_by.rubygems.where(organization_id: nil).order(:name)
+  end
+
+  def selected_rubygems
+    @selected_rubygems ||= Rubygem.preload({ ownerships: :user }, :organization).where(id: rubygems)
+  end
+
+  def rubygems=(value)
+    @selected_rubygems = nil
+    super
+  end
+
   private
 
   def remove_ownerships_for_joining_members
     invited_users = invites.includes(:user).reject { |invite| invite.role.nil? || invite.outside_contributor? }.map(&:user)
     invited_users << created_by
 
-    Ownership.includes(:rubygem, :user, :api_key_rubygem_scopes).where(user: invited_users, rubygem: rubygem).destroy_all
+    Ownership.includes(:rubygem, :user, :api_key_rubygem_scopes).where(user: invited_users, rubygem: selected_rubygems).destroy_all
   end
 
   def demote_outside_contributors_to_maintainer
@@ -60,10 +75,10 @@ class RubygemTransfer < ApplicationRecord
   end
 
   def users_for_rubygem
-    return User.none if rubygem.blank? || created_by.blank?
+    return User.none if selected_rubygems.blank? || created_by.blank?
     User
       .joins(:ownerships)
-      .where(ownerships: { rubygem_id: rubygem.id })
+      .where(ownerships: { rubygem_id: rubygems })
       .where.not(ownerships: { user_id: created_by.id })
   end
 
@@ -72,19 +87,28 @@ class RubygemTransfer < ApplicationRecord
     self.invites = users_for_rubygem.map { |user| existing_invites[user.id] || OrganizationInvite.new(user: user) }
   end
 
-  def rubygem_ownership
-    return if RubygemPolicy.new(created_by, rubygem).transfer_gem?
-    errors.add(:rubygem, "does not have permission to transfer this gem")
+  def created_by_gem_ownerships
+    return if created_by.blank? || rubygems.blank?
+
+    ownerships = Ownership.where(user: created_by, rubygem: rubygems).index_by(&:rubygem_id)
+
+    selected_rubygems.reject { ownerships[it.id].present? && ownerships[it.id].owner? }.each do |rubygem|
+      errors.add(:created_by, "must be an owner of the #{rubygem.name} gem")
+    end
   end
 
-  def organization_ownership
+  def created_by_organization_ownership
     return if OrganizationPolicy.new(created_by, organization).transfer_gem?
-    errors.add(:organization, "does not have permission to transfer gems to this organization")
+    errors.add(:created_by, "does not have permission to transfer gems to this organization")
   end
 
   def rubygem_existing_organization
-    return if rubygem.organization.nil?
-    errors.add(:rubygem, "is already owned by an organization")
+    rubygems_with_organization = Rubygem.where(id: rubygems).where.not(organization_id: nil)
+    return if rubygems_with_organization.empty?
+
+    rubygems_with_organization.each do |rubygem|
+      errors.add(:rubygems, "#{rubygem.name} is already owned by an organization")
+    end
   end
 
   def email_onboarded_users(memberships)

--- a/app/models/rubygem_transfer.rb
+++ b/app/models/rubygem_transfer.rb
@@ -9,7 +9,7 @@ class RubygemTransfer < ApplicationRecord
 
   accepts_nested_attributes_for :invites
 
-  validate :created_by_gem_ownerships, :created_by_organization_ownership, :rubygem_existing_organization
+  validate :rubygems_owned_by_transferrer, :created_by_organization_ownership, :rubygem_existing_organization
 
   before_save :sync_invites, if: :rubygems_changed?
 
@@ -87,7 +87,7 @@ class RubygemTransfer < ApplicationRecord
     self.invites = users_for_rubygem.map { |user| existing_invites[user.id] || OrganizationInvite.new(user: user) }
   end
 
-  def created_by_gem_ownerships
+  def rubygems_owned_by_transferrer
     return if created_by.blank? || rubygems.blank?
 
     ownerships = Ownership.where(user: created_by, rubygem: rubygems).index_by(&:rubygem_id)

--- a/app/models/rubygem_transfer.rb
+++ b/app/models/rubygem_transfer.rb
@@ -70,7 +70,7 @@ class RubygemTransfer < ApplicationRecord
     outside_contributors = invites.select(&:outside_contributor?).map(&:user)
 
     Ownership.includes(:rubygem, :user, api_key_rubygem_scopes: :api_key)
-      .where(user: outside_contributors, rubygem: rubygem)
+      .where(user: outside_contributors, rubygem: rubygems)
       .update_all(role: :maintainer)
   end
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -65,6 +65,11 @@
       <% end %>
     <% end %>
   <% end %>
+  <% if policy(@organization).add_gem? %>
+  <div class="pt-6 flex flex-row justify-end">
+    <%= render ButtonComponent.new t(".transfer"), transfer_rubygems_path, type: :link %>
+  </div>
+  <% end %>
 <% end %>
 
 <%= render CardComponent.new do |c| %>

--- a/app/views/rubygems/_aside.html.erb
+++ b/app/views/rubygems/_aside.html.erb
@@ -76,6 +76,5 @@
     <%= oidc_api_key_role_links(@rubygem) if policy(@rubygem).configure_oidc? %>
     <%= resend_owner_confirmation_link(@rubygem) if @rubygem.unconfirmed_ownership?(current_user) %>
     <%= rubygem_security_events_link(@rubygem) if policy(@rubygem).show_events? %>
-    <%= rubygem_organization_transfer_link(@rubygem) if policy(@rubygem).transfer_gem? && @rubygem.organization.blank? && current_user&.organizations&.any? %>
   </div>
 </div>

--- a/app/views/rubygems/transfer/_progress.html.erb
+++ b/app/views/rubygems/transfer/_progress.html.erb
@@ -1,5 +1,6 @@
 <%= render Onboarding::StepsComponent.new(current_step) do |s| %>
-  <%= s.step "Organization", rubygem_transfer_organization_path(@rubygem.slug) %>
-  <%= s.step "Invite Owners", rubygem_transfer_users_path(@rubygem.slug) %>
-  <%= s.step "Finalize", rubygem_transfer_confirm_path(@rubygem.slug) %>
+  <%= s.step "Organization", organization_transfer_rubygems_path %>
+  <%= s.step "RubyGems", rubygems_transfer_rubygems_path %>
+  <%= s.step "Invite Owners", users_transfer_rubygems_path %>
+  <%= s.step "Finalize", confirm_transfer_rubygems_path %>
 <% end %>

--- a/app/views/rubygems/transfer/_progress.html.erb
+++ b/app/views/rubygems/transfer/_progress.html.erb
@@ -1,6 +1,6 @@
 <%= render Onboarding::StepsComponent.new(current_step) do |s| %>
   <%= s.step "Organization", organization_transfer_rubygems_path %>
   <%= s.step "RubyGems", rubygems_transfer_rubygems_path %>
-  <%= s.step "Invite Owners", users_transfer_rubygems_path %>
+  <%= s.step "Owners", users_transfer_rubygems_path %>
   <%= s.step "Finalize", confirm_transfer_rubygems_path %>
 <% end %>

--- a/app/views/rubygems/transfer/_summary.html.erb
+++ b/app/views/rubygems/transfer/_summary.html.erb
@@ -8,7 +8,7 @@
   <div class="flex justify-between items-center">
     <h3 class="text-b1 text-neutral-900 dark:text-white">Organization</h3>
     <% if current_step > 1 %>
-      <%= link_to "edit", rubygem_transfer_organization_path(@rubygem.slug), class: "text-orange-500" %>
+      <%= link_to "edit", organization_transfer_rubygems_path, class: "text-orange-500" %>
     <% end %>
   </div>
   <div class="mt-4">
@@ -23,11 +23,29 @@
 <div class="mb-6">
   <div class="flex justify-between items-center">
     <h3 class="text-b1 text-neutral-900 dark:text-white">
+      Gems
+      <span class="text-neutral-600 font-light ml-1"><%= @rubygem_transfer.selected_rubygems.size %></span>
+    </h3>
+    <% if current_step > 2 %>
+      <%= link_to "edit", rubygems_transfer_rubygems_path, class: "text-orange-500" %>
+    <% end %>
+  </div>
+  <ul class="mt-4">
+    <% @rubygem_transfer.selected_rubygems.each do |rubygem| %>
+      <li class="mt-2 text-neutral-800 dark:text-neutral-200"><%= rubygem.name %></li>
+    <% end %>
+  </ul>
+</div>
+<hr class="border-neutral-400 my-6">
+
+<div class="mb-6">
+  <div class="flex justify-between items-center">
+    <h3 class="text-b1 text-neutral-900 dark:text-white">
       People
       <span class="text-neutral-600 font-light ml-1"><%= @rubygem_transfer.approved_invites.size %></span>
     </h3>
     <% if current_step > 2 %>
-      <%= link_to "edit", rubygem_transfer_users_path(@rubygem.slug), class: "text-orange-500" %>
+      <%= link_to "edit", users_transfer_rubygems_path, class: "text-orange-500" %>
     <% end %>
   </div>
   <ul class="mt-2 items-center space-y-4">

--- a/app/views/rubygems/transfer/confirmations/edit.html.erb
+++ b/app/views/rubygems/transfer/confirmations/edit.html.erb
@@ -1,19 +1,19 @@
-<% @title = "Transfer a Gem" %>
+<% @title = "Transfer Gems" %>
 
-<%= render "rubygems/transfer/progress", current_step: 3 %>
+<%= render "rubygems/transfer/progress", current_step: 4 %>
 
 <h2 class="text-h4 mb-10">Finalize</h2>
 
 <p class="mb-10">Review the summary and confirm everything looks good.</p>
 
 <div class="mt-10">
-  <%= render "rubygems/transfer/summary", current_step: 3 %>
+  <%= render "rubygems/transfer/summary", current_step: 4 %>
 </div>
 
-<%= form_with(model: @rubygem_transfer, url: rubygem_transfer_confirm_path(@rubygem.slug), method: :patch) do |form| %>
+<%= form_with(model: @rubygem_transfer, url: confirm_transfer_rubygems_path, method: :patch) do |form| %>
   <%= render "rubygems/transfer/error", transfer: @rubygem_transfer if @rubygem_transfer.errors.any? %>
   <div class="flex border-t border-neutral-400 lg:-mx-10 lg:px-10 pt-10 mt-10 justify-between">
-    <%= render ButtonComponent.new("Back", rubygem_transfer_users_path(@rubygem.slug), type: :link, color: :neutral, style: :outline) %>
-    <%= render ButtonComponent.new("Transfer Gem", type: :submit, style: :fill) %>
+    <%= render ButtonComponent.new("Back", users_transfer_rubygems_path, type: :link, color: :neutral, style: :outline) %>
+    <%= render ButtonComponent.new("Transfer Gems", type: :submit, style: :fill) %>
   </div>
 <% end %>

--- a/app/views/rubygems/transfer/organizations/new.html.erb
+++ b/app/views/rubygems/transfer/organizations/new.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Transfer a Gem" %>
+<% @title = "Transfer Gems" %>
 
 <% content_for :aside do %>
   <%= render "rubygems/transfer/summary", current_step: 1 %>
@@ -12,7 +12,7 @@
   Choose which organization you want to transfer your gem to.
 </p>
 
-<%= form_with(model: @rubygem_transfer, url: rubygem_transfer_organization_path(@rubygem.slug), method: :post) do |f| %>
+<%= form_with(model: @rubygem_transfer, url: organization_transfer_rubygems_path, method: :post) do |f| %>
   <%= render "rubygems/transfer/error", transfer: @rubygem_transfer if @rubygem_transfer.errors.any? %>
   <%= f.label :organization, t(".organization"), class: 'form__label block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2' %>
   <label class="flex flex-col xl:flex-row items-center rounded-lg border border-neutral-400 dark:border-neutral-600 overflow-hidden">
@@ -30,7 +30,7 @@
   </label>
 
   <div class="flex border-t border-neutral-400 lg:-mx-10 lg:px-10 pt-10 mt-10 justify-between">
-    <%= render ButtonComponent.new("Cancel", rubygem_transfer_path, type: :link, color: :neutral, style: :outline, method: :delete) %>
+    <%= render ButtonComponent.new("Cancel", transfer_rubygems_path, type: :link, color: :neutral, style: :outline, method: :delete) %>
     <%= render ButtonComponent.new("Continue", type: :submit, style: :outline) %>
   </div>
 <% end %>

--- a/app/views/rubygems/transfer/rubygems/edit.html.erb
+++ b/app/views/rubygems/transfer/rubygems/edit.html.erb
@@ -1,0 +1,48 @@
+<% @title = "Transfer Gems" %>
+
+<% content_for :aside do %>
+  <%= render "rubygems/transfer/summary", current_step: 2 %>
+<% end %>
+
+<%= render "rubygems/transfer/progress", current_step: 2 %>
+
+<h2 class="text-h4 mb-10">Add gems to your Organization</h2>
+
+<%= form_with(model: @rubygem_transfer, url: rubygems_transfer_rubygems_path, method: :patch, data: { controller: "onboarding-gems counter" }) do |form| %>
+  <div class="border border-neutral-700 dark:border-neutral-300 rounded-lg" data-controller="checkbox-select-all">
+    <div class="flex flex-row p-4 w-full border-b border-neutral-700 dark:border-neutral-300 justify-between items-center">
+      <h3 class="text-b2 font-semibold">Gems<span data-counter-target="counter" class="ml-2 font-light text-neutral-600"><%= @rubygem_transfer.rubygems.size %></span></h3>
+      <label class="flex items-center">
+        <span class="mr-3">Select all</span>
+        <input
+          type="checkbox"
+          data-checkbox-select-all-target="checkboxAll"
+          class="h-5 w-5 border-neutral-500 rounded focus:ring-2 focus:ring-orange-500 disabled:text-neutral-700 dark:disabled:text-neutral-700 text-orange-500"
+        />
+      </label>
+    </div>
+    <ul class="divide-y divide-neutral-300 dark:divide-neutral-700">
+      <% @rubygem_transfer.available_rubygems.each do |gem| %>
+        <li class="flex items-center">
+          <label class="flex w-full px-4 py-2 items-center justify-between space-x-2">
+            <span class="flex">
+              <span class="text-neutral-800 dark:text-white"><%= gem.name %></span>
+            </span>
+            <%= check_box_tag(
+              "rubygem_transfer[rubygems][]",
+              gem.id,
+              @rubygem_transfer.rubygems.include?(gem.id),
+              class: "h-5 w-5 text-orange-500 border-neutral-500 rounded focus:ring-2 focus:ring-orange-500 rounded disabled:text-neutral-700 dark:disabled:text-neutral-700",
+              data: { counter_target: "checked", checkbox_select_all_target: "checkbox" }
+            ) %>
+          </label>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="flex border-t border-neutral-400 lg:-mx-10 lg:px-10 pt-10 mt-10 justify-between">
+    <%= render ButtonComponent.new("Back", organization_transfer_rubygems_path, type: :link, color: :neutral, style: :outline) %>
+    <%= render ButtonComponent.new("Continue", type: :submit, style: :outline) %>
+  </div>
+<% end %>

--- a/app/views/rubygems/transfer/users/edit.html.erb
+++ b/app/views/rubygems/transfer/users/edit.html.erb
@@ -1,10 +1,10 @@
-<% @title = "Transfer a Gem" %>
+<% @title = "Transfer Gems" %>
 
 <% content_for :aside do %>
-  <%= render "rubygems/transfer/summary", current_step: 2 %>
+  <%= render "rubygems/transfer/summary", current_step: 3 %>
 <% end %>
 
-<%= render "rubygems/transfer/progress", current_step: 2 %>
+<%= render "rubygems/transfer/progress", current_step: 3 %>
 
 <h2 class="text-h4 mb-10">Manage Members</h2>
 
@@ -60,7 +60,7 @@
   </div>
 </div>
 
-<%= form_with(model: @rubygem_transfer, url: rubygem_transfer_users_path(@rubygem.slug), method: :patch) do |form| %>
+<%= form_with(model: @rubygem_transfer, url: users_transfer_rubygems_path, method: :patch) do |form| %>
   <%= render "rubygems/transfer/error", transfer: @rubygem_transfer if @rubygem_transfer.errors.any? %>
   <% if @rubygem_transfer.invites.any? %>
   <ul>
@@ -89,9 +89,9 @@
   <% end %>
 
   <div class="flex border-t border-neutral-400 lg:-mx-10 lg:px-10 pt-10 mt-10 justify-between">
-    <%= render ButtonComponent.new("Back", rubygem_transfer_organization_path(@rubygem.slug), type: :link, color: :neutral, style: :outline) %>
+    <%= render ButtonComponent.new("Back", rubygems_transfer_rubygems_path, type: :link, color: :neutral, style: :outline) %>
     <span class="space-x-2">
-      <%= render ButtonComponent.new("Skip for now", rubygem_transfer_confirm_path(@rubygem.slug), type: :link, color: :neutral, style: :plain) %>
+      <%= render ButtonComponent.new("Skip for now", confirm_transfer_rubygems_path, type: :link, color: :neutral, style: :plain) %>
       <%= render ButtonComponent.new("Continue", type: :submit, style: :outline) %>
     </span>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -466,6 +466,7 @@ de:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -879,6 +880,7 @@ de:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -886,6 +886,8 @@ de:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -424,6 +424,7 @@ en:
       no_gems: No gems yet
       add_member: Invite Member
       invite: Invite
+      transfer: Transfer
     members:
       create:
         user_already_invited: User already invited to the organization.
@@ -800,11 +801,12 @@ en:
       title: Security Events
       description_html: "This page shows the security events that have occurred on %{gem}. If you see any suspicious activity, please <a href='mailto:support@rubygems.org'>contact support</a>."
     transfer:
+      cancelled: Your draft gem transfer has been cancelled.
       organizations:
         new:
           organization: Organization
       confirm:
-        success: "%{gem} has been transferred successfully to %{organization}."
+        success: "Your gems have been transferred successfully to %{organization}."
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -806,7 +806,9 @@ en:
         new:
           organization: Organization
       confirm:
-        success: "Your gems have been transferred successfully to %{organization}."
+        success:
+          one: "Successfully transferred 1 gem to %{organization}."
+          other: "Successfully transferred %{count} gems to %{organization}."
   reverse_dependencies:
     index:
       title: "Reverse dependencies for %{name}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -461,6 +461,7 @@ es:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -906,6 +907,7 @@ es:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -913,6 +913,8 @@ es:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: Dependencias inversas para %{name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -843,6 +843,8 @@ fr:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: Dépendances inversées pour %{name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -429,6 +429,7 @@ fr:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -836,6 +837,7 @@ fr:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -426,6 +426,7 @@ ja:
       no_gems: まだgemがありません
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -810,6 +811,7 @@ ja:
       title: セキュリティ事象
       description_html: このページには%{gem}に起こったセキュリティ事象が表示されます。何か疑わしい活動が見られたときは、<a href='mailto:support@rubygems.org'>サポートまでお問い合わせ</a>ください。
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -817,6 +817,8 @@ ja:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: "%{name}の被依存関係"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -416,6 +416,7 @@ nl:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -793,6 +794,7 @@ nl:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -800,6 +800,8 @@ nl:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -822,6 +822,8 @@ pt-BR:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: Dependências Reversas para %{name}

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -427,6 +427,7 @@ pt-BR:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -815,6 +816,7 @@ pt-BR:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -813,6 +813,8 @@ zh-CN:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: "%{name} 的反向依赖"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -430,6 +430,7 @@ zh-CN:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -806,6 +807,7 @@ zh-CN:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -801,6 +801,8 @@ zh-TW:
           organization:
       confirm:
         success:
+          one:
+          other:
   reverse_dependencies:
     index:
       title: "%{name} 的反向依賴"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -421,6 +421,7 @@ zh-TW:
       no_gems:
       add_member:
       invite:
+      transfer:
     members:
       create:
         user_already_invited:
@@ -794,6 +795,7 @@ zh-TW:
       title:
       description_html:
     transfer:
+      cancelled:
       organizations:
         new:
           organization:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,18 +220,23 @@ Rails.application.routes.draw do
       end
       resources :trusted_publishers, controller: 'oidc/rubygem_trusted_publishers', only: %i[index create destroy new]
 
-      get "transfer", to: redirect("/gems/%{rubygem_id}/transfer/organization")
-      delete "transfer", to: "rubygems/transfers#destroy"
+      collection do
+        get "transfer", to: redirect("/gems/transfer/organization")
+        delete "transfer", to: "rubygems/transfers#destroy"
 
-      namespace :transfer do
-        get "organization", to: "/rubygems/transfer/organizations#new"
-        post "organization", to: "/rubygems/transfer/organizations#create"
+        namespace :transfer do
+          get "organization", to: "/rubygems/transfer/organizations#new"
+          post "organization", to: "/rubygems/transfer/organizations#create"
 
-        get "users", to: "/rubygems/transfer/users#edit"
-        patch "users", to: "/rubygems/transfer/users#update"
+          get "rubygems", to: "/rubygems/transfer/rubygems#edit"
+          patch "rubygems", to: "/rubygems/transfer/rubygems#update"
 
-        get "confirm", to: "/rubygems/transfer/confirmations#edit"
-        patch "confirm", to: "/rubygems/transfer/confirmations#update"
+          get "users", to: "/rubygems/transfer/users#edit"
+          patch "users", to: "/rubygems/transfer/users#update"
+
+          get "confirm", to: "/rubygems/transfer/confirmations#edit"
+          patch "confirm", to: "/rubygems/transfer/confirmations#update"
+        end
       end
     end
 

--- a/db/migrate/20250805054836_add_rubygem_to_rubygem_transfer.rb
+++ b/db/migrate/20250805054836_add_rubygem_to_rubygem_transfer.rb
@@ -1,0 +1,9 @@
+class AddRubygemToRubygemTransfer < ActiveRecord::Migration[8.0]
+  def change
+    add_column :rubygem_transfers, :rubygems, :integer, array: true, default: []
+
+    safety_assured do
+      remove_column :rubygem_transfers, :rubygem_id, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_02_195347) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_05_054836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -530,14 +530,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_195347) do
     t.string "status", default: "pending", null: false
     t.bigint "organization_id"
     t.bigint "created_by_id", null: false
-    t.bigint "rubygem_id", null: false
     t.datetime "completed_at"
     t.text "error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "rubygems", default: [], array: true
     t.index ["created_by_id"], name: "index_rubygem_transfers_on_created_by_id"
     t.index ["organization_id"], name: "index_rubygem_transfers_on_organization_id"
-    t.index ["rubygem_id"], name: "index_rubygem_transfers_on_rubygem_id"
   end
 
   create_table "rubygems", id: :serial, force: :cascade do |t|
@@ -734,7 +733,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_195347) do
   add_foreign_key "ownership_requests", "users", name: "ownership_requests_user_id_fk"
   add_foreign_key "ownerships", "users", on_delete: :cascade
   add_foreign_key "rubygem_transfers", "organizations"
-  add_foreign_key "rubygem_transfers", "rubygems"
   add_foreign_key "rubygem_transfers", "users", column: "created_by_id"
   add_foreign_key "rubygems", "organizations", on_delete: :nullify
   add_foreign_key "versions", "api_keys", column: "pusher_api_key_id"

--- a/test/factories/rubygem_transfer.rb
+++ b/test/factories/rubygem_transfer.rb
@@ -1,17 +1,21 @@
 FactoryBot.define do
   factory :rubygem_transfer do
-    rubygem { association :rubygem }
     created_by { association :user }
     organization { association :organization }
+    rubygems { [create(:rubygem).id] }
 
     before(:create) do |rubygem_transfer|
-      rubygem_transfer.rubygem.ownerships.create_with(
-        authorizer: rubygem_transfer.created_by,
-        confirmed_at: Time.zone.now
-      ).find_or_create_by!(
-        user: rubygem_transfer.created_by,
-        role: :owner
-      )
+      rubygem_transfer.rubygems.each do |rubygem|
+        next if rubygem.blank?
+        Ownership.create_with(
+          authorizer: rubygem_transfer.created_by,
+          confirmed_at: Time.zone.now
+        ).find_or_create_by!(
+          rubygem_id: rubygem,
+          user: rubygem_transfer.created_by,
+          role: :owner
+        )
+      end
 
       rubygem_transfer.organization.memberships
         .create_with(

--- a/test/functional/rubygems/transfer/confirmations_controller_test.rb
+++ b/test/functional/rubygems/transfer/confirmations_controller_test.rb
@@ -15,7 +15,7 @@ class Rubygems::Transfer::ConfirmationsControllerTest < ActionDispatch::Integrat
 
     assert_response :redirect
     assert_redirected_to organization_path(@organization.handle)
-    assert_equal flash[:notice], "Your gems have been transferred successfully to #{@organization.name}."
+    assert_equal flash[:notice], "Successfully transferred 1 gem to #{@organization.name}."
   end
 
   test "PATCH /rubygems/:rubygem_id/transfer/confirm when transfer is invalid" do

--- a/test/functional/rubygems/transfer/confirmations_controller_test.rb
+++ b/test/functional/rubygems/transfer/confirmations_controller_test.rb
@@ -29,11 +29,48 @@ class Rubygems::Transfer::ConfirmationsControllerTest < ActionDispatch::Integrat
     assert_equal flash[:error], "Onboarding error: #{error_message}"
   end
 
-  test "PATCH /rubygems/:rubygem_id/transfer/confirm with an unauthorized user" do
-    unauthorized_user = create(:user)
+  test "PATCH /rubygems/:rubygem_id/transfer/confirm with a different user redirects to start transfer flow" do
+    different_user = create(:user)
 
-    patch confirm_transfer_rubygems_path(as: unauthorized_user)
+    patch confirm_transfer_rubygems_path(as: different_user)
 
-    assert_response :not_found
+    assert_response :redirect
+    assert_redirected_to organization_transfer_rubygems_path
+  end
+
+  test "GET /rubygems/transfer/confirm redirects when organization is nil" do
+    @transfer.update_column(:organization_id, nil)
+
+    get confirm_transfer_rubygems_path(as: @owner)
+
+    assert_response :redirect
+    assert_redirected_to organization_transfer_rubygems_path
+  end
+
+  test "PATCH /rubygems/transfer/confirm redirects when organization is nil" do
+    @transfer.update_column(:organization_id, nil)
+
+    patch confirm_transfer_rubygems_path(as: @owner)
+
+    assert_response :redirect
+    assert_redirected_to organization_transfer_rubygems_path
+  end
+
+  test "GET /rubygems/transfer/confirm redirects when no rubygems selected" do
+    @transfer.update_column(:rubygems, [])
+
+    get confirm_transfer_rubygems_path(as: @owner)
+
+    assert_response :redirect
+    assert_redirected_to organization_transfer_rubygems_path
+  end
+
+  test "PATCH /rubygems/transfer/confirm redirects when no rubygems selected" do
+    @transfer.update_column(:rubygems, [])
+
+    patch confirm_transfer_rubygems_path(as: @owner)
+
+    assert_response :redirect
+    assert_redirected_to organization_transfer_rubygems_path
   end
 end

--- a/test/functional/rubygems/transfer/organizations_controller_test.rb
+++ b/test/functional/rubygems/transfer/organizations_controller_test.rb
@@ -7,39 +7,39 @@ class Rubygems::Transfer::OrganizationsControllerTest < ActionDispatch::Integrat
     @rubygem = create(:rubygem, owners: [@user])
   end
 
-  test "GET /rubygems/:rubygem_id/transfer/organization" do
-    get rubygem_transfer_organization_path(@rubygem.slug, as: @user)
+  test "GET /rubygems/transfer/organization" do
+    get organization_transfer_rubygems_path(as: @user)
 
     assert_response :success
   end
 
-  test "GET /rubygems/:rubygem_id/transfer/organization with existing rubygems transfer" do
-    transfer = create(:rubygem_transfer, rubygem: @rubygem, organization: @organization, created_by: @user, status: :pending)
+  test "GET /rubygems/transfer/organization with existing rubygems transfer" do
+    transfer = create(:rubygem_transfer, organization: @organization, created_by: @user, status: :pending)
 
-    get rubygem_transfer_organization_path(@rubygem.slug, as: @user)
+    get organization_transfer_rubygems_path(as: @user)
 
     assert_response :success
     assert_select "select[name=?] option[selected=selected][value=?]", "rubygem_transfer[organization]", transfer.organization.handle
   end
 
-  test "POST /rubygems/:rubygem_id/transfer/organization" do
-    post rubygem_transfer_organization_path(@rubygem.slug, as: @user), params: { rubygem_transfer: { organization: @organization.handle } }
+  test "POST /rubygems/transfer/organization" do
+    post organization_transfer_rubygems_path(as: @user), params: { rubygem_transfer: { organization: @organization.handle } }
 
-    assert RubygemTransfer.exists?(rubygem: @rubygem, organization: @organization, created_by: @user, status: :pending)
+    assert RubygemTransfer.exists?(organization: @organization, created_by: @user, status: :pending)
 
     assert_response :redirect
-    assert_redirected_to rubygem_transfer_users_path(@rubygem.slug)
+    assert_redirected_to rubygems_transfer_rubygems_path
   end
 
-  test "POST /rubygems/:rubygem_id/transfer/organization with non-owner user" do
+  test "POST /rubygems/transfer/organization with non-owner user" do
     non_owner = create(:user)
-    post rubygem_transfer_organization_path(@rubygem.slug, as: non_owner), params: { rubygem_transfer: { organization: @organization.handle } }
+    post organization_transfer_rubygems_path(as: non_owner), params: { rubygem_transfer: { organization: @organization.handle } }
 
-    assert_response :not_found
+    assert_response :unprocessable_entity
   end
 
-  test "POST /rubygems/:rubygem_id/transfer/organization with invalid organization" do
-    post rubygem_transfer_organization_path(@rubygem.slug, as: @user), params: { rubygem_transfer: { organization: "invalid_handle" } }
+  test "POST /rubygems/transfer/organization with invalid organization" do
+    post organization_transfer_rubygems_path(as: @user), params: { rubygem_transfer: { organization: "invalid_handle" } }
 
     assert_response :unprocessable_content
   end

--- a/test/functional/rubygems/transfer/rubygems_controller_test.rb
+++ b/test/functional/rubygems/transfer/rubygems_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Rubygems::Transfer::RubygemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @organization = create(:organization, owners: [@user])
+    @rubygem = create(:rubygem, owners: [@user])
+    @rubygem_transfer = create(:rubygem_transfer, organization: @organization, created_by: @user, status: :pending, rubygems: [])
+  end
+
+  test "GET /rubygems/transfer/rubygems" do
+    get rubygems_transfer_rubygems_path(as: @user)
+
+    assert_response :success
+  end
+
+  test "PATCH /rubygems/transfer/rubygems" do
+    patch rubygems_transfer_rubygems_path(as: @user), params: { rubygem_transfer: { rubygems: [@rubygem.id] } }
+
+    assert_response :redirect
+    assert_redirected_to users_transfer_rubygems_path
+    assert_includes @rubygem_transfer.reload.rubygems, @rubygem.id
+  end
+
+  test "PATCH /rubygems/transfer/rubygems with unowned gem" do
+    other_gem = create(:rubygem)
+    patch rubygems_transfer_rubygems_path(as: @user), params: { rubygem_transfer: { rubygems: [other_gem.id] } }
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/functional/rubygems/transfer/users_controller_test.rb
+++ b/test/functional/rubygems/transfer/users_controller_test.rb
@@ -48,7 +48,7 @@ class Rubygems::Transfer::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "PATCH /rubygems/:rubygem_id/transfer/users with outside contributor role" do
-    patch rubygem_transfer_users_path(@rubygem.slug, as: @user), params: {
+    patch users_transfer_rubygems_path(as: @owner), params: {
       rubygem_transfer: {
         invites_attributes: {
           "0" => { id: @invites[0].id, role: "outside_contributor" },
@@ -57,10 +57,10 @@ class Rubygems::Transfer::UsersControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_equal "outside_contributor", @transfer.invites.find_by(user_id: @other_users[0].id).role
-    assert_equal "maintainer", @transfer.invites.find_by(user_id: @other_users[1].id).role
+    assert_equal "outside_contributor", @transfer.invites.find_by(user_id: @maintainers[0].id).role
+    assert_equal "maintainer", @transfer.invites.find_by(user_id: @maintainers[1].id).role
 
     assert_response :redirect
-    assert_redirected_to rubygem_transfer_confirm_path(@rubygem.slug)
+    assert_redirected_to confirm_transfer_rubygems_path
   end
 end

--- a/test/models/rubygem_transfer_test.rb
+++ b/test/models/rubygem_transfer_test.rb
@@ -5,7 +5,7 @@ class RubygemTransferTest < ActiveSupport::TestCase
     @owner = create(:user)
     @rubygem = create(:rubygem)
     @organization = create(:organization)
-    @transfer = create(:rubygem_transfer, created_by: @owner, rubygem: @rubygem, organization: @organization)
+    @transfer = create(:rubygem_transfer, created_by: @owner, rubygems: [@rubygem.id], organization: @organization)
   end
 
   test "record errors when transfer fails" do
@@ -36,16 +36,26 @@ class RubygemTransferTest < ActiveSupport::TestCase
     assert_includes @rubygem.reload.owners, user
   end
 
+  test "updating invites when rubygems change" do
+    maintainer = create(:user)
+    other_rubygem = create(:rubygem, owners: [@owner], maintainers: [maintainer])
+
+    @transfer.rubygems = [other_rubygem.id]
+    @transfer.save
+
+    assert_includes @transfer.invites.map(&:user), maintainer
+  end
+
   test "validates rubygem ownership before transfer" do
     non_owner = create(:user)
     @transfer.created_by = non_owner
 
     assert_not @transfer.valid?
-    assert_includes @transfer.errors[:rubygem], "does not have permission to transfer this gem"
-    assert_includes @transfer.errors[:organization], "does not have permission to transfer gems to this organization"
+    assert_includes @transfer.errors[:created_by], "must be an owner of the #{@rubygem.name} gem"
+    assert_includes @transfer.errors[:created_by], "does not have permission to transfer gems to this organization"
   end
 
-  test "sets the organization for the rubygem" do
+  test "sets the organization for each rubygem" do
     @transfer.transfer!
 
     assert_equal @organization, @rubygem.reload.organization
@@ -117,6 +127,6 @@ class RubygemTransferTest < ActiveSupport::TestCase
     @rubygem.update!(organization: existing_organization)
 
     assert_not @transfer.valid?
-    assert_includes @transfer.errors[:rubygem], "is already owned by an organization"
+    assert_includes @transfer.errors[:rubygems], "#{@rubygem.name} is already owned by an organization"
   end
 end

--- a/test/models/rubygem_transfer_test.rb
+++ b/test/models/rubygem_transfer_test.rb
@@ -40,6 +40,8 @@ class RubygemTransferTest < ActiveSupport::TestCase
     maintainer = create(:user)
     other_rubygem = create(:rubygem, owners: [@owner], maintainers: [maintainer])
 
+    assert_empty @transfer.invites
+
     @transfer.rubygems = [other_rubygem.id]
     @transfer.save
 

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -41,7 +41,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     click_on "Transfer Gem"
 
-    assert_text "Your gems have been transferred successfully to #{@organization.name}."
+    assert_text "Successfully transferred 1 gem to #{@organization.name}."
   end
 
   test "transfer a rubygem to an organization with users" do
@@ -70,7 +70,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     click_on "Transfer Gem"
 
-    assert_text "Your gems have been transferred successfully to #{@organization.name}."
+    assert_text "Successfully transferred 1 gem to #{@organization.name}."
 
     visit organization_path(@organization.handle)
     click_on "Members"

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -86,12 +86,16 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     visit rubygem_path(@rubygem.slug)
 
-    click_on "Transfer to Organization"
+    visit organization_path(@organization.handle)
+    click_on "Transfer"
 
-    assert_current_path rubygem_transfer_organization_path(@rubygem.slug)
+    assert_current_path organization_transfer_rubygems_path
 
     select @organization.name, from: "Organization"
 
+    click_on "Continue"
+
+    check @rubygem.name
     click_on "Continue"
 
     select "Outside Contributor", from: maintainer.handle
@@ -102,9 +106,11 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     click_on "Transfer Gem"
 
+    visit rubygem_path(@rubygem.name)
+
     assert_text "MANAGED BY: #{@organization.name}", normalize_ws: true
 
-    visit rubygem_owners_path(@rubygem.slug)
+    click_on "Owners"
 
     assert_text "Please confirm your password to continue"
 


### PR DESCRIPTION
## What's this about?

A `RubygemTransfer` allows users to migrate an existing RubyGem from user ownership to an organisation. Currently, users can only transfer a single RubyGem at a time, which is convenient for those with fewer than 10 gems. However, some organisations have over 400 RubyGems that cannot be realistically processed in a serialised manner. We’ve discussed implementing an API, but we found that making the transfer feature functional in a similar way to Organisation Onboarding would be more practical.

## Solution

I've updated the transfer feature to now allow users to select many gems from a list, similar to the Organization Onboarding feature. The way that users are invited to organisations will also work the same way from Organization Onboarding.

## Screenshots

<img width="1510" height="970" alt="Screenshot 2025-08-07 at 3 54 14 pm" src="https://github.com/user-attachments/assets/ebbde29e-8e34-494d-b70d-f4b80e7d8db0" />
