### PR TITLE
📈 Bump `multi_json` to maintained version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,7 +481,7 @@ GEM
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
-    multi_json (1.15.0)
+    multi_json (1.17.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
@@ -1205,7 +1205,7 @@ CHECKSUMS
   minitest-retry (0.2.5) sha256=2f968fd33706fe91c6f38b6e3e2a2f581d5e8aeceb80113eab0c6a6ed96185fc
   mocha (2.7.1) sha256=8f7d538d5d3ebc75fc788b3d92fbab913a93a78462d2a3ce99d1bdde7af7f851
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
-  multi_json (1.15.0) sha256=1fd04138b6e4a90017e8d1b804c039031399866ff3fbabb7822aea367c78615d
+  multi_json (1.17.0) sha256=76581f6c96aebf2e85f8a8b9854829e0988f335e8671cd1a56a1036eb75e4a1b
   multi_xml (0.7.1) sha256=4fce100c68af588ff91b8ba90a0bb3f0466f06c909f21a32f4962059140ba61b
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.2.0) sha256=b6ef0c6c842ede846f2ec0ade9e266b1a9dac0bc151682b04835e8ebd54840d5


### PR DESCRIPTION
`multi_json` had not seen maintenance [for a while](https://github.com/intridea/multi_json/tags), but it's got a [new owner](https://github.com/sferik/multi_json) 🎉 This is an indirect dependency for us, so the primary benefit is the removal of deprecated code (which was causing a warning that ran on all test executions) 👇  

#### Before

```plaintext
$ bin/rails test test/models/rubygem_test.rb
/Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/multi_json-1.15.0/lib/multi_json/adapters/json_common.rb:18: warning: JSON::PRETTY_STATE_PROTOTYPE is deprecated and will be removed in json 3.0.0, just use JSON.pretty_generate
Run options: --seed 19984

# Running:

........................................................................................................................................

Finished in 6.011151s, 22.6246 runs/s, 48.4100 assertions/s.
```

#### After

```plaintext
$ bin/rails test test/models/rubygem_test.rb
Run options: --seed 64426

# Running:

........................................................................................................................................

Finished in 6.056076s, 22.4568 runs/s, 48.0509 assertions/s.
```