### PR TITLE
🪵 Use `Rails.logger` in View Component

### DIFF
--- a/app/components/avo/audited_changes_record_diff/show_component.rb
+++ b/app/components/avo/audited_changes_record_diff/show_component.rb
@@ -11,7 +11,7 @@ class Avo::AuditedChangesRecordDiff::ShowComponent < ViewComponent::Base
     global_id = GlobalID.parse(gid)
     resource_class = Avo.resource_manager.get_resource_by_model_class(global_id.model_class)
     unless resource_class
-      logger.info "No avo resource class for #{global_id} found"
+      Rails.logger.info "No avo resource class for #{global_id} found"
       return
     end
 


### PR DESCRIPTION
This came about because the view component does not have access to `logger`, which is specified by the controller. Rather than using the suggested `before_render`, I opted to specify `Rails.logger`, which should be available regardless of the context.

I'm open to adopting the suggested approach, but I don't currently see enough benefit from moving logic around. If you can share how `before_render` would be preferable, please let me know!