### PR TITLE
❄️ Attempt to Fix Flaky Tests

### DIFF
--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -23,12 +23,12 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    assert page.has_content? "Multi-factor authentication"
-    assert page.has_content? "Security Device"
+    assert_text "Multi-factor authentication"
+    assert_text "Security Device"
 
     click_on "Authenticate with security device"
 
-    assert page.has_content? "Dashboard"
+    assert_text "Dashboard"
     refute page.has_content? "We now support security devices!"
   end
 
@@ -39,14 +39,14 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    assert page.has_content? "Multi-factor authentication"
-    assert page.has_content? "Security Device"
+    assert_text "Multi-factor authentication"
+    assert_text "Security Device"
 
     travel 30.minutes do
       click_on "Authenticate with security device"
 
-      assert page.has_content? "Your login page session has expired."
-      assert page.has_content? "Sign in"
+      assert_text "Your login page session has expired."
+      assert_text "Sign in"
     end
   end
 
@@ -57,15 +57,15 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    assert page.has_content? "Multi-factor authentication"
-    assert page.has_content? "Security Device"
+    assert_text "Multi-factor authentication"
+    assert_text "Security Device"
 
     @user.update!(webauthn_id: "a")
 
     click_on "Authenticate with security device"
 
     refute page.has_content? "Dashboard"
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 
   test "sign in with webauthn mfa using recovery codes" do
@@ -75,13 +75,13 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     fill_in "Password", with: @user.password
     click_button "Sign in"
 
-    assert page.has_content? "Multi-factor authentication"
-    assert page.has_content? "Security Device"
+    assert_text "Multi-factor authentication"
+    assert_text "Security Device"
 
     fill_in "otp", with: @mfa_recovery_codes.first
     click_button "Authenticate"
 
-    assert page.has_content? "Dashboard"
+    assert_text "Dashboard"
   end
 
   test "sign in with webauthn" do
@@ -89,7 +89,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
 
     click_on "Authenticate with security device"
 
-    assert page.has_content? "Dashboard"
+    assert_text "Dashboard"
     refute page.has_content? "We now support security devices!"
   end
 
@@ -111,7 +111,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     click_on "Authenticate with security device"
 
     refute page.has_content? "Dashboard"
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 
   test "sign in with webauthn does not expire" do
@@ -120,7 +120,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     travel 30.minutes do
       click_on "Authenticate with security device"
 
-      assert page.has_content? "Dashboard"
+      assert_text "Dashboard"
     end
   end
 
@@ -131,7 +131,7 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     click_on "Authenticate with security device"
 
     refute page.has_content? "Dashboard"
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
     assert page.has_content? "Your account was blocked by rubygems team. Please email support@rubygems.org to recover your account."
   end
 
@@ -142,6 +142,6 @@ class SignInWebauthnTest < ApplicationSystemTestCase
     click_on "Authenticate with security device"
 
     refute page.has_content? "Dashboard"
-    assert page.has_content? "Sign in"
+    assert_text "Sign in"
   end
 end

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -13,7 +13,6 @@ class SignInWebauthnTest < ApplicationSystemTestCase
 
   teardown do
     @authenticator&.remove!
-    Capybara.reset_sessions!
     Capybara.use_default_driver
   end
 

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -12,14 +12,14 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   test "when verifying webauthn credential" do
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert page.has_content?("Authenticate with Security Device")
-    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+    assert_text "Authenticate with Security Device"
+    assert_text "Authenticating as #{@user.handle}".upcase
 
     click_on "Authenticate"
 
     assert redirect_to("http://localhost:#{@port}?code=#{@verification.otp}")
     assert redirect_to(successful_verification_webauthn_verification_path)
-    assert page.has_content?("Success!")
+    assert_text "Success!"
     assert_link_is_expired
     assert_successful_verification_not_found
   end
@@ -28,14 +28,14 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     assert_poll_status("pending")
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert page.has_content?("Authenticate with Security Device")
-    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+    assert_text "Authenticate with Security Device"
+    assert_text "Authenticating as #{@user.handle}".upcase
 
     click_on "Authenticate"
 
     Browser::Chrome.any_instance.stubs(:safari?).returns true
 
-    assert page.has_content?("Success!")
+    assert_text "Success!"
     assert_current_path(successful_verification_webauthn_verification_path)
 
     assert_link_is_expired
@@ -46,16 +46,16 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   test "when client closes connection during verification" do
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert page.has_content?("Authenticate with Security Device")
-    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+    assert_text "Authenticate with Security Device"
+    assert_text "Authenticating as #{@user.handle}".upcase
 
     @mock_client.kill_server
     click_on "Authenticate"
 
     assert redirect_to("http://localhost:#{@port}?code=#{@verification.otp}")
     assert redirect_to(failed_verification_webauthn_verification_path)
-    assert page.has_content?("Failed to fetch")
-    assert page.has_content?("Please close this browser and try again.")
+    assert_text "Failed to fetch"
+    assert_text "Please close this browser and try again."
     assert_link_is_expired
     assert_failed_verification_not_found
   end
@@ -64,15 +64,15 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     wrong_port = 1111
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: wrong_port })
 
-    assert page.has_content?("Authenticate with Security Device")
-    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+    assert_text "Authenticate with Security Device"
+    assert_text "Authenticating as #{@user.handle}".upcase
 
     click_on "Authenticate"
 
     assert redirect_to("http://localhost:#{wrong_port}?code=#{@verification.otp}")
     assert redirect_to(failed_verification_webauthn_verification_path)
-    assert page.has_content?("Failed to fetch")
-    assert page.has_content?("Please close this browser and try again.")
+    assert_text "Failed to fetch"
+    assert_text "Please close this browser and try again."
     assert_link_is_expired
     assert_failed_verification_not_found
   end
@@ -81,14 +81,14 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     @mock_client.response = @mock_client.bad_request_response
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert page.has_content?("Authenticate with Security Device")
-    assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+    assert_text "Authenticate with Security Device"
+    assert_text "Authenticating as #{@user.handle}".upcase
 
     click_on "Authenticate"
 
     assert redirect_to(failed_verification_webauthn_verification_path)
-    assert page.has_content?("Failed to fetch")
-    assert page.has_content?("Please close this browser and try again.")
+    assert_text "Failed to fetch"
+    assert_text "Please close this browser and try again."
     assert_link_is_expired
     assert_failed_verification_not_found
   end
@@ -97,14 +97,14 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     travel 3.minutes do
-      assert page.has_content?("Authenticate with Security Device")
-      assert page.has_content?("Authenticating as #{@user.handle}".upcase)
+      assert_text "Authenticate with Security Device"
+      assert_text "Authenticating as #{@user.handle}".upcase
 
       click_on "Authenticate"
 
       assert redirect_to(failed_verification_webauthn_verification_path)
-      assert page.has_content?("The token in the link you used has either expired or been used already.")
-      assert page.has_content?("Please close this browser and try again.")
+      assert_text "The token in the link you used has either expired or been used already."
+      assert_text "Please close this browser and try again."
       assert_failed_verification_not_found
     end
   end
@@ -120,7 +120,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   def assert_link_is_expired
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
-    assert page.has_content?("The token in the link you used has either expired or been used already.")
+    assert_text "The token in the link you used has either expired or been used already."
   end
 
   def assert_poll_status(status)
@@ -138,13 +138,13 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   def assert_successful_verification_not_found
     visit successful_verification_webauthn_verification_path
 
-    assert page.has_content?("Page not found.")
+    assert_text "Page not found."
   end
 
   def assert_failed_verification_not_found
     visit failed_verification_webauthn_verification_path
 
-    assert page.has_content?("Page not found.")
+    assert_text "Page not found."
   end
 
   class MockClientServer

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -112,7 +112,6 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   def teardown
     @mock_client.kill_server
     @authenticator&.remove!
-    Capybara.reset_sessions!
     Capybara.use_default_driver
   end
 


### PR DESCRIPTION
We've continually experienced [intermittent test failures](https://github.com/rubygems/rubygems.org/actions/runs/16991941604/job/48173267274?pr=5914) in our system tests for a while now. A [recent fix](https://github.com/rubygems/rubygems.org/pull/5812) was targeted at ensuring the page loads via `page.has_content?`, but these issues have not gone away. In fact, I don't think we've seen a drop in them.

I analyzed a set of flaky CI runs, accounting for 25 failing tests which succeeded on subsequent runs. Of these, all are (unsurprisingly) system tests. All failures were "Expected false to be truthy." All failures are from calls to `page.has_content?`.

  | **Test File**                     | **Test Method**                                                    | **Failing Line** | **Failure Count** |
  |-------------------------------|----------------------------------------------------------------|--------------|---------------|
  | webauthn_verification_test.rb | test_when_webauthn_verification_is_expired_during_verification | Line 106     | 6             |
  | webauthn_verification_test.rb | test_when_client_closes_connection_during_verification         | Line 57      | 5             |
  | webauthn_verification_test.rb | test_when_verifying_webauthn_credential_on_safari              | Line 38      | 4             |
  | sign_in_webauthn_test.rb      | test_sign_in_with_webauthn_mfa_but_it_expired                  | Lines 47-49  | 4             |
  | sign_in_webauthn_test.rb      | test_sign_in_with_webauthn_mfa                                 | Line 32      | 2             |
  | webauthn_verification_test.rb | test_when_port_given_does_not_match_the_client_port            | Line 74      | 1             |
  | multifactor_auths_test.rb     | test_updating_mfa_level_with_webauthn                          | Line 170     | 2             |
  | sign_in_webauthn_test.rb      | test_sign_in_with_webauthn_mfa_wrong_user_handle               | Line 68      | 1             |

---

While I don't believe we have a smoking gun, or a great explanation as to _why_ `page.has_content?` would be problematic, I think the correlation justifies trying to use `assert_text`, which is expected to have equivalent behavior.