### PR TITLE
Configure Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 99
   versioning-strategy: increase
   groups:
@@ -20,7 +20,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 99
 - package-ecosystem: docker
   directory: /


### PR DESCRIPTION
I don't think there's much value in performing daily updates. We do merge updates relatively often, but not every day. By performing this weekly, we use (significantly) fewer resources while ensuring we get updates often.

**Note:** this does not apply to security updates, so if a vulnerability is discovered, we'll still an update as soon as it is available.