### PR TITLE
Remove `docker` configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: daily


### PR DESCRIPTION
We dynamically build the image that we use based on the current Ruby and Alpine versions:

```plaintext
ARG RUBY_VERSION=3.4.4
ARG ALPINE_VERSION=3.20
FROM ruby:$RUBY_VERSION-alpine${ALPINE_VERSION} AS base
```

This approach isn't compatible with Dependabot's versioning scheme, so we haven't had a Dependabot update for Docker in [over two years](https://github.com/rubygems/rubygems.org/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot+label%3Adocker). We can have Dependabot stop consuming resources and remove this configuration altogether.