### PR TITLE
[DO NOT MERGE] Test CodeQL's handling of prepended

### DIFF
--- a/app/controllers/concerns/avo_auditable.rb
+++ b/app/controllers/concerns/avo_auditable.rb
@@ -7,7 +7,7 @@ module AvoAuditable
     prepend_around_action :unscope_users
   end
 
-  def perform_action_and_record_errors(&)
+  def perform_action_and_record_errors(&blk)
     super do
       action = params.fetch(:action)
       fields = action == "destroy" ? {} : cast_nullable(model_params)
@@ -23,7 +23,7 @@ module AvoAuditable
         fields: fields.reverse_merge(comment: action_name),
         arguments: {},
         models: [@record],
-        &
+        &blk
       )
       value
     end

--- a/app/controllers/concerns/can_codeql_handle_prepended_able.rb
+++ b/app/controllers/concerns/can_codeql_handle_prepended_able.rb
@@ -1,0 +1,7 @@
+module CanCodeQLHandlePrepended
+  extend ActiveSupport::Concern
+
+  prepended do
+    self
+  end
+end

--- a/app/controllers/concerns/can_codeql_handle_prepended_able.rb
+++ b/app/controllers/concerns/can_codeql_handle_prepended_able.rb
@@ -1,7 +1,0 @@
-module CanCodeQLHandlePrepended
-  extend ActiveSupport::Concern
-
-  prepended do
-    self
-  end
-end

--- a/app/controllers/concerns/maintenance_tasks_auditable.rb
+++ b/app/controllers/concerns/maintenance_tasks_auditable.rb
@@ -5,27 +5,27 @@ module MaintenanceTasksAuditable
     include Auditable
 
     around_action :audit_action
+  end
 
-    def audit_action(&)
-      return yield if params[:action].in?(%w[show index])
+  def audit_action(&)
+    return yield if params[:action].in?(%w[show index])
 
-      action = params.fetch(:action)
-      task_name = params.fetch(:task_id)
+    action = params.fetch(:action)
+    task_name = params.fetch(:task_id)
 
-      action_name = "Manual #{action} of #{task_name}"
+    action_name = "Manual #{action} of #{task_name}"
 
-      run = @run
+    run = @run
 
-      value, _audit = in_audited_transaction(
-        auditable: run || ->(changed_records:) { changed_records.keys.grep(MaintenanceTasks::Run).sole },
-        admin_github_user: admin_user,
-        action: action_name,
-        fields: params.slice(:comment).reverse_merge(comment: action_name),
-        arguments: params,
-        models: [run].compact,
-        &
-      )
-      value
-    end
+    value, _audit = in_audited_transaction(
+      auditable: run || ->(changed_records:) { changed_records.keys.grep(MaintenanceTasks::Run).sole },
+      admin_github_user: admin_user,
+      action: action_name,
+      fields: params.slice(:comment).reverse_merge(comment: action_name),
+      arguments: params,
+      models: [run].compact,
+      &
+    )
+    value
   end
 end

--- a/app/controllers/concerns/maintenance_tasks_auditable.rb
+++ b/app/controllers/concerns/maintenance_tasks_auditable.rb
@@ -7,7 +7,7 @@ module MaintenanceTasksAuditable
     around_action :audit_action
   end
 
-  def audit_action(&)
+  def audit_action(&blk)
     return yield if params[:action].in?(%w[show index])
 
     action = params.fetch(:action)
@@ -24,7 +24,7 @@ module MaintenanceTasksAuditable
       fields: params.slice(:comment).reverse_merge(comment: action_name),
       arguments: params,
       models: [run].compact,
-      &
+      &blk
     )
     value
   end


### PR DESCRIPTION
We've had CodeQL warnings being emitted because the tool fails to parse two Ruby files. Both files use the `prepended do` pattern, so I want to test if this is the cause.