### PR TITLE
Fix CodeQL Parser Errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,13 @@ Rails/Output:
     - app/views/**/*_view.rb
     - app/views/**/*_component.rb
 
+# Disable block forwarding style enforcement - let context determine choice
+Naming/BlockForwarding:
+  Enabled: false
+
+Style/ArgumentsForwarding:
+  Enabled: false
+
 Layout/ArgumentAlignment:
   Enabled: false
 

--- a/app/controllers/concerns/avo_auditable.rb
+++ b/app/controllers/concerns/avo_auditable.rb
@@ -7,7 +7,7 @@ module AvoAuditable
     prepend_around_action :unscope_users
   end
 
-  def perform_action_and_record_errors(&)
+  def perform_action_and_record_errors(&blk)
     super do
       action = params.fetch(:action)
       fields = action == "destroy" ? {} : cast_nullable(model_params)
@@ -23,7 +23,7 @@ module AvoAuditable
         fields: fields.reverse_merge(comment: action_name),
         arguments: {},
         models: [@record],
-        &
+        &blk
       )
       value
     end

--- a/app/controllers/concerns/maintenance_tasks_auditable.rb
+++ b/app/controllers/concerns/maintenance_tasks_auditable.rb
@@ -6,7 +6,7 @@ module MaintenanceTasksAuditable
 
     around_action :audit_action
 
-    def audit_action(&)
+    def audit_action(&blk)
       return yield if params[:action].in?(%w[show index])
 
       action = params.fetch(:action)
@@ -23,7 +23,7 @@ module MaintenanceTasksAuditable
         fields: params.slice(:comment).reverse_merge(comment: action_name),
         arguments: params,
         models: [run].compact,
-        &
+        &blk
       )
       value
     end


### PR DESCRIPTION
CodeQL has been [failing to parse](https://github.com/rubygems/rubygems.org/actions/runs/17104368086/job/48509269173?pr=5925) a couple of files for as long as I can determine (output from a previous run)👇 

```plaintext
|                            Metric                            | Value |
+--------------------------------------------------------------+-------+
| Total number of Ruby files that were extracted without error |  1364 |
| Total number of Ruby files that were extracted with errors   |     2 |
```

The failures are from the files which are being updated in this pull request:
```
/home/runner/work/_temp/codeql_databases/ruby/working/files-to-index11417357392682997911.list]
  [2025-08-18 00:18:35] [build-stdout] [2025-08-18 00:18:35] [build-stdout]  WARN /home/runner/work/rubygems.org/rubygems.org/app/controllers/concerns/avo_auditable.rb:26: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
  [2025-08-18 00:18:35] [build-stdout] [2025-08-18 00:18:35] [build-stdout]  WARN /home/runner/work/rubygems.org/rubygems.org/app/controllers/concerns/maintenance_tasks_auditable.rb:26: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
```

While the syntax we were using **is** valid Ruby, it's causing CodeQL to not parse the files. I've opened [an issue](https://github.com/github/codeql/issues/20257) on the CodeQL repo. To facilitate using Syntax that CodeQL _can_ parse, I've updated our Rubocop configuration. These cops were more lenient than it would seem on the surface (grep for `(&)` and `(&blk)` and you'll see that we use them inconsistently), so allowing context determine choice seems reasonable to me.