### PR TITLE
Introduce `.editorconfig` for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root=true
+
+# line endings
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# indentation
+indent_style = space
+indent_size = 2
+
+# allow formatting-specific whitespace in markdown
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I've seen a couple requests lately to add newlines at the end of a file, both by humans and coding agents. These standards are enforced by Rubocop, and should be picked up by various tools. They're not meant to be new rules, but hints for tooling to make a contributor' (or reviewer's) job easier.