### PR TITLE
👬 Resolve duplicate key warning

### DIFF
--- a/test/jobs/refresh_oidc_provider_job_test.rb
+++ b/test/jobs/refresh_oidc_provider_job_test.rb
@@ -112,7 +112,7 @@ class RefreshOIDCProviderJobTest < ActiveJob::TestCase
 
   context "when the configuration endpoint returns an invalid configuration" do
     setup do
-      stub_requests(config_body: { "jwks_uri" => nil })
+      stub_requests(config_body: { jwks_uri: nil })
     end
 
     should "raise an error" do


### PR DESCRIPTION
By intermixing Symbol and String keys we ended up with duplicate keys.

#### Before
```plaintext
$ bin/rails test test/jobs/refresh_oidc_provider_job_test.rb
Run options: --seed 48542

../Users/me/ruby-central/rubygems.org/vendor/bundle/ruby/3.4.0/gems/faraday-2.13.4/lib/faraday/response/json.rb:36: warning: detected duplicate key "jwks_uri" in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true` at line 1 column 1
....

Finished in 0.205353s, 29.2180 runs/s, 73.0450 assertions/s.
```

#### After
```plaintext
$ bin/rails test test/jobs/refresh_oidc_provider_job_test.rb
Run options: --seed 15444

# Running:

......

Finished in 0.150681s, 39.8192 runs/s, 99.5481 assertions/s.
```