### PR TITLE
🙅 Prevent unnecessary link verification attempts

### DIFF
--- a/app/jobs/verify_link_job.rb
+++ b/app/jobs/verify_link_job.rb
@@ -26,6 +26,8 @@ class VerifyLinkJob < ApplicationJob
   TIMEOUT_SEC = 5
 
   def perform(link_verification:)
+    return unless link_verification.should_verify?
+
     verify_link!(link_verification.uri, link_verification.linkable)
     record_success
   end


### PR DESCRIPTION
We've got a very high failure rate in our link verification job. One reason for this is that we bail early (via exception) when we should not perform verification. This change prevents such attempts as they will never succeed.