### PR TITLE
Add X-Request-Start header to nginx (and set env in DD_TAGS)

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -82,6 +82,7 @@ data:
         proxy_set_header X-Forwarded-Host "";
         proxy_set_header Client-IP "";
         proxy_set_header Host $host;
+        proxy_set_header X-Request-Start "t=${msec}";
         proxy_redirect off;
 
         client_max_body_size 500M;

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -68,7 +68,7 @@ spec:
           - name: RAILS_MAX_THREADS
             value: "5"
           - name: DD_TAGS
-            value: "app:rubygems.org"
+            value: "app:rubygems.org env:<%= environment %>"
           - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Presently, scaling the rubygems.org in the event of sudden bursts of traffic is a manual task that we have to do in Shipit, which means there's a significant lag in allocating the right resources when we have a sudden burst of traffic. This can sometimes be minutes, hours or even days sometimes. We've currently provisioned a fairly large amount of compute power to handle peak consumption, but this means that about 60% of our available compute is sitting idle during most of the week.

I'm aiming to introduce a Horizontal Pod Autoscale policy that given the right metrics, will allocate the right resources to handle web traffic without any manual intervention (within reasonable limits).

In https://github.com/rubygems/rubygems.org/pull/5931 I introduced the ability for Datadog to receive Puma metrics, and in this PR I am adding the next metric that will help inform the HPA scaling policy, Queue Time.

### Queue Time

Queue time measures how long a request waits before being processed by our application. It's the time between when Nginx receives a request and when Rails/Puma begins processing it. This metric is critical because:

> Queue time is the only measurement that tells you if your servers have capacity for more requests or if they’re already pushed beyond their limits. CPU and memory might give you some hints about this, but they don’t tell you the actual impact on your users.

https://judoscale.com/blog/request-queue-time

### Why not add this to Fastly?

We can certainly add the `X-Request-Start` header to Fastly, but doing so could lead to false positives. The current rubygems.org request path is: Fastly → AWS ELB → Nginx → Rails/Puma. If we measured queue time from Fastly, it would include:
  - Network latency between Fastly and AWS
  - ELB processing and health check delays
  - Nginx request handling time

### What not add this to the Elastic Load Balancer

 ELBs unfortunately do not automatically add an `X-Request-Start` header, and there is presently no mechanism to add custom headers at the ELB layer without using additional services like Lambda@Edge.

### Resources

* https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby/#http-request-queuing
