### PR TITLE
Update deprecated response type

### DIFF
--- a/app/controllers/api/v1/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/api/v1/oidc/rubygem_trusted_publishers_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::OIDC::RubygemTrustedPublishersController < Api::BaseController
     if trusted_publisher.save
       render json: trusted_publisher, status: :created
     else
-      render json: { errors: trusted_publisher.errors, status: :unprocessable_entity }, status: :unprocessable_content
+      render json: { errors: trusted_publisher.errors, status: :unprocessable_content }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/rubygems/transfer/rubygems_controller.rb
+++ b/app/controllers/rubygems/transfer/rubygems_controller.rb
@@ -8,7 +8,7 @@ class Rubygems::Transfer::RubygemsController < Rubygems::Transfer::BaseControlle
     if @rubygem_transfer.update(rubygem_transfer_params)
       redirect_to users_transfer_rubygems_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/test/functional/rubygems/transfer/organizations_controller_test.rb
+++ b/test/functional/rubygems/transfer/organizations_controller_test.rb
@@ -35,7 +35,7 @@ class Rubygems::Transfer::OrganizationsControllerTest < ActionDispatch::Integrat
     non_owner = create(:user)
     post organization_transfer_rubygems_path(as: non_owner), params: { rubygem_transfer: { organization: @organization.handle } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test "POST /rubygems/transfer/organization with invalid organization" do

--- a/test/functional/rubygems/transfer/rubygems_controller_test.rb
+++ b/test/functional/rubygems/transfer/rubygems_controller_test.rb
@@ -26,6 +26,6 @@ class Rubygems::Transfer::RubygemsControllerTest < ActionDispatch::IntegrationTe
     other_gem = create(:rubygem)
     patch rubygems_transfer_rubygems_path(as: @user), params: { rubygem_transfer: { rubygems: [other_gem.id] } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end


### PR DESCRIPTION
There was a pass done recently to update references to `unprocessable_entity`, but some changes have since been merged. `unprocessable_entity` has been replaced with `unprocessable_content`.