### PR TITLE
Correctly show HTML getting from Kaminari helper methods on Security Events page

### DIFF
--- a/app/views/components/events/table_component.rb
+++ b/app/views/components/events/table_component.rb
@@ -15,7 +15,7 @@ class Events::TableComponent < ApplicationComponent
 
   def view_template
     header(class: "gems__header push--s") do
-      p(class: "gems__meter l-mb-0") { plain page_entries_info(security_events) }
+      p(class: "gems__meter l-mb-0") { raw page_entries_info(security_events) } # rubocop:disable Rails/OutputSafety
     end
 
     if security_events.any?
@@ -36,7 +36,7 @@ class Events::TableComponent < ApplicationComponent
       end
     end
 
-    plain paginate(security_events)
+    raw paginate(security_events) # rubocop:disable Rails/OutputSafety
   end
 
   private


### PR DESCRIPTION
Currently, the header on Security Events page shows HTML as is.

<img width="963" height="137" alt="rubygems org_gems_watchcat_security_events" src="https://github.com/user-attachments/assets/9aee5782-efbc-403b-a0bc-bccafd785e72" />


This is because Kaminari helpers methods return HTML, but showing those with `plain`.
https://github.com/kaminari/kaminari/blob/ca4a5dcfce40ede7990ebfe00a12f21e78e910d9/kaminari-core/config/locales/kaminari.yml#L21

This PR changes to use `raw` to show HTML correctly. `paginate` also had the same issue and fixed it too.