### PR TITLE
Normalize Paths to Prevent Cardinality Explosion

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -36,6 +36,26 @@ data:
 
       proxy_cache_path  /var/lib/nginx/cache  levels=1:2 keys_zone=cache-versions:10m inactive=24h  max_size=100m;
 
+      # Normalize request URIs for metrics collection
+      # Converts dynamic paths (/gems/rails-7.0.1) to patterns (/gems/GEM_NAME)
+      # This is meant to keep our custom metrics within quota
+      map $request_uri $normalized_path {
+        ~^/$                                          /;
+        ~^/gems$                                      /gems;
+        ~^/api/v\d+/dependencies$                     /api/vN/dependencies;
+        ~^/api/v\d+/dependencies\.json$               /api/vN/dependencies.json;
+        ~^/api/v\d+/timeframe_versions\.json$         /api/vN/timeframe_versions.json;
+        ~^/gems/[^/]+(/.*)?$                          /gems/GEM_NAME$1;
+        ~^/api/v\d+/gems/[^/]+(/.*)?$                 /api/vN/gems/GEM_NAME$1;
+        ~^/api/v\d+/gems/[^/]+/versions/[^/]+(/.*)?$  /api/vN/gems/GEM_NAME/versions/VERSION$1;
+        ~^/gems/[^/]+/versions/[^/]+(/.*)?$           /gems/GEM_NAME/versions/VERSION$1;
+        ~^/search\?.*$                                /search?QUERY;
+        ~^/versions/[^/]+(/.*)?$                      /versions/VERSION$1;
+        ~^/api/v\d+/search\?.*$                       /api/vN/search?QUERY;
+        ~^/api/v\d+/dependencies\?.*$                 /api/vN/dependencies?QUERY;
+        default                                       $request_uri;
+      }
+
       include /etc/nginx/conf.d/logging.conf;
       include /etc/nginx/sites-enabled/*;
     }
@@ -164,7 +184,11 @@ data:
       '"http": {'
         '"status_code": $status, '
         '"scheme": "$scheme_from_fastly", '
-        '"url": "$scheme_from_fastly://$http_host$request_uri", '
+        '"url": "$scheme_from_fastly://$http_host$normalized_path", '
+        '"url_details": {'
+          '"path": "$normalized_path", '
+          '"host": "$http_host"'
+        '}, '
         '"args": "$args", '
         '"dest_host": "$http_host", '
         '"content_type": "$sent_http_content_type", '


### PR DESCRIPTION
## 🖼️ Context

Our custom metrics usage is currently almost entirely consumed by the high-cardinality values of `http.url_details.path`, which maps to over 800k values. This change is intended to normalize the paths so that we evaluate paths in a way similar to how the config/routes.rb file defines them.

### How It's Used

`sidecar_nginx.response_bytes_written` accounts for 99.9% of our custom metrics 👇 

<img width="1245" height="340" alt="image" src="https://github.com/user-attachments/assets/f683501b-2d3c-4f7f-a943-da97db08d7a1" />

This metric uses the following configuration, in which you can observe that over the past eight hours there are more than one million values mapped to its tags. 👇 

<img width="655" height="830" alt="image" src="https://github.com/user-attachments/assets/5ae1a470-523b-4055-92c9-8b066a1b9ea3" />

By normalizing the the paths, we will maintain insight into general access patterns while taming our use of custom metrics.