### PR TITLE
Specifically call the "verify" method on Gem packages

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -90,6 +90,11 @@ class Pusher
     # ensure the body can't be treated as a file path
     package_source = Gem::Package::IOSource.new(body)
     package = Gem::Package.new(package_source, gem_security_policy)
+
+    # Verify the contents of the gem
+    package.verify
+
+    # Get the spec
     @spec = package.spec
     @files = package.files
     validate_spec && serialize_spec


### PR DESCRIPTION
I would like to purposely call the "verify" method on Gem::Package.

A side-effect of calling the `spec` method is that the `verify` method gets called:

  https://github.com/rubygems/rubygems/blob/1cfe20f1fb9b74c2254c22e0bfe9cb4d551d42d7/lib/rubygems/package.rb#L602-L606

But I think RubyGems.org should be _intentionally_ verifying the package contents (not just as a side-effect).  The functionality should be the same, but I think this change better communicates the intent of the code.