### PR TITLE
Report when jobs are discarded

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -18,4 +18,12 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  after_discard do |job, exception|
+    tags = job.statsd_tags.merge(
+      exception: exception.class.name,
+      adapter: job.class.queue_adapter.class.name
+    )
+    StatsD.increment("good_job.discarded", tags: tags)
+  end
 end

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,4 +1,31 @@
 require "test_helper"
 
 class ApplicationJobTest < ActiveSupport::TestCase
+  class TestDiscardableJob < ApplicationJob
+    discard_on ArgumentError
+
+    def perform(should_raise: false)
+      raise ArgumentError, "Test error" if should_raise
+    end
+  end
+
+  test "after_discard callback reports metrics to StatsD" do
+    job = TestDiscardableJob.new(should_raise: true)
+
+    # allow reporting performance measurements
+    StatsD.stubs(:increment)
+
+    StatsD.expects(:increment).with(
+      "good_job.discarded",
+      tags: {
+        queue: "default",
+        priority: nil,
+        job_class: "ApplicationJobTest::TestDiscardableJob",
+        exception: "ArgumentError",
+        adapter: "ActiveJob::QueueAdapters::TestAdapter"
+      }
+    ).once
+
+    job.perform_now
+  end
 end


### PR DESCRIPTION
In order to achieve better observability, this change introduces the capturing of discard events. This should provide a better lens into failure cases and overall health.