### PR TITLE
Add Datadog service/environment tags via DD_TAGS

### DIFF
--- a/config/deploy/db-migrate.yaml.erb
+++ b/config/deploy/db-migrate.yaml.erb
@@ -21,6 +21,8 @@ spec:
         value: "<%= environment %>"
       - name: ENV
         value: "<%= environment %>"
+      - name: DD_TAGS
+        value: "service:rubygems.org env:<%= environment %>"
       - name: DD_AGENT_HOST
         valueFrom:
           fieldRef:

--- a/config/deploy/jobs.yaml.erb
+++ b/config/deploy/jobs.yaml.erb
@@ -63,6 +63,8 @@ spec:
             value: "<%= environment %>"
           - name: ENV
             value: "<%= environment %>"
+          - name: DD_TAGS
+            value: "service:rubygems.org env:<%= environment %>"
           - name: GOOD_JOB_PROBE_PORT
             value: "7001"
           - name: GOOD_JOB_QUEUE_SELECT_LIMIT

--- a/config/deploy/jobs_within_24_hours.yaml.erb
+++ b/config/deploy/jobs_within_24_hours.yaml.erb
@@ -54,6 +54,8 @@ spec:
             value: "<%= environment %>"
           - name: ENV
             value: "<%= environment %>"
+          - name: DD_TAGS
+            value: "service:rubygems.org env:<%= environment %>"
           - name: GOOD_JOB_PROBE_PORT
             value: "7001"
           - name: GOOD_JOB_QUEUE_SELECT_LIMIT

--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -48,6 +48,8 @@ spec:
             value: "<%= environment %>"
           - name: ENV
             value: "<%= environment %>"
+          - name: DD_TAGS
+            value: "service:rubygems.org env:<%= environment %>"
           - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -68,7 +68,7 @@ spec:
           - name: RAILS_MAX_THREADS
             value: "5"
           - name: DD_TAGS
-            value: "app:rubygems.org env:<%= environment %>"
+            value: "app:rubygems.org service:rubygems.org env:<%= environment %>"
           - name: DD_AGENT_HOST
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This enables reliable filtering of Datadog dashboards and monitors by service, which has been inconsistent across different metric types. The scoped tagging approach (via environment variable rather than Datadog agent configuration) ensures infrastructure metrics remain unaffected.