### PR TITLE
Tune Shoryuken resources in staging

### DIFF
--- a/config/deploy/shoryuken.yaml.erb
+++ b/config/deploy/shoryuken.yaml.erb
@@ -37,11 +37,11 @@ spec:
             memory: 700Mi
           <% else %>
           requests:
-            cpu: 100m
-            memory: 250Mi
+            cpu: 150m
+            memory: 350Mi
           limits:
-            cpu: 400m
-            memory: 300Mi
+            cpu: 600m
+            memory: 450Mi
           <% end %>
         env:
           - name: RAILS_ENV


### PR DESCRIPTION
We recently adjusted the production resources for Shoryuken, which seems to have brought stability to the deploy. Staging needs similar adjustments, so I'm making those here.

**Production** (arrow represents deploy of #5963)

| CPU | Memory |
|--------|--------|
| <img width="1873" height="318" alt="image" src="https://github.com/user-attachments/assets/1e4ccaa7-516b-432d-9c8e-c4b162b8f175" /> | <img width="1866" height="330" alt="image" src="https://github.com/user-attachments/assets/68c485f0-7d11-4897-ba5a-384f1ea60f38" /> |

**Staging** (consistently at limit/over requesting)
| CPU | Memory |
|--------|--------|
| <img width="1857" height="311" alt="image" src="https://github.com/user-attachments/assets/e39ef7c8-bde5-4b1e-928b-0bcdbb4bed83" /> | <img width="1868" height="323" alt="image" src="https://github.com/user-attachments/assets/37b5e92a-db94-460b-a8e5-b61205e60966" /> | 
