### PR TITLE
Correctly format the `.htpasswd` file

### DIFF
--- a/config/deploy/staging/secrets.ejson
+++ b/config/deploy/staging/secrets.ejson
@@ -33,7 +33,7 @@
     "nginx-basic-auth": {
       "_type": "Opaque",
       "data": {
-        ".htpasswd": "EJ[1:uu50norhxStvYmf5VdVbpiJURYUInzy1pH1tbpj7Tms=:B2SQ9SLnM+g1bNfKTpEDSKPbJO3rvnCL:rDqX0Z3p/HNzkQEzh5LWIA+jaHRSeX6SDmSK1uG6x7XreZlxNU+mJDoaHlWpiB2C]"
+        ".htpasswd": "EJ[1:lZza+O4HRmlQl8ugocbQqHa+U4wHXoDrjzsG9dgdnQE=:9/PUwvkQ3MLH8OGPkSrkrXtlLnws8k3V:Jn5B4r8+5EQoHGgd6tnKMMzhO6kwbfO72qmAqXue/PugKJwAXjdbLRyJ0bqoGCG8SIElYt5DZNQaPVgZt/Z5w76s1jR8wQ==]"
       }
     }
   }


### PR DESCRIPTION
Follow up to https://github.com/rubygems/rubygems.org/pull/6045,

I did not correctly format the credentials correctly previously, following https://github.com/rubygems/rubygems.org/pull/2486#discussion_r470185004, it is now `user:pass_hash` following https://www.hostwinds.com/tutorials/create-use-htpasswd