### PR TITLE
Report successful attestations

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -203,6 +203,7 @@ class Pusher
       @version.attestations << Attestation.new(body: bundle, media_type: bundle.media_type)
     end
 
+    StatsD.increment("attestation.verified", tags: { rubygem: rubygem.name })
     true
   rescue Sigstore::Error => e
     notify <<~MSG, 422


### PR DESCRIPTION
This should help to track how often attestations are being used, as well as how many projects are relying on them.