### PR TITLE
Use a more durable Git SHA for sigstore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "discard", "~> 1.4"
 gem "user_agent_parser", "~> 2.20"
 gem "pghero", "~> 3.7"
 gem "faraday-multipart", "~> 1.1"
-gem "sigstore", github: "landongrindheim/sigstore-ruby", ref: "6fafa2324662735b9c93e067e1c3465ba5ab69d8"
+gem "sigstore", github: "sigstore/sigstore-ruby", ref: "8d5b49629ddcda7d61b328a37a42fb10291d96ad"
 gem "kramdown", "~> 2.5"
 gem "zlib", "~> 3.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/landongrindheim/sigstore-ruby.git
-  revision: 6fafa2324662735b9c93e067e1c3465ba5ab69d8
-  ref: 6fafa2324662735b9c93e067e1c3465ba5ab69d8
+  remote: https://github.com/sigstore/sigstore-ruby.git
+  revision: 8d5b49629ddcda7d61b328a37a42fb10291d96ad
+  ref: 8d5b49629ddcda7d61b328a37a42fb10291d96ad
   specs:
     sigstore (0.2.1)
       logger


### PR DESCRIPTION
We're still waiting on a release of sigstore. While we wait, I think it makes sense to use a SHA from the project itself, rather than a fork (which landongrindheim/sigstore-ruby is).