### PR TITLE
Conditionally call memoization invalidation

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -344,7 +344,7 @@ class Pusher
   end
 
   def validate_spec
-    spec.send(:invalidate_memoized_attributes)
+    spec.send(:invalidate_memoized_attributes) if spec.respond_to?(:invalidate_memoized_attributes, true)
 
     spec = self.spec.dup
 


### PR DESCRIPTION
RubyGems removed this memoization in https://github.com/ruby/rubygems/pull/9017 so this method doesn't exist anymore.  Lets first check respond_to? before trying to call the method.  Once RG.o bumps the minimum RG version, we can just remove this code.