### PR TITLE
Install postgresql client in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,9 @@ WORKDIR /app
 
 RUN mkdir -p tmp/pids
 
+# Install postgresql14-client
+RUN apk update && apk add postgresql14-client && rm -rf /var/cache/apk/*
+
 # Copy built application from previous stage
 COPY --link --from=build /app/ /app/
 


### PR DESCRIPTION
Follow up to: https://github.com/rubygems/rubygems.org/pull/6091

This enables us to create a db readonly user for blazer via the postgresql client.

### Testing

Added the app to the docker-compose file and built it

```yml
services:
  app:
    build:
      context: .
      dockerfile: Dockerfile
    environment:
      - RAILS_ENV=production
      - SECRET_KEY_BASE=secret_key_base
      - DATABASE_URL=postgresql://postgres@db:5432/rubygems_production
```

was able to `psql` and run the commands to create the db user. 

Example
```sql
BEGIN;
CREATE ROLE blazer LOGIN PASSWORD 'secret';
GRANT CONNECT ON DATABASE rubygems_production TO blazer;
GRANT USAGE ON SCHEMA public TO blazer;
GRANT SELECT ON ALL TABLES IN SCHEMA public TO blazer;
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO blazer;
```

```sql
rubygems_production=# \du
                                   List of roles
 Role name |                         Attributes                         | Member of 
-----------+------------------------------------------------------------+-----------
 blazer    |                                                            | {}
 postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
```
