### PR TITLE
Always show source code on sidebar, even if duplicate link

### DIFF
--- a/app/models/links.rb
+++ b/app/models/links.rb
@@ -35,8 +35,18 @@ class Links
   delegate :keys, to: :links
 
   def unique_links
-    links.uniq do |_short, long|
-      send(long)
+    seen_urls = {}
+    links.select do |short, long|
+      url = send(long)
+      # always include 'code' (source_code_uri) even if URL is duplicate
+      if short == "code"
+        true
+      elsif seen_urls[url]
+        false
+      else
+        seen_urls[url] = true
+        true
+      end
     end
   end
 

--- a/test/models/links_test.rb
+++ b/test/models/links_test.rb
@@ -69,6 +69,19 @@ class LinksTest < ActiveSupport::TestCase
     assert_equal([["home", "https://example.code"], ["download", "/downloads/.gem"]], enumerated)
   end
 
+  should "always include source code even when duplicate" do
+    metadata = { "homepage_uri" => "https://example.com", "source_code_uri" => "https://example.com" }
+    version = build(:version, indexed: true, metadata: metadata)
+    rubygem = build(:rubygem, linkset: build(:linkset), versions: [version])
+    links = rubygem.links(version)
+
+    enumerated = links.map do |short, value|
+      [short, value]
+    end
+
+    assert_equal([["home", "https://example.code"], ["code", "https://example.code"], ["download", "/downloads/.gem"]], enumerated)
+  end
+
   context "metadata includes unknown uri key" do
     setup do
       metadata = {


### PR DESCRIPTION
### Motivation / Background

Browsing rubygems.org recently I found it strange that some gems show a "Source Code" link in the sidebar while others do not, even if it is set in the gemspec's `source_code_uri` field.

For example:

[Rake](https://rubygems.org/gems/rake) **does not** show "Source Code"

[ActiveSupport](https://rubygems.org/gems/activesupport) **does** show "Source Code"

Both gems specify a `source_code_uri` value in their respective gemspec files.

I dove into this and it looks like [we are deduping links to declutter the sidebar](https://github.com/rubygems/rubygems.org/pull/3755).

I think this is generally a good idea but would like to propose we always show "Source Code" if it is set. Yes, users can always find the Github page for a gem by clicking the Github Star icon but it feels more intuitive to click "Source Code" if you're looking for the source code.

@etherbob Do you have a strong opinion about this? I don't want to completely revert your change but I also see that even you noted in your original PR, "There's probably also a question to be asked about gem author intent with the duplicate links and whether or not someone might get confused if they don't see a specific link to "source code" for instance if it's been superseded by the "home page" link." I think this is exactly what I'm experiencing and maybe others are as well 😅

### Detail

This Pull Request modifies the `unique_links` method implementation to remove duplicate links but always include `source_code_uri`.

I decided to change the `unique_links` method to preserve most of the existing behavior. Given that I'm introducing a uniqueness exception to `source_code_uri`, should we rename this method? It is still removing duplicate links so maybe it's fine but value others' opinions. 