### PR TITLE
Reset webauthn devices in reset 2FA action

### DIFF
--- a/app/avo/actions/reset_user_2fa.rb
+++ b/app/avo/actions/reset_user_2fa.rb
@@ -5,14 +5,17 @@ class Avo::Actions::ResetUser2fa < Avo::Actions::ApplicationAction
   }
 
   self.message = lambda {
-    "Are you sure you would like to disable MFA and reset the password for #{record.handle} #{record.email}?"
+    "Are you sure you would like to disable MFA, WebAuthn devices, and reset the password for #{record.handle} #{record.email}?"
   }
 
   self.confirm_button_label = "Reset MFA"
 
   class ActionHandler < Avo::Actions::ActionHandler
     def handle_record(user)
-      user.disable_totp!
+      user.disable_totp! if user.totp_enabled?
+      user.webauthn_credentials.destroy_all if user.webauthn_enabled?
+      user.reset_mfa_attributes
+
       user.password = SecureRandom.hex(20).encode("UTF-8")
       user.save!
     end

--- a/app/models/concerns/user_multifactor_methods.rb
+++ b/app/models/concerns/user_multifactor_methods.rb
@@ -72,6 +72,12 @@ module UserMultifactorMethods
     self.mfa_hashed_recovery_codes = new_mfa_recovery_codes.map { |code| BCrypt::Password.create(code) }
   end
 
+  def reset_mfa_attributes
+    self.mfa_level = "disabled"
+    self.new_mfa_recovery_codes = nil
+    self.mfa_hashed_recovery_codes = []
+  end
+
   private
 
   def strong_mfa_level?

--- a/app/models/concerns/user_totp_methods.rb
+++ b/app/models/concerns/user_totp_methods.rb
@@ -12,10 +12,7 @@ module UserTotpMethods
   def disable_totp!
     self.totp_seed = nil
 
-    if no_mfa_devices?
-      self.mfa_level = "disabled"
-      self.mfa_hashed_recovery_codes = []
-    end
+    reset_mfa_attributes if no_mfa_devices?
 
     save!(validate: false)
     Mailer.totp_disabled(id, Time.now.utc).deliver_later

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -28,9 +28,7 @@ class WebauthnCredential < ApplicationRecord
 
   def disable_user_mfa
     return unless user.no_mfa_devices?
-    user.mfa_level = :disabled
-    user.new_mfa_recovery_codes = nil
-    user.mfa_hashed_recovery_codes = []
+    user.reset_mfa_attributes
     user.save!(validate: false)
   end
 end


### PR DESCRIPTION
A support request came in to reset their 2FA. I noticed that the admin action doesn't reset Webauthn devices so if a user has a passkey set up, the action won't completely reset their MFA.