### PR TITLE
[Rubygems 4 compatibility] Do not extract files if destination directory exists

### DIFF
--- a/test/jobs/store_version_contents_job_test.rb
+++ b/test/jobs/store_version_contents_job_test.rb
@@ -16,7 +16,7 @@ class StoreVersionContentsJobTest < ActiveJob::TestCase
     @version = Version.last
 
     @destination_dir = Rails.root.join("tmp", "gems", @gem_package.spec.full_name)
-    @gem_package.extract_files(@destination_dir.to_s) # TODO: expand once per test run?
+    @gem_package.extract_files(@destination_dir.to_s) unless @destination_dir.exist?
   end
 
   def each_file_in_gem

--- a/test/unit/gem_package_enumerator_test.rb
+++ b/test/unit/gem_package_enumerator_test.rb
@@ -6,7 +6,7 @@ class GemPackageEnumeratorTest < ActiveSupport::TestCase
     @gem_package = Gem::Package.new(@gem)
     @enum = GemPackageEnumerator.new(@gem_package)
     @destination_dir = Rails.root.join("tmp", "gems", @gem_package.spec.full_name)
-    @gem_package.extract_files(@destination_dir.to_s) unless @destination_dir.join(@gem_package.spec.full_name).exist?
+    @gem_package.extract_files(@destination_dir.to_s) unless @destination_dir.exist?
   end
 
   teardown do


### PR DESCRIPTION
CI is failing on RubyGems 4 https://github.com/rubygems/rubygems.org/actions/runs/19900740275/job/57046017773?pr=6125

```
GemPackageEnumeratorTest#test_: #map should enumerate all the same files as Gem::Package#contents. :
Errno::EEXIST: File exists @ syserr_fail2_in - /home/runner/work/rubygems.org/rubygems.org/tmp/gems/bin_and_img-0.1.0/exe/hello
    test/unit/gem_package_enumerator_test.rb:9:in 'block in <class:GemPackageEnumeratorTest>'
```

We shouldn't extract files if it's been extracted already. 

Relevant RG change: https://github.com/ruby/rubygems/pull/8974

File structure
```
tmp/gems/bin_and_img-0.1.0/
  exe/hello
  lib/bin_and_img.rb
  lib/bin_and_img/version.rb
  images/ruby.png
```

The clause in `GemPackageEnumeratorTest` is incorrect since it is checking `tmp/gems/bin_and_img-0.1.0/bin_and_img-0.1.0` and not `tmp/gems/bin_and_img-0.1.0`.