### PR TITLE
add rake task to fix attestation data

### DIFF
--- a/lib/tasks/fix_attestations.rake
+++ b/lib/tasks/fix_attestations.rake
@@ -73,7 +73,6 @@ namespace :attestations do
           if needs_fix
             if dry_run
               puts "[#{processed}/#{total_count}] WOULD FIX Attestation #{attestation.id} — #{changes.join(', ')}"
-              fixed += 1
             else
               attestation.update!(body: body)
               puts "[#{processed}/#{total_count}] FIXED Attestation #{attestation.id} — #{changes.join(', ')}"


### PR DESCRIPTION
Based on the issues reported in https://github.com/rubygems/rubygems.org/issues/6098 some of the attestation data was stored incorrectly in the database. This rake task is able to fix two issues 1) missing kindVersion field 2) double encoded `verificationMaterial.certificate.rawBytes`

Before
> curl http://localhost:3000/api/v1/attestations/faraday-2.14.0 | jq | grep -A 3 kindVersion
_no matches_

> cosign verify-blob --bundle faraday-2.14.0.sigstore.json --certificate-identity-regexp "https://github.com/lostisland/faraday/.github/workflows/publish.yml@refs/tags/v2.14.0" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" faraday-2.14.0.gem  
Error: bundle does not contain cert for verification, please provide public key
error during command execution: bundle does not contain cert for verification, please provide public key

After `bundle exec rake attestations:repair`

>  curl http://localhost:3000/api/v1/attestations/faraday-2.14.0 | jq | grep -A 3 kindVersion
          "kindVersion": {
            "kind": "dsse",
            "version": "0.0.1"
          },

> cosign verify-blob --bundle faraday-2.14.0-fixed.sigstore.json --certificate-identity-regexp "https://github.com/lostisland/faraday/.github/workflows/publish.yml@refs/tags/v2.14.0" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" faraday-2.14.0.gem 
Verified OK