### PR TITLE
Set the organization creator as owner in approved invitees

### DIFF
--- a/app/controllers/organizations/onboarding/base_controller.rb
+++ b/app/controllers/organizations/onboarding/base_controller.rb
@@ -28,7 +28,7 @@ class Organizations::Onboarding::BaseController < ApplicationController
   helper_method :available_rubygems
 
   def approved_invites
-    owner = OrganizationInvite.new(user: @organization_onboarding.created_by, role: :admin)
+    owner = OrganizationInvite.new(user: @organization_onboarding.created_by, role: :owner)
     @approved_invites ||= @organization_onboarding.approved_invites.prepend(owner)
   end
   helper_method :approved_invites

--- a/test/functional/organizations/onboarding/users_controller_test.rb
+++ b/test/functional/organizations/onboarding/users_controller_test.rb
@@ -37,6 +37,16 @@ class Organizations::Onboarding::UsersControllerTest < ActionDispatch::Integrati
   end
 
   context "on GET /organizations/onboarding/users" do
+    should "show the creator with Owner role in approved invites" do
+      get organization_onboarding_users_path(as: @user)
+
+      assert_response :ok
+
+      creator_invite = @controller.view_assigns["approved_invites"].find { |i| i.user == @user }
+
+      assert_equal "owner", creator_invite.role
+    end
+
     should "render the list of users to invite" do
       get organization_onboarding_users_path(as: @user)
 


### PR DESCRIPTION
In organization onboarding, the owner is set as admin in the sidebar. This is more of an aesthetic bug fix as when the organization is created, the user that creates it is created as an owner. 

<img width="1626" height="840" alt="Screenshot 2026-01-12 at 12 08 03 PM" src="https://github.com/user-attachments/assets/ce1376a3-ada2-4c6d-bd9c-2da6a4117756" />
