### PR TITLE
Fix polymorphic errors when viewing organization invites

### DIFF
--- a/app/avo/resources/organization_invite.rb
+++ b/app/avo/resources/organization_invite.rb
@@ -4,7 +4,8 @@ class Avo::Resources::OrganizationInvite < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :invitable, as: :belongs_to
+    field :invitable_type, as: :text
+    field :invitable, as: :belongs_to, polymorphic_as: :invitable
     field :user, as: :belongs_to
     field :role, as: :select, enum: OrganizationInvite.roles
   end


### PR DESCRIPTION
Fixes server error for organization invite avo resource. Also added invitable type to see which kind of invite it is.

<img width="975" height="304" alt="Screenshot 2026-01-12 at 3 22 52 PM" src="https://github.com/user-attachments/assets/a72dc07f-e66b-4e00-8bf8-4fe271a9147f" />
