### PR TITLE
Add searchkick timeout of 2 seconds

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -18,8 +18,8 @@ end
 options = {}
 
 options[:url] = ENV['ELASTICSEARCH_URL'] || "http://localhost:#{port}"
-
 options[:tracer] = SemanticLogger[OpenSearch::Client]
+options[:request_timeout] = 2
 
 Searchkick.client = OpenSearch::Client.new(**options.compact) do |f|
   unless Rails.env.local?


### PR DESCRIPTION
[Timed out requests](https://github.com/rubygems/rubygems.org/blob/dbae043ec991813ff51e48002669d375da582e01/lib/elastic_searcher.rb#L2-L8) will receive `Search is currently unavailable. Please try again later.`

<img width="989" height="328" alt="Screenshot 2026-01-15 at 6 05 28 PM" src="https://github.com/user-attachments/assets/b987f757-86ae-485c-a1f4-9a8c393a1cb1" />