### PR TITLE
Add admin action to change organization handle

### DIFF
--- a/app/avo/actions/change_organization_handle.rb
+++ b/app/avo/actions/change_organization_handle.rb
@@ -1,0 +1,23 @@
+class Avo::Actions::ChangeOrganizationHandle < Avo::Actions::ApplicationAction
+  def fields
+    field :new_handle, as: :text, required: true
+    super
+  end
+
+  self.name = "Change Organization Handle"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+  self.message = lambda {
+    "Are you sure you would like to change the handle for organization '#{record.handle}'?"
+  }
+  self.confirm_button_label = "Change Handle"
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_record(organization)
+      organization.handle = fields["new_handle"]
+
+      organization.save!
+    end
+  end
+end

--- a/app/avo/resources/organization.rb
+++ b/app/avo/resources/organization.rb
@@ -32,4 +32,8 @@ class Avo::Resources::Organization < Avo::BaseResource
       field :organization_onboarding, as: :belongs_to
     end
   end
+
+  def actions
+    action Avo::Actions::ChangeOrganizationHandle
+  end
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -86,4 +86,54 @@ class OrganizationTest < ActiveSupport::TestCase
       assert_equal "org:#{organization.handle}", organization.flipper_id
     end
   end
+
+  context "#find_by_handle" do
+    should "return organization by handle" do
+      organization = create(:organization)
+
+      assert_equal organization, Organization.find_by_handle(organization.handle)
+    end
+
+    should "return organizations by handles" do
+      organization1 = create(:organization)
+      organization2 = create(:organization)
+
+      assert_equal [organization1, organization2], Organization.find_by_handle([organization1.handle, organization2.handle])
+    end
+
+    should "return nil if organization is not found" do
+      assert_nil Organization.find_by_handle("nonexistent")
+    end
+
+    should "return empty array if organizations are not found" do
+      assert_predicate Organization.find_by_handle(%w[nonexistent nonexistent2]), :empty?
+    end
+  end
+
+  context "#find_by_handle!" do
+    should "return organization by handle" do
+      organization = create(:organization)
+
+      assert_equal organization, Organization.find_by_handle!(organization.handle)
+    end
+
+    should "return organizations by handles" do
+      organization1 = create(:organization)
+      organization2 = create(:organization)
+
+      assert_equal [organization1, organization2], Organization.find_by_handle!([organization1.handle, organization2.handle])
+    end
+
+    should "raise error if organization is not found" do
+      assert_raises ActiveRecord::RecordNotFound do
+        Organization.find_by_handle!("nonexistent")
+      end
+    end
+
+    should "raise error if organizations are not found" do
+      assert_raises ActiveRecord::RecordNotFound do
+        Organization.find_by_handle!(%w[nonexistent nonexistent2])
+      end
+    end
+  end
 end

--- a/test/unit/avo/actions/change_organization_handle_test.rb
+++ b/test/unit/avo/actions/change_organization_handle_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ChangeOrganizationHandleTest < ActiveSupport::TestCase
+  setup do
+    @organization = create(:organization, handle: "old-handle")
+    @current_user = create(:admin_github_user, :is_admin)
+    @resource = Avo::Resources::Organization.new.hydrate(record: @organization)
+    @action = Avo::Actions::ChangeOrganizationHandle.new(
+      record: @organization,
+      resource: @resource,
+      user: @current_user,
+      view: :show
+    )
+  end
+
+  should "change organization handle" do
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@organization],
+      fields: {
+        comment: "Onboarding a new organization 1234567",
+        new_handle: "new-handle"
+      }.with_indifferent_access,
+      query: nil
+    }
+
+    @action.handle(**args)
+
+    assert_equal "new-handle", @organization.reload.handle
+
+    audit = @organization.audits.sole
+
+    assert_equal @organization, audit.auditable
+    assert_equal "Change Organization Handle", audit.action
+    assert_equal @current_user, audit.admin_github_user
+    assert_equal({ "new_handle" => "new-handle" }, audit.audited_changes["fields"])
+  end
+
+  should "ask for confirmation" do
+    action_mock = Data.define(:record).new(record: @organization)
+
+    message = action_mock.instance_exec(&Avo::Actions::ChangeOrganizationHandle.message)
+
+    assert_includes message, "old-handle"
+  end
+
+  should "be visible" do
+    action_mock = Data.define(:current_user, :view).new(current_user: @current_user, view: :show)
+
+    assert action_mock.instance_exec(&Avo::Actions::ChangeOrganizationHandle.visible)
+  end
+end


### PR DESCRIPTION
Currently, users are only able to create an organization based on a gem name they own. As more organizations onboard and get created, we need to be able to help them change their handle in admin if none of their gems match the name they want. 

This PR adds an admin action to change the org handle.