### PR TITLE
Remove onboarding gems if no gems were selected

### DIFF
--- a/app/views/organizations/onboarding/gems/edit.html.erb
+++ b/app/views/organizations/onboarding/gems/edit.html.erb
@@ -22,25 +22,21 @@
       </label>
     </div>
     <ul class="divide-y divide-neutral-300 dark:divide-neutral-700">
-      <% available_rubygems.each do |gem| %>
-        <% required = @organization_onboarding.namesake_rubygem == gem %>
-
+      <%= form.collection_check_boxes :rubygems, available_rubygems, :id, :name do |b| %>
+        <% required = @organization_onboarding.namesake_rubygem == b.object %>
+        <%
+          data = { counter_target: "checked" }
+          data[:checkbox_select_all_target] = "checkbox" unless required
+        %>
         <li class="flex items-center">
           <label class="flex w-full px-4 py-2 items-center justify-between space-x-2">
             <span class="flex">
-              <span class="text-neutral-800 dark:text-white"><%= gem.name %></span>
+              <span class="text-neutral-800 dark:text-white"><%= b.object.name %></span>
               <% if required %>
                 <span class="flex flex-row text-xs text-neutral-900 bg-orange-100 dark:text-white dark:bg-orange-900 px-2 py-0.5 rounded ml-2">Required</span>
               <% end %>
             </span>
-            <%
-              data = { counter_target: "checked" }
-              data[:checkbox_select_all_target] = "checkbox" unless required
-            %>
-            <%= check_box_tag(
-              "organization_onboarding[rubygems][]",
-              gem.id,
-              @organization_onboarding.rubygems.include?(gem.id),
+            <%= b.check_box(
               class: "h-5 w-5 text-orange-500 border-neutral-500 rounded focus:ring-2 focus:ring-orange-500 rounded disabled:text-neutral-700 dark:disabled:text-neutral-700",
               disabled: required,
               data: data,

--- a/test/functional/organizations/onboarding/gems_controller_test.rb
+++ b/test/functional/organizations/onboarding/gems_controller_test.rb
@@ -44,7 +44,11 @@ class Organizations::Onboarding::GemsControllerTest < ActionDispatch::Integratio
       assert_equal [@namesake_rubygem.id], @organization_onboarding.reload.rubygems
     end
 
-    should "ignore empty params" do
+    should "remove non namesake gems if rubygems param is empty" do
+      @organization_onboarding.update!(rubygems: [@gem.id])
+
+      assert_equal [@namesake_rubygem.id, @gem.id], @organization_onboarding.reload.rubygems
+
       patch organization_onboarding_gems_path(as: @user), params: { organization_onboarding: { rubygems: [""] } }
 
       assert_redirected_to organization_onboarding_users_path


### PR DESCRIPTION
Currently, when a user unselects all optional gems in onboarding, gems won't get removed.

<img width="1138" height="261" alt="Screenshot 2026-01-21 at 11 11 11 PM" src="https://github.com/user-attachments/assets/e125ea85-aa7b-412e-a211-c563e49e772e" />

This is because when submitted, no gems selected will cause no params to be passed to the controller which prevents any update.

Using `collection_check_boxes` includes a hidden field that provides an empty string for `organization_onboarding: { rubygems: [""] }` so that params are sent, and the organization onboarding is updated correctly.
