### PR TITLE
Add `safety_assured` in AddWorkflowRepository migration

### DIFF
--- a/db/migrate/20260107200000_add_workflow_repository_to_oidc_trusted_publisher_github_actions.rb
+++ b/db/migrate/20260107200000_add_workflow_repository_to_oidc_trusted_publisher_github_actions.rb
@@ -1,8 +1,10 @@
 class AddWorkflowRepositoryToOIDCTrustedPublisherGitHubActions < ActiveRecord::Migration[8.0]
   def change
-    change_table :oidc_trusted_publisher_github_actions, bulk: true do |t|
-      t.string :workflow_repository_owner
-      t.string :workflow_repository_name
+    safety_assured do
+      change_table :oidc_trusted_publisher_github_actions, bulk: true do |t|
+        t.string :workflow_repository_owner
+        t.string :workflow_repository_name
+      end
     end
   end
 end


### PR DESCRIPTION
Fix forward for https://github.com/rubygems/rubygems.org/pull/6184

Strong migrations is preventing the migration to be run because it can't evaluate a `change_table` block. The migration should be safe to run since it's only adding null columns.