### PR TITLE
Remove no longer necessary RuboCop `ParserEngine` config entry

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,6 @@ AllCops:
     - !ruby/regexp /(vendor|bundle|bin|db/(migrate/|schema\.rb)|tmp|server)($|\/.*)/
   DisplayCopNames: true
   DisplayStyleGuide: true
-  ParserEngine: parser_prism
   TargetRubyVersion: 3.4
   NewCops: enable
 


### PR DESCRIPTION
### Description

Proposing we remove the `ParseEngine` config entry ([docs](https://docs.rubocop.org/rubocop/configuration.html#setting-the-parser-engine)) because as of [RuboCop 1.75.0](https://github.com/rubocop/rubocop/releases/tag/v1.75.0) RuboCop defaults to `parser_prism` for Ruby >= 3.4 ([code](https://github.com/rubocop/rubocop/blob/a47b83dc3afdeb55e1ddd4e3f65b3b1f2acd209f/lib/rubocop/rspec/cop_helper.rb#L15)). As we're using Ruby 3.4 and RuboCop > 1.75.0 the config entry is redundant and can be removed.

Follow up to https://github.com/rubygems/rubygems.org/pull/5425

### How?

:fire: :fire: :fire: :fire: :fire: 

### Testing

https://github.com/user-attachments/assets/78a107f5-18f9-4956-93ce-c6a943eb408d