### PR TITLE
Remove all enabled by default RuboCop config entries and options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,9 +17,6 @@ AllCops:
   TargetRubyVersion: 3.4
   NewCops: enable
 
-Rails:
-  Enabled: true
-
 Rails/SkipsModelValidations:
   Enabled: false
 
@@ -123,12 +120,6 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 Style/AndOr:
   Exclude:
     - app/controllers/internal/ping_controller.rb
@@ -138,7 +129,6 @@ Naming/AccessorMethodName:
     - app/controllers/application_controller.rb
 
 Rails/SafeNavigation:
-  Enabled: true
   ConvertTry: true
 
 Style/Documentation:
@@ -161,138 +151,11 @@ Style/EmptyMethod:
 Style/FormatStringToken:
   Enabled: false
 
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-Style/GlobalStdStream:
-  Enabled: true
-
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-Style/SingleArgumentDig:
-  Enabled: true
-
-Style/StringConcatenation:
-  Enabled: true
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
-
-Performance/AncestorsInclude:
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-
-Performance/RedundantSortBlock:
-  Enabled: true
-
-Performance/RedundantStringChars:
-  Enabled: true
-
-Performance/ReverseFirst:
-  Enabled: true
-
-Performance/SortReverse:
-  Enabled: true
-
-Performance/Squeeze:
-  Enabled: true
-
-Performance/StringInclude:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/AccessorGrouping:
-  Enabled: true
-
-Style/ArrayCoercion:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-Style/CaseLikeIf:
-  Enabled: true
-
 Style/HashAsLastArrayItem:
-  Enabled: true
   EnforcedStyle: no_braces
-
-Style/HashLikeCase:
-  Enabled: true
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: either
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
 
 Minitest/MultipleAssertions:
   Enabled: false


### PR DESCRIPTION
### Description

Proposing we clean up the RuboCop config by removing all "enable this cop" type entries and `enable: true` config entries for cops that are already enabled by default, leaving only non-default configuration.

Fully removed entries (enabled by default, no custom options):
- Rails: Enabled: true (redundant with the plugin)
- Layout/EmptyLinesAroundAttributeAccessor, Layout/SpaceAroundMethodCallOperator
- 14 Lint/* cops
- 8 Performance/* cops
- 20 Style/* cops

Kept entries but dropped `Enabled: true` (have non-default options):
- Rails/SafeNavigation — kept ConvertTry: true (default is false)
- Style/HashAsLastArrayItem — kept EnforcedStyle: no_braces (default is braces)

### How?

Disclosure, I used a LLM assist to lookup which cops are enabled by default. For those with no non-default options I removed the cop entry entirely. For those with custom non-default options just removed the `Enabled: true`. For non-default cops, nothing was done.


### Testing

Zero diff after running RuboCop with cleaned up config.

<img width="2880" height="1856" alt="Screenshot From 2026-02-20 14-27-02" src="https://github.com/user-attachments/assets/621566ff-9068-4dcb-a3ae-ca59eb4c6c24" />