### PR TITLE
Enable lazy loading of the debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :assets, :development do
 end
 
 group :development, :test do
-  gem "debug", "~> 1.0"
+  gem "debug", "~> 1.0", require: "debug/prelude"
   gem "toxiproxy", "~> 2.0"
   gem "factory_bot_rails", "~> 6.5"
   gem "dotenv-rails", "~> 3.2"


### PR DESCRIPTION
The debug gem is currently causing file watcher issues on main during `bin/rails s`. We should lazily load the debug gem via only requiring `debug/prelude` in the Gemfile.

```
'Listen::Event::Loop#start': thread didn't start in 5.0 seconds (in state: :starting) (Listen::Error::NotStarted)
        from /Users/jennyshen/.gem/ruby/3.4.4/gems/listen-3.10.0/lib/listen/listener.rb:75:in 'block in <class:Listener>'
```