### PR TITLE
[Security] Bump zlib from 3.2.2 to 3.2.3 to address CVE-2026-27820

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -921,7 +921,7 @@ GEM
     yaml-schema (1.2.0)
     yard (0.9.38)
     zeitwerk (2.7.5)
-    zlib (3.2.2)
+    zlib (3.2.3)
 
 PLATFORMS
   aarch64-linux
@@ -1407,7 +1407,7 @@ CHECKSUMS
   yaml-schema (1.2.0) sha256=642577657e826a8bbc20a30a64e27f7b6086b29c9ef0f53fbf437d45279d3ec2
   yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
-  zlib (3.2.2) sha256=908e61263f99c1371b5422581e2d6663bd37c6b04ae13b5f8cb10b0d09379f40
+  zlib (3.2.3) sha256=5bd316698b32f31a64ab910a8b6c282442ca1626a81bbd6a1674e8522e319c20
 
 RUBY VERSION
    ruby 4.0.1p0


### PR DESCRIPTION
### Description

Bump zlib from `3.2.2` to `3.2.3` to address CVE-2026-27820.

- https://www.ruby-lang.org/en/news/2026/03/05/buffer-overflow-zlib-cve-2026-27820/
- https://github.com/ruby/zlib/releases/tag/v3.2.3

### How?

`bundle update zlib`