### PR TITLE
Fix `bin/rubocop` comment capitalization

### DIFF
--- a/bin/rubocop
+++ b/bin/rubocop
@@ -2,7 +2,7 @@
 require "rubygems"
 require "bundler/setup"
 
-# explicit rubocop config increases performance slightly while avoiding config confusion.
+# Explicit RuboCop config increases performance slightly while avoiding config confusion.
 ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
 
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
Proposing a little capitalization fix, pulled out of https://github.com/rubygems/rubygems.org/pull/6092.