### PR TITLE
Fix `LogTicket` model scope single record semantics

### DIFF
--- a/app/models/log_ticket.rb
+++ b/app/models/log_ticket.rb
@@ -8,11 +8,11 @@ class LogTicket < ApplicationRecord
     scope = pending.limit(1).lock(true).order(:id)
     scope = scope.where(key: key) if key
     scope = scope.where(directory: directory) if directory
-    scope.sole.tap do |ticket|
+    scope.take!.tap do |ticket|
       ticket.update_column(:status, "processing")
     end
   rescue ActiveRecord::RecordNotFound
-    nil # no ticket in queue found by `sole` call
+    nil # no ticket in queue found by `take!` call
   end
 
   def fs


### PR DESCRIPTION
Proposing this semantic fix for the `LogTicket` model, pulled out of https://github.com/rubygems/rubygems.org/pull/6092. The idea behind this fix, I believe, is that `sole` is meant to assert that there is only one record however there's already only at most one record because of the `limit(1)`. Thus, because we want to grab the record and if there isn't one we want to raise, we should use `take!` as a clearer, more semantically appropriate call for the same end-result.

https://github.com/rubygems/rubygems.org/blob/99db1cc8afe208dd5c30d9e4ea2139a10f9d7e6f/app/models/log_ticket.rb#L8