### PR TITLE
Add CI step for `herb` based html erb linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,18 @@ jobs:
           bundler-cache: true
       - name: Rubocop
         run: bundle exec rubocop
+  herb:
+    name: Herb 🌿
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
+        with:
+          bundler-cache: true
+      - name: Herb Analyze
+        run: bundle exec herb analyze
   brakeman:
     name: Brakeman
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Description

Proposing we add herb based html erb linting as a follow up to the following PR.

- https://github.com/rubygems/rubygems.org/pull/6340

### How?

Simply followed the existing CI linting steps format and added one for `herb analyze`.

### Testing

CI itself is a good test of this new lint step: https://github.com/rubygems/rubygems.org/actions/runs/23320633070/job/67830916463?pr=6341.