### PR TITLE
Add liveness prob for the web service

### DIFF
--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -42,7 +42,7 @@ spec:
           periodSeconds: 5
         livenessProbe:
           tcpSocket:
-            port: 3000
+            port: http-puma
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
Earlier this week we received a couple of pages due to a sudden increase in latency on the web service. An investigation revealed this was because Kubernetes had killed a few web pods due to the health check failing. Datadog shows that the most likely cause was puma workers being fully utilised and the health check unable to receive a response within the defined timeframe.

This PR adds a new liveness probe (pod restart decision) that will check that the TCP socket is open instead of sending a health check (which is already done by the ALB load balancer)