### PR TITLE
fix: include period in name validation error message

### DIFF
--- a/lib/name_format_validator.rb
+++ b/lib/name_format_validator.rb
@@ -5,7 +5,7 @@ class NameFormatValidator < ActiveModel::EachValidator
     return record.errors.add attribute, "must be a String" if value.class != String
 
     record.errors.add attribute, "must include at least one letter" if requires_letter? && !Patterns::LETTER_REGEXP.match?(value)
-    record.errors.add attribute, "can only include letters, numbers, dashes, and underscores" unless Patterns::NAME_PATTERN.match?(value)
+    record.errors.add attribute, "can only include letters, numbers, periods, dashes, and underscores" unless Patterns::NAME_PATTERN.match?(value)
     record.errors.add attribute, "can not begin with a period, dash, or underscore" if Patterns::SPECIAL_CHAR_PREFIX_REGEXP.match?(value)
     record.errors.add attribute, "can not end with a period, dash, or underscore" if Patterns::SPECIAL_CHAR_SUFFIX_REGEXP.match?(value)
     record.errors.add attribute, "can not end with a common file extension" if Patterns::BANNED_EXTENSION_REGEXP.match?(value)

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -134,7 +134,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       @cutter = Pusher.new(@api_key, @gem)
       @cutter.process
 
-      assert_match(/Dependency unresolved name can only include letters, numbers, dashes, and underscores/, @cutter.message)
+      assert_match(/Dependency unresolved name can only include letters, numbers, periods, dashes, and underscores/, @cutter.message)
       assert_equal 403, @cutter.code
     end
 


### PR DESCRIPTION
## Summary

Updated the gem name validation error message to include "periods" as an allowed character, matching what `Patterns::NAME_PATTERN` actually permits.

## Why this matters

`lib/patterns.rb` defines `SPECIAL_CHARACTERS = ".-_"` and `ALLOWED_CHARACTERS` includes all three. But the error message in `lib/name_format_validator.rb` only mentioned "letters, numbers, dashes, and underscores" - omitting the period. Users who tried names with dots got a misleading error suggesting dots weren't allowed.

## Changes

- `lib/name_format_validator.rb`: Added "periods" to the error message string
- `test/integration/pusher_test.rb`: Updated the test assertion to match the corrected message

## Testing

Verified that `Patterns::NAME_PATTERN` matches names containing periods. Updated the existing integration test to assert the corrected message.

Fixes #6349

This contribution was developed with AI assistance (Claude Code).