### PR TITLE
Disallow pusher to push versions of a reserved gem

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -256,7 +256,7 @@ class Pusher
   end
 
   def notify_unauthorized
-    if !api_key.user?
+    if !api_key.user? || rubygem.reserved_name?
       notify("You are not allowed to push this gem.", 403)
     elsif rubygem.unconfirmed_ownership?(owner)
       notify("You do not have permission to push to this gem. " \

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -291,7 +291,11 @@ class Rubygem < ApplicationRecord
   end
 
   def pushable?
-    new_record? || (versions.indexed.none? && not_protected?)
+    new_record? || (versions.indexed.none? && not_protected? && !reserved_name?)
+  end
+
+  def reserved_name?
+    GemNameReservation.reserved?(name)
   end
 
   def create_ownership(user)
@@ -400,7 +404,7 @@ class Rubygem < ApplicationRecord
   end
 
   def reserved_names_exclusion
-    return unless GemNameReservation.reserved?(name)
+    return unless reserved_name?
     errors.add :name, "'#{name}' is a reserved gem name."
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -343,6 +343,15 @@ class PusherTest < ActiveSupport::TestCase
         assert @cutter.authorize
       end
 
+      should "be false if gem name is reserved" do
+        create(:version, rubygem: @rubygem, number: "0.1.1", indexed: false)
+        create(:gem_name_reservation, name: @rubygem.name.downcase)
+
+        refute @cutter.authorize
+        assert_equal "You are not allowed to push this gem.", @cutter.message
+        assert_equal 403, @cutter.code
+      end
+
       context "version metadata has rubygems_mfa_required set" do
         setup do
           spec = mock


### PR DESCRIPTION
Gem reservations were validated if the Rubygem record was new, which is not the case for non indexed gems.