### PR TITLE
Include created_at in compact index /info endpoint

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -108,8 +108,9 @@ class GemInfo
         end
       end
 
-      name, platform, checksum, info_checksum, ruby_version, rubygems_version, = r
-      CompactIndex::GemVersion.new(name, platform, Version._sha256_hex(checksum), info_checksum, deps, ruby_version, rubygems_version)
+      name, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = r
+      CompactIndex::GemVersion.new(name, platform, Version._sha256_hex(checksum), info_checksum, deps, ruby_version, rubygems_version,
+        created_at&.utc&.iso8601)
     end
   end
 

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -2,7 +2,8 @@
 
 module CompactIndex
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version) do
+                          :dependencies, :ruby_version, :rubygems_version,
+                          :created_at) do
     def number_and_platform
       if platform.nil? || platform == "ruby"
         number
@@ -25,6 +26,7 @@ module CompactIndex
       line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line << ",created_at:#{created_at}" if created_at
       line
     end
 

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -11,7 +11,8 @@ module CompactIndexHelpers
       args.fetch(:info_checksum, "info+#{name}+#{number}"),
       args[:dependencies],
       args[:ruby_version],
-      args[:rubygems_version]
+      args[:rubygems_version],
+      args[:created_at]
     )
   end
 end

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -14,7 +14,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
   setup do
     @rubygem2 = create(:rubygem, name: "gemB")
-    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum: "qw2dwe")
+    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum: "qw2dwe",
+      created_at: 5.days.ago)
 
     # another gem
     rubygem = create(:rubygem, name: "gemA")
@@ -22,37 +23,41 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     dep2 = create(:rubygem, name: "gemA2", indexed: true)
 
     # minimal version
-    create(:version,
+    @gem_a_v100 = create(:version,
       rubygem: rubygem,
       number: "1.0.0",
       info_checksum: "013we2",
-      required_ruby_version: nil)
+      required_ruby_version: nil,
+      created_at: 4.days.ago)
 
     # version with deps but no ruby or rubygems requirements
-    version = create(:version,
+    @gem_a_v200 = create(:version,
       rubygem: rubygem,
       number: "2.0.0",
       info_checksum: "1cf94r",
-      required_ruby_version: nil)
-    create(:dependency, rubygem: dep1, version: version)
+      required_ruby_version: nil,
+      created_at: 3.days.ago)
+    create(:dependency, rubygem: dep1, version: @gem_a_v200)
 
     # version with required ruby and rubygems version
-    create(:version,
+    @gem_a_v120 = create(:version,
       rubygem: rubygem,
       number: "1.2.0",
       info_checksum: "13q4es",
       required_rubygems_version: ">1.9",
-      required_ruby_version: ">= 2.0.0")
+      required_ruby_version: ">= 2.0.0",
+      created_at: 2.days.ago)
 
     # version with everything
-    version = create(:version,
+    @gem_a_v210 = create(:version,
       rubygem: rubygem,
       number: "2.1.0",
       info_checksum: "e217fz",
-      required_rubygems_version: ">=2.0")
+      required_rubygems_version: ">=2.0",
+      created_at: 1.day.ago)
 
-    create(:dependency, rubygem: dep1, version: version)
-    create(:dependency, rubygem: dep2, version: version)
+    create(:dependency, rubygem: dep1, version: @gem_a_v210)
+    create(:dependency, rubygem: dep2, version: @gem_a_v210)
   end
 
   test "/names output" do
@@ -149,10 +154,10 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
   test "/info with existing gem" do
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3,created_at:#{@gem_a_v100.created_at.utc.iso8601}
+      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3,created_at:#{@gem_a_v200.created_at.utc.iso8601}
+      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9,created_at:#{@gem_a_v120.created_at.utc.iso8601}
+      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0,created_at:#{@gem_a_v210.created_at.utc.iso8601}
     VERSIONS_FILE
     expected_digest = digest(expected)
 
@@ -174,10 +179,10 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
   test "/info partial response" do
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3,created_at:#{@gem_a_v100.created_at.utc.iso8601}
+      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3,created_at:#{@gem_a_v200.created_at.utc.iso8601}
+      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9,created_at:#{@gem_a_v120.created_at.utc.iso8601}
+      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0,created_at:#{@gem_a_v210.created_at.utc.iso8601}
     VERSIONS_FILE
 
     get info_path(gem_name: "gemA"), env: { range: "bytes=159-" }
@@ -188,11 +193,12 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
   test "/info with new gem" do
     rubygem = create(:rubygem, name: "gemC")
-    version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "65ea0d")
+    version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "65ea0d",
+      created_at: Time.utc(2024, 2, 1))
     create(:dependency, :development, version: version, rubygem: @rubygem2)
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:2024-02-01T00:00:00Z
     VERSIONS_FILE
     expected_digest = digest(expected)
 
@@ -234,7 +240,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{@version.created_at.utc.iso8601}
     VERSIONS_FILE
     expected_digest = digest(expected)
 

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -49,16 +49,20 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success, response.body
 
+    sigstore = Rubygem.find_by!(name: "sigstore")
+    v001 = sigstore.versions.find_by(number: "0.0.1")
+    v100 = sigstore.versions.find_by(number: "1.0.0")
+
     get info_path("sigstore")
     info_file = response.body
 
     assert_response :success
     assert_equal <<~INFO, info_file
       ---
-      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))}
+      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{v001.created_at.utc.iso8601}
+      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))},created_at:#{v100.created_at.utc.iso8601}
     INFO
-    assert_equal Digest::MD5.hexdigest(info_file), Rubygem.find_by!(name: "sigstore").versions.find_by(number: "1.0.0").info_checksum
+    assert_equal Digest::MD5.hexdigest(info_file), v100.info_checksum
 
     get api_v2_rubygem_version_path("sigstore", "1.0.0", format: "json")
 
@@ -92,10 +96,12 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?(css, count: 2)
 
-    assert_equal Digest::MD5.hexdigest(<<~INFO), Rubygem.find_by!(name: "sandworm").versions.sole.info_checksum
+    version = Rubygem.find_by!(name: "sandworm").versions.sole
+    expected_info = <<~INFO
       ---
-      1.0.0 |checksum:#{Digest::SHA256.hexdigest gem_io.string}
+      1.0.0 |checksum:#{Digest::SHA256.hexdigest gem_io.string},created_at:#{version.created_at.utc.iso8601}
     INFO
+    assert_equal Digest::MD5.hexdigest(expected_info), version.info_checksum
   end
 
   test "push a new version of a gem" do

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -14,7 +14,7 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
 
     content = <<~INFO
       ---
-      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
     INFO
 
     assert_equal content, RubygemFs.compact_index.get("info/#{version.rubygem.name}")

--- a/test/lib/compact_index_test.rb
+++ b/test/lib/compact_index_test.rb
@@ -121,5 +121,23 @@ class CompactIndexTest < ActiveSupport::TestCase
 
       assert_equal "---\n1.0.1-jruby |checksum:sum+test_gem+1.0.1\n", CompactIndex.info(param)
     end
+
+    should "show created_at timestamp" do
+      param = [build_version(number: "1.0.1", created_at: "2024-05-01T12:00:00Z")]
+
+      assert_equal "---\n1.0.1 |checksum:sum+test_gem+1.0.1,created_at:2024-05-01T12:00:00Z\n", CompactIndex.info(param)
+    end
+
+    should "show created_at with other requirements" do
+      param = [build_version(number: "1.0.1", ruby_version: ">1.9", created_at: "2024-05-01T12:00:00Z")]
+
+      assert_equal "---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:>1.9,created_at:2024-05-01T12:00:00Z\n", CompactIndex.info(param)
+    end
+
+    should "omit created_at when nil" do
+      param = [build_version(number: "1.0.1")]
+
+      refute_includes CompactIndex.info(param), "created_at"
+    end
   end
 end

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -16,9 +16,9 @@ class GemInfoTest < ActiveSupport::TestCase
   context "#compact_index_info" do
     setup do
       rubygem = create(:rubygem, name: "example")
-      version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "qw2dwe")
+      @version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "qw2dwe")
       dep = create(:rubygem, name: "exmaple_dep")
-      create(:dependency, rubygem: dep, version: version)
+      create(:dependency, rubygem: dep, version: @version)
 
       @expected_info = [CompactIndex::GemVersion.new(
         "1.0.0",
@@ -27,7 +27,8 @@ class GemInfoTest < ActiveSupport::TestCase
         "qw2dwe",
         [CompactIndex::Dependency.new("exmaple_dep", "= 1.0.0")],
         ">= 2.0.0",
-        ">= 2.6.3"
+        ">= 2.6.3",
+        @version.created_at.utc.iso8601
       )]
     end
 
@@ -35,6 +36,12 @@ class GemInfoTest < ActiveSupport::TestCase
       info = GemInfo.new("example").compact_index_info
 
       assert_equal @expected_info, info
+    end
+
+    should "include created_at timestamp in gem version" do
+      info = GemInfo.new("example").compact_index_info
+
+      assert_equal @version.created_at.utc.iso8601, info.first.created_at
     end
 
     should "write cache" do

--- a/test/system/gem_server_lifecycle_test.rb
+++ b/test/system/gem_server_lifecycle_test.rb
@@ -109,7 +109,8 @@ class GemServerLifecycleTest < ApplicationSystemTestCase
 
     assert_equal "200", info_a_after_first_push.code
     assert_equal "text/plain; charset=utf-8", info_a_after_first_push["content-type"]
-    expected_info = "---\n1.0.0 |checksum:#{gem_a100.sha256}\n"
+    a100_version = Version.find_by!(full_name: "a-1.0.0")
+    expected_info = "---\n1.0.0 |checksum:#{gem_a100.sha256},created_at:#{a100_version.created_at.utc.iso8601}\n"
 
     assert_equal expected_info, info_a_after_first_push.body
 
@@ -196,12 +197,21 @@ class GemServerLifecycleTest < ApplicationSystemTestCase
     info_a_after_second_push = do_get_info("a")
 
     assert_valid_compact_index_response info_a_after_second_push
-    assert_equal info_a_after_yank.body + "0.0.1 |checksum:#{gem_a001.sha256}\n", info_a_after_second_push.body
+    a001_version = Version.find_by!(full_name: "a-0.0.1")
+    expected_a_info = info_a_after_yank.body +
+      "0.0.1 |checksum:#{gem_a001.sha256},created_at:#{a001_version.created_at.utc.iso8601}\n"
+
+    assert_equal expected_a_info, info_a_after_second_push.body
 
     info_b = do_get_info("b")
 
     assert_valid_compact_index_response info_b
-    assert_equal "---\n1.0.0.pre a:< 1.0.0&>= 0.1.0|checksum:#{gem_b100pre.sha256},ruby:>= 2.0,rubygems:>= 2.0\n", info_b.body
+    b100pre_version = Version.find_by!(full_name: "b-1.0.0.pre")
+    expected_b_info = "---\n" \
+                      "1.0.0.pre a:< 1.0.0&>= 0.1.0|checksum:#{gem_b100pre.sha256}," \
+                      "ruby:>= 2.0,rubygems:>= 2.0,created_at:#{b100pre_version.created_at.utc.iso8601}\n"
+
+    assert_equal expected_b_info, info_b.body
 
     response = do_get_names
 
@@ -253,10 +263,13 @@ class GemServerLifecycleTest < ApplicationSystemTestCase
     info_a_after_third_push = do_get_info("a")
 
     assert_valid_compact_index_response info_a_after_third_push
+    a020_version = Version.find_by!(full_name: "a-0.2.0")
+    a020_mingw_version = Version.find_by!(full_name: "a-0.2.0-x86-mingw32")
+    a020_java_version = Version.find_by!(full_name: "a-0.2.0-java")
     expected_info_a = info_a_after_second_push.body +
-      "0.2.0 |checksum:#{gem_a020.sha256}\n" \
-      "0.2.0-x86-mingw32 |checksum:#{find_gem('a-0.2.0-x86-mingw32').sha256}\n" \
-      "0.2.0-java |checksum:#{find_gem('a-0.2.0-java').sha256}\n"
+      "0.2.0 |checksum:#{gem_a020.sha256},created_at:#{a020_version.created_at.utc.iso8601}\n" \
+      "0.2.0-x86-mingw32 |checksum:#{find_gem('a-0.2.0-x86-mingw32').sha256},created_at:#{a020_mingw_version.created_at.utc.iso8601}\n" \
+      "0.2.0-java |checksum:#{find_gem('a-0.2.0-java').sha256},created_at:#{a020_java_version.created_at.utc.iso8601}\n"
 
     assert_equal expected_info_a, info_a_after_third_push.body
 
@@ -312,7 +325,9 @@ class GemServerLifecycleTest < ApplicationSystemTestCase
     info_a_after_fourth_push = do_get_info("a")
 
     assert_valid_compact_index_response info_a_after_fourth_push
-    assert_match(/0\.3\.0 \|checksum:#{gem_a030.sha256}\n\z/, info_a_after_fourth_push.body)
+    a030_version = Version.find_by!(full_name: "a-0.3.0")
+
+    assert_match(/0\.3\.0 \|checksum:#{gem_a030.sha256},created_at:#{a030_version.created_at.utc.iso8601}\n\z/, info_a_after_fourth_push.body)
 
     specs_after_fourth_push = do_get_specs
 


### PR DESCRIPTION
## Problem

Supply chain attacks targeting package registries are a growing concern. Other package managers have already shipped minimum age features — [npm](https://github.com/npm/cli/releases/tag/v11.10.0), [pnpm](https://pnpm.io/supply-chain-security), and [yarn](https://github.com/yarnpkg/berry/issues/6899) all allow users to reject recently published versions during resolution.

Bundler currently has no equivalent. Adding one requires knowing when each gem version was published, but the compact index has no publication timestamp. Without it, clients must make a separate V1 API call per gem (`/api/v1/versions/<gem>.json`) — adding seconds of latency and hitting the RubyGems.org rate limit (10 req/s) on projects with 50+ gems.

The compact index `/info` endpoint already carries all the version data Bundler needs during resolution — except `created_at`.

## Solution

Pass the version's `created_at` (already in the SQL query) to `CompactIndex::GemVersion.new` as the 8th argument, formatted as ISO 8601 UTC.

**Before:**
```ruby
name, platform, checksum, info_checksum, ruby_version, rubygems_version, = r
CompactIndex::GemVersion.new(name, platform, Version._sha256_hex(checksum),
  info_checksum, deps, ruby_version, rubygems_version)
```

**After:**
```ruby
name, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = r
CompactIndex::GemVersion.new(name, platform, Version._sha256_hex(checksum),
  info_checksum, deps, ruby_version, rubygems_version, created_at&.utc&.iso8601)
```

The `created_at` column is already selected in the `requirements_and_dependencies` query, included in the `GROUP BY`, and used for `ORDER BY`. It just wasn't being passed through.

## Info line output

```
1.0.0 rack:>= 1.0|checksum:abc123,ruby:>= 2.7.0,created_at:2024-05-01T12:00:00Z
```

Old clients ignore unknown requirement fields, so this is fully backwards compatible.

## Dependencies

Requires [rubygems/compact_index#183](https://github.com/rubygems/compact_index/pull/183) — adds `created_at` as an optional 8th field to `GemVersion` struct.