### PR TITLE
Use default locale for all mailer actions

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -11,6 +11,7 @@ class ApplicationMailer < ActionMailer::Base
 
   layout "mailer"
 
+  around_action :use_default_locale
   after_deliver :record_delivery
 
   def record_delivery
@@ -25,5 +26,11 @@ class ApplicationMailer < ActionMailer::Base
         action: action_name,
         mailer: mailer_name)
     end
+  end
+
+  private
+
+  def use_default_locale(&block)
+    I18n.with_locale(I18n.default_locale, &block)
   end
 end

--- a/test/mailers/owners_test.rb
+++ b/test/mailers/owners_test.rb
@@ -19,4 +19,16 @@ class OwnersMailerTest < ActionMailer::TestCase
       assert_equal email.subject, "Your role was updated for the #{@rubygem.name} gem"
     end
   end
+
+  context "#owner_added" do
+    should "use default locale regardless of ambient I18n.locale" do
+      I18n.with_locale(:de) do
+        email = OwnersMailer.owner_added(@owner.id, @maintainer.id, @owner.id, @rubygem.id)
+
+        assert_emails(1) { email.deliver_now }
+        assert_equal "User #{@maintainer.display_handle} was added as an owner to the #{@rubygem.name} gem", email.subject
+        assert_match "OWNER ADDED", email.body.to_s
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #6316
`deliver_later` serializes `I18n.locale` at enqueue time. So when a german speaking user confirms gem ownership, all owners get their notification in german instead of english. This PR adds an `around_action` in `ApplicationMailer` to force default locale for all mailers.
