### PR TITLE
Add Rails 8.1 style local CI via `bin/ci`

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require_relative "../config/boot"
+require "active_support/continuous_integration"
+
+CI = ActiveSupport::ContinuousIntegration
+require_relative "../config/ci.rb"

--- a/bin/herb
+++ b/bin/herb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "herb"
+
+Herb::CLI.new(ARGV).call

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Run using bin/ci
+
+CI.run do
+  step "Setup", "bin/setup --skip-server"
+
+  step "Style: Ruby", "bin/rubocop"
+  step "Style: ERB", "bin/herb analyze"
+
+  step "Security: Importmap vulnerability audit", "bin/importmap audit"
+  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+  step "Tests: Rails", "bin/rails test"
+
+  # Optional: Run seed replant test (requires AWS S3 credentials)
+  # step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+
+  step "Tests: System", "bin/rails test:system"
+
+  # Optional: set a green GitHub commit status to unblock PR merge.
+  # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.
+  # if success?
+  #   step "Signoff: All systems go. Ready for merge and deploy.", "gh signoff"
+  # else
+  #   failure "Signoff: CI failed. Do not merge or deploy.", "Fix the issues and try again."
+  # end
+end


### PR DESCRIPTION
### Description

Proposing we add a `bin/ci` local CI tool, a new Rails feature as of Rails 8.1, for local sanity checks. For example, peeps can run `bin/ci` before pushing to check basic app setup, linting, security, and unit tests are all good prior to handing such off to hosted CI.

Notes
- I've have not enabled seed tests as they fail due to needing AWS credentials and I've not enabled system tests as they take a while and generally are a bit flaky even requiring retries in hosted CI to pass. This is meant as a quick local CI sanity check anyway.
- In an ideal world ~both~ the seed test ~and system tests~ would run well locally and this local CI would fully replicate hosted CI. At which point we could even replace the hosted (GitHub Actions) CI config "run" step with the `bin/ci`, ensuring that they're one and the same. And in that case we could even proceed with adding `gh signoff` and/or requiring `bin/ci` pass before push via a Git commit hook. Many possible enhancements. 🙂
- This along with https://github.com/rubygems/rubygems.org/pull/6427 wrap up our Rails 8.1 upgrade i.e. `bin/rails app:update` is complete and we're fully up-to-date.

References
- https://guides.rubyonrails.org/8_1_release_notes.html#local-ci
- https://www.fastruby.io/blog/rails-8-1-local-ci.html
- https://derails.dev/blog/rails-local-ci/

Follow up to:
- https://github.com/rubygems/rubygems.org/pull/6335

### Testing

Have tested using this locally quite a few times.

<img width="2880" height="1856" alt="image" src="https://github.com/user-attachments/assets/2d7040d5-6c1d-4a16-a5a8-9292f0ea06e3" />