### PR TITLE
Handle Locales as Part of URL Paths

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,6 +162,7 @@ Style/ClassAndModuleChildren:
   Exclude:
     - lib/compact_index/*.rb
     - lib/gemcutter/middleware/hostess.rb
+    - lib/gemcutter/middleware/locale_from_path.rb
     - lib/gemcutter/middleware/redirector.rb
 
 Capybara/ClickLinkOrButtonStyle:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,7 @@ class ApplicationController < ActionController::Base
     render_forbidden(e.policy.error)
   end
 
-  # TODO: Separate locales by path and re-enable
-  # before_action :set_locale
+  before_action :set_locale
   before_action :reject_null_char_param
   before_action :reject_path_params_param
   before_action :reject_null_char_cookie
@@ -42,10 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = user_locale
-
-    # after store current locale
-    session[:locale] = params[:locale] if params[:locale]
+    I18n.locale = request.env["rubygems.locale"] || I18n.default_locale
   rescue I18n::InvalidLocale
     I18n.locale = I18n.default_locale
   end
@@ -134,14 +130,6 @@ class ApplicationController < ActionController::Base
     redirect_to_page_with_error && return unless valid_page_param?(max_page)
 
     @page = params[:page].to_i
-  end
-
-  def user_locale
-    params[:locale] || session[:locale] || http_head_locale || I18n.default_locale
-  end
-
-  def http_head_locale
-    http_accept_language.language_region_compatible_from(I18n.available_locales)
   end
 
   def render_not_found

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,22 @@ module ApplicationHelper
     "is-active" if request.path_info == path
   end
 
+  def locale_switch_path(locale)
+    locale = locale.to_s
+    current_locale = I18n.locale.to_s
+    path = request.path.to_s
+
+    path = path.delete_prefix("/#{current_locale}") if current_locale != I18n.default_locale.to_s
+    path = "/" if path.empty?
+
+    query_string = request.query_parameters.except("locale").to_query
+    path = "#{path}?#{query_string}" if query_string.present?
+
+    return path if locale == I18n.default_locale.to_s
+
+    path == "/" ? "/#{locale}" : "/#{locale}#{path}"
+  end
+
   # replacement for Kaminari::ActionViewExtension#paginate
   # only shows `next` and `prev` links and not page numbers, saving a COUNT(DISTINCT ..) query
   def plain_paginate(items)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -201,7 +201,13 @@
           <span class="t-hidden">Mend.io</span>
         </a>
       </div>
-      <%# Locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
+      <div class="footer__language_selector">
+        <% I18n.available_locales.each do |language| %>
+          <div class="footer__language">
+            <%= link_to I18n.t(:locale_name, locale: language), locale_switch_path(language), class: "nav--v__link--footer" %>
+          </div>
+        <% end %>
+      </div>
     </footer>
     <%= yield :javascript %>
     <script type="text/javascript" defer src="https://www.fastly-insights.com/insights.js?k=3e63c3cd-fc37-4b19-80b9-65ce64af060a"></script>

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -64,7 +64,20 @@
                   <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                 </div>
               </div>
-              <%# Locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
+              <!-- Language Selector -->
+              <div class="flex relative ml-5" data-controller="dropdown">
+                <button data-action="dropdown#toggle click@window->dropdown#hide" class="flex items-center text-neutral-900 dark:text-white hover:text-neutral-600 dark:hover:text-neutral-400 focus:outline-none">
+                  <%= icon_tag "language", size: 5 %>
+                  <span class="ml-1 text-b3 uppercase"><%= I18n.locale %></span>
+                  <%= icon_tag "arrow-drop-down" %>
+                </button>
+
+                <div data-dropdown-target="menu" class="z-50 hidden absolute flex-row -left-4 top-8 bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded shadow-lg text-b2 text-neutral-700 dark:text-neutral-300 divide-y divide-neutral-200 dark:divide-neutral-800">
+                  <% I18n.available_locales.each do |language| %>
+                    <%= link_to I18n.t(:locale_name, locale: language), locale_switch_path(language), class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-nowrap" %>
+                  <% end %>
+                </div>
+              </div>
             </nav>
 
             <!-- Mobile Left Navigation Menu -->
@@ -106,7 +119,20 @@
                     <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "mb-4 hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                   </div>
 
-                  <%# Mobile locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
+                  <!-- Mobile Language Selector -->
+                  <div class="flex flex-col" data-controller="reveal" data-reveal-toggle-class="rotate-180">
+                    <button class="flex items-center px-8 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none justify-between" data-action="reveal#toggle" data-reveal-target="button">
+                      <span class="flex items-center">
+                        <%= icon_tag "language" %>
+                        <span class="mx-2 text-b2 uppercase"><%= I18n.locale %></span>
+                      </span>
+                      <%= icon_tag "keyboard-arrow-down", class:"transition-transform transform", data: { reveal_target: "toggle" } %>
+                    </button>
+
+                    <% I18n.available_locales.each do |language| %>
+                      <%= link_to I18n.t(:locale_name, locale: language), locale_switch_path(language), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-nowrap" %>
+                    <% end %>
+                  </div>
                 </nav>
               </div>
             </dialog>

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,9 @@ module Gemcutter
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
 
+    require_relative "../lib/gemcutter/middleware/locale_from_path"
     require_relative '../lib/gemcutter/middleware/admin_auth'
+    config.middleware.use ::Gemcutter::Middleware::LocaleFromPath
     config.middleware.use ::Gemcutter::Middleware::AdminAuth
 
     config.active_record.include_root_in_json = false

--- a/lib/gemcutter/middleware/locale_from_path.rb
+++ b/lib/gemcutter/middleware/locale_from_path.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Gemcutter::Middleware
+  class LocaleFromPath
+    ENV_KEY = "rubygems.locale"
+    ORIGINAL_PATH_INFO_KEY = "rubygems.original_path_info"
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      path_info = env["PATH_INFO"].to_s
+      query_locale_path, query_string = extract_query_locale_path_from(path_info, env["QUERY_STRING"].to_s)
+
+      return redirect_to(query_locale_path, query_string) if query_locale_path
+
+      default_locale_path = extract_default_locale_path_from(path_info)
+
+      return redirect_to(default_locale_path, env["QUERY_STRING"]) if default_locale_path
+
+      locale, remainder = extract_locale_from(path_info)
+
+      return @app.call(env) unless locale
+
+      env[ENV_KEY] = locale
+      env[ORIGINAL_PATH_INFO_KEY] = path_info
+
+      env["SCRIPT_NAME"] = "/#{locale}"
+      env["PATH_INFO"] = remainder
+
+      @app.call(env)
+    end
+
+    private
+
+    def extract_query_locale_path_from(path_info, query_string)
+      query_params = Rack::Utils.parse_nested_query(query_string)
+      return unless query_params.key?("locale")
+
+      locale = query_params.delete("locale").to_s
+      path = query_locale_path(locale, path_info)
+
+      [path, query_params.to_query]
+    end
+
+    def query_locale_path(locale, path_info)
+      path = path_without_locale_prefix(path_info)
+      return path if locale == I18n.default_locale.to_s
+      return locale_path(locale, path) if non_default_locales.include?(locale)
+
+      path_info
+    end
+
+    def path_without_locale_prefix(path_info)
+      extract_default_locale_path_from(path_info) || extract_locale_from(path_info)&.second || path_info
+    end
+
+    def locale_path(locale, path)
+      path == "/" ? "/#{locale}" : "/#{locale}#{path}"
+    end
+
+    def extract_default_locale_path_from(path_info)
+      match = path_info.match(default_locale_path_pattern)
+      return unless match
+
+      match[:remainder].presence || "/"
+    end
+
+    def extract_locale_from(path_info)
+      match = path_info.match(locale_path_pattern)
+      return unless match
+
+      locale = match[:locale]
+      remainder = match[:remainder].presence || "/"
+
+      [locale, remainder]
+    end
+
+    def default_locale_path_pattern
+      @default_locale_path_pattern ||= %r{\A/#{Regexp.escape(I18n.default_locale.to_s)}(?<remainder>/.*)?\z}
+    end
+
+    def locale_path_pattern
+      @locale_path_pattern ||= begin
+        locales = non_default_locales.map { |locale| Regexp.escape(locale) }.join("|")
+        %r{\A/(?<locale>#{locales})(?<remainder>/.*)?\z}
+      end
+    end
+
+    def non_default_locales
+      I18n.available_locales.map(&:to_s) - [I18n.default_locale.to_s]
+    end
+
+    def redirect_to(path, query_string)
+      location = path
+      location = "#{location}?#{query_string}" if query_string.present?
+
+      [301, { "Location" => location }, []]
+    end
+  end
+end

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -30,29 +30,19 @@ class GemsTest < ActionDispatch::IntegrationTest
     assert page.has_content? "sandworm"
   end
 
-  test "canonical/alternate urls for gem points to most recent version" do
-    skip "locales temporarily disabled"
-
+  test "canonical url for gem points to most recent version" do
     base_url = "http://localhost/gems/sandworm/versions/1.1.1"
     create(:version, rubygem: @rubygem, number: "1.1.1")
     get rubygem_path(@rubygem.slug)
     css = %(link[rel="canonical"][href="#{base_url}"])
 
     assert page.has_css?(css, visible: false)
-    css = %(link[rel="alternate"][hreflang])
-    alternates = page.all(:css, css, visible: false)
-    # I18n.available_locales.length + 1 (x-default)
-    assert_equal (I18n.available_locales.length + 1), alternates.length
-    exp = I18n.available_locales.map { "#{base_url}?locale=#{it}" } << base_url
-    act = alternates.pluck(:href)
-
-    assert_same_elements exp, act
   end
 
-  test "canonical locale urls for gem points to most recent version without locale" do
+  test "canonical locale urls for gem points to most recent version with locale path" do
     create(:version, rubygem: @rubygem, number: "1.1.1")
-    get rubygem_path(@rubygem.slug, locale: "en")
-    css = %(link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.1.1"])
+    get "/de/gems/#{@rubygem.slug}"
+    css = %(link[rel="canonical"][href="http://localhost/de/gems/sandworm/versions/1.1.1"])
 
     assert page.has_css?(css, visible: false)
   end

--- a/test/middleware/locale_from_path_test.rb
+++ b/test/middleware/locale_from_path_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocaleFromPathTest < ActiveSupport::TestCase
+  setup do
+    @captured_env = nil
+    @app = lambda do |env|
+      @captured_env = env.dup
+      [200, {}, ["ok"]]
+    end
+    @middleware = Gemcutter::Middleware::LocaleFromPath.new(@app)
+  end
+
+  test "extracts a non-default locale from the path" do
+    status, _headers, body = @middleware.call("PATH_INFO" => "/fr/gems/rails", "SCRIPT_NAME" => "")
+
+    assert_equal 200, status
+    assert_equal ["ok"], body
+    assert_equal "fr", @captured_env["rubygems.locale"]
+    assert_equal "/fr", @captured_env["SCRIPT_NAME"]
+    assert_equal "/gems/rails", @captured_env["PATH_INFO"]
+  end
+
+  test "leaves paths without locales untouched" do
+    status, _headers, body = @middleware.call("PATH_INFO" => "/gems/rails", "SCRIPT_NAME" => "")
+
+    assert_equal 200, status
+    assert_equal ["ok"], body
+    assert_nil @captured_env["rubygems.locale"]
+    assert_equal "", @captured_env["SCRIPT_NAME"]
+    assert_equal "/gems/rails", @captured_env["PATH_INFO"]
+  end
+
+  test "redirects locale query params to locale paths" do
+    status, headers, body = @middleware.call("PATH_INFO" => "/search", "QUERY_STRING" => "query=rails&locale=de", "SCRIPT_NAME" => "")
+
+    assert_equal 301, status
+    assert_equal "/de/search?query=rails", headers["Location"]
+    assert_equal [], body
+    assert_nil @captured_env
+  end
+
+  test "redirects default-locale query params to unprefixed paths" do
+    status, headers, body = @middleware.call("PATH_INFO" => "/de/search", "QUERY_STRING" => "query=rails&locale=en", "SCRIPT_NAME" => "")
+
+    assert_equal 301, status
+    assert_equal "/search?query=rails", headers["Location"]
+    assert_equal [], body
+    assert_nil @captured_env
+  end
+
+  test "removes unsupported locale query params without changing the path locale" do
+    status, headers, body = @middleware.call("PATH_INFO" => "/de/search", "QUERY_STRING" => "query=rails&locale=wat", "SCRIPT_NAME" => "")
+
+    assert_equal 301, status
+    assert_equal "/de/search?query=rails", headers["Location"]
+    assert_equal [], body
+    assert_nil @captured_env
+  end
+
+  test "redirects default-locale paths to unprefixed paths" do
+    status, headers, body = @middleware.call("PATH_INFO" => "/en/pages/about", "QUERY_STRING" => "page=1", "SCRIPT_NAME" => "")
+
+    assert_equal 301, status
+    assert_equal "/pages/about?page=1", headers["Location"]
+    assert_equal [], body
+    assert_nil @captured_env
+  end
+
+  test "redirects the default-locale root to the unprefixed root" do
+    status, headers, body = @middleware.call("PATH_INFO" => "/en", "SCRIPT_NAME" => "")
+
+    assert_equal 301, status
+    assert_equal "/", headers["Location"]
+    assert_equal [], body
+    assert_nil @captured_env
+  end
+end

--- a/test/system/locale_test.rb
+++ b/test/system/locale_test.rb
@@ -4,17 +4,22 @@ require "application_system_test_case"
 
 class LocaleTest < ApplicationSystemTestCase
   test "html lang attribute is set from locale" do
-    skip "locales temporarily disabled"
     I18n.available_locales.each do |locale|
-      visit root_path(locale: locale)
+      visit locale == I18n.default_locale ? root_path : "/#{locale}"
 
       assert_equal locale.to_s, page.find("html")[:lang]
     end
   end
 
-  test "locale is switched via locale menu" do
-    skip "locales temporarily disabled"
+  test "links generated during a localized request keep the locale prefix" do
+    visit "/de/pages/about"
 
+    assert_equal "de", page.find("html")[:lang]
+    assert page.has_link?(I18n.t("layouts.application.footer.about", locale: :de), href: "/de/pages/about")
+    assert page.has_link?(I18n.t("layouts.application.footer.security", locale: :de), href: "/de/pages/security")
+  end
+
+  test "locale is switched via locale menu" do
     visit root_path
 
     assert_equal I18n.default_locale.to_s, page.find("html")[:lang]
@@ -22,5 +27,15 @@ class LocaleTest < ApplicationSystemTestCase
     click_link "Deutsch"
 
     assert_equal "de", page.find("html")[:lang]
+    assert_current_path "/de"
+  end
+
+  test "locale menu preserves query params except stale locale params" do
+    visit "/search?query=rails&locale=fr"
+
+    click_link "Deutsch"
+
+    assert_equal "de", page.find("html")[:lang]
+    assert_current_path "/de/search?query=rails"
   end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -4,10 +4,8 @@ require "application_system_test_case"
 
 class PagesTest < ApplicationSystemTestCase
   test "renders /pages/about for all supported languages" do
-    skip "locales temporarily disabled"
-
     I18n.available_locales.each do |locale|
-      visit "/pages/about?locale=#{locale}"
+      visit locale == I18n.default_locale ? "/pages/about" : "/#{locale}/pages/about"
 
       assert_text I18n.t("pages.about.title", locale: locale)
     end
@@ -49,5 +47,12 @@ class PagesTest < ApplicationSystemTestCase
 
     assert_current_path "/pages/supporters"
     assert_text("Supporters")
+  end
+
+  test "redirects default locale path to unprefixed path" do
+    visit "/en/pages/about"
+
+    assert_current_path "/pages/about"
+    assert_text I18n.t("pages.about.title", locale: :en)
   end
 end


### PR DESCRIPTION
## TLDR

This PR offers a solution for URL-based locale handling via middleware.

## Background

This PR addresses: https://github.com/rubygems/rubygems.org/issues/6400#issue-4214998580

rubygems.org supports 9 languages, but locale switching was temporarily disabled in #6399 to address a bot abuse incident. Bots were exploiting the locale system (appending locale strings to URLs) to bypass Fastly's CDN cache entirely and hit the Rails origin directly, causing repeated application crashes.

The previous implementation also stored locale in session cookies in `session[:locale]` and read it from `params[:locale]` query parameters, meaning the same URL (`/gems/rails`) could return different content depending on user state. This made thorough CDN caching effectively impossible, since the cache couldn't treat any URL as a stable, language-specific resource.

## Approach Details

With this approach:

- requests to non-default locale paths are intercepted in middleware
- the locale is extracted from the path and stored in the request env
- `PATH_INFO` / `SCRIPT_NAME` are rewritten so Rails can continue routing against the existing unscoped routes
- `ApplicationController` sets `I18n.locale` from the middleware-provided value
- existing path helpers continue to generate locale-prefixed links during localized requests
- the locale switcher is reintroduced using helper logic that rewrites the current path for the selected locale

## Why this approach

One of the main motivations here was to avoid helper churn.

Because the middleware rewrites the request before Rails routing runs, most existing helpers can stay as they are:

```ruby
page_path("about")
rubygem_path("rails")
stats_path
```

During a localized request like `/de/pages/about`, those helpers still generate `/de/...` links because `SCRIPT_NAME` is set by the middleware.

## UI Changes

Re-introduced locale switchers:

<img width="954" height="129" alt="image" src="https://github.com/user-attachments/assets/efcabdb3-ac5b-4766-8897-ec289cd2674f" />

<img width="266" height="466" alt="image" src="https://github.com/user-attachments/assets/e42ee30a-e766-4646-ac18-8eaa196a2e24" />

<img width="326" height="478" alt="image" src="https://github.com/user-attachments/assets/d87386b8-2554-4299-bab2-ae32931a9e2a" />

## Alternative Considered: Scoped Routes

The other option is to put locale into the route definitions directly, for example:

```ruby
scope "(:locale)", locale: /en|de|fr/ do
  resources :gems, controller: :rubygems, only: :show
  get "/pages/:id", to: "pages#show", as: :page
end
```

That is a more "Rails-native" approach, and we could pivot to it if that feels preferable.

The main tradeoff with scoped routes is helper churn. The problem is that many existing route helpers currently rely on positional arguments, and once `locale` becomes part of the route those calls become ambiguous. In practice, helpers like `page_path("about")` and `rubygem_path("rails")` often need to become `page_path(id: "about")` and `rubygem_path(id: "rails")`, with similar changes across the app and this approach needing to be adopted by contributors going forward.

So the tradeoff as I see it is:

- middleware approach: more custom request/path handling, less helper churn
- scoped-routes approach: more conventional routing, but more widespread outbound URL updates

## Changes Included Here

- added `Gemcutter::Middleware::LocaleFromPath`
- re-enabled locale setting in `ApplicationController`
- added `locale_switch_path` helper for locale menu links
- reintroduced locale switcher UI in the layouts
- added middleware and system test coverage for localized requests and locale switching

## Notes / Feedback Requested

I wanted to put up the middleware version first because it keeps the rest of the app much closer to its current shape.

That said, as explained above I think there are two viable directions here:

1. keep the middleware-based approach
2. pivot to scoped routes and accept the helper changes

I’d especially welcome feedback on whether the team would prefer:
- a smaller-touch but more custom middleware solution, or
- a more conventional routing solution with broader helper updates

## Testing

```bash
bin/rails test test/middleware/locale_from_path_test.rb
bin/rails test test/system/locale_test.rb
bin/rubocop \
  lib/gemcutter/middleware/locale_from_path.rb \
  test/middleware/locale_from_path_test.rb \
  test/system/locale_test.rb \
  app/helpers/application_helper.rb \
  app/controllers/application_controller.rb
```