### PR TITLE
Bump bundler from 4.0.8 to 4.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1379,4 +1379,4 @@ RUBY VERSION
   ruby 4.0.2
 
 BUNDLED WITH
-  4.0.8
+  4.0.10


### PR DESCRIPTION
Simply proposing we bump bundler from 4.0.8 to 4.0.10 (latest) ~and bump a few other gems while we're at it~. :rocket: 