### PR TITLE
Fix CSRF rejection when registering a WebAuthN security device

### DIFF
--- a/app/javascript/src/webauthn.js
+++ b/app/javascript/src/webauthn.js
@@ -104,6 +104,7 @@ import { bufferToBase64url, base64urlToBuffer } from "webauthn-json";
       ".js-new-webauthn-credential--submit",
     );
     const csrfToken = getCsrfToken(credentialForm);
+    const callbackCsrfToken = credentialForm.dataset.callbackCsrfToken;
 
     credentialForm.addEventListener("submit", function (event) {
       const form = handleEvent(event);
@@ -130,7 +131,7 @@ import { bufferToBase64url, base64urlToBuffer } from "webauthn-json";
             method: "POST",
             credentials: "same-origin",
             headers: {
-              "X-CSRF-Token": csrfToken,
+              "X-CSRF-Token": callbackCsrfToken,
               "Content-Type": "application/json",
               Accept: "application/json",
             },

--- a/app/javascript/src/webauthn.js
+++ b/app/javascript/src/webauthn.js
@@ -112,10 +112,10 @@ import { bufferToBase64url, base64urlToBuffer } from "webauthn-json";
       );
       const nickname = nicknameInput ? nicknameInput.value : "";
 
-      fetch(form.action + ".json", {
+      fetch(form.action, {
         method: "POST",
         credentials: "same-origin",
-        headers: { "X-CSRF-Token": csrfToken },
+        headers: { "X-CSRF-Token": csrfToken, Accept: "application/json" },
       })
         .then(function (response) {
           return response.json();
@@ -126,12 +126,13 @@ import { bufferToBase64url, base64urlToBuffer } from "webauthn-json";
           });
         })
         .then(function (credentials) {
-          return fetch(form.action + "/callback.json", {
+          return fetch(form.action + "/callback", {
             method: "POST",
             credentials: "same-origin",
             headers: {
               "X-CSRF-Token": csrfToken,
               "Content-Type": "application/json",
+              Accept: "application/json",
             },
             body: JSON.stringify({
               credentials: credentialsToBase64(credentials),

--- a/app/views/webauthn_credentials/_form.html.erb
+++ b/app/views/webauthn_credentials/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form" }, authenticity_token: form_authenticity_token do |f| %>
+<% callback_csrf_token = form_authenticity_token(form_options: { action: callback_webauthn_credentials_path, method: "post" }) %>
+<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form", data: { callback_csrf_token: callback_csrf_token } } do |f| %>
   <h3><%= t('.new_device') %></h3>
   <div class="text_field">
     <%= f.label :nickname, t('.nickname'), class: 'form__label' %>

--- a/app/views/webauthn_credentials/_form.html.erb
+++ b/app/views/webauthn_credentials/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form" } do |f| %>
+<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form" }, authenticity_token: form_authenticity_token do |f| %>
   <h3><%= t('.new_device') %></h3>
   <div class="text_field">
     <%= f.label :nickname, t('.nickname'), class: 'form__label' %>

--- a/test/system/webauthn_credentials_test.rb
+++ b/test/system/webauthn_credentials_test.rb
@@ -7,6 +7,14 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
 
   setup do
     @user = create(:user)
+    # Forgery protection is disabled in the test env by default; enable it here
+    # so this suite catches CSRF regressions in the JS-driven webauthn flows.
+    @original_allow_forgery_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @original_allow_forgery_protection
   end
 
   should "have security device form" do


### PR DESCRIPTION
Registering a security device on `/settings/edit` is broken in production: #6385 changed how the WebAuthn JS reads the CSRF token, and the new approach didn't work for the URLs the JS actually posts to. The form now renders a CSRF token that's valid across those URLs, and the system test runs with forgery protection enabled so this kind of regression fails loudly in CI next time.

Fixes #6431