### PR TITLE
Replace Selenium WebDriver with Playwright for system tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,9 +20,9 @@
   ],
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "bin/setup --skip-server",
+  "onCreateCommand": "bin/setup",
   // Use 'updateContentCommand' to run commands when the container is updated.
-  "updateContentCommand": "bin/setup --skip-server",
+  "updateContentCommand": "bin/setup",
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,7 @@
     "db",
     "cache",
     "search",
-    "toxiproxy",
-    "selenium"
+    "toxiproxy"
   ],
   "forwardPorts": [
     3000, // Rails
@@ -21,14 +20,15 @@
   ],
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "bin/setup",
+  "onCreateCommand": "bin/setup --skip-server",
   // Use 'updateContentCommand' to run commands when the container is updated.
-  "updateContentCommand": "bin/setup",
+  "updateContentCommand": "bin/setup --skip-server",
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     // "ghcr.io/rails/devcontainer/features/activestorage": {},
     "ghcr.io/rails/devcontainer/features/postgres-client": {},
+    "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers-extra/features/apt-packages:1": {
       "packages": [
         "pkg-config"
@@ -40,7 +40,6 @@
     "EDITOR": "code --wait",
     "GIT_EDITOR": "code --wait",
     "CAPYBARA_SERVER_PORT": "31337",
-    "SELENIUM_HOST": "selenium",
     "ELASTICSEARCH_URL": "http://search:9200",
     "DATABASE_URL": "postgres://postgres@db:5432",
     "DEVCONTAINER_APP_HOST": "http://rails-app",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,8 +9,10 @@ services:
     depends_on:
       - search
       - db
-      - selenium
 
-  selenium:
-    image: selenium/standalone-chromium
-    restart: unless-stopped
+  # Codespaces' kernel does not allow raising vm.max_map_count, which
+  # OpenSearch needs to use mmap-backed index storage. Fall back to NIO so
+  # the search container can boot. Local dev and CI keep the default (mmap).
+  search:
+    environment:
+      - "node.store.allow_mmap=false"

--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Install Avo gem"
     required: false
     default: "true"
+  install-playwright:
+    description: "Install Playwright browsers (only needed for system tests)"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -31,6 +35,10 @@ runs:
     - name: Print bundle environment
       shell: bash
       run: bundle env
+    - name: Install Playwright browsers
+      if: inputs.install-playwright == 'true'
+      shell: bash
+      run: bin/playwright install --with-deps chromium
     - name: Prepare environment
       shell: bash
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           ruby-version: .ruby-version
           rubygems-version: ${{ env.RUBYGEMS_VERSION }}
           install-avo-pro: ${{ matrix.tests.id != 'avo-without-pro' }}
+          install-playwright: ${{ matrix.tests.id != 'general' }}
 
       - name: Tests ${{ matrix.tests.name }}
         id: test-all

--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,7 @@ group :test do
   gem "mocha", "~> 3.1", require: false
   gem "shoulda-context", "~> 3.0.0.rc1"
   gem "shoulda-matchers", "~> 7.0"
-  gem "selenium-webdriver", "~> 4.44"
+  gem "capybara-playwright-driver", "~> 0.5"
   gem "webmock", "~> 3.26"
   gem "simplecov", "~> 0.22", require: false
   gem "simplecov-cobertura", "~> 3.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-playwright-driver (0.5.9)
+      addressable
+      capybara
+      playwright-ruby-client (>= 1.16.0)
     cbor (0.5.10.1)
     cgi (0.5.1)
     chartkick (5.2.1)
@@ -469,6 +473,10 @@ GEM
     memory_profiler (1.1.0)
     meta-tags (2.23.0)
       actionpack (>= 6.0.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -590,6 +598,10 @@ GEM
       phlex (~> 2.4.0)
       railties (>= 7.1, < 9)
       zeitwerk (~> 2.7)
+    playwright-ruby-client (1.60.0)
+      base64
+      concurrent-ruby (>= 1.1.6)
+      mime-types (>= 3.0)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -771,7 +783,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-statistics (4.0.1)
     ruby2_keywords (0.0.5)
-    rubyzip (3.3.0)
     safely_block (1.0.0)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
@@ -784,12 +795,6 @@ GEM
     searchkick (6.1.1)
       activemodel (>= 7.2)
     securerandom (0.4.1)
-    selenium-webdriver (4.44.0)
-      base64 (~> 0.2)
-      logger (~> 1.4)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 4.0)
-      websocket (~> 1.0)
     semantic_logger (4.18.0)
       concurrent-ruby (~> 1.0)
     shoryuken (7.0.2)
@@ -884,7 +889,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -924,6 +928,7 @@ DEPENDENCIES
   brakeman (~> 8.0)
   browser (~> 6.2)
   capybara (~> 3.40)
+  capybara-playwright-driver (~> 0.5)
   chartkick (~> 5.2)
   clearance (~> 2.12)
   csv (~> 3.3)
@@ -1011,7 +1016,6 @@ DEPENDENCIES
   rubocop-rails (~> 2.34)
   ruby-magic (~> 0.6)
   searchkick (~> 6.1)
-  selenium-webdriver (~> 4.44)
   shoryuken (~> 7.0)
   shoulda-context (~> 3.0.0.rc1)
   shoulda-matchers (~> 7.0)
@@ -1082,6 +1086,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  capybara-playwright-driver (0.5.9) sha256=4c17fed20817b7e1bde2cfc8186e7bf5cd72017ce1aa695e35130f8e600e7282
   cbor (0.5.10.1) sha256=79cdf79f18dcd9ee97e0b849c6d573e5a2e3ddc1954d180f384d6ed2612b6df0
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
@@ -1200,6 +1205,8 @@ CHECKSUMS
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8
   meta-tags (2.23.0) sha256=ffe78b5bee398de4ff5ac3316f5a786049538a651643b8476def06c3acc762c1
+  mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_histogram (0.3.1) sha256=6a114b504e4618b0e076cc672996036870f7cc6f16b8e5c25c0c637726d2dd94
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
@@ -1253,6 +1260,7 @@ CHECKSUMS
   pghero (3.8.0) sha256=f6fda87a095c2bd153954cb895366a3ffc4c8f7785b2b9234a5dbd1cbcabb360
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
+  playwright-ruby-client (1.60.0) sha256=942242d6130e797b21213d9c49dc09d31235cab429a9edae73401ed112c94853
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
@@ -1317,14 +1325,12 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-statistics (4.0.1) sha256=aede68e6261b979431b31ba39aa661844c18f97a89966768cb60edf2a56b6782
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
-  rubyzip (3.3.0) sha256=a372fc67892a4f8c0bc8ec906b720353d8e48807a64b2e63adf99b1e3583a034
   safely_block (1.0.0) sha256=bea80e084e620adeada62fd98cf461bbb9888d40dc0f06d337df9d01e1a658e5
   safety_net_attestation (0.5.0) sha256=c8cd01dd550dbe8553862918af6355a04672db11d218ec96104ce3955293f2aa
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984
   sawyer (0.9.2) sha256=fa3a72d62a4525517b18857ddb78926aab3424de0129be6772a8e2ba240e7aca
   searchkick (6.1.1) sha256=33607661453f303197814461eaff39df2c70999917bf3985ac3a03fce721dd30
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
   semantic_logger (4.18.0) sha256=b00e4480b63d844628ce383e80d564626fe2fdb525ecf378dbc4df7828dead8b
   shoryuken (7.0.2) sha256=10bc249f72d0ea67f434cc6a13dabbe12cc806030ec04023f1b2035279ee06bf
   shoulda-context (3.0.0.rc1) sha256=6e0d9d52ab798c13bc2b490c8537d4bf30cfd318a1ea839c39a66d1d293c6a1a
@@ -1367,7 +1373,6 @@ CHECKSUMS
   webauthn (3.4.3) sha256=9be6f5f838f3405b0226e560aa40b67cc8c15ec9154509b997caa7ec9a05e1fc
   webfinger (2.1.3) sha256=567a52bde77fb38ca6b67e55db755f988766ec4651c1d24916a65aa70540695c
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
-  websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xml-simple (1.1.9) sha256=d21131e519c86f1a5bc2b6d2d57d46e6998e47f18ed249b25cad86433dbd695d

--- a/bin/playwright
+++ b/bin/playwright
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Pin the Playwright CLI to the version that matches the playwright-ruby-client
+# gem currently in the bundle. The Node-side driver must match the gem exactly,
+# so resolving the version from the gem keeps them in lockstep across bumps.
+
+set -eu
+
+PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')
+
+exec npx --yes "playwright@${PLAYWRIGHT_CLI_VERSION}" "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
+  puts "\n== Installing Playwright browser (used by system tests) =="
+  system! "bin/playwright install chromium"
+
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")
     FileUtils.cp "config/database.yml.sample", "config/database.yml"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,22 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-
-# Workaround for ChromeDriver bug where Turbo Drive DOM replacement causes
-# "Node with given id does not belong to the document" to be raised as a generic
-# UnknownError instead of StaleElementReferenceError. Capybara only retries the
-# latter, so the error crashes the test instead of being retried.
-# See: https://github.com/SeleniumHQ/selenium/issues/15401
-# TODO: Remove when migrating to Playwright (capybara-playwright-driver)
-module ChromeNodeStaleElementPatch
-  def visible?
-    super
-  rescue Selenium::WebDriver::Error::UnknownError => e
-    raise Selenium::WebDriver::Error::StaleElementReferenceError, e.message if e.message.include?("does not belong to the document")
-    raise
-  end
-end
-Capybara::Selenium::ChromeNode.prepend(ChromeNodeStaleElementPatch)
+require "capybara-playwright-driver"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include OauthHelpers
@@ -26,22 +11,32 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     SimpleCov.command_name "system-worker-#{worker}"
   end
 
-  if ENV["CAPYBARA_SERVER_PORT"]
-    served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
+  served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"] if ENV["CAPYBARA_SERVER_PORT"]
 
-    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400], options: {
-      browser: :remote,
-      url: "http://#{ENV['SELENIUM_HOST']}:4444"
-    }
-  else
-    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
-  end
+  # Rails' driven_by registers the :playwright Capybara driver itself, so any
+  # standalone Capybara.register_driver block would be overwritten. Pass the
+  # Capybara::Playwright::Driver options through `options:` instead — that's
+  # what gets forwarded to the driver constructor.
+  driven_by :playwright, screen_size: [1400, 1400], options: {
+    playwright_cli_executable_path: File.expand_path("../bin/playwright", __dir__),
+    browser_type: :chromium,
+    headless: true
+  }
 
   teardown do
-    # Clear Chrome's HTTP cache between tests to prevent stale responses.
-    # Pages with Cache-Control: public headers are cached by the browser,
-    # causing subsequent tests to see stale content when visiting the same URL.
-    page.driver.browser.execute_cdp("Network.clearBrowserCache") if page.driver.browser.respond_to?(:execute_cdp)
+    if page.driver.respond_to?(:with_playwright_page)
+      page.driver.with_playwright_page do |pw_page|
+        pw_page.context.clear_cookies
+        # Clear HTTP cache between tests to prevent stale responses.
+        # Pages with Cache-Control: public headers are cached by the browser,
+        # causing subsequent tests to see stale content when visiting the same URL.
+        cdp = pw_page.context.new_cdp_session(pw_page)
+        cdp.send_message("Network.clearBrowserCache")
+        cdp.detach
+      rescue Playwright::TargetClosedError
+        # Browser already closed
+      end
+    end
   end
 
   def sign_in(user = nil)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -24,18 +24,25 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   }
 
   teardown do
-    if page.driver.respond_to?(:with_playwright_page)
-      page.driver.with_playwright_page do |pw_page|
-        pw_page.context.clear_cookies
-        # Clear HTTP cache between tests to prevent stale responses.
-        # Pages with Cache-Control: public headers are cached by the browser,
-        # causing subsequent tests to see stale content when visiting the same URL.
-        cdp = pw_page.context.new_cdp_session(pw_page)
-        cdp.send_message("Network.clearBrowserCache")
-        cdp.detach
-      rescue Playwright::TargetClosedError
-        # Browser already closed
-      end
+    clear_browser_cache(clear_cookies: true)
+  end
+
+  # Clear the browser's HTTP cache, and optionally its cookies. Pages served with
+  # `Cache-Control: public` headers are cached by the browser, so a later visit to
+  # the same URL can return stale content; clearing the cache between (or within)
+  # tests prevents that. Cookies are cleared in teardown to isolate sessions
+  # between tests, but callers that need to bust the cache mid-test should leave
+  # them intact. Safe to call when the browser may have already closed.
+  def clear_browser_cache(clear_cookies: false)
+    return unless page.driver.respond_to?(:with_playwright_page)
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.context.clear_cookies if clear_cookies
+      cdp = pw_page.context.new_cdp_session(pw_page)
+      cdp.send_message("Network.clearBrowserCache")
+      cdp.detach
+    rescue Playwright::TargetClosedError
+      # Browser already closed
     end
   end
 

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -326,9 +326,9 @@ class ApiKeysTest < ApplicationSystemTestCase
     api_key = create(:api_key, owner: @user)
 
     visit_profile_api_keys_path
-    click_button "Delete"
-
-    page.accept_alert
+    accept_alert do
+      click_button "Delete"
+    end
 
     assert_text "New API key"
     page.assert_text "Successfully deleted API key: #{api_key.name}"
@@ -341,9 +341,9 @@ class ApiKeysTest < ApplicationSystemTestCase
     api_key = create(:api_key, owner: @user)
 
     visit_profile_api_keys_path
-    click_button "Reset"
-
-    page.accept_alert
+    accept_alert do
+      click_button "Reset"
+    end
 
     assert_text "New API key"
     page.assert_no_text api_key.name

--- a/test/system/autocompletes_test.rb
+++ b/test/system/autocompletes_test.rb
@@ -32,9 +32,9 @@ class AutocompletesTest < ApplicationSystemTestCase
   end
 
   test "selected field is only one with arrow key selecting" do
-    @fill_field.native.send_keys :down
+    @fill_field.send_keys :down
     find ".selected"
-    @fill_field.native.send_keys :down
+    @fill_field.send_keys :down
 
     assert_selector ".selected", count: 1
   end
@@ -52,25 +52,25 @@ class AutocompletesTest < ApplicationSystemTestCase
   end
 
   test "down arrow key to choose suggestion" do
-    @fill_field.native.send_keys :down
+    @fill_field.send_keys :down
 
     assert page.has_no_field? "query", with: "rubo"
   end
 
   test "up arrow key to choose suggestion" do
-    @fill_field.native.send_keys :up
+    @fill_field.send_keys :up
 
     assert page.has_no_field? "query", with: "rubo"
   end
 
   test "down arrow key should loop" do
-    @fill_field.native.send_keys :down, :down, :down, :down
+    @fill_field.send_keys :down, :down, :down, :down
 
     assert_selector ".suggest-list .menu-item:last-child.selected"
   end
 
   test "up arrow key should loop" do
-    @fill_field.native.send_keys :up, :up, :up, :up
+    @fill_field.send_keys :up, :up, :up, :up
 
     assert_selector ".suggest-list .menu-item:first-child.selected"
   end

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -23,13 +23,19 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Reset User 2FA"
 
-    assert_no_changes "User.find(#{user.id}).attributes" do
-      click_button "Reset MFA"
+    within("[role='dialog']") do
+      assert_no_changes "User.find(#{user.id}).attributes" do
+        click_button "Reset MFA"
+      end
     end
     page.assert_text "Must supply a sufficiently detailed comment"
 
-    fill_in "Comment", with: "A nice long comment"
-    click_button "Reset MFA"
+    within("[role='dialog']") do
+      fill_in "Comment", with: "A nice long comment"
+
+      assert_field "Comment", with: "A nice long comment"
+      click_button "Reset MFA"
+    end
 
     page.assert_text "Action ran successfully!"
     page.assert_text user.to_global_id.uri.to_s
@@ -102,13 +108,19 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Block User"
 
-    assert_no_changes "User.find(#{user.id}).attributes" do
-      click_button "Block User"
+    within("[role='dialog']") do
+      assert_no_changes "User.find(#{user.id}).attributes" do
+        click_button "Block User"
+      end
     end
     page.assert_text "Must supply a sufficiently detailed comment"
 
-    fill_in "Comment", with: "A nice long comment"
-    click_button "Block User"
+    within("[role='dialog']") do
+      fill_in "Comment", with: "A nice long comment"
+
+      assert_field "Comment", with: "A nice long comment"
+      click_button "Block User"
+    end
 
     page.assert_text "Action ran successfully!"
     page.assert_text user.to_global_id.uri.to_s
@@ -200,14 +212,20 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
       click_button "Actions"
       click_on "Reset Api Key"
 
-      assert_no_changes "User.find(#{user.id}).attributes" do
-        click_button "Reset Api Key"
+      within("[role='dialog']") do
+        assert_no_changes "User.find(#{user.id}).attributes" do
+          click_button "Reset Api Key"
+        end
       end
       page.assert_text "Must supply a sufficiently detailed comment"
 
-      fill_in "Comment", with: "A nice long comment"
-      select("Public Gem", from: "Template")
-      click_button "Reset Api Key"
+      within("[role='dialog']") do
+        fill_in "Comment", with: "A nice long comment"
+
+        assert_field "Comment", with: "A nice long comment"
+        select("Public Gem", from: "Template")
+        click_button "Reset Api Key"
+      end
 
       page.assert_text "Action ran successfully!"
 
@@ -278,15 +296,23 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Yank all Rubygems"
 
-    assert_no_changes "User.find(#{user.id}).attributes" do
-      click_button "Yank all Rubygems"
+    within("[role='dialog']") do
+      assert_no_changes "User.find(#{user.id}).attributes" do
+        click_button "Yank all Rubygems"
+      end
     end
     page.assert_text "Must supply a sufficiently detailed comment"
 
-    fill_in "Comment", with: "A nice long comment"
+    within("[role='dialog']") do
+      fill_in "Comment", with: "A nice long comment"
+
+      assert_field "Comment", with: "A nice long comment"
+    end
 
     assert_enqueued_jobs 1, only: YankRubygemsForUserJob do
-      click_button "Yank all Rubygems"
+      within("[role='dialog']") do
+        click_button "Yank all Rubygems"
+      end
 
       page.assert_text "Yanking all rubygems for #{user.handle} has been scheduled"
     end
@@ -333,15 +359,23 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Yank User"
 
-    assert_no_changes "User.find(#{user.id}).attributes" do
-      click_button "Yank User"
+    within("[role='dialog']") do
+      assert_no_changes "User.find(#{user.id}).attributes" do
+        click_button "Yank User"
+      end
     end
     page.assert_text "Must supply a sufficiently detailed comment"
 
-    fill_in "Comment", with: "A nice long comment"
+    within("[role='dialog']") do
+      fill_in "Comment", with: "A nice long comment"
+
+      assert_field "Comment", with: "A nice long comment"
+    end
 
     assert_enqueued_jobs 1, only: YankRubygemsForUserJob do
-      click_button "Yank User"
+      within("[role='dialog']") do
+        click_button "Yank User"
+      end
 
       page.assert_text "Action ran successfully!"
     end
@@ -437,14 +471,20 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
       click_button "Actions"
       click_on "Change User Email"
 
-      assert_no_changes "User.find(#{user.id}).attributes" do
-        click_button "Change User Email"
+      within("[role='dialog']") do
+        assert_no_changes "User.find(#{user.id}).attributes" do
+          click_button "Change User Email"
+        end
       end
       page.assert_text "Must supply a sufficiently detailed comment"
 
-      fill_in "Comment", with: "A nice long comment"
-      fill_in "Email", with: "gem-maintainer-001@rubygems-test.org"
-      click_button "Change User Email"
+      within("[role='dialog']") do
+        fill_in "Comment", with: "A nice long comment"
+
+        assert_field "Comment", with: "A nice long comment"
+        fill_in "Email", with: "gem-maintainer-001@rubygems-test.org"
+        click_button "Change User Email"
+      end
 
       page.assert_text "Action ran successfully!"
 
@@ -513,14 +553,20 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Create User"
 
-    assert_no_changes "User.count" do
-      click_button "Create User"
+    within("[role='dialog']") do
+      assert_no_changes "User.count" do
+        click_button "Create User"
+      end
     end
     page.assert_text "Must supply a sufficiently detailed comment"
 
-    fill_in "Comment", with: "A nice long comment"
-    fill_in "Email", with: "gem-user-001@rubygems-test.org"
-    click_button "Create User"
+    within("[role='dialog']") do
+      fill_in "Comment", with: "A nice long comment"
+
+      assert_field "Comment", with: "A nice long comment"
+      fill_in "Email", with: "gem-user-001@rubygems-test.org"
+      click_button "Create User"
+    end
 
     page.assert_text "Action ran successfully!"
     perform_enqueued_jobs

--- a/test/system/email_confirmation_test.rb
+++ b/test/system/email_confirmation_test.rb
@@ -47,11 +47,7 @@ class EmailConfirmationTest < ApplicationSystemTestCase
     assert_text "Sign in"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
 
-    page.driver.with_playwright_page do |pw_page|
-      cdp = pw_page.context.new_cdp_session(pw_page)
-      cdp.send_message("Network.clearBrowserCache")
-      cdp.detach
-    end
+    clear_browser_cache
     visit link
 
     assert page.has_selector? "#flash_alert", text: "Please double check the URL or try submitting it again."

--- a/test/system/email_confirmation_test.rb
+++ b/test/system/email_confirmation_test.rb
@@ -47,6 +47,11 @@ class EmailConfirmationTest < ApplicationSystemTestCase
     assert_text "Sign in"
     assert page.has_selector? "#flash_notice", text: "Your email address has been verified"
 
+    page.driver.with_playwright_page do |pw_page|
+      cdp = pw_page.context.new_cdp_session(pw_page)
+      cdp.send_message("Network.clearBrowserCache")
+      cdp.detach
+    end
     visit link
 
     assert page.has_selector? "#flash_alert", text: "Please double check the URL or try submitting it again."
@@ -143,8 +148,7 @@ class EmailConfirmationTest < ApplicationSystemTestCase
   end
 
   teardown do
-    @authenticator&.remove!
+    disable_virtual_authenticator
     Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/feature_flagging_test.rb
+++ b/test/system/feature_flagging_test.rb
@@ -34,8 +34,9 @@ class FeatureFlaggingTest < ApplicationSystemTestCase
     click_button "Add Feature"
 
     assert_text "my_feature"
+    # Wait for Flipper's DOMContentLoaded JS handlers to be attached before interacting
+    page.driver.with_playwright_page { |pw_page| pw_page.wait_for_load_state(state: "load") }
     click_button "Add an actor"
-
     fill_in "value", with: "user:#{allowed_user.handle}"
     click_button "Add Actor"
 

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -11,9 +11,8 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
 
   teardown do
     @user.disable_totp!
-    @authenticator&.remove!
+    disable_virtual_authenticator
     Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 
   context "cache-control" do
@@ -154,12 +153,12 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     end
 
     should "user with webauthn can change mfa level" do
-      fullscreen_headless_chrome_driver
+      fullscreen_playwright_driver
 
       sign_in
       visit edit_settings_path
 
-      @authenticator = create_webauthn_credential_while_signed_in
+      create_webauthn_credential_while_signed_in
 
       assert_text "UI and gem signin"
 
@@ -247,7 +246,5 @@ class MultifactorAuthsTest < ApplicationSystemTestCase
     click_button "Update"
   end
 
-  def go_back
-    page.evaluate_script("window.history.back()")
-  end
+  delegate :go_back, to: :page
 end

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -153,6 +153,7 @@ class OIDCTest < ApplicationSystemTestCase
 
     click_button "Edit API Key Role"
 
+    page.driver.with_playwright_page { |pw_page| pw_page.wait_for_load_state(state: "load") }
     click_button "Add statement"
 
     statements = page.find_all(id: /oidc_api_key_role_access_policy_statements_attributes_\d+_wrapper/)

--- a/test/system/onboarding_test.rb
+++ b/test/system/onboarding_test.rb
@@ -156,6 +156,7 @@ class OnboardingTest < ApplicationSystemTestCase
     click_button "Confirm"
 
     # headers:               OWNER                STATUS     MFA                         ADDED BY                               ROLE
-    assert_text "#{outside_contributor.handle}\nConfirmed\nDisabled\n#{outside_contributor.ownerships.first.authorizer_name} Maintainer"
+    assert_text "#{outside_contributor.handle} Confirmed Disabled #{outside_contributor.ownerships.first.authorizer_name} Maintainer",
+normalize_ws: true
   end
 end

--- a/test/system/owner_test.rb
+++ b/test/system/owner_test.rb
@@ -339,7 +339,7 @@ class OwnerTest < ApplicationSystemTestCase
   end
 
   teardown do
-    @authenticator&.remove!
+    disable_virtual_authenticator
   end
 
   private

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -328,8 +328,7 @@ class PasswordResetTest < ApplicationSystemTestCase
   end
 
   teardown do
-    @authenticator&.remove!
+    disable_virtual_authenticator
     Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -121,7 +121,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
     click_button "Confirm"
 
     # headers:         OWNER             STATUS     MFA                         ADDED BY                      ROLE
-    assert_text "#{maintainer.handle}\nConfirmed\nDisabled\n#{maintainer.ownerships.first.authorizer_name} Maintainer"
+    assert_text "#{maintainer.handle} Confirmed Disabled #{maintainer.ownerships.first.authorizer_name} Maintainer", normalize_ws: true
   end
 
   test "cancelling a rubygem transfer" do

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -312,6 +312,5 @@ class SignInTest < ApplicationSystemTestCase
 
   teardown do
     Capybara.reset_sessions!
-    Capybara.use_default_driver
   end
 end

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -10,12 +10,11 @@ class SignInWebauthnTest < ApplicationSystemTestCase
                   mfa_level: :ui_only, totp_seed: "thisisonetotpseed",
                   mfa_recovery_codes: @mfa_recovery_codes)
 
-    @authenticator = create_webauthn_credential
+    create_webauthn_credential
   end
 
   teardown do
-    @authenticator&.remove!
-    Capybara.use_default_driver
+    disable_virtual_authenticator
   end
 
   test "sign in with webauthn mfa" do

--- a/test/system/webauthn_credentials_test.rb
+++ b/test/system/webauthn_credentials_test.rb
@@ -54,8 +54,9 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
       assert_no_text "You don't have any security devices"
       assert_text @webauthn_credential.nickname
 
-      click_on "Delete"
-      page.accept_alert
+      accept_alert do
+        click_on "Delete"
+      end
 
       assert_text "You don't have any security devices"
       assert_no_text @webauthn_credential.nickname
@@ -78,8 +79,9 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
       assert_no_text "You don't have any security devices"
       assert_text @webauthn_credential.nickname
 
-      click_on "Delete"
-      page.dismiss_confirm
+      dismiss_confirm do
+        click_on "Delete"
+      end
 
       assert_no_text "You don't have any security devices"
       assert_text @webauthn_credential.nickname
@@ -98,8 +100,7 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
 
     assert_text "You don't have any security devices"
 
-    options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new
-    authenticator = page.driver.browser.add_virtual_authenticator(options)
+    enable_virtual_authenticator
     WebAuthn::PublicKeyCredentialWithAttestation.any_instance.stubs(:verify).returns true
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
@@ -124,6 +125,6 @@ class WebauthnCredentialsTest < ApplicationSystemTestCase
     assert_equal "New security device added on RubyGems.org", webauthn_credential_creation_email.subject
 
     # Cleanup test data
-    authenticator.remove!
+    disable_virtual_authenticator
   end
 end

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -128,14 +128,17 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
   def assert_poll_status(status)
     @api_key ||= create(:api_key, key: "12345", scopes: %i[push_rubygem], owner: @user)
 
-    Capybara.current_driver = :rack_test
-    page.driver.header "AUTHORIZATION", "12345"
+    # Poll the JSON status endpoint via rack_test (authenticated with an API key
+    # header) rather than the browser. using_driver restores the Playwright
+    # driver on block exit, even if the assertion below fails, so the surrounding
+    # browser-driven test can continue.
+    Capybara.using_driver(:rack_test) do
+      page.driver.header "AUTHORIZATION", "12345"
 
-    visit status_api_v1_webauthn_verification_path(webauthn_token: @verification.path_token, format: :json)
+      visit status_api_v1_webauthn_verification_path(webauthn_token: @verification.path_token, format: :json)
 
-    assert_equal status, JSON.parse(page.text)["status"]
-  ensure
-    fullscreen_playwright_driver
+      assert_equal status, JSON.parse(page.text)["status"]
+    end
   end
 
   def assert_successful_verification_not_found

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -113,8 +113,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
 
   def teardown
     @mock_client.kill_server
-    @authenticator&.remove!
-    Capybara.use_default_driver
+    disable_virtual_authenticator
   end
 
   private
@@ -135,7 +134,8 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit status_api_v1_webauthn_verification_path(webauthn_token: @verification.path_token, format: :json)
 
     assert_equal status, JSON.parse(page.text)["status"]
-    fullscreen_headless_chrome_driver
+  ensure
+    fullscreen_playwright_driver
   end
 
   def assert_successful_verification_not_found

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,9 +50,7 @@ Avo::Current.license = Avo::Licensing::LicenseManager.new(Avo::Licensing::HQ.new
 WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: [
-    "chromedriver.storage.googleapis.com",
     "search", # DevContainer services
-    "selenium",
     "rails-app"
   ]
 )
@@ -64,7 +62,7 @@ WebMock.globally_stub_request(:after_local_stubs) do |request|
   end
 end
 
-Capybara.default_max_wait_time = 2
+Capybara.default_max_wait_time = 5
 Capybara.app_host = "#{Gemcutter::PROTOCOL}://#{Gemcutter::HOST}" if ENV["DEVCONTAINER_APP_HOST"].blank?
 Capybara.always_include_port = true
 Capybara.server_port = 31_337
@@ -207,52 +205,40 @@ class ActiveSupport::TestCase
     end
   end
 
-  def headless_chrome_driver
-    Capybara.current_driver = :selenium_chrome_headless
-    Capybara.default_max_wait_time = 2
-    Selenium::WebDriver.logger.level = :error
-  end
-
-  def fullscreen_headless_chrome_driver
-    headless_chrome_driver
-    driver = page.driver
-    fullscreen_width = 1200
-    fullscreen_height = 1000
-    driver.resize_window_to(driver.current_window_handle, fullscreen_width, fullscreen_height)
+  def fullscreen_playwright_driver
+    Capybara.current_driver = :playwright unless Capybara.current_driver == :playwright
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.set_viewport_size(width: 1200, height: 1000)
+    end
   end
 
   def create_webauthn_credential
-    fullscreen_headless_chrome_driver
+    fullscreen_playwright_driver
 
-    visit sign_in_path
+    unless page.has_content?("Dashboard", wait: 0)
+      visit sign_in_path
 
-    assert page.has_content?("Sign in")
+      assert page.has_content?("Sign in")
 
-    fill_in "Email or Username", with: @user.reload.email
-    fill_in "Password", with: @user.password
-    click_button "Sign in"
+      fill_in "Email or Username", with: @user.reload.email
+      fill_in "Password", with: @user.password
+      click_button "Sign in"
 
-    assert page.has_content? "Dashboard"
+      assert page.has_content? "Dashboard"
+    end
 
-    @authenticator = create_webauthn_credential_while_signed_in
+    create_webauthn_credential_while_signed_in
 
     find(:css, ".header__popup-link").click
     click_on "Sign out"
 
     assert page.has_content?("Sign in")
-
-    @authenticator
   end
 
   def create_webauthn_credential_while_signed_in
     visit edit_settings_path
 
-    options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
-      resident_key: true,
-      user_verification: true,
-      user_verified: true
-    )
-    @authenticator = page.driver.browser.add_virtual_authenticator(options)
+    enable_virtual_authenticator(resident_key: true, user_verification: true, user_verified: true)
 
     credential_nickname = "new cred"
     fill_in "Nickname", with: credential_nickname
@@ -268,7 +254,38 @@ class ActiveSupport::TestCase
     first("div", text: credential_nickname)
 
     @user.reload
-    @authenticator
+  end
+
+  def enable_virtual_authenticator(resident_key: false, user_verification: false, user_verified: false)
+    page.driver.with_playwright_page do |pw_page|
+      @cdp_session ||= pw_page.context.new_cdp_session(pw_page)
+      @cdp_session.send_message("WebAuthn.enable")
+      result = @cdp_session.send_message("WebAuthn.addVirtualAuthenticator", params: {
+                                           options: {
+                                             protocol: "ctap2",
+                                             transport: "internal",
+                                             hasResidentKey: resident_key,
+                                             hasUserVerification: user_verification,
+                                             isUserVerified: user_verified
+                                           }
+                                         })
+      @authenticator_id = result["authenticatorId"]
+    end
+  end
+
+  def disable_virtual_authenticator
+    return unless @cdp_session && @authenticator_id
+
+    page.driver.with_playwright_page do |_pw_page|
+      @cdp_session.send_message("WebAuthn.removeVirtualAuthenticator", params: {
+                                  authenticatorId: @authenticator_id
+                                })
+    rescue Playwright::TargetClosedError
+      # Browser already closed during teardown
+    ensure
+      @authenticator_id = nil
+      @cdp_session = nil
+    end
   end
 
   def setup_rstuf

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -276,16 +276,21 @@ class ActiveSupport::TestCase
   def disable_virtual_authenticator
     return unless @cdp_session && @authenticator_id
 
-    page.driver.with_playwright_page do |_pw_page|
-      @cdp_session.send_message("WebAuthn.removeVirtualAuthenticator", params: {
-                                  authenticatorId: @authenticator_id
-                                })
-    rescue Playwright::TargetClosedError
-      # Browser already closed during teardown
-    ensure
-      @authenticator_id = nil
-      @cdp_session = nil
+    # Teardown can run while the page is on a non-Playwright driver (e.g. a test
+    # that switched to :rack_test). Guard the Playwright-only call so cleanup
+    # can't raise NoMethodError and mask the original test failure.
+    if page.driver.respond_to?(:with_playwright_page)
+      page.driver.with_playwright_page do |_pw_page|
+        @cdp_session.send_message("WebAuthn.removeVirtualAuthenticator", params: {
+                                    authenticatorId: @authenticator_id
+                                  })
+      rescue Playwright::TargetClosedError
+        # Browser already closed during teardown
+      end
     end
+  ensure
+    @authenticator_id = nil
+    @cdp_session = nil
   end
 
   def setup_rstuf


### PR DESCRIPTION
The main change here is swapping Selenium for Playwright as the system-test driver. The Selenium suite had developed a pattern of timing flakes, particularly in the Avo admin tests, and Playwright's auto-waiting model cleans those up without needing explicit waits scattered through the tests.

The trickiest part of the switch is keeping the Node-side Playwright version in sync with the Ruby gem. To handle that, I've added `bin/playwright` — a small shim that reads `Playwright::COMPATIBLE_PLAYWRIGHT_VERSION` from the bundled gem and pins npx to that version. This means Dependabot bumps to the Ruby gem automatically pull the correct Node driver along with them, with no manual coordination required.

CI now uses `bin/playwright install --with-deps chromium` in the setup action, replacing the previous inline Ruby snippet. A handful of Avo system tests have been tightened for reliability under the new driver, and CONTRIBUTING.md has been updated to reflect the Playwright-based setup.