### PR TITLE
Add automatically created `devcontainer-lock.json` with Dependabot support

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/rails/devcontainer/features/postgres-client": {
+      "version": "1.1.3",
+      "resolved": "ghcr.io/rails/devcontainer/features/postgres-client@sha256:dc995acf6d691de8fc2dcc88fede02c55df608aa9de17cfa4b38de06903d7715",
+      "integrity": "sha256:dc995acf6d691de8fc2dcc88fede02c55df608aa9de17cfa4b38de06903d7715"
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+- package-ecosystem: "devcontainers"
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Proposing we commit this new `devcoontainer-lock.json` which was automatically created while rebuilding my devcontainer. It appears such lockfiles are now automatically created as of vscode v1.118, i.e. as of about last week or so as the current version is v1.119.

https://code.visualstudio.com/updates/v1_118#_dev-container-lockfile-for-features-enabled-by-default

Dependabot: https://containers.dev/guide/dependabot