### PR TITLE
Fix most_recent_version for non Ruby Platform Gems

### DIFF
--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -60,9 +60,12 @@ class Rubygem < ApplicationRecord
 
   has_one :most_recent_version,
     lambda {
-      order(Arel.sql("case when #{quoted_table_name}.latest AND #{quoted_table_name}.platform = 'ruby' then 2 else 1 end desc"))
-        .order(Arel.sql("case when #{quoted_table_name}.latest then #{quoted_table_name}.number else NULL end desc"))
-        .order(id: :desc)
+      order(
+        Arel.sql("case when #{quoted_table_name}.latest AND #{quoted_table_name}.platform = 'ruby' then 0 " \
+                 "when #{quoted_table_name}.latest then 1 else 2 end"),
+        :position,
+        id: :desc
+      )
     },
     class_name: "Version", inverse_of: :rubygem
 

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -163,6 +163,24 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version1pre, @rubygem.reload.most_recent_version
     end
 
+    should "return the most recent non-ruby platform version when multiple non-ruby platform versions exist" do
+      create(:version, rubygem: @rubygem, number: "0.3.8", platform: "universal-darwin")
+      version2 = create(:version, rubygem: @rubygem, number: "0.3.9", platform: "universal-darwin")
+
+      @rubygem.reorder_versions
+
+      assert_equal version2, @rubygem.reload.most_recent_version
+    end
+
+    should "return the highest semver version across platforms" do
+      create(:version, rubygem: @rubygem, number: "0.3.9", platform: "x86_64-linux")
+      version2 = create(:version, rubygem: @rubygem, number: "0.3.10", platform: "universal-darwin")
+
+      @rubygem.reorder_versions
+
+      assert_equal version2, @rubygem.reload.most_recent_version
+    end
+
     should "return the most_recent indexed version when a more recent yanked version exists" do
       create(:version, rubygem: @rubygem, number: "0.1.1", indexed: false)
       indexed_v1 = create(:version, rubygem: @rubygem, number: "0.1.0", indexed: true)


### PR DESCRIPTION
## What

- Closes: https://github.com/rubygems/rubygems.org/issues/6348

Fix `most_recent_version` returning the wrong version for gems that only have non-ruby platform versions (e.g. `universal-darwin`).

## Why

The `most_recent_version` association used a `CASE WHEN latest THEN number ELSE NULL END DESC` ordering. 

**PostgreSQL sorts `NULL` first in `DESC` order**, so versions with `latest=false` (producing `NULL`) were incorrectly preferred over versions with `latest=true`. For gems with only non-ruby platform versions, the first ordering clause is a tie (all score 1), so the broken second clause decided the result — picking the wrong version.

The fix replaces `NULL`-producing expressions with explicit `0`/`1` integers and uses the `position` column (which is already correctly computed via `Gem::Version` semantic comparison in `reorder_versions`.

## Tophat

I created a mock gem page with versions locally and confirmed that header shows the correct version
<img width="682" height="469" alt="Monosnap testgem | RubyGems org | your community gem host 2026-05-06 14-33-14" src="https://github.com/user-attachments/assets/3140ca74-2ab3-4495-ba63-5b8b994ce467" />

You can also run tests

```bash
bin/rails test test/models/rubygem_test.rb -n "/most recent non-ruby/"
```