### PR TITLE
Require confirmed email for API access

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -55,6 +55,7 @@ class Api::BaseController < ApplicationController
     @api_key   = ApiKey.unexpired.find_by_hashed_key(hashed_key)
     return render_unauthorized unless @api_key
     set_tags "gemcutter.api_key.owner" => @api_key.owner.to_gid, "gemcutter.user.api_key_id" => @api_key.id
+    return render_forbidden(t(:email_not_confirmed)) if @api_key.user&.unconfirmed?
     Current.user = @api_key.user
     render_forbidden(t(:api_key_soft_deleted)) if @api_key.soft_deleted?
   end

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -50,7 +50,10 @@ class Api::V1::ApiKeysController < Api::BaseController
   private
 
   def check_mfa(user)
-    if user&.mfa_gem_signin_authorized?(otp)
+    return false unless user
+    if user.unconfirmed?
+      render_forbidden t(:email_not_confirmed)
+    elsif user.mfa_gem_signin_authorized?(otp)
       if user.mfa_required_not_yet_enabled?
         render_forbidden t("multifactor_auths.api.mfa_required_not_yet_enabled").chomp
       elsif user.mfa_required_weak_level_enabled?
@@ -58,7 +61,7 @@ class Api::V1::ApiKeysController < Api::BaseController
       else
         yield
       end
-    elsif user&.mfa_enabled?
+    elsif user.mfa_enabled?
       prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)
       render plain: prompt_text, status: :unauthorized
     else

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,6 +32,7 @@ de:
   api_key_forbidden:
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: Zugriff verweigert. Bitte melden Sie sich unter https://rubygems.org
     mit einem Konto an
   please_sign_in: Bitte melden Sie sich an, um fortzufahren.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   api_key_forbidden: The API key doesn't have access
   api_key_soft_deleted: An invalid API key cannot be used. Please delete it and create a new one.
   api_key_insufficient_scope: This API key cannot perform the specified action on this gem.
+  email_not_confirmed: Please confirm your email address before using the API. Check your inbox for a confirmation link.
   please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
   please_sign_in: Please sign in to continue.
   otp_incorrect: Your OTP code is incorrect. Please check it and retry.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,6 +30,7 @@ es:
   api_key_forbidden: La clave API no tiene acceso
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: Acceso denegado. Por favor regístrate en https://rubygems.org
   please_sign_in: Por favor, ingresa en tu cuenta para continuar.
   otp_incorrect: Tu código OTP es incorrecto. Por favor verifícalo y prueba nuevamente.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -30,6 +30,7 @@ fr:
   api_key_forbidden:
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: Accès refusé. Inscrivez-vous sur https://rubygems.org
   please_sign_in:
   otp_incorrect:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,7 @@ ja:
   api_key_forbidden: APIキーにアクセス権がありません
   api_key_soft_deleted: 正しくないAPIキーは使えません。削除して新規作成してください。
   api_key_insufficient_scope: このAPIキーはこのgemに対して指定された動作を実行できません。
+  email_not_confirmed:
   please_sign_up: アクセスが拒否されました。https://rubygems.org でアカウント登録を行ってください。
   please_sign_in: サインインしてお進みください。
   otp_incorrect: OTPのコードが正しくありません。ご確認の上再試行してください。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -25,6 +25,7 @@ nl:
   api_key_forbidden:
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: Toegang geweigerd. Schrijf je in voor een account op https://rubygems.org
   please_sign_in:
   otp_incorrect:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -29,6 +29,7 @@ pt-BR:
   api_key_forbidden:
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: Acesso Negado. Por favor se registre em https://rubygems.org
   please_sign_in: Por favor, faça login em sua conta para continuar.
   otp_incorrect: Seu código OTP está incorreto. Por favor, verifique-o e tente novamente.

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -26,6 +26,7 @@ zh-CN:
   api_key_forbidden: API 密钥没有访问权限
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: 拒绝访问，请在 https://rubygems.org 上注册一个账号。
   please_sign_in: 请先登录以继续
   otp_incorrect: 您的 OTP 码不正确，请检查后重试。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -25,6 +25,7 @@ zh-TW:
   api_key_forbidden: API 金鑰沒有存取權限
   api_key_soft_deleted:
   api_key_insufficient_scope:
+  email_not_confirmed:
   please_sign_up: 存取遭拒。請先在 https://rubygems.org 上註冊帳號
   please_sign_in: 請登入以繼續。
   otp_incorrect: 您的 OTP 碼不正確。請檢查後再試一次。

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -252,6 +252,20 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
       should_expect_otp_for_show
     end
 
+    context "with unconfirmed email" do
+      setup do
+        @user = create(:user, :unconfirmed)
+        authorize_with("#{@user.email}:#{@user.password}")
+        get :show
+      end
+
+      should respond_with :forbidden
+
+      should "return email confirmation error" do
+        assert_match "Please confirm your email address", @response.body
+      end
+    end
+
     context "when user has old sha1 password" do
       setup do
         @user = create(:user, encrypted_password: "b35e3b6e1b3021e71645b4df8e0a3c7fd98a95fa")
@@ -281,6 +295,20 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
         post :create
       end
       should_deny_access
+    end
+
+    context "with unconfirmed email" do
+      setup do
+        @user = create(:user, :unconfirmed)
+        authorize_with("#{@user.email}:#{@user.password}")
+        post :create, params: { name: "test-key", index_rubygems: "true" }
+      end
+
+      should respond_with :forbidden
+
+      should "return email confirmation error" do
+        assert_match "Please confirm your email address", @response.body
+      end
     end
 
     context "with correct credentials" do

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -206,6 +206,23 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
     end
 
+    context "when user email is unconfirmed" do
+      setup do
+        @user.update!(email_confirmed: false)
+        post :create, body: gem_file(&:read)
+      end
+
+      should respond_with :forbidden
+
+      should "return email confirmation error" do
+        assert_match "Please confirm your email address", @response.body
+      end
+
+      should "not register any gem" do
+        assert_equal 0, Rubygem.count
+      end
+    end
+
     context "When mfa for UI and API is enabled" do
       setup do
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)


### PR DESCRIPTION
Unconfirmed email accounts could create API keys and push gems via the API because the email confirmation check only applied to web UI sign-in (Clearance guard), not to API key authentication or HTTP Basic auth used for key creation.

Add email confirmation checks to both API paths:
- authenticate_with_api_key in Api::BaseController (covers all API key-authenticated endpoints, including gem push)
- check_mfa in Api::V1::ApiKeysController (covers key creation, retrieval, and update via HTTP Basic auth)