### PR TITLE
 Rate limit the web hook test-fire endpoint

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -171,6 +171,18 @@ class Rack::Attack
     req.ip if protected_route?(protected_yank_action, req.path, req.request_method)
   end
 
+  # Throttle web hook test-fire requests (sends an outbound HTTP request to a user-supplied URL)
+  WEBHOOK_FIRE_LIMIT = 10
+  protected_webhook_fire_action = [controller: "api/v1/web_hooks", action: "fire"]
+
+  throttle("webhook_fire/ip", limit: WEBHOOK_FIRE_LIMIT, period: LIMIT_PERIOD) do |req|
+    req.ip if protected_route?(protected_webhook_fire_action, req.path, req.request_method)
+  end
+
+  throttle("webhook_fire/api_key", limit: WEBHOOK_FIRE_LIMIT, period: LIMIT_PERIOD) do |req|
+    api_key_owner_id(req) if protected_route?(protected_webhook_fire_action, req.path, req.request_method)
+  end
+
   ############################# rate limit per handle ############################
   # Throttle POST requests to /login by email param
   #

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -113,6 +113,28 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "web hook fire requests" do
+      setup do
+        create(:rubygem, name: "gemcutter", number: "0.0.1")
+        create(:api_key, key: "12334", scopes: %i[access_webhooks], owner: @user)
+
+        stub_request(:post, "https://api.hookrelay.dev/hooks///webhook_id-fire")
+          .to_return(status: 200, body: '{"id":"delivery-id"}', headers: { "Content-Type" => "application/json" })
+        stub_request(:get, "https://app.hookrelay.dev/api/v1/accounts//hooks//deliveries/delivery-id")
+          .to_return(status: 200, body: { "status" => "success", "responses" => [
+            "code" => 200, "body" => "OK", "headers" => { "Content-Type" => "text/plain" }
+          ] }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      should "allow web hook fire by ip" do
+        post "/api/v1/web_hooks/fire",
+          params: { gem_name: WebHook::GLOBAL_PATTERN, url: "http://example.org" },
+          headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: "12334" }
+
+        assert_response :success
+      end
+    end
+
     context "params" do
       should "return 400 for bad request" do
         post "/session"
@@ -421,6 +443,23 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         post "/api/v1/gems",
           params: gem_file("test-1.0.0.gem", &:read),
           headers: { REMOTE_ADDR: @ip_address, HTTP_AUTHORIZATION: "12334", CONTENT_TYPE: "application/octet-stream" }
+
+        assert_response :too_many_requests
+      end
+
+      should "throttle web hook fire by ip" do
+        update_limit_for("webhook_fire/ip:#{@ip_address}", Rack::Attack::WEBHOOK_FIRE_LIMIT)
+
+        post "/api/v1/web_hooks/fire", headers: { REMOTE_ADDR: @ip_address }
+
+        assert_response :too_many_requests
+      end
+
+      should "throttle web hook fire by api key" do
+        api_key = create(:api_key, key: "12334", scopes: %i[access_webhooks], owner: @user)
+        update_limit_for("webhook_fire/api_key:#{api_key.owner.to_gid}", Rack::Attack::WEBHOOK_FIRE_LIMIT)
+
+        post "/api/v1/web_hooks/fire", headers: { HTTP_AUTHORIZATION: "12334" }
 
         assert_response :too_many_requests
       end


### PR DESCRIPTION
## What

Adds Rack::Attack throttling to `POST /api/v1/web_hooks/fire` (`Api::V1::WebHooksController#fire`).

- `WEBHOOK_FIRE_LIMIT = 10` requests per `LIMIT_PERIOD` (10 minutes)
- Throttled on two discriminators:
  - `webhook_fire/ip` — by client IP
  - `webhook_fire/api_key` — by API key owner (so IP rotation doesn't bypass it)
- Over-limit requests get the standard `429 Too Many Requests` and are logged through the existing `throttle.rack_attack` notification → Datadog pipeline.

Mirrors the existing `yank/ip` throttle pattern.

## Why

We've been getting Datadog alerts for accounts abusing the test-fire feature. The endpoint triggers a synchronous outbound HTTP request (via Hook Relay) to a user-supplied URL, so unbounded use makes rubygems.org a request relay / amplification vector. Test-fire is a manual "did my webhook work?" check — legitimate use is a handful of calls — so a low cap stops abuse without affecting real users.

The endpoint already requires an API key with the `access_webhooks` scope and a confirmed-email account (`authenticate_with_api_key`); this adds the missing rate limit on top.

## Testing

- New integration tests in `test/integration/rack_attack_test.rb`: allowed under the limit, throttled by IP, throttled by API key.
- `bin/rails test test/integration/rack_attack_test.rb` → 84 runs, 0 failures.
- Rubocop clean.

## Follow-up (not in this PR)

Considering a per-account cap on the number of registered webhooks as a separate change, pending a look at current usage distribution.