### PR TITLE
Remove unused methods from `RateLimitHelpers`

### DIFF
--- a/test/helpers/rate_limit_helpers.rb
+++ b/test/helpers/rate_limit_helpers.rb
@@ -41,17 +41,9 @@ module RateLimitHelpers
     update_limit_for("#{scope}:#{@user.email}", exceeding_email_limit)
   end
 
-  def exceed_handle_limit_for(scope, user)
-    update_limit_for("#{scope}:#{user.handle}", exceeding_email_limit)
-  end
-
   def exceed_push_limit_for(scope)
     exceeding_push_limit = (Rack::Attack::PUSH_LIMIT * 1.25).to_i
     update_limit_for("#{scope}:#{@ip_address}", exceeding_push_limit, push_limit_period)
-  end
-
-  def exceed_exp_base_limit_for(scope)
-    update_limit_for("#{scope}:#{@ip_address}", exceeding_exp_base_limit, exp_base_limit_period)
   end
 
   def stay_under_limit_for(scope)


### PR DESCRIPTION
## What

Remove `exceed_handle_limit_for` and `exceed_exp_base_limit_for` from `test/helpers/rate_limit_helpers.rb`.

When callers were removed for `exceed_exp_base_limit_for`  method:
- https://github.com/rubygems/rubygems.org/pull/2330

PR where `exceed_handle_limit_for` was added, since no caller was added.
- https://github.com/rubygems/rubygems.org/pull/2357/changes#diff-bf7fda8257ede64b50e7c26a0183252938f49ef9b48cedefeb65c1edbe780714R42-R45

## Why

These test helper methods have zero callers. `exceed_handle_limit_for` was for a throttle-by-handle rule that no longer exists. `exceed_exp_base_limit_for` was superseded by `exceed_exponential_limit_for(scope, level)` which takes an explicit level parameter.