### PR TITLE
Rate limiting gem yanks in admin action

### DIFF
--- a/app/jobs/yank_rubygem_job.rb
+++ b/app/jobs/yank_rubygem_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class YankRubygemJob < ApplicationJob
+  queue_as :default
+  queue_with_priority PRIORITIES.fetch(:push)
+
+  def perform(rubygem:)
+    rubygem.yank_versions!(force: true)
+  end
+end

--- a/app/jobs/yank_rubygems_for_user_job.rb
+++ b/app/jobs/yank_rubygems_for_user_job.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class YankRubygemsForUserJob < ApplicationJob
+  STAGGER_INTERVAL = 2.seconds
+
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:push)
 
   def perform(user:)
-    user.rubygems.find_each do |rubygem|
-      rubygem.yank_versions!(force: true)
+    user.rubygems.find_each.with_index do |rubygem, index|
+      YankRubygemJob.set(wait: index * STAGGER_INTERVAL).perform_later(rubygem: rubygem)
     end
   end
 end

--- a/test/jobs/yank_rubygem_job_test.rb
+++ b/test/jobs/yank_rubygem_job_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class YankRubygemJobTest < ActiveJob::TestCase
+  test "yanks all versions of the rubygem" do
+    security_user = create(:user, email: "security@rubygems.org")
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+    version1 = create(:version, rubygem: rubygem, number: "1.0.0")
+    version2 = create(:version, rubygem: rubygem, number: "2.0.0")
+
+    YankRubygemJob.perform_now(rubygem: rubygem)
+
+    assert_predicate version1.reload, :yanked?
+    assert_predicate version2.reload, :yanked?
+    assert_equal 2, security_user.deletions.count
+  end
+
+  test "skips already yanked versions" do
+    create(:user, email: "security@rubygems.org")
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+    create(:version, rubygem: rubygem, indexed: false, yanked_at: Time.now.utc)
+
+    assert_no_difference "Deletion.count" do
+      YankRubygemJob.perform_now(rubygem: rubygem)
+    end
+  end
+
+  test "force yanks versions with high download counts" do
+    security_user = create(:user, email: "security@rubygems.org")
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+    version = create(:version, rubygem: rubygem)
+    GemDownload.increment(100_001, rubygem_id: rubygem.id, version_id: version.id)
+
+    YankRubygemJob.perform_now(rubygem: rubygem)
+
+    assert_predicate version.reload, :yanked?
+    assert_equal 1, security_user.deletions.count
+  end
+
+  test "handles rubygem with no versions" do
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+
+    assert_nothing_raised do
+      YankRubygemJob.perform_now(rubygem: rubygem)
+    end
+  end
+end

--- a/test/jobs/yank_rubygems_for_user_job_test.rb
+++ b/test/jobs/yank_rubygems_for_user_job_test.rb
@@ -4,42 +4,22 @@ require "test_helper"
 
 class YankRubygemsForUserJobTest < ActiveJob::TestCase
   test "yanks all versions for all of the user's rubygems" do
-    security_user = create(:user, email: "security@rubygems.org")
     user = create(:user)
-    rubygem1 = create(:rubygem, owners: [user])
-    version1 = create(:version, rubygem: rubygem1)
-    rubygem2 = create(:rubygem, owners: [user])
-    version2 = create(:version, rubygem: rubygem2)
+    rubygems = create_list(:rubygem, 3, owners: [user])
 
-    YankRubygemsForUserJob.perform_now(user: user)
-
-    assert_predicate version1.reload, :yanked?
-    assert_predicate version2.reload, :yanked?
-    assert_equal 2, security_user.deletions.count
-  end
-
-  test "skips already yanked versions" do
-    create(:user, email: "security@rubygems.org")
-    user = create(:user)
-    rubygem = create(:rubygem, owners: [user])
-    create(:version, rubygem: rubygem, indexed: false, yanked_at: Time.now.utc)
-
-    assert_no_difference "Deletion.count" do
+    freeze_time do
       YankRubygemsForUserJob.perform_now(user: user)
+
+      rubygems.each_with_index do |rubygem, index|
+        assert_enqueued_with(
+          job: YankRubygemJob,
+          args: [rubygem: rubygem],
+          at: (index * 2.seconds).from_now
+        )
+      end
+
+      assert_enqueued_jobs 3, only: YankRubygemJob
     end
-  end
-
-  test "force yanks versions with high download counts" do
-    security_user = create(:user, email: "security@rubygems.org")
-    user = create(:user)
-    rubygem = create(:rubygem, owners: [user])
-    version = create(:version, rubygem: rubygem)
-    GemDownload.increment(100_001, rubygem_id: rubygem.id, version_id: version.id)
-
-    YankRubygemsForUserJob.perform_now(user: user)
-
-    assert_predicate version.reload, :yanked?
-    assert_equal 1, security_user.deletions.count
   end
 
   test "handles user with no rubygems" do
@@ -48,19 +28,7 @@ class YankRubygemsForUserJobTest < ActiveJob::TestCase
     assert_nothing_raised do
       YankRubygemsForUserJob.perform_now(user: user)
     end
-  end
 
-  test "yanks multiple versions of the same rubygem" do
-    security_user = create(:user, email: "security@rubygems.org")
-    user = create(:user)
-    rubygem = create(:rubygem, owners: [user])
-    version1 = create(:version, rubygem: rubygem, number: "1.0.0")
-    version2 = create(:version, rubygem: rubygem, number: "2.0.0")
-
-    YankRubygemsForUserJob.perform_now(user: user)
-
-    assert_predicate version1.reload, :yanked?
-    assert_predicate version2.reload, :yanked?
-    assert_equal 2, security_user.deletions.count
+    assert_enqueued_jobs 0, only: YankRubygemJob
   end
 end


### PR DESCRIPTION
For users that have a lot of gems to be yanked, this affects the queue latency of the service. Proposing that we rate limit gem yanks by 1 for every 2 seconds.