### PR TITLE
Create and Write to V2 Info Checksum Columns

### DIFF
--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -16,8 +16,7 @@ class AfterVersionWriteJob < ApplicationJob
       ReindexRubygemJob.perform_later(rubygem:)
       StoreVersionContentsJob.perform_later(version:)
       version.update!(indexed: true)
-      checksum = GemInfo.new(rubygem.name, cached: false).info_checksum
-      version.update_attribute :info_checksum, checksum
+      version.update_columns(GemInfo.new(rubygem.name, cached: false).info_checksums)
       SetLinksetHomeJob.perform_later(version:)
     end
   end

--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -16,7 +16,11 @@ class AfterVersionWriteJob < ApplicationJob
       ReindexRubygemJob.perform_later(rubygem:)
       StoreVersionContentsJob.perform_later(version:)
       version.update!(indexed: true)
-      version.update_columns(GemInfo.new(rubygem.name, cached: false).info_checksums)
+      gem_info = GemInfo.new(rubygem.name, cached: false)
+      version.update_columns(
+        info_checksum: gem_info.info_checksum(version: 1),
+        info_checksum_v2: gem_info.info_checksum(version: 2)
+      )
       SetLinksetHomeJob.perform_later(version:)
     end
   end

--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -17,10 +17,11 @@ class AfterVersionWriteJob < ApplicationJob
       StoreVersionContentsJob.perform_later(version:)
       version.update!(indexed: true)
       gem_info = GemInfo.new(rubygem.name, cached: false)
-      version.update_columns(
-        info_checksum: gem_info.info_checksum(version: 1),
-        info_checksum_v2: gem_info.info_checksum(version: 2)
-      )
+
+      version.info_checksum = gem_info.info_checksum(version: 1)
+      version.info_checksum_v2 = gem_info.info_checksum(version: 2)
+      version.save(validate: false)
+
       SetLinksetHomeJob.perform_later(version:)
     end
   end

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -17,7 +17,9 @@ class UploadInfoFileJob < ApplicationJob
   )
 
   def perform(rubygem_name:)
-    compact_index_info = GemInfo.new(rubygem_name, cached: false).compact_index_info
+    gem_info = GemInfo.new(rubygem_name, cached: false)
+    compact_index_info = gem_info.compact_index_info
+    gem_info.compact_index_info_v2
     response_body = CompactIndex.info(compact_index_info)
 
     content_md5 = Digest::MD5.base64digest(response_body)

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -19,7 +19,8 @@ class UploadInfoFileJob < ApplicationJob
   def perform(rubygem_name:)
     gem_info = GemInfo.new(rubygem_name, cached: false)
     compact_index_info = gem_info.compact_index_info
-    gem_info.compact_index_info_v2
+
+    gem_info.compact_index_info(version: 2) # Warm the v2 compact index info cache
     response_body = CompactIndex.info(compact_index_info)
 
     content_md5 = Digest::MD5.base64digest(response_body)

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -96,7 +96,7 @@ class Deletion < ApplicationRecord
   end
 
   def restore_to_index
-    version.update!(indexed: true, yanked_at: nil, yanked_info_checksum: nil)
+    version.update!(indexed: true, yanked_at: nil, yanked_info_checksum: nil, yanked_info_checksum_v2: nil)
     reindex
     Rstuf::AddJob.perform_later(version:)
   end
@@ -138,8 +138,11 @@ class Deletion < ApplicationRecord
   end
 
   def set_yanked_info_checksum
-    checksum = GemInfo.new(version.rubygem.name).info_checksum
-    version.update_attribute :yanked_info_checksum, checksum
+    checksums = GemInfo.new(version.rubygem.name).info_checksums
+    version.update_columns(
+      yanked_info_checksum: checksums.fetch(:info_checksum),
+      yanked_info_checksum_v2: checksums.fetch(:info_checksum_v2)
+    )
   end
 
   def send_gem_yanked_mail

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -138,10 +138,10 @@ class Deletion < ApplicationRecord
   end
 
   def set_yanked_info_checksum
-    checksums = GemInfo.new(version.rubygem.name).info_checksums
+    gem_info = GemInfo.new(version.rubygem.name)
     version.update_columns(
-      yanked_info_checksum: checksums.fetch(:info_checksum),
-      yanked_info_checksum_v2: checksums.fetch(:info_checksum_v2)
+      yanked_info_checksum: gem_info.info_checksum(version: 1),
+      yanked_info_checksum_v2: gem_info.info_checksum(version: 2)
     )
   end
 

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -139,10 +139,10 @@ class Deletion < ApplicationRecord
 
   def set_yanked_info_checksum
     gem_info = GemInfo.new(version.rubygem.name)
-    version.update_columns(
-      yanked_info_checksum: gem_info.info_checksum(version: 1),
-      yanked_info_checksum_v2: gem_info.info_checksum(version: 2)
-    )
+
+    version.yanked_info_checksum = gem_info.info_checksum(version: 1)
+    version.yanked_info_checksum_v2 = gem_info.info_checksum(version: 2)
+    version.save(validate: false)
   end
 
   def send_gem_yanked_mail

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -113,22 +113,24 @@ class GemInfo
   end
 
   def compute_compact_index_info(version:)
-    config = VERSIONS.fetch(version)
     requirements_and_dependencies.map do |row|
-      deps = []
+      dependencies = []
       if row[DEPENDENCY_REQUIREMENTS_INDEX]
         reqs = row[DEPENDENCY_REQUIREMENTS_INDEX].split("@")
         dep_names = row[DEPENDENCY_NAMES_INDEX].split(",")
         raise "BUG: different size of reqs and dep_names." unless reqs.size == dep_names.size
         dep_names.zip(reqs).each do |name, req|
-          deps << CompactIndex::Dependency.new(name, req) unless name == "0"
+          dependencies << CompactIndex::Dependency.new(name, req) unless name == "0"
         end
       end
 
-      name, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = row
-      args = [name, platform, Version._sha256_hex(checksum), info_checksum, deps, ruby_version, rubygems_version]
-      args << created_at&.utc&.iso8601 if config[:klass] == CompactIndex::GemVersionV2
-      config[:klass].new(*args)
+      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = row
+      version_class = VERSIONS.dig(version, :klass)
+      checksum = Version._sha256_hex(checksum)
+      created_at = created_at&.utc&.iso8601
+      args = { number:, platform:, checksum:, info_checksum:, dependencies:, ruby_version:, rubygems_version:, created_at: }
+      args = args.slice(*version_class.members)
+      version_class.new(**args)
     end
   end
 

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -27,26 +27,9 @@ class GemInfo
     end
   end
 
-  def compact_index_info_v2
-    compact_index_info(version: 2)
-  end
-
   def info_checksum(version: 1)
     compact_index_info = CompactIndex.info(compute_compact_index_info(version:))
     Digest::MD5.hexdigest(compact_index_info)
-  end
-
-  def info_checksum_v2
-    info_checksum(version: 2)
-  end
-
-  def info_checksums
-    rows = requirements_and_dependencies
-
-    {
-      info_checksum: checksum_for(rows, version: 1),
-      info_checksum_v2: checksum_for(rows, version: 2)
-    }
   end
 
   def self.ordered_names(cached: true)
@@ -129,18 +112,9 @@ class GemInfo
     nil
   end
 
-  def checksum_for(rows, version:)
-    compact_index_info = CompactIndex.info(compute_compact_index_info_from(rows, version:))
-    Digest::MD5.hexdigest(compact_index_info)
-  end
-
   def compute_compact_index_info(version:)
-    compute_compact_index_info_from(requirements_and_dependencies, version:)
-  end
-
-  def compute_compact_index_info_from(rows, version:)
     config = VERSIONS.fetch(version)
-    rows.map do |row|
+    requirements_and_dependencies.map do |row|
       deps = []
       if row[DEPENDENCY_REQUIREMENTS_INDEX]
         reqs = row[DEPENDENCY_REQUIREMENTS_INDEX].split("@")

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -1,26 +1,52 @@
 # frozen_string_literal: true
 
 class GemInfo
+  VERSIONS = {
+    1 => { cache_prefix: "info", stats_prefix: "compact_index.memcached.info", klass: CompactIndex::GemVersion },
+    2 => { cache_prefix: "info_v2", stats_prefix: "compact_index.memcached.info_v2", klass: CompactIndex::GemVersionV2 }
+  }.freeze
+
   def initialize(rubygem_name, cached: true)
     @rubygem_name = rubygem_name
     @cached = cached
   end
 
-  def compact_index_info
-    if @cached && (info = read_cache("info/#{@rubygem_name}"))
-      StatsD.increment "compact_index.memcached.info.hit"
+  def compact_index_info(version: 1)
+    config = VERSIONS.fetch(version)
+    cache_key = "#{config[:cache_prefix]}/#{@rubygem_name}"
+    stats_key = config[:stats_prefix]
+
+    if @cached && (info = read_cache(cache_key))
+      StatsD.increment "#{stats_key}.hit"
       info
     else
-      StatsD.increment "compact_index.memcached.info.miss"
-      compute_compact_index_info.tap do |compact_index_info|
-        Rails.cache.write("info/#{@rubygem_name}", compact_index_info)
+      StatsD.increment "#{stats_key}.miss"
+      compute_compact_index_info(version:).tap do |result|
+        Rails.cache.write(cache_key, result)
       end
     end
   end
 
-  def info_checksum
-    compact_index_info = CompactIndex.info(compute_compact_index_info)
+  def compact_index_info_v2
+    compact_index_info(version: 2)
+  end
+
+  def info_checksum(version: 1)
+    compact_index_info = CompactIndex.info(compute_compact_index_info(version:))
     Digest::MD5.hexdigest(compact_index_info)
+  end
+
+  def info_checksum_v2
+    info_checksum(version: 2)
+  end
+
+  def info_checksums
+    rows = requirements_and_dependencies
+
+    {
+      info_checksum: checksum_for(rows, version: 1),
+      info_checksum_v2: checksum_for(rows, version: 2)
+    }
   end
 
   def self.ordered_names(cached: true)
@@ -96,31 +122,47 @@ class GemInfo
 
   DEPENDENCY_REQUIREMENTS_INDEX = 7
 
-  # Marshal.load of pre-deploy cache entries fails when GemVersion changes number of Struct fields.
+  # Marshal.load of pre-deploy cache entries fails when GemVersion grows a Struct field.
   def read_cache(cache_key)
     Rails.cache.read(cache_key)
   rescue TypeError
     nil
   end
 
-  def compute_compact_index_info
-    requirements_and_dependencies.map do |r|
+  def checksum_for(rows, version:)
+    compact_index_info = CompactIndex.info(compute_compact_index_info_from(rows, version:))
+    Digest::MD5.hexdigest(compact_index_info)
+  end
+
+  def compute_compact_index_info(version:)
+    compute_compact_index_info_from(requirements_and_dependencies, version:)
+  end
+
+  def compute_compact_index_info_from(rows, version:)
+    config = VERSIONS.fetch(version)
+    rows.map do |row|
       deps = []
-      if r[DEPENDENCY_REQUIREMENTS_INDEX]
-        reqs = r[DEPENDENCY_REQUIREMENTS_INDEX].split("@")
-        dep_names = r[DEPENDENCY_NAMES_INDEX].split(",")
+      if row[DEPENDENCY_REQUIREMENTS_INDEX]
+        reqs = row[DEPENDENCY_REQUIREMENTS_INDEX].split("@")
+        dep_names = row[DEPENDENCY_NAMES_INDEX].split(",")
         raise "BUG: different size of reqs and dep_names." unless reqs.size == dep_names.size
         dep_names.zip(reqs).each do |name, req|
           deps << CompactIndex::Dependency.new(name, req) unless name == "0"
         end
       end
 
-      name, platform, checksum, info_checksum, ruby_version, rubygems_version, = r
-      CompactIndex::GemVersion.new(name, platform, Version._sha256_hex(checksum), info_checksum, deps, ruby_version, rubygems_version)
+      name, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = row
+      args = [name, platform, Version._sha256_hex(checksum), info_checksum, deps, ruby_version, rubygems_version]
+      args << created_at&.utc&.iso8601 if config[:klass] == CompactIndex::GemVersionV2
+      config[:klass].new(*args)
     end
   end
 
   def requirements_and_dependencies
+    @requirements_and_dependencies ||= fetch_requirements_and_dependencies
+  end
+
+  def fetch_requirements_and_dependencies
     group_by_columns = "number, platform, sha256, info_checksum, required_ruby_version, required_rubygems_version, versions.created_at"
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -2,7 +2,8 @@
 
 module CompactIndex
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version) do
+                          :dependencies, :ruby_version, :rubygems_version,
+                          :created_at) do
     def number_and_platform
       if platform.nil? || platform == "ruby"
         number
@@ -25,6 +26,7 @@ module CompactIndex
       line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line << ",created_at:#{created_at}" if created_at
       line
     end
 

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module CompactIndex
-  GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version,
-                          :created_at) do
+  module GemVersionMethods
     def number_and_platform
       if platform.nil? || platform == "ruby"
         number
@@ -26,7 +24,6 @@ module CompactIndex
       line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
-      line << ",created_at:#{created_at}" if created_at
       line
     end
 
@@ -52,6 +49,23 @@ module CompactIndex
       requirements = requirements.split(", ")
       requirements.sort!
       requirements.join("&")
+    end
+  end
+
+  GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
+                          :dependencies, :ruby_version, :rubygems_version) do
+    include GemVersionMethods
+  end
+
+  GemVersionV2 = Struct.new(:number, :platform, :checksum, :info_checksum,
+                            :dependencies, :ruby_version, :rubygems_version,
+                            :created_at) do
+    include GemVersionMethods
+
+    def to_line
+      line = super
+      line << ",created_at:#{created_at}" if created_at
+      line
     end
   end
 end

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -11,7 +11,8 @@ module CompactIndexHelpers
       args.fetch(:info_checksum, "info+#{name}+#{number}"),
       args[:dependencies],
       args[:ruby_version],
-      args[:rubygems_version]
+      args[:rubygems_version],
+      args[:created_at]
     )
   end
 end

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 module CompactIndexHelpers
-  def build_version(**args)
+  def build_version(version: 1, **args)
     name = args.fetch(:name, "test_gem")
     number = args.fetch(:number, "1.0")
-    CompactIndex::GemVersion.new(
+    common = [
       number,
       args[:platform],
       args.fetch(:checksum, "sum+#{name}+#{number}"),
       args.fetch(:info_checksum, "info+#{name}+#{number}"),
       args[:dependencies],
       args[:ruby_version],
-      args[:rubygems_version],
-      args[:created_at]
-    )
+      args[:rubygems_version]
+    ]
+    if version == 2
+      CompactIndex::GemVersionV2.new(*common, args[:created_at])
+    else
+      CompactIndex::GemVersion.new(*common)
+    end
   end
 end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -92,10 +92,18 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?(css, count: 2)
 
-    assert_equal Digest::MD5.hexdigest(<<~INFO), Rubygem.find_by!(name: "sandworm").versions.sole.info_checksum
+    version = Rubygem.find_by!(name: "sandworm").versions.sole
+    sha256 = Digest::SHA256.hexdigest gem_io.string
+
+    assert_equal Digest::MD5.hexdigest(<<~INFO), version.info_checksum
       ---
-      1.0.0 |checksum:#{Digest::SHA256.hexdigest gem_io.string}
+      1.0.0 |checksum:#{sha256}
     INFO
+    assert_equal Digest::MD5.hexdigest(<<~INFO), version.info_checksum_v2
+      ---
+      1.0.0 |checksum:#{sha256},created_at:#{version.created_at.utc.iso8601}
+    INFO
+    refute_equal version.info_checksum, version.info_checksum_v2
   end
 
   test "push a new version of a gem" do

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -7,6 +7,18 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
 
   test "uploads the info file" do
     version = create(:version, number: "0.0.1", required_ruby_version: ">= 2.0.0", required_rubygems_version: ">= 2.6.3")
+    version.reload
+    checksum = "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78"
+    compact_index_info = [CompactIndex::GemVersion.new(
+      "0.0.1", "ruby", checksum, version.info_checksum, [], ">= 2.0.0", ">= 2.6.3"
+    )]
+    compact_index_info_v2 = [CompactIndex::GemVersionV2.new(
+      "0.0.1", "ruby", checksum, version.info_checksum, [], ">= 2.0.0", ">= 2.6.3",
+      version.created_at.utc.iso8601
+    )]
+
+    Rails.cache.expects(:write).with("info/#{version.rubygem.name}", compact_index_info)
+    Rails.cache.expects(:write).with("info_v2/#{version.rubygem.name}", compact_index_info_v2)
 
     perform_enqueued_jobs only: [UploadInfoFileJob] do
       UploadInfoFileJob.perform_now(rubygem_name: version.rubygem.name)

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -30,4 +30,18 @@ class CompactIndex::GemVersionTest < ActiveSupport::TestCase
       assert_equal 0, v1 <=> v2
     end
   end
+
+  context "#to_line" do
+    should "not include created_at when absent" do
+      version = build_version(number: "1.0")
+
+      assert_equal "1.0 |checksum:sum+test_gem+1.0", version.to_line
+    end
+
+    should "include created_at when present" do
+      version = build_version(number: "1.0", created_at: "2026-05-12T10:00:00Z")
+
+      assert_equal "1.0 |checksum:sum+test_gem+1.0,created_at:2026-05-12T10:00:00Z", version.to_line
+    end
+  end
 end

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -32,16 +32,22 @@ class CompactIndex::GemVersionTest < ActiveSupport::TestCase
   end
 
   context "#to_line" do
-    should "not include created_at when absent" do
-      version = build_version(number: "1.0")
+    should "not include created_at for v1" do
+      v = build_version(number: "1.0")
 
-      assert_equal "1.0 |checksum:sum+test_gem+1.0", version.to_line
+      assert_equal "1.0 |checksum:sum+test_gem+1.0", v.to_line
     end
 
-    should "include created_at when present" do
-      version = build_version(number: "1.0", created_at: "2026-05-12T10:00:00Z")
+    should "not include created_at for v2 when absent" do
+      v = build_version(version: 2, number: "1.0")
 
-      assert_equal "1.0 |checksum:sum+test_gem+1.0,created_at:2026-05-12T10:00:00Z", version.to_line
+      assert_equal "1.0 |checksum:sum+test_gem+1.0", v.to_line
+    end
+
+    should "include created_at for v2 when present" do
+      v = build_version(version: 2, number: "1.0", created_at: "2026-05-12T10:00:00Z")
+
+      assert_equal "1.0 |checksum:sum+test_gem+1.0,created_at:2026-05-12T10:00:00Z", v.to_line
     end
   end
 end

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -97,8 +97,9 @@ class DeletionTest < ActiveSupport::TestCase
         assert @version.reload.yanked_at
       end
 
-      should "set the yanked info checksum" do
+      should "set the yanked info checksums" do
         refute_nil @version.reload.yanked_info_checksum
+        refute_nil @version.yanked_info_checksum_v2
       end
 
       should "delete the .gem file" do
@@ -123,6 +124,20 @@ class DeletionTest < ActiveSupport::TestCase
       GemCachePurger.expects(:call).with(@gem_name)
 
       delete_gem
+    end
+
+    should "set different yanked info checksums when another version remains indexed" do
+      other_version = create(:version, rubygem: @version.rubygem, number: "0.0.1")
+
+      delete_gem
+      @version.reload
+      checksum = Version._sha256_hex(other_version.sha256)
+      expected_v1_line = "0.0.1 |checksum:#{checksum},ruby:>= 2.0.0,rubygems:>= 2.6.3"
+      expected_v2_line = "#{expected_v1_line},created_at:#{other_version.created_at.utc.iso8601}"
+
+      assert_equal Digest::MD5.hexdigest("---\n#{expected_v1_line}\n"), @version.yanked_info_checksum
+      assert_equal Digest::MD5.hexdigest("---\n#{expected_v2_line}\n"), @version.yanked_info_checksum_v2
+      refute_equal @version.yanked_info_checksum, @version.yanked_info_checksum_v2
     end
   end
 
@@ -208,6 +223,7 @@ class DeletionTest < ActiveSupport::TestCase
       should "remove the yanked time and yanked_info_checksum" do
         assert_nil @version.yanked_at
         assert_nil @version.yanked_info_checksum
+        assert_nil @version.yanked_info_checksum_v2
       end
 
       should "purge fastly" do

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -54,21 +54,14 @@ class GemInfoTest < ActiveSupport::TestCase
     end
 
     should "return v2 gem version and dependency with created_at" do
-      info = GemInfo.new("example").compact_index_info_v2
+      info = GemInfo.new("example").compact_index_info(version: 2)
 
       assert_equal @expected_info_v2, info
     end
 
     should "compute v2 info checksum with created_at" do
-      assert_equal @expected_info_checksum_v2, GemInfo.new("example").info_checksum_v2
-      refute_equal GemInfo.new("example").info_checksum, GemInfo.new("example").info_checksum_v2
-    end
-
-    should "compute v1 and v2 info checksums together" do
-      assert_equal({
-                     info_checksum: @expected_info_checksum,
-                     info_checksum_v2: @expected_info_checksum_v2
-                   }, GemInfo.new("example").info_checksums)
+      assert_equal @expected_info_checksum_v2, GemInfo.new("example").info_checksum(version: 2)
+      refute_equal GemInfo.new("example").info_checksum, GemInfo.new("example").info_checksum(version: 2)
     end
 
     should "write cache" do
@@ -88,13 +81,13 @@ class GemInfoTest < ActiveSupport::TestCase
     should "write v2 cache" do
       Rails.cache.expects(:write).with("info_v2/example", @expected_info_v2)
 
-      GemInfo.new("example").compact_index_info_v2
+      GemInfo.new("example").compact_index_info(version: 2)
     end
 
     should "read v2 from cache when cache exists" do
       Rails.cache.expects(:read).with("info_v2/example")
 
-      info = GemInfo.new("example").compact_index_info_v2
+      info = GemInfo.new("example").compact_index_info(version: 2)
 
       assert_equal @expected_info_v2, info
     end

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -105,7 +105,7 @@ class GemInfoTest < ActiveSupport::TestCase
       Rails.cache.expects(:read).with("info_v2/example").raises(TypeError, "struct size differs")
 
       info = nil
-      assert_nothing_raised { info = GemInfo.new("example").compact_index_info_v2 }
+      assert_nothing_raised { info = GemInfo.new("example").compact_index_info(version: 2) }
 
       assert_equal @expected_info_v2, info
     end

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -6,19 +6,21 @@ class GemInfoTest < ActiveSupport::TestCase
   setup do
     Rails.cache.delete("names")
     Rails.cache.delete("info/example")
+    Rails.cache.delete("info_v2/example")
   end
 
   teardown do
     Rails.cache.delete("names")
     Rails.cache.delete("info/example")
+    Rails.cache.delete("info_v2/example")
   end
 
   context "#compact_index_info" do
     setup do
       rubygem = create(:rubygem, name: "example")
-      version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "qw2dwe")
+      @version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "qw2dwe")
       dep = create(:rubygem, name: "exmaple_dep")
-      create(:dependency, rubygem: dep, version: version)
+      create(:dependency, rubygem: dep, version: @version)
 
       @expected_info = [CompactIndex::GemVersion.new(
         "1.0.0",
@@ -29,12 +31,44 @@ class GemInfoTest < ActiveSupport::TestCase
         ">= 2.0.0",
         ">= 2.6.3"
       )]
+
+      @expected_info_v2 = [CompactIndex::GemVersionV2.new(
+        "1.0.0",
+        "ruby",
+        "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
+        "qw2dwe",
+        [CompactIndex::Dependency.new("exmaple_dep", "= 1.0.0")],
+        ">= 2.0.0",
+        ">= 2.6.3",
+        @version.created_at.utc.iso8601
+      )]
+
+      @expected_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(@expected_info))
+      @expected_info_checksum_v2 = Digest::MD5.hexdigest(CompactIndex.info(@expected_info_v2))
     end
 
     should "return gem version and dependency" do
       info = GemInfo.new("example").compact_index_info
 
       assert_equal @expected_info, info
+    end
+
+    should "return v2 gem version and dependency with created_at" do
+      info = GemInfo.new("example").compact_index_info_v2
+
+      assert_equal @expected_info_v2, info
+    end
+
+    should "compute v2 info checksum with created_at" do
+      assert_equal @expected_info_checksum_v2, GemInfo.new("example").info_checksum_v2
+      refute_equal GemInfo.new("example").info_checksum, GemInfo.new("example").info_checksum_v2
+    end
+
+    should "compute v1 and v2 info checksums together" do
+      assert_equal({
+                     info_checksum: @expected_info_checksum,
+                     info_checksum_v2: @expected_info_checksum_v2
+                   }, GemInfo.new("example").info_checksums)
     end
 
     should "write cache" do
@@ -51,13 +85,36 @@ class GemInfoTest < ActiveSupport::TestCase
       assert_equal @expected_info, info
     end
 
-    should "recompute when cache deserialization fails" do
+    should "write v2 cache" do
+      Rails.cache.expects(:write).with("info_v2/example", @expected_info_v2)
+
+      GemInfo.new("example").compact_index_info_v2
+    end
+
+    should "read v2 from cache when cache exists" do
+      Rails.cache.expects(:read).with("info_v2/example")
+
+      info = GemInfo.new("example").compact_index_info_v2
+
+      assert_equal @expected_info_v2, info
+    end
+
+    should "recompute when v1 cache deserialization fails" do
       Rails.cache.expects(:read).with("info/example").raises(TypeError, "struct size differs")
 
       info = nil
       assert_nothing_raised { info = GemInfo.new("example").compact_index_info }
 
       assert_equal @expected_info, info
+    end
+
+    should "recompute when v2 cache deserialization fails" do
+      Rails.cache.expects(:read).with("info_v2/example").raises(TypeError, "struct size differs")
+
+      info = nil
+      assert_nothing_raised { info = GemInfo.new("example").compact_index_info_v2 }
+
+      assert_equal @expected_info_v2, info
     end
   end
 

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -70,10 +70,11 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
               "indexed" => [false, true],
               "yanked_at" => [version_attributes[:yanked_at].as_json, nil],
               "yanked_info_checksum" => [version_attributes[:yanked_info_checksum], nil],
+              "yanked_info_checksum_v2" => [version_attributes[:yanked_info_checksum_v2], nil],
               "updated_at" => [version_attributes[:updated_at].as_json, version.updated_at.as_json]
             },
             "unchanged" => version_attributes
-              .except("updated_at", "yanked_info_checksum", "yanked_at", "indexed")
+              .except("updated_at", "yanked_info_checksum", "yanked_info_checksum_v2", "yanked_at", "indexed")
               .merge("position" => 0, "latest" => false)
               .transform_values(&:as_json)
           },


### PR DESCRIPTION
### TLDR

Adds v2 info checksum columns to `Version` and writes to these on gem push and yank, clears them on restore, and adds the `created_at` field to the `GemVersion` struct and appends it to output when present. 

Addresses https://github.com/rubygems/rubygems.org/issues/6477

### Description

In order to support both the cooldown project and the native extensions work, we need to adjust the compact index to include `created_at`. A [dual-write approach](https://github.com/rubygems/rubygems.org/issues/6412#issuecomment-4392624899) has been decided on to achieve this, so that we can cautiously migrate over to v2 of the compact index (which includes `created_at`) and have the option of switching back to the current version (v1) if there are early issues. 

This PR begins support for the v2 compact index with the following changes: 

- Add `info_checksum_v2` (string) and `yanked_info_checksum_v2` (string) to `versions`
- Add `created_at` field to the GemVersion struct and append it to `to_line` output when present
- Add version: parameter to `compute_compact_index_info` (default `1`, pass `2` to include `created_at`).
- Dual-write `info_checksum_v2` on gem push and dual-write `yanked_info_checksum_v2` on yank, clear `yanked_info_checksum_v2` on restore.
- Refresh the V2 compact index info cache in `UploadInfoFileJob` as we already do this for the existing compact index info cache. 

### Tests

Tests were added to `gem_info_test`, `gem_version_test`, `deletion_test` and `push_test` to cover the changes. Tests verify that pushes write both v1 and v2 info_checksum (with differing values), yanks write both yanked checksums, and restores clear both, as well as confirming the correct formatting and inclusion of `created_at` where required.

### Rollout
Will monitor gem pushes are working fine + populating the new columns.