### PR TITLE
👨‍🔬 Add flags to CodeCov config to stop fork PRs from failing project status

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,27 @@
 codecov:
   notify:
     after_n_builds: 2
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        flags:
+          - core
+      avo:
+        target: auto
+        informational: true
+        flags:
+          - avo
+    patch:
+      default:
+        target: auto
+
+flags:
+  core:
+    paths:
+      - "!app/avo/"
+  avo:
+    paths:
+      - "app/avo/"


### PR DESCRIPTION
👨‍🔬 testing to see if it's possible to prevent fork PRs from failing CodeCov project CI 👨‍🔬 

Context: I believe due to security reasons, PRs from forks of the repo cannot run the avo tests as they lack access to the credentials which leads to CodeCov reporting a descrease in test coverage at the project level and thus a failed CI status check. Meanwhile the CodeCov patch level CI status check passes just fine.