### PR TITLE
Skip public cache headers on homepage when flash is present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,7 +82,7 @@ class ApplicationController < ActionController::Base
   end
 
   def cacheable_request?
-    !signed_in?
+    !signed_in? && flash.empty?
   end
 
   def cache_expiry_headers(expiry: 60, fastly_expiry: 3600)

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -27,6 +27,16 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert_includes response.headers["Cache-Control"], "public"
   end
 
+  test "request with non empty flash hash does not set public cache headers" do
+    get update_email_confirmations_path(token: "invalid_token")
+
+    follow_redirect!
+
+    assert_response :success
+    refute_includes response.headers["Cache-Control"], "public"
+    assert_nil response.headers["Surrogate-Control"]
+  end
+
   test "authenticated request sets a session cookie" do
     user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
     post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })


### PR DESCRIPTION
## What

Skip public cache headers on the homepage when there's a flash message present (`flash.empty?` check in `HomeController#index`).

Prev PR implementing caching:
- https://github.com/rubygems/rubygems.org/pull/6385

## Why

`EmailConfirmationTest#test_re-using_confirmation_link` is failing on master.

The homepage sets `Cache-Control: public, max-age=60` for logged-out users (via `cache_expiry_headers` in `HomeController#index`, added in #6385 to reduce server load). The problem: when any controller redirects to `/` with a flash message, the browser may already have a cached copy of the homepage from a recent visit. Since the cache is still fresh (within 60s), the browser serves the cached HTML without hitting the server — so the flash never gets rendered and the user never sees the message.

Adding `&& flash.empty?` ensures we only set public cache headers when there's no flash to display. If a flash is present (e.g., from a redirect after an invalid confirmation token), the page won't tell the browser to cache it, so the server always gets a chance to render the flash into the HTML. Normal homepage visits without flash messages continue to be cached as before.

## Tophat

1. Go to the sign in page
2. Click "Didn't receive confirmation mail?"
3. Enter `security@rubygems.com` and click Resend Confirmation
4. Go to the letter opener page (`/letter_opener`) and open the confirmation email
5. Click the confirmation link — you should see the banner: "Your email address has been verified"
6. Click the same confirmation link again — you should see the banner: "Please double check the URL or try submitting it again."

Tested locally to repro this issue. With this fix, banners now render on redirect:
<img width="1124" height="678" alt="Screenshot 2026-05-14 at 2 57 33 PM" src="https://github.com/user-attachments/assets/8d8d44f3-3146-42d9-a27f-a34aa2077f3c" />
<img width="1120" height="674" alt="Screenshot 2026-05-14 at 2 57 38 PM" src="https://github.com/user-attachments/assets/b028e22b-0cae-4249-8e1e-4f8b5d1cf23e" />