### PR TITLE
Add maintenance task to discard spam accounts

### DIFF
--- a/app/tasks/maintenance/discard_spam_accounts_task.rb
+++ b/app/tasks/maintenance/discard_spam_accounts_task.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Soft-deletes unconfirmed users with no gem ownerships matching an email domain.
+#
+# Parameters:
+#   created_after:  Start of the time window (required)
+#   created_before: End of the time window (defaults to now)
+#   domain_suffix:  Email domain to match, e.g. "example.com"
+class Maintenance::DiscardSpamAccountsTask < MaintenanceTasks::Task
+  attribute :created_after, :datetime
+  attribute :created_before, :datetime, default: -> { Time.current }
+  attribute :domain_suffix, :string
+
+  validates :created_after, presence: true
+  validates :domain_suffix, presence: true
+
+  def collection
+    User.where("email LIKE ?", "%@#{ActiveRecord::Base.sanitize_sql_like(domain_suffix)}")
+      .where(created_at: created_after..created_before)
+      .where(email_confirmed: false)
+      .where.missing(:ownerships)
+  end
+
+  def process(user)
+    return if user.discarded?
+    without_deletion_email { user.discard! }
+  rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
+    Rails.error.report(e, context: { user_id: user.id }, handled: true)
+  end
+
+  private
+
+  def without_deletion_email
+    User.skip_callback(:discard, :after, :send_deletion_complete_email)
+    yield
+  ensure
+    User.set_callback(:discard, :after, :send_deletion_complete_email)
+  end
+end

--- a/test/tasks/maintenance/discard_spam_accounts_task_test.rb
+++ b/test/tasks/maintenance/discard_spam_accounts_task_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+
+  test "#process discards a matching user" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+
+    Maintenance::DiscardSpamAccountsTask.process(user)
+
+    assert_predicate user.reload, :discarded?
+  end
+
+  test "#process expires API keys" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    api_key = create(:api_key, owner: user)
+
+    Maintenance::DiscardSpamAccountsTask.process(user)
+
+    assert_predicate api_key.reload, :expired?
+  end
+
+  test "#process destroys webhooks" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    webhook = create(:global_web_hook, user: user)
+
+    Maintenance::DiscardSpamAccountsTask.process(user)
+
+    assert_not WebHook.exists?(webhook.id)
+  end
+
+  test "#process does not send a deletion complete email" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+
+    assert_no_enqueued_emails do
+      Maintenance::DiscardSpamAccountsTask.process(user)
+    end
+  end
+
+  test "#process restores deletion email callback after processing" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    Maintenance::DiscardSpamAccountsTask.process(user)
+
+    other_user = create(:user, email: "regular@example.com", created_at: 1.day.ago)
+
+    assert_enqueued_emails 1 do
+      other_user.discard!
+    end
+  end
+
+  test "#process reports error when discard fails" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+
+    User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
+
+    assert_nothing_raised do
+      Maintenance::DiscardSpamAccountsTask.process(user)
+    end
+
+    assert_not user.reload.discarded?
+  end
+
+  test "#process skips already discarded users" do
+    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user.discard!
+
+    assert_no_changes -> { user.reload.deleted_at } do
+      Maintenance::DiscardSpamAccountsTask.process(user)
+    end
+  end
+
+  test "#collection only includes unconfirmed users matching domain with no gems in the date range" do
+    task = Maintenance::DiscardSpamAccountsTask.new
+    task.created_after = 3.days.ago
+    task.created_before = 1.day.ago
+    task.domain_suffix = "example.com"
+
+    matching = create(:user, email: "recent@example.com", created_at: 2.days.ago, email_confirmed: false)
+    too_recent = create(:user, email: "new@example.com", created_at: 1.hour.ago, email_confirmed: false)
+    old_example = create(:user, email: "old@example.com", created_at: 5.days.ago, email_confirmed: false)
+    other_domain = create(:user, email: "recent@anotherexample.com", created_at: 2.days.ago, email_confirmed: false)
+    confirmed = create(:user, email: "confirmed@example.com", created_at: 2.days.ago, email_confirmed: true)
+    with_gems = create(:user, email: "gems@example.com", created_at: 2.days.ago, email_confirmed: false)
+    create(:ownership, user: with_gems, rubygem: create(:rubygem))
+
+    collection = task.collection
+
+    assert_includes collection, matching
+    assert_not_includes collection, too_recent
+    assert_not_includes collection, old_example
+    assert_not_includes collection, other_domain
+    assert_not_includes collection, confirmed
+    assert_not_includes collection, with_gems
+  end
+
+  test "#collection defaults created_before to now" do
+    task = Maintenance::DiscardSpamAccountsTask.new
+    task.created_after = 3.days.ago
+    task.domain_suffix = "example.com"
+
+    recent = create(:user, email: "just-now@example.com", created_at: 1.minute.ago, email_confirmed: false)
+
+    assert_includes task.collection, recent
+  end
+
+  test "validates presence of created_after and domain_suffix" do
+    task = Maintenance::DiscardSpamAccountsTask.new
+
+    assert_not task.valid?
+    assert_includes task.errors[:created_after], "can't be blank"
+    assert_includes task.errors[:domain_suffix], "can't be blank"
+  end
+end


### PR DESCRIPTION
## Background

During a recent incident, many bot accounts were created using disposable email domains. These accounts are unconfirmed, have no gems, and have no legitimate activity. They need to be cleaned up.

## Changes

Adds a new maintenance task: `Maintenance::DiscardSpamAccountsTask`. It discards unconfirmed users matching an email domain within a configurable time window.

### Collection filters:
- Email matches input domain
- Created within the `created_after..created_before` range
- `email_confirmed` is false
- User has no gem ownerships

### What discard! does per user:
- Yanks sole-owner gems (no-op for these users)
- Expires all API keys
- Destroys ownerships, webhooks, subscriptions, webauthn credentials
- Scrubs PII (email → deleted+<id>@rubygems.org, nulls handle, name, etc.)
- Sets `deleted_at` (soft delete)

## What this task intentionally skips:
- Deletion confirmation email — no point emailing spam accounts. The callback is suppressed via
`skip_callback`.

<details><summary>Script to seed users to test in development</summary>

```ruby
# frozen_string_literal: true

# Usage: bin/rails runner script/seed_spam_users.rb
#
# Creates test users to verify the DiscardSpamAccountsTask maintenance task.
# After running, you can run the task from the maintenance_tasks UI with:
#   domain_suffix: [example.com](http://example.com/)
#   created_after:  <some time before now>
#   created_before: <now>

puts "Seeding test users for DiscardSpamAccountsTask..."

password = "#{SecureRandom.hex(24)}!A1a"

# === SHOULD BE DELETED (match all criteria) ===

5.times do |i|
  User.create!(
    email: "spam-bot-#{i}@example.com",
    handle: "spambot#{i}#{SecureRandom.hex(4)}",
    password: password,
    email_confirmed: false,
    policies_acknowledged_at: Time.zone.now
  )
end

puts "  :white_check_mark: Created 5 unconfirmed @example.com users with no gems (should be deleted)"

3.times do |i|
  User.create!(
    email: "attack-#{i}@example.org",
    handle: "attacker#{i}#{SecureRandom.hex(4)}",
    password: password,
    email_confirmed: false,
    policies_acknowledged_at: Time.zone.now
  )
end

puts "  :white_check_mark: Created 3 unconfirmed @example.org users with no gems (should be deleted when domain_suffix=example.org)"

# === SHOULD NOT BE DELETED ===

# 1. Confirmed @example.com user
confirmed = User.create!(
  email: "[legit@example.com](mailto:legit@example.com)",
  handle: "legit_user_#{SecureRandom.hex(4)}",
  password: password,
  email_confirmed: true,
  policies_acknowledged_at: Time.zone.now
)
confirmed.confirm_email!

puts "  :shield:  Created 1 confirmed @example.com user (should NOT be deleted)"

# 2. Unconfirmed @example.com user WITH gem ownership
owner = User.create!(
  email: "[owner@example.com](mailto:owner@example.com)",
  handle: "gem_owner_#{SecureRandom.hex(4)}",
  password: password,
  email_confirmed: false,
  policies_acknowledged_at: Time.zone.now
)
gem_name = "test-spam-gem-#{SecureRandom.hex(4)}"
rubygem = Rubygem.create!(name: gem_name)
Ownership.create!(user: owner, rubygem: rubygem, confirmed_at: Time.zone.now, authorizer: owner)

puts "  :shield:  Created 1 unconfirmed @example.com user with gem ownership (should NOT be deleted)"

# 3. Unconfirmed @example.com user WITH an API key
with_api_key = User.create!(
  email: "[apikey@example.com](mailto:apikey@example.com)",
  handle: "apikey_#{SecureRandom.hex(4)}",
  password: password,
  email_confirmed: false,
  policies_acknowledged_at: Time.zone.now
)
ApiKey.create!(
  owner: with_api_key,
  name: "ci-key",
  hashed_key: Digest::SHA256.hexdigest(SecureRandom.hex(16)),
  scopes: %w[index_rubygems]
)

puts "  :white_check_mark: Created 1 unconfirmed @example.com user with API key but no gems (should be deleted, API key expired)"

# 4. Unconfirmed user with different domain
User.create!(
  email: "[innocent@gmail.com](mailto:innocent@gmail.com)",
  handle: "innocent_#{SecureRandom.hex(4)}",
  password: password,
  email_confirmed: false,
  policies_acknowledged_at: Time.zone.now
)

puts "  :shield:  Created 1 unconfirmed [@Gmail Alerts](https://shopify.enterprise.slack.com/team/U0AAU9K39GQ).com user (should NOT be deleted)"

# 5. Old unconfirmed @example.com user (outside typical attack window)
old_user = User.create!(
  email: "[old-spam@example.com](mailto:old-spam@example.com)",
  handle: "old_spam_#{SecureRandom.hex(4)}",
  password: password,
  email_confirmed: false,
  policies_acknowledged_at: Time.zone.now
)
old_user.update_column(:created_at, 30.days.ago)

puts "  :shield:  Created 1 old unconfirmed @example.com user (should NOT be deleted if date range excludes it)"

puts ""
puts "Done! Summary:"
puts "  Total users created: 12"
puts "  Expected to be deleted ([example.com](http://example.com/)): 6 (5 plain + 1 with API key)"
puts "  Expected to be deleted ([mailnesia.com](http://mailnesia.com/)): 3"
puts "  Expected to be kept: 3 (confirmed, has gems, different domain)"
puts "  Expected to be kept if date range < 30 days: 1 (old user)"
```
</details>