### PR TITLE
Disallow users from registering emails from reserved domains

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
     uniqueness: { case_sensitive: false }
   validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP },
     allow_blank: true
-  validates :email, reserved_domain: true, if: :email_changed?
+  validates :email, reserved_domain: true, if: -> { email_changed? || email_confirmed_changed?(to: true) }
   validates :unconfirmed_email, reserved_domain: true, if: :unconfirmed_email_changed?
 
   validates :handle, uniqueness: { case_sensitive: false }, allow_nil: true, if: :handle_changed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -274,9 +274,10 @@ class User < ApplicationRecord
   def unblock!
     raise ArgumentError, "User is not blocked" unless blocked?
 
-    self.email = blocked_email
-    self.blocked_email = nil
-    save(validate: false)
+    update!(
+      email: blocked_email,
+      blocked_email: nil
+    )
   end
 
   def blocked?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,10 @@ class User < ApplicationRecord
 
   validates :email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, presence: true,
     uniqueness: { case_sensitive: false }
-  validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+  validates :unconfirmed_email, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }, format: { with: URI::MailTo::EMAIL_REGEXP },
+    allow_blank: true
+  validates :email, reserved_domain: true, if: :email_changed?
+  validates :unconfirmed_email, reserved_domain: true, if: :unconfirmed_email_changed?
 
   validates :handle, uniqueness: { case_sensitive: false }, allow_nil: true, if: :handle_changed?
   validates :handle, format: { with: Patterns::HANDLE_PATTERN }, length: { within: 2..40 }, allow_nil: true
@@ -271,10 +274,9 @@ class User < ApplicationRecord
   def unblock!
     raise ArgumentError, "User is not blocked" unless blocked?
 
-    update!(
-      email: blocked_email,
-      blocked_email: nil
-    )
+    self.email = blocked_email
+    self.blocked_email = nil
+    save(validate: false)
   end
 
   def blocked?

--- a/app/validators/reserved_domain_validator.rb
+++ b/app/validators/reserved_domain_validator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Rejects email addresses whose domain falls under a reserved or special-use
+# name that can never carry deliverable mail:
+#
+#   * RFC 2606 — .test, .example, .invalid, .localhost (TLDs);
+#                example.com, example.net, example.org (second-level)
+#   * RFC 6761 — .localhost, .invalid, .example, .test (special-use, same set)
+#   * RFC 6762 / mDNS — .local
+#   * RFC 7686 — .onion
+class ReservedDomainValidator < ActiveModel::EachValidator
+  RESERVED_TLDS = %w[test example invalid localhost local onion].freeze
+  RESERVED_DOMAINS = %w[example.com example.net example.org].freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    domain = value.split("@").last
+    return if domain.blank?
+
+    domain = domain.downcase
+    return unless reserved?(domain)
+
+    record.errors.add(attribute, I18n.t("activerecord.errors.messages.reserved_domain", domain: domain))
+  end
+
+  private
+
+  def reserved?(domain)
+    return true if RESERVED_DOMAINS.any? { |d| domain == d || domain.end_with?(".#{d}") }
+    tld = domain.split(".").last
+    RESERVED_TLDS.include?(tld)
+  end
+end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -108,6 +108,7 @@ de:
           werden
         blocked: Die Domain '%{domain}' wurde wegen Spam blockiert. Bitte verwenden
           Sie eine gültige persönliche E-Mail-Adresse.
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,7 @@ en:
       messages:
         not_pwned: has previously appeared in a data breach and should not be used
         blocked: "domain '%{domain}' has been blocked for spamming. Please use a valid personal email."
+        reserved_domain: "domain '%{domain}' is reserved and cannot be used for registration. Please use a valid personal email."
       models:
         api_key:
           attributes:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -104,6 +104,7 @@ es:
           debería usar
         blocked: El dominio '%{domain}' ha sido bloqueado por spam. Por favor utiliza
           un email personal válido.
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -101,6 +101,7 @@ fr:
       messages:
         not_pwned:
         blocked:
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -97,6 +97,7 @@ ja:
       messages:
         not_pwned: 過去にデータ侵害を受けたためお使いになれません
         blocked: ドメイン %{domain} はスパムのため差し止められました。正しい個人のEメールを使ってください。
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -96,6 +96,7 @@ nl:
       messages:
         not_pwned:
         blocked:
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -102,6 +102,7 @@ pt-BR:
         not_pwned: já apareceu anteriormente em um vazamento de dados e não deve ser
           utilizada
         blocked:
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -97,6 +97,7 @@ zh-CN:
       messages:
         not_pwned: 曾出现过数据泄露，不应该再使用
         blocked: 域名 '%{domain}' 因发送垃圾邮件已被禁用，请使用另外有效的个人邮箱。
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -96,6 +96,7 @@ zh-TW:
       messages:
         not_pwned: 曾出現在資料外洩事件中，不應再使用
         blocked: 網域 '%{domain}' 因濫發垃圾郵件而遭封鎖。請使用有效的個人電子郵件地址。
+        reserved_domain:
       models:
         api_key:
           attributes:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,19 +12,19 @@ author = User.create_with(
   password: password,
   email_confirmed: true,
   webauthn_id: "a1TLW3o1W18mTuDBfDALHhL2tZ1_E-2B03Fqsdu8Rv05V4tSsRzepe-L7Uprg356dw1tktXXcTI9TIRaK4gM-A"
-).find_or_create_by!(email: "gem-author@example.com")
+).find_or_create_by!(email: "gem-author@rubygems-test.org")
 
 maintainer = User.create_with(
   handle: "gem-maintainer",
   password: password,
   email_confirmed: true
-).find_or_create_by!(email: "gem-maintainer@example.com")
+).find_or_create_by!(email: "gem-maintainer@rubygems-test.org")
 
 user = User.create_with(
   handle: "gem-user",
   password: password,
   email_confirmed: true
-).find_or_create_by!(email: "gem-user@example.com")
+).find_or_create_by!(email: "gem-user@rubygems-test.org")
 
 Membership.create_with(
   role: :owner,

--- a/test/components/previews/events/user_event/email/added_component_preview.rb
+++ b/test/components/previews/events/user_event/email/added_component_preview.rb
@@ -2,7 +2,7 @@
 
 class Events::UserEvent::Email::AddedComponentPreview < Lookbook::Preview
   # @param email email
-  def default(email: "user@example.com")
+  def default(email: "user@rubygems-test.org")
     event = FactoryBot.build(:events_user_event, tag: Events::UserEvent::EMAIL_ADDED, additional:
     {
       email:

--- a/test/components/previews/events/user_event/email/sent_component_preview.rb
+++ b/test/components/previews/events/user_event/email/sent_component_preview.rb
@@ -4,7 +4,7 @@ class Events::UserEvent::Email::SentComponentPreview < Lookbook::Preview
   # @param subject text
   # @param from email
   # @param to email
-  def default(subject: "[Subject]", from: "example@rubygems.org", to: "user@example.com")
+  def default(subject: "[Subject]", from: "example@rubygems.org", to: "user@rubygems-test.org")
     event = FactoryBot.build(:events_user_event, tag: Events::UserEvent::EMAIL_SENT, additional:
     {
       subject:,

--- a/test/components/previews/events/user_event/email/verified_component_preview.rb
+++ b/test/components/previews/events/user_event/email/verified_component_preview.rb
@@ -2,7 +2,7 @@
 
 class Events::UserEvent::Email::VerifiedComponentPreview < Lookbook::Preview
   # @param email email
-  def default(email: "user@example.com")
+  def default(email: "user@rubygems-test.org")
     event = FactoryBot.build(:events_user_event, tag: Events::UserEvent::EMAIL_VERIFIED, additional:
     {
       email:

--- a/test/components/previews/events/user_event/user/created_component_preview.rb
+++ b/test/components/previews/events/user_event/user/created_component_preview.rb
@@ -2,7 +2,7 @@
 
 class Events::UserEvent::User::CreatedComponentPreview < Lookbook::Preview
   # @param email email
-  def default(email: "user@example.com")
+  def default(email: "user@rubygems-test.org")
     event = FactoryBot.build(:events_user_event, tag: Events::UserEvent::CREATED, additional:
     {
       email:

--- a/test/factories/sequences.rb
+++ b/test/factories/sequences.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   sequence :email do |n|
-    "user#{n}@example.com"
+    "user#{n}@rubygems-test.org"
   end
 
   sequence :handle do |n|

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
     trait :blocked do
       email { "security+locked-#{SecureRandom.hex(4)}@rubygems.org" }
-      blocked_email { "test@example.com" }
+      blocked_email { "test@rubygems-test.org" }
     end
   end
 end

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -418,7 +418,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       context "when mfa is required" do
         setup do
           User.any_instance.stubs(:mfa_required?).returns true
-          @emails = [@second_user.email, "doesnotexist@example.com", @user.email]
+          @emails = [@second_user.email, "doesnotexist@rubygems-test.org", @user.email]
         end
 
         context "by user with mfa disabled" do
@@ -484,7 +484,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       context "when mfa is recommended" do
         setup do
           User.any_instance.stubs(:mfa_recommended?).returns true
-          @emails = [@second_user.email, "doesnotexist@example.com", @user.email]
+          @emails = [@second_user.email, "doesnotexist@rubygems-test.org", @user.email]
         end
 
         context "by user with mfa disabled" do
@@ -815,7 +815,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       context "when mfa is required" do
         setup do
           User.any_instance.stubs(:mfa_required?).returns true
-          @emails = [@second_user.email, "doesnotexist@example.com", @user.email, "no@permission.com"]
+          @emails = [@second_user.email, "doesnotexist@rubygems-test.org", @user.email, "no@permission.com"]
         end
 
         context "by user with mfa disabled" do
@@ -881,7 +881,7 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
       context "when mfa is recommended" do
         setup do
           User.any_instance.stubs(:mfa_recommended?).returns true
-          @emails = [@second_user.email, "doesnotexist@example.com", @user.email, "nopermission@example.com"]
+          @emails = [@second_user.email, "doesnotexist@rubygems-test.org", @user.email, "nopermission@rubygems-test.org"]
         end
 
         context "by user with mfa disabled" do

--- a/test/functional/email_confirmations_controller_test.rb
+++ b/test/functional/email_confirmations_controller_test.rb
@@ -29,7 +29,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       setup do
         @user.confirm_email! # must be confirmed to sign in
         sign_in_as(@user)
-        @user.update!(unconfirmed_email: "new@example.com")
+        @user.update!(unconfirmed_email: "new@rubygems-test.org")
         get :update, params: { token: @user.confirmation_token }
       end
 
@@ -211,7 +211,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
         setup do
           @user.confirm_email!
           sign_in_as(@user)
-          @user.update!(unconfirmed_email: "new@example.com")
+          @user.update!(unconfirmed_email: "new@rubygems-test.org")
 
           assert @user.confirmation_token
           get :update, params: { token: @user.confirmation_token }
@@ -316,7 +316,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
       setup do
         @user.confirm_email!
         sign_in_as(@user)
-        @user.update!(unconfirmed_email: "new@example.com")
+        @user.update!(unconfirmed_email: "new@rubygems-test.org")
         @challenge = session[:webauthn_authentication]["challenge"]
         WebauthnHelpers.create_credential(
           webauthn_credential: @webauthn_credential,
@@ -339,7 +339,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
       should "change the user's email" do
         assert @user.reload.email_confirmed
-        assert_equal "new@example.com", @user.email
+        assert_equal "new@rubygems-test.org", @user.email
       end
 
       should "clear mfa_expires_at" do
@@ -517,7 +517,7 @@ class EmailConfirmationsControllerTest < ActionController::TestCase
 
     context "user is signed in" do
       setup do
-        @user = create(:user, confirmation_token: "something", unconfirmed_email: "new@example.com")
+        @user = create(:user, confirmation_token: "something", unconfirmed_email: "new@rubygems-test.org")
         sign_in_as(@user)
       end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -327,8 +327,8 @@ class ProfilesControllerTest < ActionController::TestCase
 
         create(:events_user_event, user: @user, tag: Events::UserEvent::EMAIL_SENT)
 
-        create(:events_user_event, user: @user, tag: Events::UserEvent::EMAIL_ADDED, additional: { email: "other@example.com" })
-        create(:events_user_event, user: @user, tag: Events::UserEvent::EMAIL_VERIFIED, additional: { email: "other@example.com" })
+        create(:events_user_event, user: @user, tag: Events::UserEvent::EMAIL_ADDED, additional: { email: "other@rubygems-test.org" })
+        create(:events_user_event, user: @user, tag: Events::UserEvent::EMAIL_VERIFIED, additional: { email: "other@rubygems-test.org" })
 
         create(:events_user_event, user: @user, tag: Events::UserEvent::API_KEY_CREATED, additional: { gem: create(:rubygem).name })
         create(:events_user_event, user: @user, tag: Events::UserEvent::API_KEY_DELETED)

--- a/test/helpers/gem_helpers.rb
+++ b/test/helpers/gem_helpers.rb
@@ -129,7 +129,7 @@ module GemHelpers # rubocop:disable Metrics/ModuleLength
       s.authors = ["Someone"]
       s.date = Time.zone.now.strftime("%Y-%m-%d")
       s.description = summary.to_s
-      s.email = "someone@example.com"
+      s.email = "someone@rubygems-test.org"
       s.files = []
       s.homepage = "http://example.com/#{name}"
       s.require_paths = ["lib"]

--- a/test/integration/gem_validator/signed_rubygem_validator_test.rb
+++ b/test/integration/gem_validator/signed_rubygem_validator_test.rb
@@ -13,7 +13,7 @@ class GemValidator::SignedGemTest < Minitest::Test
   KEY = Gem::Security.create_key "ec"
   PRIVATE_KEY = KEY.to_pem Gem::Security::KEY_CIPHER, "password"
   expiration_length_days = Gem.configuration.cert_expiration_length_days
-  CERT = Gem::Security.create_cert_email("foo@example.com", KEY,
+  CERT = Gem::Security.create_cert_email("foo@rubygems-test.org", KEY,
     Gem::Security::ONE_DAY * expiration_length_days)
   PUB_KEY = CERT.to_pem
 
@@ -110,7 +110,7 @@ class GemValidator::SignedGemTest < Minitest::Test
   def test_wrong_pub_key
     key = Gem::Security.create_key "ec"
     expiration_length_days = Gem.configuration.cert_expiration_length_days
-    cert = Gem::Security.create_cert_email("foo@example.com", key,
+    cert = Gem::Security.create_cert_email("foo@rubygems-test.org", key,
       Gem::Security::ONE_DAY * expiration_length_days)
     pub_key = cert.to_pem
 

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -9,7 +9,7 @@ class OAuthTest < ActionDispatch::IntegrationTest
       uid: "95144751",
       info: {
         nickname: "jackson-keeling",
-        email: "jackson.keeling@example.com",
+        email: "jackson.keeling@rubygems-test.org",
         name: "Jackson Keeling",
         image: "https://via.placeholder.com/300x300.png",
         urls: {
@@ -43,7 +43,7 @@ class OAuthTest < ActionDispatch::IntegrationTest
           company: nil,
           blog: nil,
           location: "Paigeton, Massachusetts",
-          email: "jackson.keeling@example.com",
+          email: "jackson.keeling@rubygems-test.org",
           hireable: nil,
           bio: nil,
           public_repos: 263,

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -517,7 +517,7 @@ class PushTest < ActionDispatch::IntegrationTest
           '@original_platform': 'not-ruby'
           '@new_platform': ruby
           '@summary': 'malicious'
-          '@authors': [test@example.com]
+          '@authors': [test@rubygems-test.org]
       YAML
 
       push_gem "malicious.gem"
@@ -543,7 +543,7 @@ class PushTest < ActionDispatch::IntegrationTest
           '@original_platform': 'not-ruby'
           '@new_platform': ruby
           '@summary': 'malicious'
-          '@authors': [test@example.com]
+          '@authors': [test@rubygems-test.org]
       YAML
 
       push_gem "malicious.gem"
@@ -567,7 +567,7 @@ class PushTest < ActionDispatch::IntegrationTest
           platform: !ruby/object:Gem::Platform
             os: ruby
           summary: 'malicious'
-          authors: [test@example.com]
+          authors: [test@rubygems-test.org]
         YAML
         push_gem "malicious.gem"
 
@@ -588,7 +588,7 @@ class PushTest < ActionDispatch::IntegrationTest
           version: '1'
           platform: [ruby]
           summary: 'malicious'
-          authors: [test@example.com]
+          authors: [test@rubygems-test.org]
         YAML
         push_gem "malicious.gem"
 
@@ -603,7 +603,7 @@ class PushTest < ActionDispatch::IntegrationTest
           version: []
         version: '1'
         summary: 'malicious'
-        authors: [test@example.com]
+        authors: [test@rubygems-test.org]
       YAML
       push_gem "malicious.gem"
 
@@ -620,7 +620,7 @@ class PushTest < ActionDispatch::IntegrationTest
             os: "../../../../../etc/passwd"
           '@original_platform': ruby
           '@summary': 'malicious'
-          '@authors': [test@example.com]
+          '@authors': [test@rubygems-test.org]
       YAML
       push_gem "malicious.gem"
 
@@ -635,7 +635,7 @@ class PushTest < ActionDispatch::IntegrationTest
         version: '1'
         platform: ruby
         summary: 'malicious'
-        authors: [test@example.com]
+        authors: [test@rubygems-test.org]
         date: !ruby/object:Time
           a: 1
       YAML

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -7,7 +7,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
   include GemspecYamlTemplateHelpers
 
   setup do
-    @user = create(:user, email: "user@example.com")
+    @user = create(:user, email: "user@rubygems-test.org")
     @api_key = create(:api_key, owner: @user)
     @gem = gem_file
     @cutter = Pusher.new(@api_key, @gem)

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -10,7 +10,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
     @ip_address = "1.2.3.4"
-    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
+    @user = create(:user, email: "nick@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                    remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
   end
 
@@ -143,7 +143,7 @@ class RackAttackTest < ActionDispatch::IntegrationTest
       end
 
       should "return 401 for unauthorized request" do
-        post "/session", params: { session: { who: "no@example.com", password: @user.password } }
+        post "/session", params: { session: { who: "no@rubygems-test.org", password: @user.password } }
 
         assert_response :unauthorized
       end
@@ -682,14 +682,14 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
         should "throttle for sign in ignoring case" do
           post "/password",
-               params: { password: { email: "Nick@example.com" } }
+               params: { password: { email: "Nick@rubygems-test.org" } }
 
           assert_response :too_many_requests
         end
 
         should "throttle for sign in ignoring spaces" do
           post "/password",
-               params: { password: { email: "n ick@example.com" } }
+               params: { password: { email: "n ick@rubygems-test.org" } }
 
           assert_response :too_many_requests
         end

--- a/test/integration/sendgrid_webhook_test.rb
+++ b/test/integration/sendgrid_webhook_test.rb
@@ -38,8 +38,8 @@ class SendgridWebhookTest < ActionDispatch::IntegrationTest
 
   test "saves events and schedules jobs" do
     params = [
-      { email: "user1@example.com", sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i, event: "bounce" },
-      { email: "user2@example.com", sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==", timestamp: Time.current.to_i, event: "delivered" }
+      { email: "user1@rubygems-test.org", sg_event_id: "nwlyJ3Ej3wUBZQiaCAL5YA==", timestamp: Time.current.to_i, event: "bounce" },
+      { email: "user2@rubygems-test.org", sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==", timestamp: Time.current.to_i, event: "delivered" }
     ]
     assert_enqueued_jobs 2, only: ProcessSendgridEventJob do
       post "/sendgrid_events", params: params, as: :json, headers: authorization_header
@@ -50,8 +50,8 @@ class SendgridWebhookTest < ActionDispatch::IntegrationTest
     events = SendgridEvent.all
 
     assert_equal 2, events.size
-    assert_equal "user1@example.com", events.first.email
-    assert_equal "user2@example.com", events.last.email
+    assert_equal "user1@rubygems-test.org", events.first.email
+    assert_equal "user2@rubygems-test.org", events.last.email
     assert events.all?(&:pending?)
   end
 

--- a/test/mailers/policies_mailer_test.rb
+++ b/test/mailers/policies_mailer_test.rb
@@ -19,7 +19,7 @@ class PoliciesMailerTest < ActionMailer::TestCase
 
   test "send policy announcement to user with blocked email" do
     @user.email = "blocked@rubygems.org"
-    @user.blocked_email = "original-email@example.com"
+    @user.blocked_email = "original-email@rubygems-test.org"
     @user.save!
 
     PoliciesMailer.policy_update_announcement(@user).deliver_now

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -190,7 +190,7 @@ class MailerPreview < ActionMailer::Preview
         handle: "gem-user-with-yubikey",
         password: "super-secret-password",
         email_confirmed: true
-      ).find_or_create_by!(email: "gem-user-with-yubikey@example.com")
+      ).find_or_create_by!(email: "gem-user-with-yubikey@rubygems-test.org")
 
       webauthn_credential = user_with_yubikey.webauthn_credentials.create_with(
         external_id: "external-id",

--- a/test/models/parallel_pusher_test.rb
+++ b/test/models/parallel_pusher_test.rb
@@ -9,7 +9,7 @@ class ParallelPusherTest < ActiveSupport::TestCase
   context "when pushing gems in parallel" do
     setup do
       @fs = RubygemFs.mock!
-      @user = create(:user, email: "user@example.com")
+      @user = create(:user, email: "user@rubygems-test.org")
       @api_key = create(:api_key, owner: @user)
     end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -7,7 +7,7 @@ class PusherTest < ActiveSupport::TestCase
   include GemspecYamlTemplateHelpers
 
   setup do
-    @user = create(:user, email: "user@example.com")
+    @user = create(:user, email: "user@rubygems-test.org")
     @api_key = create(:api_key, owner: @user)
     @gem = gem_file
     @cutter = Pusher.new(@api_key, @gem)
@@ -309,7 +309,8 @@ class PusherTest < ActiveSupport::TestCase
         create(:version, rubygem: @rubygem, number: "0.1.1")
 
         refute @cutter.authorize
-        assert_equal "You do not have permission to push to this gem. Ask an owner to add you with: gem owner the_gem_name --add user@example.com",
+        assert_equal "You do not have permission to push to this gem. " \
+                     "Ask an owner to add you with: gem owner the_gem_name --add user@rubygems-test.org",
           @cutter.message
         assert_equal 403, @cutter.code
       end

--- a/test/models/sendgrid_event_test.rb
+++ b/test/models/sendgrid_event_test.rb
@@ -7,58 +7,58 @@ class SendgridEventTest < ActiveSupport::TestCase
 
   context ".fails_since_last_delivery" do
     should "return 0 for email with no events" do
-      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@example.com")
+      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@rubygems-test.org")
     end
 
     should "return 0 for email with no delivery failures" do
-      create(:sendgrid_event, event_type: "delivered", occurred_at: 1.day.ago, email: "user@example.com")
+      create(:sendgrid_event, event_type: "delivered", occurred_at: 1.day.ago, email: "user@rubygems-test.org")
 
-      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@example.com")
+      assert_equal 0, SendgridEvent.fails_since_last_delivery("user@rubygems-test.org")
     end
 
     should "return number of mail delivery failures" do
       freeze_time do
-        create(:sendgrid_event, event_type: "dropped", occurred_at: 1.day.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "bounce", occurred_at: 2.days.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 1.day.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 2.days.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@rubygems-test.org")
       end
 
-      assert_equal 3, SendgridEvent.fails_since_last_delivery("user@example.com")
+      assert_equal 3, SendgridEvent.fails_since_last_delivery("user@rubygems-test.org")
     end
 
     should "return number of delivery failures for given email only" do
       freeze_time do
-        create(:sendgrid_event, email: "user.a@example.com", event_type: "bounce", occurred_at: 1.day.ago)
-        create(:sendgrid_event, email: "user.b@example.com", event_type: "bounce", occurred_at: 2.days.ago)
-        create(:sendgrid_event, email: "user.a@example.com", event_type: "bounce", occurred_at: 3.days.ago)
+        create(:sendgrid_event, email: "user.a@rubygems-test.org", event_type: "bounce", occurred_at: 1.day.ago)
+        create(:sendgrid_event, email: "user.b@rubygems-test.org", event_type: "bounce", occurred_at: 2.days.ago)
+        create(:sendgrid_event, email: "user.a@rubygems-test.org", event_type: "bounce", occurred_at: 3.days.ago)
       end
 
-      assert_equal 2, SendgridEvent.fails_since_last_delivery("user.a@example.com")
-      assert_equal 1, SendgridEvent.fails_since_last_delivery("user.b@example.com")
+      assert_equal 2, SendgridEvent.fails_since_last_delivery("user.a@rubygems-test.org")
+      assert_equal 1, SendgridEvent.fails_since_last_delivery("user.b@rubygems-test.org")
     end
 
     should "count no more than one delivery failure per day" do
       freeze_time do
-        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "dropped", email: "user@example.com")
-        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "bounce", email: "user@example.com")
-        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@example.com")
-        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@example.com")
-        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "dropped", email: "user@example.com")
+        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "dropped", email: "user@rubygems-test.org")
+        create(:sendgrid_event, occurred_at: 1.day.ago, event_type: "bounce", email: "user@rubygems-test.org")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@rubygems-test.org")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "bounce", email: "user@rubygems-test.org")
+        create(:sendgrid_event, occurred_at: 2.days.ago, event_type: "dropped", email: "user@rubygems-test.org")
       end
 
-      assert_equal 2, SendgridEvent.fails_since_last_delivery("user@example.com")
+      assert_equal 2, SendgridEvent.fails_since_last_delivery("user@rubygems-test.org")
     end
 
     should "only count failures since last successful delivery" do
       freeze_time do
-        create(:sendgrid_event, event_type: "bounce", occurred_at: 1.day.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "delivered", occurred_at: 2.days.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "bounce", occurred_at: 4.days.ago, email: "user@example.com")
-        create(:sendgrid_event, event_type: "delivered", occurred_at: 5.days.ago, email: "user@example.com")
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 1.day.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "delivered", occurred_at: 2.days.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "dropped", occurred_at: 3.days.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "bounce", occurred_at: 4.days.ago, email: "user@rubygems-test.org")
+        create(:sendgrid_event, event_type: "delivered", occurred_at: 5.days.ago, email: "user@rubygems-test.org")
       end
 
-      assert_equal 1, SendgridEvent.fails_since_last_delivery("user@example.com")
+      assert_equal 1, SendgridEvent.fails_since_last_delivery("user@rubygems-test.org")
     end
   end
 
@@ -67,7 +67,7 @@ class SendgridEventTest < ActiveSupport::TestCase
       occurred_at = 1.minute.ago.change(usec: 0)
 
       SendgridEvent.process_later(
-        email: "user@example.com",
+        email: "user@rubygems-test.org",
         sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==",
         event: "bounce",
         timestamp: occurred_at.to_i
@@ -75,13 +75,13 @@ class SendgridEventTest < ActiveSupport::TestCase
 
       event = SendgridEvent.last
 
-      assert_equal("user@example.com", event.email)
+      assert_equal("user@rubygems-test.org", event.email)
       assert_equal("t61hI0Xpmk8XSR1YX4s0Kg==", event.sendgrid_id)
       assert_equal("bounce", event.event_type)
       assert_equal(occurred_at, event.occurred_at)
       assert_predicate event, :pending?
       assert_equal_hash(
-        { "email" => "user@example.com",
+        { "email" => "user@rubygems-test.org",
           "sg_event_id" => "t61hI0Xpmk8XSR1YX4s0Kg==",
           "event" => "bounce",
           "timestamp" => occurred_at.to_i },
@@ -92,7 +92,7 @@ class SendgridEventTest < ActiveSupport::TestCase
     should "schedule job to process event later" do
       assert_enqueued_jobs 1, only: ProcessSendgridEventJob do
         SendgridEvent.process_later(
-          email: "user@example.com",
+          email: "user@rubygems-test.org",
           sg_event_id: "t61hI0Xpmk8XSR1YX4s0Kg==",
           timestamp: Time.current.to_i
         )

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1025,20 +1025,6 @@ class UserTest < ActiveSupport::TestCase
         end
       end
     end
-
-    context "when the blocked email is a now-reserved domain" do
-      setup do
-        @user = create(:user, :blocked)
-        @user.update_columns(blocked_email: "grandfathered@example.com")
-      end
-
-      should "still restore the email" do
-        @user.unblock!
-
-        assert_equal "grandfathered@example.com", @user.email
-        assert_nil @user.blocked_email
-      end
-    end
   end
 
   context "#blocked?" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -191,6 +191,15 @@ class UserTest < ActiveSupport::TestCase
 
         assert user.update(full_name: "New Name")
       end
+
+      should "be invalid when activating an account with a reserved domain email" do
+        user = create(:user, email_confirmed: false)
+        user.update_columns(email: "grandfathered@example.com")
+
+        refute user.update(email_confirmed: true)
+        assert_contains user.errors[:email],
+          "domain 'example.com' is reserved and cannot be used for registration. Please use a valid personal email."
+      end
     end
 
     context "unconfirmed_email" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -96,14 +96,14 @@ class UserTest < ActiveSupport::TestCase
 
     context "email" do
       should "be less than 255 characters" do
-        user = build(:user, email: format("%s@example.com", "a" * 255))
+        user = build(:user, email: format("%s@rubygems-test.org", "a" * 255))
 
         refute_predicate user, :valid?
         assert_contains user.errors[:email], "is too long (maximum is 255 characters)"
       end
 
       should "be valid when it matches URI mail email regex" do
-        user = build(:user, email: "mail@example.com")
+        user = build(:user, email: "mail@rubygems-test.org")
 
         assert_predicate user, :valid?
       end
@@ -153,6 +153,44 @@ class UserTest < ActiveSupport::TestCase
           assert_contains user.errors[:email], "is not a valid email"
         end
       end
+
+      %w[user@example.com user@example.net user@example.org
+         user@mail.example.com user@deep.sub.example.org
+         user@foo.test user@bar.example user@baz.invalid user@host.localhost
+         user@printer.local user@silkroad.onion
+         USER@Example.COM].each do |email|
+        should "be invalid with reserved domain #{email}" do
+          user = build(:user, email: email)
+
+          refute_predicate user, :valid?
+          domain = email.split("@").last.downcase
+
+          assert_contains user.errors[:email],
+"domain '#{domain}' is reserved and cannot be used for registration. Please use a valid personal email."
+        end
+      end
+
+      should "be valid with a non-reserved domain" do
+        user = build(:user, email: "user@rubygems.org")
+
+        assert_predicate user, :valid?
+      end
+
+      should "be invalid when an existing user changes email to a reserved domain" do
+        user = create(:user)
+        user.email = "switched@example.com"
+
+        refute_predicate user, :valid?
+        assert_contains user.errors[:email],
+          "domain 'example.com' is reserved and cannot be used for registration. Please use a valid personal email."
+      end
+
+      should "not re-run reserved domain validation on saves that do not change email" do
+        user = create(:user)
+        user.update_columns(email: "grandfathered@example.com")
+
+        assert user.update(full_name: "New Name")
+      end
     end
 
     context "unconfirmed_email" do
@@ -161,6 +199,14 @@ class UserTest < ActiveSupport::TestCase
 
         refute_predicate user, :valid?
         assert_contains user.errors[:unconfirmed_email], "is invalid"
+      end
+
+      should "be invalid with a reserved domain" do
+        user = build(:user, unconfirmed_email: "user@example.com")
+
+        refute_predicate user, :valid?
+        assert_contains user.errors[:unconfirmed_email],
+          "domain 'example.com' is reserved and cannot be used for registration. Please use a valid personal email."
       end
     end
 
@@ -228,7 +274,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "not authenticate with bad email, good password" do
-      assert_nil User.authenticate("bad@example.com", @user.password)
+      assert_nil User.authenticate("bad@rubygems-test.org", @user.password)
     end
 
     should "not authenticate with good email, bad password" do
@@ -304,7 +350,7 @@ class UserTest < ActiveSupport::TestCase
 
       context "when user has an unconfirmed email" do
         setup do
-          @user.update(unconfirmed_email: "unconfirmed@example.com")
+          @user.update(unconfirmed_email: "unconfirmed@rubygems-test.org")
         end
 
         should "delete the unconfirmed email by default" do
@@ -322,7 +368,7 @@ class UserTest < ActiveSupport::TestCase
             @user.save!
           end
 
-          assert_equal "unconfirmed@example.com", @user.unconfirmed_email
+          assert_equal "unconfirmed@rubygems-test.org", @user.unconfirmed_email
         end
       end
 
@@ -970,6 +1016,20 @@ class UserTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "when the blocked email is a now-reserved domain" do
+      setup do
+        @user = create(:user, :blocked)
+        @user.update_columns(blocked_email: "grandfathered@example.com")
+      end
+
+      should "still restore the email" do
+        @user.unblock!
+
+        assert_equal "grandfathered@example.com", @user.email
+        assert_nil @user.blocked_email
+      end
+    end
   end
 
   context "#blocked?" do
@@ -994,20 +1054,20 @@ class UserTest < ActiveSupport::TestCase
 
     should "preserve valid characters so that the format error can be returned" do
       # UTF-8 "香" character, which is valid UTF-8, but we reject utf-8 in email addresses
-      assert_equal "香@example.com", User.normalize_email(String.new("\u9999@example.com", encoding: "utf-8"))
+      assert_equal "香@rubygems-test.org", User.normalize_email(String.new("\u9999@rubygems-test.org", encoding: "utf-8"))
 
       # ISO-8859-1 "Å" character (valid in ISO-8859-1)
-      encoded_email = String.new("myem\xC5il@example.com", encoding: "ISO-8859-1")
+      encoded_email = String.new("myem\xC5il@rubygems-test.org", encoding: "ISO-8859-1")
 
       assert_equal encoded_email, User.normalize_email(encoded_email)
     end
 
     should "return an empty string on invalid inputs" do
       # bad encoding when sent as ASCII-8BIT
-      assert_equal "", User.normalize_email(String.new("\u9999@example.com", encoding: "ascii"))
+      assert_equal "", User.normalize_email(String.new("\u9999@rubygems-test.org", encoding: "ascii"))
 
       # ISO-8859-1 "Å" character (invalid in UTF-8, which uses \xC385 for this character)
-      assert_equal "", User.normalize_email(String.new("myem\xC5il@example.com", encoding: "UTF-8"))
+      assert_equal "", User.normalize_email(String.new("myem\xC5il@rubygems-test.org", encoding: "UTF-8"))
     end
 
     should "return an empty string for nil" do

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -443,7 +443,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
       page.assert_text "Must supply a sufficiently detailed comment"
 
       fill_in "Comment", with: "A nice long comment"
-      fill_in "Email", with: "gem-maintainer-001@example.com"
+      fill_in "Email", with: "gem-maintainer-001@rubygems-test.org"
       click_button "Change User Email"
 
       page.assert_text "Action ran successfully!"
@@ -487,7 +487,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
               "unchanged" => {}
             }
           },
-          "fields" => { "from_email" => "gem-maintainer-001@example.com" },
+          "fields" => { "from_email" => "gem-maintainer-001@rubygems-test.org" },
           "arguments" => {},
           "models" => ["gid://gemcutter/User/#{user.id}"]
         },
@@ -519,7 +519,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     page.assert_text "Must supply a sufficiently detailed comment"
 
     fill_in "Comment", with: "A nice long comment"
-    fill_in "Email", with: "gem-user-001@example.com"
+    fill_in "Email", with: "gem-user-001@rubygems-test.org"
     click_button "Create User"
 
     page.assert_text "Action ran successfully!"
@@ -545,7 +545,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
             "unchanged" => {}
           }
         },
-        "fields" => { "email" => "gem-user-001@example.com" },
+        "fields" => { "email" => "gem-user-001@rubygems-test.org" },
         "arguments" => {},
         "models" => []
       },

--- a/test/system/email_confirmation_test.rb
+++ b/test/system/email_confirmation_test.rb
@@ -21,7 +21,7 @@ class EmailConfirmationTest < ApplicationSystemTestCase
   end
 
   test "requesting confirmation mail does not tell if a user exists" do
-    request_confirmation_mail "someone@example.com"
+    request_confirmation_mail "someone@rubygems-test.org"
 
     assert_text "We will email you confirmation link to activate your account if one exists."
   end

--- a/test/system/multifactor_auths_test.rb
+++ b/test/system/multifactor_auths_test.rb
@@ -4,7 +4,7 @@ require "application_system_test_case"
 
 class MultifactorAuthsTest < ApplicationSystemTestCase
   setup do
-    @user = create(:user, email: "testuser@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "testuser")
+    @user = create(:user, email: "testuser@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "testuser")
     @seed = ROTP::Base32.random_base32
     @totp = ROTP::TOTP.new(@seed)
   end

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -28,7 +28,7 @@ class PasswordResetTest < ApplicationSystemTestCase
   end
 
   test "reset password form does not tell if a user exists" do
-    forgot_password_with "someone@example.com"
+    forgot_password_with "someone@rubygems-test.org"
 
     assert_text "instructions for changing your password"
   end
@@ -213,7 +213,7 @@ class PasswordResetTest < ApplicationSystemTestCase
     visit sign_in_path
 
     email = @user.email
-    new_email = "hijack@example.com"
+    new_email = "hijack@rubygems-test.org"
 
     fill_in "Email or Username", with: email
     fill_in "Password", with: @user.password

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -6,7 +6,7 @@ class ProfileTest < ApplicationSystemTestCase
   include ActiveJob::TestHelper
 
   setup do
-    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
+    @user = create(:user, email: "nick@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
   end
 
   test "changing handle" do
@@ -25,7 +25,7 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "changing to an existing handle" do
-    create(:user, email: "nick2@example.com", handle: "nick2")
+    create(:user, email: "nick2@rubygems-test.org", handle: "nick2")
 
     sign_in
     visit profile_path("nick1")
@@ -56,19 +56,19 @@ class ProfileTest < ApplicationSystemTestCase
     visit profile_path("nick1")
     click_link "Edit Profile"
 
-    fill_in "Email address", with: "nick2@example.com"
+    fill_in "Email address", with: "nick2@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
       click_button "Update"
     end
 
-    assert page.has_selector? "input[value='nick@example.com']"
+    assert page.has_selector? "input[value='nick@rubygems-test.org']"
     assert page.has_selector? "#flash_notice", text: "You will receive " \
                                                      "an email within the next few minutes. It contains instructions " \
                                                      "for confirming your new email address."
 
-    assert_event Events::UserEvent::EMAIL_ADDED, { email: "nick2@example.com" },
+    assert_event Events::UserEvent::EMAIL_ADDED, { email: "nick2@rubygems-test.org" },
       @user.events.where(tag: Events::UserEvent::EMAIL_ADDED).sole
 
     link = last_email_link
@@ -81,10 +81,10 @@ class ProfileTest < ApplicationSystemTestCase
       assert_text("Your email address has been verified")
       visit edit_profile_path
 
-      assert page.has_selector? "input[value='nick2@example.com']"
+      assert page.has_selector? "input[value='nick2@rubygems-test.org']"
     end
 
-    assert_event Events::UserEvent::EMAIL_VERIFIED, { email: "nick2@example.com" },
+    assert_event Events::UserEvent::EMAIL_VERIFIED, { email: "nick2@rubygems-test.org" },
       @user.events.where(tag: Events::UserEvent::EMAIL_VERIFIED).sole
   end
 

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -4,7 +4,7 @@ require "application_system_test_case"
 
 class SettingsTest < ApplicationSystemTestCase
   setup do
-    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
+    @user = create(:user, email: "nick@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: "nick1", mail_fails: 1)
   end
 
   def enable_otp

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -4,15 +4,15 @@ require "application_system_test_case"
 
 class SignInTest < ApplicationSystemTestCase
   setup do
-    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
-    @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
+    @user = create(:user, email: "nick@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @mfa_user = create(:user, email: "john@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, totp_seed: "thisisonetotpseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
   end
 
   test "signing in" do
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -20,12 +20,12 @@ class SignInTest < ApplicationSystemTestCase
     assert_text "We now support security devices!"
 
     assert_event Events::UserEvent::LOGIN_SUCCESS, { authentication_method: "password" },
-      User.find_by(email: "nick@example.com").events.where(tag: Events::UserEvent::LOGIN_SUCCESS).sole
+      User.find_by(email: "nick@rubygems-test.org").events.where(tag: Events::UserEvent::LOGIN_SUCCESS).sole
   end
 
   test "signing in with uppercase email" do
     visit sign_in_path
-    fill_in "Email or Username", with: "Nick@example.com"
+    fill_in "Email or Username", with: "Nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -34,7 +34,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with wrong password" do
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: "wordcrimes12345"
     click_button "Sign in"
 
@@ -44,7 +44,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with wrong email" do
     visit sign_in_path
-    fill_in "Email or Username", with: "someone@example.com"
+    fill_in "Email or Username", with: "someone@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -73,7 +73,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with current valid otp when mfa enabled" do
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -87,12 +87,12 @@ class SignInTest < ApplicationSystemTestCase
     assert_text "We now support security devices!"
 
     assert_event Events::UserEvent::LOGIN_SUCCESS, { authentication_method: "password", two_factor_method: "otp", two_factor_label: "OTP" },
-      User.find_by(email: "john@example.com").events.where(tag: Events::UserEvent::LOGIN_SUCCESS).sole
+      User.find_by(email: "john@rubygems-test.org").events.where(tag: Events::UserEvent::LOGIN_SUCCESS).sole
   end
 
   test "signing in with current valid otp when mfa enabled but 30 minutes has passed" do
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -111,7 +111,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with invalid otp when mfa enabled" do
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -124,7 +124,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with valid recovery code when mfa enabled" do
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -138,7 +138,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in with invalid recovery code when mfa enabled" do
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -158,7 +158,7 @@ class SignInTest < ApplicationSystemTestCase
     )
 
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -179,7 +179,7 @@ class SignInTest < ApplicationSystemTestCase
     )
 
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -206,7 +206,7 @@ class SignInTest < ApplicationSystemTestCase
     )
 
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -229,7 +229,7 @@ class SignInTest < ApplicationSystemTestCase
     )
 
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -246,7 +246,7 @@ class SignInTest < ApplicationSystemTestCase
     @mfa_user.update_attribute(:handle, nil)
 
     visit sign_in_path
-    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Email or Username", with: "john@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -254,13 +254,13 @@ class SignInTest < ApplicationSystemTestCase
     fill_in "OTP or recovery code", with: ROTP::TOTP.new("thisisonetotpseed").now
     click_button "Authenticate"
 
-    assert_text "john@example.com"
+    assert_text "john@rubygems-test.org"
     assert_text "Dashboard"
   end
 
   test "signing out" do
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -273,7 +273,7 @@ class SignInTest < ApplicationSystemTestCase
 
   test "session expires in two weeks" do
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -287,10 +287,10 @@ class SignInTest < ApplicationSystemTestCase
   end
 
   test "sign in to blocked account" do
-    User.find_by!(email: "nick@example.com").block!
+    User.find_by!(email: "nick@rubygems-test.org").block!
 
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 
@@ -299,10 +299,10 @@ class SignInTest < ApplicationSystemTestCase
   end
 
   test "sign in to deleted account" do
-    User.find_by!(email: "nick@example.com").update!(deleted_at: Time.zone.now)
+    User.find_by!(email: "nick@rubygems-test.org").update!(deleted_at: Time.zone.now)
 
     visit sign_in_path
-    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Email or Username", with: "nick@rubygems-test.org"
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Sign in"
 

--- a/test/system/sign_in_webauthn_test.rb
+++ b/test/system/sign_in_webauthn_test.rb
@@ -4,9 +4,9 @@ require "application_system_test_case"
 
 class SignInWebauthnTest < ApplicationSystemTestCase
   setup do
-    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @user = create(:user, email: "nick@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
     @mfa_recovery_codes = %w[0123456789ab ba9876543210]
-    @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
+    @mfa_user = create(:user, email: "john@rubygems-test.org", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, totp_seed: "thisisonetotpseed",
                   mfa_recovery_codes: @mfa_recovery_codes)
 

--- a/test/tasks/maintenance/discard_spam_accounts_task_test.rb
+++ b/test/tasks/maintenance/discard_spam_accounts_task_test.rb
@@ -6,7 +6,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
 
   test "#process discards a matching user" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
 
     Maintenance::DiscardSpamAccountsTask.process(user)
 
@@ -14,7 +14,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process expires API keys" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
     api_key = create(:api_key, owner: user)
 
     Maintenance::DiscardSpamAccountsTask.process(user)
@@ -23,7 +23,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process destroys webhooks" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
     webhook = create(:global_web_hook, user: user)
 
     Maintenance::DiscardSpamAccountsTask.process(user)
@@ -32,7 +32,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process does not send a deletion complete email" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
 
     assert_no_enqueued_emails do
       Maintenance::DiscardSpamAccountsTask.process(user)
@@ -40,10 +40,10 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process restores deletion email callback after processing" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
     Maintenance::DiscardSpamAccountsTask.process(user)
 
-    other_user = create(:user, email: "regular@example.com", created_at: 1.day.ago)
+    other_user = create(:user, email: "regular@spammy-test.org", created_at: 1.day.ago)
 
     assert_enqueued_emails 1 do
       other_user.discard!
@@ -51,7 +51,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process reports error when discard fails" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
 
     User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
 
@@ -63,7 +63,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   end
 
   test "#process skips already discarded users" do
-    user = create(:user, email: "spam@example.com", created_at: 1.day.ago, email_confirmed: false)
+    user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
     user.discard!
 
     assert_no_changes -> { user.reload.deleted_at } do
@@ -75,14 +75,14 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
     task = Maintenance::DiscardSpamAccountsTask.new
     task.created_after = 3.days.ago
     task.created_before = 1.day.ago
-    task.domain_suffix = "example.com"
+    task.domain_suffix = "spammy-test.org"
 
-    matching = create(:user, email: "recent@example.com", created_at: 2.days.ago, email_confirmed: false)
-    too_recent = create(:user, email: "new@example.com", created_at: 1.hour.ago, email_confirmed: false)
-    old_example = create(:user, email: "old@example.com", created_at: 5.days.ago, email_confirmed: false)
-    other_domain = create(:user, email: "recent@anotherexample.com", created_at: 2.days.ago, email_confirmed: false)
-    confirmed = create(:user, email: "confirmed@example.com", created_at: 2.days.ago, email_confirmed: true)
-    with_gems = create(:user, email: "gems@example.com", created_at: 2.days.ago, email_confirmed: false)
+    matching = create(:user, email: "recent@spammy-test.org", created_at: 2.days.ago, email_confirmed: false)
+    too_recent = create(:user, email: "new@spammy-test.org", created_at: 1.hour.ago, email_confirmed: false)
+    old_example = create(:user, email: "old@spammy-test.org", created_at: 5.days.ago, email_confirmed: false)
+    other_domain = create(:user, email: "recent@anotherspammy-test.org", created_at: 2.days.ago, email_confirmed: false)
+    confirmed = create(:user, email: "confirmed@spammy-test.org", created_at: 2.days.ago, email_confirmed: true)
+    with_gems = create(:user, email: "gems@spammy-test.org", created_at: 2.days.ago, email_confirmed: false)
     create(:ownership, user: with_gems, rubygem: create(:rubygem))
 
     collection = task.collection
@@ -98,9 +98,9 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
   test "#collection defaults created_before to now" do
     task = Maintenance::DiscardSpamAccountsTask.new
     task.created_after = 3.days.ago
-    task.domain_suffix = "example.com"
+    task.domain_suffix = "spammy-test.org"
 
-    recent = create(:user, email: "just-now@example.com", created_at: 1.minute.ago, email_confirmed: false)
+    recent = create(:user, email: "just-now@spammy-test.org", created_at: 1.minute.ago, email_confirmed: false)
 
     assert_includes task.collection, recent
   end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -80,7 +80,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
   context "avatar" do
     setup do
-      @user = create(:user, email: "email@example.com")
+      @user = create(:user, email: "email@rubygems-test.org")
     end
 
     should "raise when invalid theme is requested" do

--- a/test/unit/helpers/users_helper_test.rb
+++ b/test/unit/helpers/users_helper_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class UsersHelperTest < ActionView::TestCase
   context "obfuscate_email" do
     should "obfuscate standard email" do
-      assert_equal "g*******@e******.com", obfuscate_email("gem-user@example.com")
+      assert_equal "g*******@r************.org", obfuscate_email("gem-user@rubygems-test.org")
     end
 
     should "obfuscate email with short local part" do
@@ -17,11 +17,11 @@ class UsersHelperTest < ActionView::TestCase
     end
 
     should "handle two character local part" do
-      assert_equal "h*@e******.com", obfuscate_email("hi@example.com")
+      assert_equal "h*@r************.org", obfuscate_email("hi@rubygems-test.org")
     end
 
     should "handle single character local part" do
-      assert_equal "*@e******.com", obfuscate_email("a@example.com")
+      assert_equal "*@r************.org", obfuscate_email("a@rubygems-test.org")
     end
 
     should "handle subdomain in TLD" do

--- a/test/views/events/user_event/email/added_component_test.rb
+++ b/test/views/events/user_event/email/added_component_test.rb
@@ -6,6 +6,6 @@ class Events::UserEvent::Email::AddedComponentTest < ComponentTest
   should "render preview" do
     preview
 
-    assert_text "user@example.com"
+    assert_text "user@rubygems-test.org"
   end
 end

--- a/test/views/events/user_event/email/sent_component_test.rb
+++ b/test/views/events/user_event/email/sent_component_test.rb
@@ -8,6 +8,6 @@ class Events::UserEvent::Email::SentComponentTest < ComponentTest
 
     assert_text "Subject: [Subject]"
     assert_text "From: example@rubygems.org"
-    assert_text "To: user@example.com"
+    assert_text "To: user@rubygems-test.org"
   end
 end

--- a/test/views/events/user_event/email/verified_component_test.rb
+++ b/test/views/events/user_event/email/verified_component_test.rb
@@ -6,6 +6,6 @@ class Events::UserEvent::Email::VerifiedComponentTest < ComponentTest
   should "render preview" do
     preview rubygem: create(:rubygem)
 
-    assert_text "user@example.com", exact: true
+    assert_text "user@rubygems-test.org", exact: true
   end
 end

--- a/test/views/events/user_event/user/created_component_test.rb
+++ b/test/views/events/user_event/user/created_component_test.rb
@@ -6,6 +6,6 @@ class Events::UserEvent::User::CreatedComponentTest < ComponentTest
   should "render preview" do
     preview
 
-    assert_text "Email: user@example.com", exact: true, normalize_ws: false
+    assert_text "Email: user@rubygems-test.org", exact: true, normalize_ws: false
   end
 end


### PR DESCRIPTION
Currently we allow users to register emails with a domain that RFC 2606, 6761, 6762 and 7686 list as reserved and could never pass signup validation. Let's close this door on bots using these domains in the future.

This PR has chosen to allow existing users with reserved domains to continue using their account, and to make changes to it, ie: changing email. We'll tackle how to handle the existing emails in a separate discussion. 