### PR TITLE
Add Backfill `info_checksum_v2` Maintenance Task

### DIFF
--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -16,11 +16,17 @@ class UploadInfoFileJob < ApplicationJob
     key: -> { "#{self.class.name}:#{rubygem_name_arg}" }
   )
 
-  def perform(rubygem_name:)
+  PATH_PREFIXES = { 1 => "info", 2 => "v2/info" }.freeze
+
+  def perform(rubygem_name:, backfill_only_version: nil)
     gem_info = GemInfo.new(rubygem_name, cached: false)
 
-    upload_info_file(gem_info, rubygem_name, version: 1, path_prefix: "info")
-    upload_info_file(gem_info, rubygem_name, version: 2, path_prefix: "v2/info")
+    if backfill_only_version
+      upload_info_file(gem_info, rubygem_name, version: backfill_only_version, purge: false)
+    else
+      upload_info_file(gem_info, rubygem_name, version: 1, purge: true)
+      upload_info_file(gem_info, rubygem_name, version: 2, purge: true)
+    end
   end
 
   private
@@ -29,12 +35,13 @@ class UploadInfoFileJob < ApplicationJob
     arguments.first.fetch(:rubygem_name)
   end
 
-  def upload_info_file(gem_info, rubygem_name, version:, path_prefix:)
+  def upload_info_file(gem_info, rubygem_name, version:, purge:)
     compact_index_info = gem_info.compact_index_info(version:)
     response_body = CompactIndex.info(compact_index_info)
 
     content_md5 = Digest::MD5.base64digest(response_body)
     checksum_sha256 = Digest::SHA256.base64digest(response_body)
+    path_prefix = PATH_PREFIXES.fetch(version)
     key = "#{path_prefix}/#{rubygem_name}"
 
     response = RubygemFs.compact_index.store(
@@ -54,6 +61,6 @@ class UploadInfoFileJob < ApplicationJob
 
     logger.info(message: "Uploading v#{version} info file for #{rubygem_name} succeeded", response:)
 
-    FastlyPurgeJob.perform_later(key: "s3-#{key}", soft: true)
+    FastlyPurgeJob.perform_later(key: "s3-#{key}", soft: true) if purge
   end
 end

--- a/app/tasks/maintenance/backfill_compact_index_v2_task.rb
+++ b/app/tasks/maintenance/backfill_compact_index_v2_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
+  attribute :min_rubygem_id, :integer
+  attribute :max_rubygem_id, :integer
+
+  def collection
+    scope = Rubygem.with_versions
+    scope = scope.where(rubygems: { id: min_rubygem_id.. }) if min_rubygem_id.present?
+    scope = scope.where(rubygems: { id: ..max_rubygem_id }) if max_rubygem_id.present?
+    scope
+  end
+
+  def process(rubygem)
+    # Backfill info_checksum_v2 on the most recent version (same logic as CompactIndexTasksHelper)
+    gem_info = GemInfo.new(rubygem.name, cached: false)
+    checksum_v2 = gem_info.info_checksum_v2
+
+    last_version = rubygem.versions
+      .order(Arel.sql("COALESCE(yanked_at, created_at) DESC, number DESC, platform DESC"))
+      .first
+
+    return unless last_version
+
+    if last_version.indexed
+      last_version.update_column(:info_checksum_v2, checksum_v2)
+    else
+      last_version.update_column(:yanked_info_checksum_v2, checksum_v2)
+    end
+
+    # Regenerate and upload v2 info file (UploadInfoFileJob dual-writes v1 and v2)
+    UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
+  end
+end

--- a/app/tasks/maintenance/backfill_compact_index_v2_task.rb
+++ b/app/tasks/maintenance/backfill_compact_index_v2_task.rb
@@ -12,15 +12,18 @@ class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
   end
 
   def process(rubygem)
-    # Backfill info_checksum_v2 on the most recent version (same logic as CompactIndexTasksHelper)
-    gem_info = GemInfo.new(rubygem.name, cached: false)
-    checksum_v2 = gem_info.info_checksum_v2
-
     last_version = rubygem.versions
       .order(Arel.sql("COALESCE(yanked_at, created_at) DESC, number DESC, platform DESC"))
       .first
 
     return unless last_version
+
+    # Skip if already backfilled
+    return if last_version.info_checksum_v2.present? || last_version.yanked_info_checksum_v2.present?
+
+    # Compute and persist the v2 checksum
+    gem_info = GemInfo.new(rubygem.name, cached: false)
+    checksum_v2 = gem_info.info_checksum(version: 2)
 
     if last_version.indexed
       last_version.update_column(:info_checksum_v2, checksum_v2)
@@ -28,7 +31,7 @@ class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
       last_version.update_column(:yanked_info_checksum_v2, checksum_v2)
     end
 
-    # Regenerate and upload v2 info file (UploadInfoFileJob dual-writes v1 and v2)
-    UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
+    # Create s3 v2 info file
+    UploadInfoFileJob.perform_later(rubygem_name: rubygem.name, backfill_only_version: 2)
   end
 end

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -90,6 +90,18 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
     assert_equal Digest::MD5.hexdigest(v2_body), version.info_checksum_v2
   end
 
+  test "backfill_only_version uploads only that version and skips Fastly purge" do
+    version = create(:version, number: "0.0.1", required_ruby_version: ">= 2.0.0", required_rubygems_version: ">= 2.6.3")
+
+    perform_enqueued_jobs only: [UploadInfoFileJob] do
+      UploadInfoFileJob.perform_now(rubygem_name: version.rubygem.name, backfill_only_version: 2)
+    end
+
+    assert_nil RubygemFs.compact_index.get("info/#{version.rubygem.name}")
+    assert_not_nil RubygemFs.compact_index.get("v2/info/#{version.rubygem.name}")
+    assert_no_enqueued_jobs only: FastlyPurgeJob
+  end
+
   test "#good_job_concurrency_key" do
     job = UploadInfoFileJob.new(rubygem_name: "foo")
 

--- a/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
+++ b/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  context "#collection" do
+    should "return rubygems with versions between min_rubygem_id and max_rubygem_id" do
+      gem1 = create(:rubygem)
+      gem2 = create(:rubygem)
+      gem3 = create(:rubygem)
+      create(:version, rubygem: gem1)
+      create(:version, rubygem: gem2)
+      create(:version, rubygem: gem3)
+
+      task = Maintenance::BackfillCompactIndexV2Task.new
+      task.min_rubygem_id = gem1.id
+      task.max_rubygem_id = gem2.id
+
+      assert_equal [gem1, gem2], task.collection.to_a
+    end
+  end
+
+  context "#process" do
+    context "with an indexed last version" do
+      should "backfill info_checksum_v2 on the most recent version and enqueue UploadInfoFileJob" do
+        rubygem = create(:rubygem, name: "testgem")
+        version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
+        version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: true, info_checksum_v2: nil)
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.process(rubygem)
+
+        assert_not_nil version2.reload.info_checksum_v2
+        assert_nil version.reload.info_checksum_v2
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem"])
+      end
+    end
+
+    context "with a yanked last version" do
+      should "backfill yanked_info_checksum_v2 on the most recent version and enqueue UploadInfoFileJob" do
+        rubygem = create(:rubygem, name: "testgem")
+        version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
+        version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: false, yanked_info_checksum_v2: nil)
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.process(rubygem)
+
+        assert_not_nil version2.reload.yanked_info_checksum_v2
+        assert_nil version.reload.info_checksum_v2
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem"])
+      end
+    end
+
+    context "with no versions" do
+      should "do nothing" do
+        rubygem = create(:rubygem, name: "testgem")
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.process(rubygem)
+
+        assert_no_enqueued_jobs only: UploadInfoFileJob
+      end
+    end
+  end
+end

--- a/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
+++ b/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
@@ -24,7 +24,7 @@ class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
 
   context "#process" do
     context "with an indexed last version" do
-      should "backfill info_checksum_v2 on the most recent version and enqueue UploadInfoFileJob" do
+      should "backfill info_checksum_v2 and enqueue UploadInfoFileJob for v2 only without purge" do
         rubygem = create(:rubygem, name: "testgem")
         version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
         version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: true, info_checksum_v2: nil)
@@ -34,12 +34,12 @@ class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
 
         assert_not_nil version2.reload.info_checksum_v2
         assert_nil version.reload.info_checksum_v2
-        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem"])
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
       end
     end
 
     context "with a yanked last version" do
-      should "backfill yanked_info_checksum_v2 on the most recent version and enqueue UploadInfoFileJob" do
+      should "backfill yanked_info_checksum_v2 and enqueue UploadInfoFileJob for v2 only without purge" do
         rubygem = create(:rubygem, name: "testgem")
         version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
         version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: false, yanked_info_checksum_v2: nil)
@@ -49,13 +49,35 @@ class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
 
         assert_not_nil version2.reload.yanked_info_checksum_v2
         assert_nil version.reload.info_checksum_v2
-        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem"])
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
       end
     end
 
     context "with no versions" do
       should "do nothing" do
         rubygem = create(:rubygem, name: "testgem")
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.process(rubygem)
+
+        assert_no_enqueued_jobs only: UploadInfoFileJob
+      end
+    end
+
+    context "when already backfilled" do
+      should "skip version that already has info_checksum_v2" do
+        rubygem = create(:rubygem, name: "testgem")
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: "already_set")
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.process(rubygem)
+
+        assert_no_enqueued_jobs only: UploadInfoFileJob
+      end
+
+      should "skip version that already has yanked_info_checksum_v2" do
+        rubygem = create(:rubygem, name: "testgem")
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: false, yanked_info_checksum_v2: "already_set")
 
         task = Maintenance::BackfillCompactIndexV2Task.new
         task.process(rubygem)


### PR DESCRIPTION
### TL;DR

Adds `Maintenance::BackfillCompactIndexV2Task`, a one-shot maintenance task that, for every gem (optionally filtered by ID range if we want to run this against a smaller sample), computes `info_checksum_v2`, writes it onto the gem's most recent version, and enqueues `UploadInfoFileJob` to regenerate the v2 info file.

Addresses #6479.

### Description

In #6504 (currently awaiting merge, so commit also exists in this PR), the v2 compact-index columns (`info_checksum_v2`, `yanked_info_checksum_v2`) now exist on `versions`, and new pushes/yanks populate them automatically via `AfterVersionWriteJob`. But rows that pre-date the columns are all NULL and there's no way to safely serve a v2 compact index until those are filled in.
  
This PR adds a `MaintenanceTasks::Task` to backfill those columns for the latest gem version of each gem (depending on yanked or not), and enqueue `UploadInfoFileJob` to regenerate the gem's info file.

`min_rubygem_id` and `max_rubygem_id` attributes are also exposed so the task can be tested on a small group before applied to all gems. 

### Dependencies
  
⚠️ https://github.com/rubygems/rubygems.org/pull/6504 and https://github.com/rubygems/rubygems.org/pull/6511 must be merged before this PR.

### Tophatting

1. Ensure that your database contains gems and gem versions, with some yanked examples.

2. Open a console and run the task:

```
  task = Maintenance::BackfillCompactIndexV2Task.new
  task.collection.find_each { |r| task.process(r) }
```

3. Verify the most-recent version of each gem got its v2 column populated, verify yanked gem versions had the `yanked_info_checksum_v2` column populated, and verify the `UploadInfoFileJob` was enqueued for each gem.