### PR TITLE
Add Rake Task to Regenerate V2 Versions File

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -65,9 +65,13 @@ class GemInfo
     map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] })
   end
 
-  def self.compact_index_public_versions(updated_at)
+  def self.compact_index_public_versions(updated_at, version: 1)
+    config = VERSIONS.fetch(version)
+    checksum_column = config[:checksum_column]
+    yanked_checksum_column = config[:yanked_checksum_column]
+
     query = ["SELECT r.name, v.indexed, COALESCE(v.yanked_at, v.created_at) as stamp,
-                     v.sha256, COALESCE(v.yanked_info_checksum, v.info_checksum) as info_checksum,
+                     v.sha256, COALESCE(v.#{yanked_checksum_column}, v.#{checksum_column}) as info_checksum,
                      v.number, v.platform
               FROM rubygems AS r, versions AS v
               WHERE v.rubygem_id = r.id AND

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -8,6 +8,7 @@ development:
   s3_region: us-east-1
   s3_endpoint: s3.amazonaws.com
   versions_file_location: "./config/versions.list"
+  versions_file_location_v2: "./config/versions_v2.list"
 
 test:
   protocol: http
@@ -19,6 +20,7 @@ test:
   s3_region: us-east-1
   s3_endpoint: s3.amazonaws.com
   versions_file_location: "./test/helpers/versions.list"
+  versions_file_location_v2: "./test/helpers/versions_v2.list"
 
 staging:
   protocol: https
@@ -30,6 +32,7 @@ staging:
   s3_contents_bucket: contents.oregon.staging.s3.rubygems.org
   s3_compact_index_bucket: compact-index.oregon.staging.s3.rubygems.org
   versions_file_location: "./config/versions.list"
+  versions_file_location_v2: "./config/versions_v2.list"
 
 production:
   protocol: https
@@ -41,4 +44,5 @@ production:
   s3_contents_bucket: contents.oregon.production.s3.rubygems.org
   s3_compact_index_bucket: compact-index.oregon.production.s3.rubygems.org
   versions_file_location: "./config/versions.list"
+  versions_file_location_v2: "./config/versions_v2.list"
   separate_admin_host: rubygems.team

--- a/lib/tasks/compact_index_v2.rake
+++ b/lib/tasks/compact_index_v2.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :compact_index_v2 do
+  desc "Generate/update the baseline v2 versions.list file"
+  task update_versions_file: :environment do
+    ts = Time.now.utc.iso8601
+    file_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    versions_file = CompactIndex::VersionsFile.new(file_path)
+    gems = GemInfo.compact_index_public_versions(ts, version: 2)
+
+    versions_file.create(gems, ts)
+    version_file_content = File.read(file_path)
+
+    RubygemFs.instance.store("versions/versions_v2.list", version_file_content)
+  end
+end

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -211,4 +211,47 @@ class GemInfoTest < ActiveSupport::TestCase
       assert_equal expected_versions, versions
     end
   end
+
+  context ".compact_index_public_versions version: 2" do
+    setup do
+      @ts               = 5.minutes.ago
+      @version          = create(:version, number: "0.0.1", created_at: @ts, info_checksum_v2: "v2qw2dwe")
+
+      _updated_after_ts = create(:version, number: "2.0.0", created_at: @ts + 1.second, info_checksum_v2: "v2qw2dwe")
+    end
+
+    should "not return version updated after ts" do
+      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+
+      expected_versions = [CompactIndex::Gem.new(
+        @version.rubygem.name,
+        [CompactIndex::GemVersion.new(@version.number, @version.platform, @version.sha256, @version.info_checksum_v2)]
+      )]
+
+      assert_equal expected_versions, versions
+    end
+
+    should "not return yanked versions" do
+      rubygem = create(:rubygem, name: "bar")
+      indexed_version = create(:version, rubygem: rubygem, number: "1.0.0", created_at: 10.minutes.ago, info_checksum_v2: "v2qw2dwe")
+      create(:version, :yanked, rubygem: rubygem, number: "2.0.0", created_at: 9.minutes.ago,
+                                yanked_at: 8.minutes.ago, yanked_info_checksum_v2: "v2yanked")
+
+      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+
+      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
+    end
+
+    should "fall back to info_checksum_v2 for yanked rows missing yanked_info_checksum_v2" do
+      rubygem = create(:rubygem, name: "bar")
+      indexed_version = create(:version, rubygem: rubygem, number: "1.0.0", created_at: 10.minutes.ago, info_checksum_v2: "v2qw2dwe")
+      create(:version, :yanked, rubygem: rubygem, number: "2.0.0", created_at: 9.minutes.ago,
+                                yanked_at: 8.minutes.ago, info_checksum_v2: "v2qw2dwe",
+                                yanked_info_checksum_v2: nil)
+
+      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+
+      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2qw2dwe")])
+    end
+  end
 end

--- a/test/unit/update_v2_versions_file_test.rb
+++ b/test/unit/update_v2_versions_file_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpdateV2VersionsFileTest < ActiveSupport::TestCase
+  include RakeTaskHelper
+
+  setup do
+    @tmp_versions_file = Tempfile.new("tmp_v2_versions_file")
+    @original_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    Rails.application.config.rubygems["versions_file_location_v2"] = @tmp_versions_file.path
+
+    setup_rake_tasks("compact_index_v2.rake")
+  end
+
+  def update_versions_file
+    freeze_time do
+      @created_at = Time.now.utc.iso8601
+      Rake::Task["compact_index_v2:update_versions_file"].invoke
+    end
+  end
+
+  teardown do
+    Rails.application.config.rubygems["versions_file_location_v2"] = @original_path
+    @tmp_versions_file.unlink
+  end
+
+  context "file header" do
+    setup do
+      update_versions_file
+    end
+
+    should "use today's timestamp as header" do
+      expected_header = "created_at: #{@created_at}\n---\n"
+
+      assert_equal expected_header, @tmp_versions_file.read
+    end
+  end
+
+  context "file content" do
+    setup do
+      @rubygem = create(:rubygem, name: "rubyrubyruby")
+      create(:version, rubygem: @rubygem, number: "0.0.1", created_at: 2.minutes.ago,
+                       info_checksum_v2: "v2_13q4e1")
+      create(:version, rubygem: @rubygem, number: "0.0.2", created_at: 1.minute.ago,
+                       info_checksum_v2: "v2_qw212r")
+
+      update_versions_file
+    end
+
+    should "include both versions with the latest info_checksum_v2 in the local file" do
+      expected_output = "rubyrubyruby 0.0.1,0.0.2 v2_qw212r\n"
+
+      assert_equal expected_output, @tmp_versions_file.readlines[2]
+    end
+
+    should "upload the file to the main bucket for baseline versions" do
+      uploaded_main = RubygemFs.instance.get("versions/versions_v2.list")
+
+      assert_not_nil uploaded_main
+      assert_includes uploaded_main, "rubyrubyruby 0.0.1,0.0.2 v2_qw212r"
+    end
+  end
+
+  context "yanked version" do
+    setup do
+      @rubygem = create(:rubygem, name: "rubyrubyruby")
+      create(:version, rubygem: @rubygem, number: "0.0.1", created_at: 5.minutes.ago,
+                       info_checksum_v2: "v2_qw212r")
+      create(:version, indexed: false, rubygem: @rubygem, number: "0.0.2",
+                       created_at: 3.minutes.ago, yanked_at: 1.minute.ago,
+                       info_checksum_v2: "v2_sd12q",
+                       yanked_info_checksum_v2: "v2_yanked")
+
+      update_versions_file
+    end
+
+    should "not include yanked version, but use yanked_info_checksum_v2" do
+      expected_output = "rubyrubyruby 0.0.1 v2_yanked\n"
+
+      assert_equal expected_output, @tmp_versions_file.readlines[2]
+    end
+  end
+end


### PR DESCRIPTION
### Description 

This PR adds a rake task (and associated tests) to update the V2 compact index versions file once backfill is complete (https://github.com/rubygems/rubygems.org/pull/6512). 

⚠️ This PR depends on:
- https://github.com/rubygems/rubygems.org/pull/6504 - creating and writing the info_checksum_v2 columns
- https://github.com/rubygems/rubygems.org/pull/6511 - writing the new files to S3
- https://github.com/rubygems/rubygems.org/pull/6512 - the maintenance task to backfill the info_checksum_v2 columns.

### Tophatting
Rake task can be run locally to confirm that the versions file is correctly updating with the correct content, depending on local gems/versions in db. 

### Tests
Tests have been added to cover both the new methods in `gem_info` and the rake task logic. 