### PR TITLE
Don't pass trace object to datadog appsec event

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,8 +13,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     @user.policies_acknowledged_at = Time.zone.now
     if @user.save
-      trace = Datadog::Tracing.active_trace
-      Datadog::Kit::AppSec::Events.track("users.signup", trace, nil, { "usr.id" => @user.id.to_s }) if trace
+      Datadog::Kit::AppSec::Events.track("users.signup", "usr.id": @user.id.to_s)
       Mailer.email_confirmation(@user).deliver_later
       flash[:notice] = t(".email_sent")
       redirect_back_or_to root_path

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -79,10 +79,8 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       should "track signup with Datadog AppSec" do
-        trace = mock("trace")
-        Datadog::Tracing.stubs(:active_trace).returns(trace)
-        Datadog::Kit::AppSec::Events.expects(:track).with do |event, t, user, metadata|
-          event == "users.signup" && t == trace && user.nil? && metadata["usr.id"].is_a?(String)
+        Datadog::Kit::AppSec::Events.expects(:track).with do |event, **metadata|
+          event == "users.signup" && metadata[:"usr.id"].is_a?(String)
         end
 
         post :create, params: { user: { email: "foo@bar.com", password: PasswordHelpers::SECURE_TEST_PASSWORD } }


### PR DESCRIPTION
There's currently an error on registration submissions because we're calling #track incorrectly - `Datadog::Kit::AppSec::Events.track's signature is (event, trace = nil, span = nil, **others)`, and our string-keyed hash was being treated as a 4th positional arg. This wasn't caught by our tests due to the trace guard, which has now also been dropped as the Datadog gem handles this automatically.