### PR TITLE
Add a combined group for minor + patch Actions Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  groups:
+    github-actions-patch-minor:
+      patterns: ["*"]
+      update-types:
+        - version-update:semver-patch
+        - version-update:semver-minor
 - package-ecosystem: "devcontainers"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       update-types:
         - version-update:semver-patch
         - version-update:semver-minor
-- package-ecosystem: "devcontainers"
+- package-ecosystem: devcontainers
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
Proposing a combined group for minor + patch Actions Dependabot bumps as a means of reducing noise. Note that major version Actions Dependabot bumps will still be created as individual PRs. Also burns some useless quotes. 

Part of addressing https://github.com/rubygems/rubygems.org/issues/6538