### PR TITLE
Make codecov/project status informational

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,13 @@
 codecov:
   notify:
     after_n_builds: 2
+
+coverage:
+  status:
+    # Informational: total coverage drifts independently of the diff
+    # (flaky system tests, fork PRs with partial uploads). Patch is the gate.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
The codecov check fails on PRs whose own diff is fully covered (codecov/patch passes) because `.github/codecov.yml` configured no project status, so Codecov's default 0% threshold fails on any downward drift in total coverage.

That drift is unrelated to the PR's code:
- non-deterministic system-test coverage (tiny -0.01% dips), and
- fork PRs, where secrets (CODECOV_TOKEN) are unavailable so uploads run tokenless and often only one of the two parallel reports merges (~-2.5%).

Add a project status with a 1% threshold and informational: true so it reports without blocking; patch coverage remains the real per-PR gate.