### PR TITLE
Agent setup instructions

### DIFF
--- a/.agents/skills/run-rubygems-org/LEARNINGS.md
+++ b/.agents/skills/run-rubygems-org/LEARNINGS.md
@@ -30,4 +30,31 @@ Copy this block to the top of "Entries" and fill it in:
 
 ## Entries
 
-_None yet. First entry will live here. Add new entries at the top so the most recent is easiest to find._
+_Add new entries at the top so the most recent is easiest to find._
+
+## 2026-06-11 — native Postgres rejects `db:prepare` with password auth
+
+**Environment:** Linux container (Ubuntu 24.04, fresh cloud agent sandbox), Postgres 16 via apt
+**Triggered by:** `bin/setup` (step `bin/rails db:prepare`)
+**Symptom:** `PG::ConnectionBad: ... FATAL: password authentication failed for user "postgres"` on stderr — *after* the development DB had already been created successfully.
+**Root cause:** `db:prepare` prepares dev *and* test, and `config/database.yml` expects different passwords for the same `postgres` role (`devpassword` vs `testpassword`). Only a server that doesn't check passwords can satisfy both. Docker's `POSTGRES_HOST_AUTH_METHOD=trust` and Homebrew's default local `trust` do; apt's default `scram-sha-256` doesn't.
+**Fix:** set the local/`127.0.0.1` entries in `pg_hba.conf` to `trust` (`sed -i 's/scram-sha-256/trust/g; s/peer$/trust/' "$(sudo -u postgres psql -tAc 'SHOW hba_file')"`), restart Postgres, re-run `bin/setup`.
+**Status:** graduated (#6546 — Prerequisites trap + Troubleshooting row in SKILL.md)
+
+## 2026-06-11 — `mise install` Ruby not picked up in non-interactive shells
+
+**Environment:** Linux container (Ubuntu 24.04, fresh cloud agent sandbox), system Ruby 3.3.6, mise 2026.6.2
+**Triggered by:** `bin/setup` right after `mise install`
+**Symptom:** bundler aborts with a Ruby version mismatch (Gemfile wants 4.0.x, got 3.3.6), even though `mise install` reported `ruby 4.0.5 ✓ installed`.
+**Root cause:** mise only rewrites PATH in shells where it's activated (shell rc hook). Agent/CI shells are non-interactive, so the freshly installed Ruby never shadows the system one.
+**Fix:** `eval "$(mise activate bash --shims)"` before running anything, or prefix each command with `mise exec --`.
+**Status:** graduated (#6546 — Prerequisites trap + Troubleshooting row in SKILL.md)
+
+## 2026-06-11 — Docker Hub unauthenticated pull rate limit
+
+**Environment:** Linux container (Ubuntu 24.04, fresh cloud agent sandbox — shared egress IP)
+**Triggered by:** `docker compose up -d db cache search`
+**Symptom:** `error from registry: You have reached your unauthenticated pull rate limit` on stderr; persisted across retries with backoff.
+**Root cause:** Docker Hub rate-limits anonymous pulls per source IP; cloud sandboxes and CI runners share egress IPs, so a fresh environment can be rate-limited before its first pull.
+**Fix:** pulled OpenSearch from the AWS mirror instead — `docker run -d -p 127.0.0.1:9200:9200 -e discovery.type=single-node -e DISABLE_SECURITY_PLUGIN=true -e 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m' public.ecr.aws/opensearchproject/opensearch:2.13.0` — and installed Postgres + memcached via apt (see the Postgres trust-auth entry above).
+**Status:** graduated (#6546 — Troubleshooting row in SKILL.md)

--- a/.agents/skills/run-rubygems-org/LEARNINGS.md
+++ b/.agents/skills/run-rubygems-org/LEARNINGS.md
@@ -1,0 +1,33 @@
+# Learnings: running rubygems.org locally
+
+A running log of failure modes encountered while bringing up rubygems.org and the fixes that worked. **This file exists so the skill can learn.** When `smoke.sh` fails:
+
+1. **Read this file first** — someone may have already solved it (Ctrl-F your error string).
+2. **Read `tmp/run-skill/diagnostic.txt`** — `smoke.sh` writes a structured snapshot of the environment whenever it fails (ports, docker state, rails log tail, ruby/bundle versions).
+3. **Fix the issue.** Note the exact command(s) that worked.
+4. **Add an entry below.** Use the template. Be specific — future-you / future-agent reads this cold and needs to act on it.
+5. **Graduate stable fixes.** If the failure is likely to recur (not a one-off environment quirk), do one or both:
+   - Add a row to `SKILL.md` > Troubleshooting (symptom → fix).
+   - Update `smoke.sh` to auto-detect or auto-recover.
+   - Then mark the entry below "**Status:** graduated" with a link to the commit/PR.
+
+Don't skip step 4 even if you graduated immediately — this file is the *why* behind the SKILL changes.
+
+## Entry template
+
+Copy this block to the top of "Entries" and fill it in:
+
+```markdown
+## YYYY-MM-DD — short title
+
+**Environment:** macOS arm64 14.5 / Ubuntu 22.04 / Linux container / etc.
+**Triggered by:** `./.agents/skills/run-rubygems-org/smoke.sh` (or the specific command, if narrower)
+**Symptom:** one-line error + where it appeared (stderr, `tmp/run-skill/rails.log`, `tmp/run-skill/diagnostic.txt`)
+**Root cause:** the actual reason (not just the surface error)
+**Fix:** the exact command(s) that worked, in order
+**Status:** in-the-wild  |  graduated (link to commit/PR)
+```
+
+## Entries
+
+_None yet. First entry will live here. Add new entries at the top so the most recent is easiest to find._

--- a/.agents/skills/run-rubygems-org/SKILL.md
+++ b/.agents/skills/run-rubygems-org/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-rubygems-org
-description: Run rubygems.org locally — boot the Rails server, hit it with curl, screenshot pages with headless Chrome. Use when asked to run, start, boot, smoke-test, or screenshot the rubygems.org / gemcutter app.
+description: Run rubygems.org locally — boot the Rails server, hit it with curl, screenshot pages via bin/playwright, or invoke internal code with bin/rails runner. Use when asked to run, start, boot, smoke-test, screenshot, or poke models/jobs/controllers in the rubygems.org / gemcutter app.
 ---
 
 # Run rubygems.org
@@ -40,7 +40,7 @@ docker run -d -p 9200:9200 \
 bin/setup
 ```
 
-See `CONTRIBUTING.md` > Development Setup for the Linux/apt variant. `bin/setup` installs Playwright's bundled Chromium into `~/Library/Caches/ms-playwright/chromium-*/` — `smoke.sh` uses that same binary for screenshots, so you don't need a separate browser.
+See `CONTRIBUTING.md` > Development Setup for the Linux/apt variant. `bin/setup` runs `bin/playwright install --with-deps chromium`; `smoke.sh` shells out to `bin/playwright screenshot`, which uses that same bundled Chromium — no separate browser needed.
 
 ## Run (agent path — preferred)
 
@@ -76,6 +76,33 @@ bin/rails s                  # foreground on :3000
 
 Opens nothing — just listens. Useless headless; for an agent driving the app, always use `smoke.sh` so you get the screenshots and HTTP assertions.
 
+## Direct invocation (poking internal code)
+
+Most PRs in this repo touch a model, job, policy, or controller — not the HTML surface. For those, skip `smoke.sh` and call the code directly. All of these run against the dev DB and respect any local changes without restarting a server:
+
+```bash
+# One-liner: import + call + observe (matches AGENTS.md examples)
+bin/rails runner 'p Rubygem.find_by(name: "rubygem0")&.versions&.count'
+
+# REPL — for exploratory work or anything multi-step
+bin/rails c
+
+# Run one test file (fastest feedback loop for a model/job change)
+bin/rails test test/models/rubygem_test.rb
+bin/rails test test/models/rubygem_test.rb:42      # one line
+bin/rails test -n /pattern/                         # name pattern
+
+# Enqueue / run a job inline against the dev DB
+bin/rails runner 'YourJob.new.perform(Rubygem.last.id)'
+```
+
+If a job/policy depends on the gem index or OpenSearch being current, run the indexer first:
+
+```bash
+bundle exec rake gemcutter:index:update             # compact_index / specs.*.gz
+bundle exec rake searchkick:reindex CLASS=Rubygem   # OpenSearch
+```
+
 ## When this skill fails (learn-and-teach loop)
 
 This skill keeps a running [`LEARNINGS.md`](LEARNINGS.md) so each failure becomes a one-time cost, not a recurring one. **When `smoke.sh` fails with something not already in the Troubleshooting table:**
@@ -110,7 +137,7 @@ bin/ci                                          # full CI suite (lint + brakeman
 - **Seeded gems are `rubygem0`/`rubygem1`/`rubygem2`,** not real gems. `/api/v1/gems/rails.json` returns "This rubygem could not be found." — use `rubygem0` in any smoke check.
 - **Tailwind runs in a separate process** (`bin/rails tailwindcss:watch` is auto-spawned in dev). It writes CSS asynchronously after boot; if the homepage looks unstyled in a screenshot, give it 2–3 more seconds.
 - **`bin/setup` is destructive of dev DB schema.** It runs `db:prepare` which will create+migrate. To load real anonymized data, use `script/load-pg-dump` (see AGENTS.md).
-- **The Playwright Chromium path is version-pinned.** `smoke.sh` globs `~/Library/Caches/ms-playwright/chromium-*/` so it survives upgrades, but if you blow away that cache, re-run `bin/playwright install --with-deps chromium`.
+- **Screenshots go through `bin/playwright`, not a hand-found Chromium.** `bin/playwright` is the Node CLI pinned to the `playwright-ruby-client` gem version, and `playwright screenshot` resolves its own bundled browser — so we don't care where Chromium lives on disk. If you blow away the cache, `bin/playwright install --with-deps chromium` rehydrates it.
 
 ## Troubleshooting
 
@@ -122,5 +149,6 @@ bin/ci                                          # full CI suite (lint + brakeman
 | `Address already in use - bind(2) for "127.0.0.1" port 3000` | A previous Rails is still alive: `pkill -f 'puma.*3000'` (or `kill $(cat tmp/run-skill/rails.pid)` if `smoke.sh` started it). |
 | Smoke says `homepage never returned 200 (last 500)` | `tail -100 tmp/run-skill/rails.log` — usually a missing migration (`bin/rails db:migrate`) or DB seed (`bin/rails db:seed`). |
 | Smoke says `gem JSON API failed (expected 200, got 404)` | DB is fresh and unseeded: `bin/rails db:seed` recreates `rubygem0`. |
-| `no chromium found` in smoke output | `bin/playwright install --with-deps chromium`. The smoke script falls back to `/Applications/Google Chrome.app` if present. |
+| `screenshot <name> failed` in smoke output | Chromium isn't installed for the pinned playwright version: `bin/playwright install --with-deps chromium`. |
+| `bin/playwright unavailable` in smoke output | No `node` on PATH or `bin/playwright` missing — install Node (or use `mise`/`asdf`), then re-run. |
 | Screenshot is blank/white | Server returned 200 but the page errored client-side; open `tmp/run-skill/rails.log` and look for the request just before — Tailwind not ready yet is the most common cause. Re-run `smoke.sh`. |

--- a/.agents/skills/run-rubygems-org/SKILL.md
+++ b/.agents/skills/run-rubygems-org/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: run-rubygems-org
+description: Run rubygems.org locally — boot the Rails server, hit it with curl, screenshot pages with headless Chrome. Use when asked to run, start, boot, smoke-test, or screenshot the rubygems.org / gemcutter app.
+---
+
+# Run rubygems.org
+
+A Rails 8 app (internal name: `gemcutter`) that needs Postgres, OpenSearch, and Memcached. Backing services run in Docker; everything else (Ruby 4, Puma, headless Chrome) runs on the host.
+
+**The agent path is `./.agents/skills/run-rubygems-org/smoke.sh`** — it brings services up, boots Rails on :3000 if it isn't already, curls four key endpoints, and writes three PNG screenshots to `tmp/run-skill/`.
+
+All paths in this doc are relative to the repo root (`/Users/colby/Developer/rubygems.org`).
+
+> Canonical location: `.agents/skills/run-rubygems-org/` — the cross-tool skill convention picked up by Codex CLI, OpenCode, and Gemini CLI. Claude Code reads it through the symlink at `.claude/skills/run-rubygems-org/`.
+>
+> **If `smoke.sh` fails, see "When this skill fails" below before improvising — [`LEARNINGS.md`](LEARNINGS.md) likely has your fix.**
+
+## Prerequisites (one-time)
+
+You need Ruby 4 (via `mise`/`asdf` from `.ruby-version`), and Postgres + OpenSearch + Memcached reachable on `127.0.0.1:5432/9200/11211`. `smoke.sh` doesn't care *how* they're running — Docker, brew services, apt, or already-on-the-host — it just probes the ports.
+
+If you're on a fresh machine, pick whichever path you prefer:
+
+```bash
+# Path A: Docker (one command for all three backing services)
+mise install                  # ruby 4.0.5 per .ruby-version
+docker compose up -d db cache search
+bin/setup                     # bundle, db:prepare, db:seed, playwright install
+
+# Path B: Native (macOS via Homebrew)
+mise install
+brew install postgresql@14 memcached
+brew services start postgresql@14
+brew services start memcached
+# OpenSearch isn't in Homebrew; run it via docker even in a "native" setup:
+docker run -d -p 9200:9200 \
+  -e discovery.type=single-node -e DISABLE_SECURITY_PLUGIN=true \
+  -e 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m' \
+  opensearchproject/opensearch:2.13.0
+bin/setup
+```
+
+See `CONTRIBUTING.md` > Development Setup for the Linux/apt variant. `bin/setup` installs Playwright's bundled Chromium into `~/Library/Caches/ms-playwright/chromium-*/` — `smoke.sh` uses that same binary for screenshots, so you don't need a separate browser.
+
+## Run (agent path — preferred)
+
+```bash
+./.agents/skills/run-rubygems-org/smoke.sh
+```
+
+That single command:
+
+1. Probes Postgres (`:5432`), Memcached (`:11211`), and OpenSearch (`:9200`). If a service is already listening (native brew/apt install, or some other running container), it's left alone. If something is down and `docker compose` + `docker-compose.yml` are both available, it falls back to `docker compose up -d <service>`. If neither path works, it fails with the exact install commands to run.
+2. If nothing is on :3000, launches `bundle exec rails server -p 3000 -b 127.0.0.1` under `nohup` (pid → `tmp/run-skill/rails.pid`, log → `tmp/run-skill/rails.log`). Otherwise reuses the existing server.
+3. Polls `GET /` until it returns 200 (timeout 60s — cold start is ~3s here, ~10–15s on first boot after a code change due to Tailwind compile).
+4. Curls four endpoints and fails loudly on any non-200 or missing-substring:
+   - `/` (homepage HTML)
+   - `/api/v1/gems/rubygem0.json` (gem JSON API)
+   - `/versions` (compact_index — what `bundle` and `gem` fetch)
+   - `/gems/rubygem0` (gem detail page)
+5. Screenshots three pages with headless Chrome at 1280px wide → `tmp/run-skill/{home,gem,signin}.png`.
+
+`rubygem0` exists because `db:seed` creates it; if you've wiped the DB, re-run `bin/rails db:seed`.
+
+To stop a server `smoke.sh` started:
+
+```bash
+kill "$(cat tmp/run-skill/rails.pid)"
+```
+
+## Run (human path)
+
+```bash
+bin/rails s                  # foreground on :3000
+```
+
+Opens nothing — just listens. Useless headless; for an agent driving the app, always use `smoke.sh` so you get the screenshots and HTTP assertions.
+
+## When this skill fails (learn-and-teach loop)
+
+This skill keeps a running [`LEARNINGS.md`](LEARNINGS.md) so each failure becomes a one-time cost, not a recurring one. **When `smoke.sh` fails with something not already in the Troubleshooting table:**
+
+1. **Read [`LEARNINGS.md`](LEARNINGS.md) first** — Ctrl-F your error string; someone may have already solved it.
+2. **Read `tmp/run-skill/diagnostic.txt`** — `smoke.sh` writes a structured environment snapshot (ports, docker state, rails log tail, ruby/bundle versions) every time it fails.
+3. **Fix it.** Capture the exact command(s) that worked.
+4. **Add an entry to [`LEARNINGS.md`](LEARNINGS.md)** using the template at the top of that file. Don't skip this even if the fix is "obvious" to you — it won't be obvious to the next agent in a fresh container at 3am.
+5. **Graduate stable fixes.** If the failure mode is likely to recur (not a one-off environment quirk):
+   - Add a row to the **Troubleshooting** table below (symptom → fix), and/or
+   - Update `smoke.sh` to auto-detect or auto-recover (e.g. add a probe, extend the docker fallback)
+   - Then mark the LEARNINGS.md entry **Status: graduated** with a link to your commit/PR.
+
+This is the skill teaching itself. `LEARNINGS.md` is the *why* behind every `SKILL.md` / `smoke.sh` change — keep it even after graduation.
+
+## Tests
+
+```bash
+bin/rails test                                  # unit/integration
+bin/rails test test/models/rubygem_test.rb:42   # single test
+DB_HOST=localhost bin/rails test                # ONLY when not on the default unix-socket path — see Gotchas
+bin/rails test:system                           # Playwright + Chrome
+bin/ci                                          # full CI suite (lint + brakeman + tests)
+```
+
+## Gotchas
+
+- **`.env.local` is excluded in the test environment.** dotenv loads `.env.local` for development but not for test, so `DB_HOST` is unset there. The dev config defaults to a Unix socket (no `DB_HOST` needed) but **tests crash if Postgres isn't on the default socket path** — set `DB_HOST=localhost` inline when running tests against the Docker Postgres on TCP. See `config/database.yml` and `config/environments/test.rb`.
+- **There is no `/up` endpoint.** Rails 8's default health check is not wired up; use `GET /` (homepage) as the readiness probe. `/up` returns 404.
+- **First boot prints ~50 lines of Datadog APM/CI-Visibility noise** before "Listening on …". This is normal — `dd-trace-rb` autoloads in development. Don't mistake it for failure.
+- **OpenSearch may report `status: yellow`.** That's expected for a single-node cluster; the smoke script only requires `_cluster/health` to respond, not be green.
+- **Seeded gems are `rubygem0`/`rubygem1`/`rubygem2`,** not real gems. `/api/v1/gems/rails.json` returns "This rubygem could not be found." — use `rubygem0` in any smoke check.
+- **Tailwind runs in a separate process** (`bin/rails tailwindcss:watch` is auto-spawned in dev). It writes CSS asynchronously after boot; if the homepage looks unstyled in a screenshot, give it 2–3 more seconds.
+- **`bin/setup` is destructive of dev DB schema.** It runs `db:prepare` which will create+migrate. To load real anonymized data, use `script/load-pg-dump` (see AGENTS.md).
+- **The Playwright Chromium path is version-pinned.** `smoke.sh` globs `~/Library/Caches/ms-playwright/chromium-*/` so it survives upgrades, but if you blow away that cache, re-run `bin/playwright install --with-deps chromium`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `could not connect to server: Connection refused` (psql/Rails) | Postgres isn't running. Docker: `docker compose up -d db`. Native (macOS): `brew services start postgresql@14`. |
+| `Faraday::ConnectionFailed` against `localhost:9200` | OpenSearch is down or still booting. `smoke.sh` will auto-start it via docker if available — otherwise see the OpenSearch `docker run` line in Prerequisites. Wait ~5s for `/_cluster/health` to respond. |
+| `smoke.sh` fails: `<svc> is not responding ... docker compose isn't available here` | The probe found nothing on the port AND there's no docker on PATH. The error message lists the exact native-install command for that service — run it, then re-run `smoke.sh`. |
+| `Address already in use - bind(2) for "127.0.0.1" port 3000` | A previous Rails is still alive: `pkill -f 'puma.*3000'` (or `kill $(cat tmp/run-skill/rails.pid)` if `smoke.sh` started it). |
+| Smoke says `homepage never returned 200 (last 500)` | `tail -100 tmp/run-skill/rails.log` — usually a missing migration (`bin/rails db:migrate`) or DB seed (`bin/rails db:seed`). |
+| Smoke says `gem JSON API failed (expected 200, got 404)` | DB is fresh and unseeded: `bin/rails db:seed` recreates `rubygem0`. |
+| `no chromium found` in smoke output | `bin/playwright install --with-deps chromium`. The smoke script falls back to `/Applications/Google Chrome.app` if present. |
+| Screenshot is blank/white | Server returned 200 but the page errored client-side; open `tmp/run-skill/rails.log` and look for the request just before — Tailwind not ready yet is the most common cause. Re-run `smoke.sh`. |

--- a/.agents/skills/run-rubygems-org/SKILL.md
+++ b/.agents/skills/run-rubygems-org/SKILL.md
@@ -42,6 +42,11 @@ bin/setup
 
 See `CONTRIBUTING.md` > Development Setup for the Linux/apt variant. `bin/setup` runs `bin/playwright install --with-deps chromium`; `smoke.sh` shells out to `bin/playwright screenshot`, which uses that same bundled Chromium — no separate browser needed.
 
+Two traps on fresh machines:
+
+- **`mise install` alone doesn't put Ruby on PATH in non-interactive shells.** Activate it first (`eval "$(mise activate bash --shims)"`) or prefix commands with `mise exec --`; otherwise `bin/setup` runs against the system Ruby and bundler aborts with a version mismatch.
+- **Native Postgres on Linux needs `trust` auth.** `config/database.yml` expects *different* passwords for the same `postgres` role in dev (`devpassword`) and test (`testpassword`), which only works when the server doesn't check passwords. Docker handles this via `POSTGRES_HOST_AUTH_METHOD=trust` and Homebrew trusts local connections by default, but apt's Postgres defaults to `scram-sha-256` — set the local/`127.0.0.1` entries in `pg_hba.conf` to `trust` and restart, or `bin/rails db:prepare` fails with `password authentication failed for user "postgres"`.
+
 ## Run (agent path — preferred)
 
 ```bash
@@ -123,14 +128,14 @@ This is the skill teaching itself. `LEARNINGS.md` is the *why* behind every `SKI
 ```bash
 bin/rails test                                  # unit/integration
 bin/rails test test/models/rubygem_test.rb:42   # single test
-DB_HOST=localhost bin/rails test                # ONLY when not on the default unix-socket path — see Gotchas
+DB_HOST=db bin/rails test                       # ONLY when Postgres isn't on localhost (e.g. dev containers) — see Gotchas
 bin/rails test:system                           # Playwright + Chrome
 bin/ci                                          # full CI suite (lint + brakeman + tests)
 ```
 
 ## Gotchas
 
-- **`.env.local` is excluded in the test environment.** dotenv loads `.env.local` for development but not for test, so `DB_HOST` is unset there. The dev config defaults to a Unix socket (no `DB_HOST` needed) but **tests crash if Postgres isn't on the default socket path** — set `DB_HOST=localhost` inline when running tests against the Docker Postgres on TCP. See `config/database.yml` and `config/environments/test.rb`.
+- **`.env.local` is excluded in the test environment.** dotenv loads `.env.local` for development but not for test, so a `DB_HOST` set there is invisible to tests. `config/database.yml` defaults `DB_HOST` to `localhost` (TCP) for both dev and test, so a standard local setup needs no `DB_HOST` at all — but when Postgres lives on another host (e.g. `db` in a dev container), pass it inline: `DB_HOST=db bin/rails test`.
 - **There is no `/up` endpoint.** Rails 8's default health check is not wired up; use `GET /` (homepage) as the readiness probe. `/up` returns 404.
 - **First boot prints ~50 lines of Datadog APM/CI-Visibility noise** before "Listening on …". This is normal — `dd-trace-rb` autoloads in development. Don't mistake it for failure.
 - **OpenSearch may report `status: yellow`.** That's expected for a single-node cluster; the smoke script only requires `_cluster/health` to respond, not be green.
@@ -152,3 +157,6 @@ bin/ci                                          # full CI suite (lint + brakeman
 | `screenshot <name> failed` in smoke output | Chromium isn't installed for the pinned playwright version: `bin/playwright install --with-deps chromium`. |
 | `bin/playwright unavailable` in smoke output | No `node` on PATH or `bin/playwright` missing — install Node (or use `mise`/`asdf`), then re-run. |
 | Screenshot is blank/white | Server returned 200 but the page errored client-side; open `tmp/run-skill/rails.log` and look for the request just before — Tailwind not ready yet is the most common cause. Re-run `smoke.sh`. |
+| `FATAL: password authentication failed for user "postgres"` during `bin/setup` / `db:prepare` | Native Postgres with password auth (the apt default). Dev and test expect different passwords for the same `postgres` role, so the server must not check them: set the local/`127.0.0.1` entries in `pg_hba.conf` to `trust`, restart Postgres, re-run. See Prerequisites. |
+| `Your Ruby version is 3.x, but your Gemfile specified 4.0.x` right after `mise install` | mise isn't activated in this (non-interactive) shell: `eval "$(mise activate bash --shims)"`, or prefix commands with `mise exec --`, then re-run. |
+| `docker pull` fails: `You have reached your unauthenticated pull rate limit` | Docker Hub rate limit — common from fresh containers/CI egress IPs. OpenSearch has a drop-in mirror: swap the image in the Prerequisites `docker run` line for `public.ecr.aws/opensearchproject/opensearch:2.13.0`. Postgres and memcached can come from apt/brew instead (see Prerequisites traps for the Postgres auth caveat). |

--- a/.agents/skills/run-rubygems-org/SKILL.md
+++ b/.agents/skills/run-rubygems-org/SKILL.md
@@ -5,11 +5,11 @@ description: Run rubygems.org locally — boot the Rails server, hit it with cur
 
 # Run rubygems.org
 
-A Rails 8 app (internal name: `gemcutter`) that needs Postgres, OpenSearch, and Memcached. Backing services run in Docker; everything else (Ruby 4, Puma, headless Chrome) runs on the host.
+A Rails 8 app (internal name: `gemcutter`) that needs Postgres, OpenSearch, and Memcached reachable on `127.0.0.1:5432/9200/11211`. `smoke.sh` probes those ports and works whether the backing services are running in Docker, via native installs, or are already running on the host; everything else (Ruby 4, Puma, headless Chrome) runs on the host.
 
-**The agent path is `./.agents/skills/run-rubygems-org/smoke.sh`** — it brings services up, boots Rails on :3000 if it isn't already, curls four key endpoints, and writes three PNG screenshots to `tmp/run-skill/`.
+**The agent path is `./.agents/skills/run-rubygems-org/smoke.sh`** — it brings services up, boots Rails on :3000 if it isn't already, curls four key endpoints, and, when a Chromium binary is available, writes three PNG screenshots to `tmp/run-skill/`.
 
-All paths in this doc are relative to the repo root (`/Users/colby/Developer/rubygems.org`).
+All paths in this doc are relative to the repo root.
 
 > Canonical location: `.agents/skills/run-rubygems-org/` — the cross-tool skill convention picked up by Codex CLI, OpenCode, and Gemini CLI. Claude Code reads it through the symlink at `.claude/skills/run-rubygems-org/`.
 >

--- a/.agents/skills/run-rubygems-org/smoke.sh
+++ b/.agents/skills/run-rubygems-org/smoke.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Boot RubyGems.org locally and smoke-test it end-to-end.
+# Used by the run-rubygems-org skill. Idempotent.
+#
+# Steps:
+#   1. Ensure backing services are reachable on the standard ports
+#      (postgres 5432, memcached 11211, opensearch 9200). Probe first; only
+#      fall back to `docker compose up -d` if a service is down and docker
+#      compose is available. Native installs (brew/apt) are supported —
+#      whatever is listening on the port wins.
+#   2. Start `rails s` on :3000 in the background if nothing is listening there.
+#   3. Wait for the homepage to return 200.
+#   4. Curl key endpoints (HTML + JSON API + compact_index).
+#   5. Take headless-Chrome screenshots of the home page and a seeded gem page.
+#
+# Outputs:
+#   - server log:   tmp/run-skill/rails.log
+#   - server pid:   tmp/run-skill/rails.pid   (only when this script started it)
+#   - screenshots:  tmp/run-skill/*.png
+#
+# Stop a server this script started:
+#   kill "$(cat tmp/run-skill/rails.pid)"
+
+set -euo pipefail
+
+# Always run from the repo root, regardless of CWD.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="tmp/run-skill"
+DIAG_FILE="$OUT_DIR/diagnostic.txt"
+LEARNINGS_REL=".agents/skills/run-rubygems-org/LEARNINGS.md"
+mkdir -p "$OUT_DIR"
+
+step() { printf '\n=== %s ===\n' "$*"; }
+
+# Pure-bash TCP probe — no `nc`/`pg_isready`/`psql` dependency.
+# Hoisted above fail() so dump_diagnostics can use it.
+port_open() { (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null && return 0 || return 1; }
+
+# Write a structured snapshot of the environment to $DIAG_FILE so the agent
+# investigating a failure has one file to read instead of running 5 probes.
+dump_diagnostics() {
+  {
+    echo "=== diagnostic dump @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+    echo "host:    $(uname -a)"
+    echo "pwd:     $(pwd)"
+    echo "ruby:    $(ruby -v 2>&1 || echo MISSING)"
+    echo "bundle:  $(bundle -v 2>&1 || echo MISSING)"
+    echo "docker:  $(docker --version 2>&1 || echo MISSING)"
+    echo
+    echo "--- backing-service ports ---"
+    for p in 3000 5432 9200 11211; do
+      port_open 127.0.0.1 "$p" 2>/dev/null && echo "  :$p OPEN" || echo "  :$p closed"
+    done
+    echo
+    echo "--- opensearch /_cluster/health (if reachable) ---"
+    curl -s -m 2 http://127.0.0.1:9200/_cluster/health 2>&1 || echo "(unreachable)"
+    echo
+    echo "--- docker compose ps ---"
+    (docker compose ps 2>&1) || echo "(docker compose not available)"
+    echo
+    echo "--- rails log tail (last 80 lines) ---"
+    tail -80 "$OUT_DIR/rails.log" 2>/dev/null || echo "(no rails.log)"
+  } > "$DIAG_FILE" 2>&1
+}
+
+fail() {
+  printf '\n!!! %s\n' "$*" >&2
+  dump_diagnostics
+  cat >&2 <<EOF
+
+→ Diagnostic snapshot written to: $DIAG_FILE
+→ If you figure out a fix that's NOT in SKILL.md > Troubleshooting,
+  append it to: $LEARNINGS_REL
+  (entry template is at the top of that file). The next agent will benefit.
+EOF
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 1. backing services
+#
+# Probe first, start later. If a service is already listening (native install
+# via brew/apt, or someone else's docker), don't touch it. Only fall back to
+# `docker compose up -d` for services that are down AND defined in this
+# repo's docker-compose.yml AND a usable docker is available.
+# ---------------------------------------------------------------------------
+step "backing services"
+
+probe_pg() { port_open 127.0.0.1 5432; }
+probe_mc() { port_open 127.0.0.1 11211; }
+probe_os() { curl -sf -m 2 http://127.0.0.1:9200/_cluster/health >/dev/null; }
+
+# Decide whether docker compose is a viable fallback for a given service.
+HAVE_DOCKER=n
+if command -v docker >/dev/null && docker compose version >/dev/null 2>&1 \
+   && [[ -f docker-compose.yml ]]; then
+  HAVE_DOCKER=y
+fi
+
+bring_up() {
+  local svc=$1 probe=$2 port=$3 docker_name=$4
+  if $probe; then
+    echo "  ${svc}: already up on :${port}"
+    return 0
+  fi
+  if [[ "$HAVE_DOCKER" == y ]] && grep -q "^  ${docker_name}:" docker-compose.yml; then
+    echo "  ${svc}: not responding on :${port}, starting via docker compose..."
+    docker compose up -d "$docker_name" >/dev/null
+    for _ in $(seq 1 30); do $probe && { echo "  ${svc}: up"; return 0; }; sleep 1; done
+    fail "${svc} never came up after docker compose up -d ${docker_name} (see: docker compose logs ${docker_name})"
+  fi
+  # No docker fallback: tell the user how to bring it up natively.
+  fail "${svc} is not responding on :${port} and docker compose isn't available here.
+        Start it natively, then re-run. See CONTRIBUTING.md > Development Setup for install steps:
+          postgres   : brew services start postgresql   |  sudo systemctl start postgresql
+          memcached  : brew services start memcached    |  sudo systemctl start memcached
+          opensearch : docker run -p 9200:9200 -e discovery.type=single-node \\
+                          -e DISABLE_SECURITY_PLUGIN=true opensearchproject/opensearch:2.13.0"
+}
+
+bring_up postgres   probe_pg 5432  db
+bring_up memcached  probe_mc 11211 cache
+bring_up opensearch probe_os 9200  search
+
+# ---------------------------------------------------------------------------
+# 2. rails server
+# ---------------------------------------------------------------------------
+started_server=0
+if curl -sf -m 2 -o /dev/null http://127.0.0.1:3000/; then
+  step "rails already listening on :3000 (reusing)"
+else
+  step "starting rails s -p 3000"
+  : > "$OUT_DIR/rails.log"
+  # nohup so the puma process survives this shell exiting.
+  nohup bundle exec rails server -p 3000 -b 127.0.0.1 >"$OUT_DIR/rails.log" 2>&1 &
+  echo $! > "$OUT_DIR/rails.pid"
+  started_server=1
+  echo "  pid $(cat "$OUT_DIR/rails.pid"), log $OUT_DIR/rails.log"
+fi
+
+step "waiting for homepage to return 200 (up to 60s)"
+for i in $(seq 1 60); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 http://127.0.0.1:3000/ || echo 000)
+  [[ "$code" == 200 ]] && { echo "  ready after ${i}s"; break; }
+  sleep 1
+done
+[[ "$code" == 200 ]] || fail "homepage never returned 200 (last $code); tail -50 $OUT_DIR/rails.log"
+
+# ---------------------------------------------------------------------------
+# 3. http smoke checks
+# ---------------------------------------------------------------------------
+step "endpoint smoke checks"
+check() {
+  local name=$1 url=$2 expect=$3 substr=${4:-}
+  local resp code
+  resp=$(curl -sS -m 10 -w '\n__HTTP_CODE__%{http_code}' "$url")
+  code=${resp##*__HTTP_CODE__}
+  body=${resp%__HTTP_CODE__*}
+  printf '  %-22s %s -> %s' "$name" "$url" "$code"
+  [[ "$code" == "$expect" ]] || { echo " (expected $expect)"; fail "$name failed"; }
+  if [[ -n "$substr" ]] && ! grep -qF "$substr" <<<"$body"; then
+    echo " (missing substr '$substr')"; fail "$name body check failed"
+  fi
+  echo " ok"
+}
+check "homepage HTML"     http://127.0.0.1:3000/                          200 "RubyGems.org"
+check "gem JSON API"      http://127.0.0.1:3000/api/v1/gems/rubygem0.json 200 '"name":"rubygem0"'
+check "compact_index /versions" http://127.0.0.1:3000/versions            200 "rubygem0"
+check "gem detail page"   http://127.0.0.1:3000/gems/rubygem0             200 "rubygem0"
+
+# ---------------------------------------------------------------------------
+# 4. screenshots
+# ---------------------------------------------------------------------------
+step "screenshots via headless chrome"
+CHROME=""
+# Prefer playwright-cached chromium (the one bin/setup installs); fall back to /Applications.
+for c in "$HOME"/Library/Caches/ms-playwright/chromium-*/chrome-mac-arm64/"Google Chrome for Testing.app"/Contents/MacOS/"Google Chrome for Testing"; do
+  [[ -x "$c" ]] && CHROME="$c"
+done
+if [[ -z "$CHROME" && -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]]; then
+  CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+fi
+if [[ -z "$CHROME" ]]; then
+  echo "  no chromium found (run: bin/playwright install --with-deps chromium); skipping screenshots"
+else
+  shoot() {
+    local name=$1 url=$2 wh=${3:-1280,1400}
+    "$CHROME" --headless=new --disable-gpu --no-sandbox --hide-scrollbars \
+      --window-size="$wh" --screenshot="$OUT_DIR/$name.png" "$url" \
+      >/dev/null 2>&1
+    [[ -s "$OUT_DIR/$name.png" ]] || fail "screenshot $name produced empty file"
+    printf '  %-12s -> %s\n' "$name" "$OUT_DIR/$name.png"
+  }
+  shoot home    http://127.0.0.1:3000/                  1280,1600
+  shoot gem     http://127.0.0.1:3000/gems/rubygem0     1280,1400
+  shoot signin  http://127.0.0.1:3000/sign_in           1280,1200
+fi
+
+step "done"
+echo "  screenshots: $OUT_DIR/*.png"
+if (( started_server )); then
+  echo "  rails pid:   $(cat "$OUT_DIR/rails.pid")  (kill it when you're done)"
+fi

--- a/.agents/skills/run-rubygems-org/smoke.sh
+++ b/.agents/skills/run-rubygems-org/smoke.sh
@@ -108,7 +108,8 @@ bring_up() {
   if [[ "$HAVE_DOCKER" == y ]] && grep -q "^  ${docker_name}:" docker-compose.yml; then
     echo "  ${svc}: not responding on :${port}, starting via docker compose..."
     docker compose up -d "$docker_name" >/dev/null
-    for _ in $(seq 1 30); do $probe && { echo "  ${svc}: up"; return 0; }; sleep 1; done
+    # 60s: OpenSearch in particular can take >30s to accept connections cold.
+    for _ in $(seq 1 60); do $probe && { echo "  ${svc}: up"; return 0; }; sleep 1; done
     fail "${svc} never came up after docker compose up -d ${docker_name} (see: docker compose logs ${docker_name})"
   fi
   # No docker fallback: tell the user how to bring it up natively.
@@ -145,7 +146,10 @@ fi
 
 step "waiting for homepage to return 200 (up to 60s)"
 for i in $(seq 1 60); do
-  code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 http://127.0.0.1:3000/ || echo 000)
+  # curl -w already emits 000 on connection failure; don't `|| echo 000` or
+  # the two concatenate into "000000".
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 http://127.0.0.1:3000/ || true)
+  code=${code:-000}
   [[ "$code" == 200 ]] && { echo "  ready after ${i}s"; break; }
   sleep 1
 done
@@ -158,7 +162,10 @@ step "endpoint smoke checks"
 check() {
   local name=$1 url=$2 expect=$3 substr=${4:-}
   local resp code body
-  resp=$(curl -sS -m 10 -w '\n__HTTP_CODE__%{http_code}' "$url")
+  # `|| fail` so a connection-level curl error still writes diagnostics
+  # instead of dying silently via set -e.
+  resp=$(curl -sS -m 10 -w '\n__HTTP_CODE__%{http_code}' "$url") \
+    || fail "$name: curl could not reach $url (server died? tail -50 $OUT_DIR/rails.log)"
   code=${resp##*__HTTP_CODE__}
   body=${resp%__HTTP_CODE__*}
   printf '  %-22s %s -> %s' "$name" "$url" "$code"
@@ -178,8 +185,9 @@ check "gem detail page"   http://127.0.0.1:3000/gems/rubygem0             200 "r
 #
 # bin/playwright is the Node CLI pinned to the playwright-ruby-client gem;
 # `playwright screenshot` knows where its own bundled Chromium lives, so we
-# don't have to. If the CLI isn't usable here (e.g. no node), skip rather
-# than fail — screenshots are nice-to-have, not load-bearing.
+# don't have to. If the CLI isn't usable at all (no node / no bin/playwright),
+# skip — screenshots are nice-to-have. But if the CLI exists and a shot fails
+# (usually a missing Chromium), fail with the install command.
 # ---------------------------------------------------------------------------
 step "screenshots via playwright"
 if ! command -v node >/dev/null || ! [[ -x bin/playwright ]]; then

--- a/.agents/skills/run-rubygems-org/smoke.sh
+++ b/.agents/skills/run-rubygems-org/smoke.sh
@@ -128,7 +128,10 @@ bring_up opensearch probe_os 9200  search
 # 2. rails server
 # ---------------------------------------------------------------------------
 started_server=0
-if curl -sf -m 2 -o /dev/null http://127.0.0.1:3000/; then
+# Reuse anything bound to :3000 — even if it currently 5xx's (e.g. pending
+# migrations). Starting a second server would just fail with EADDRINUSE; let
+# the readiness loop below decide whether it becomes healthy.
+if port_open 127.0.0.1 3000; then
   step "rails already listening on :3000 (reusing)"
 else
   step "starting rails s -p 3000"
@@ -154,7 +157,7 @@ done
 step "endpoint smoke checks"
 check() {
   local name=$1 url=$2 expect=$3 substr=${4:-}
-  local resp code
+  local resp code body
   resp=$(curl -sS -m 10 -w '\n__HTTP_CODE__%{http_code}' "$url")
   code=${resp##*__HTTP_CODE__}
   body=${resp%__HTTP_CODE__*}
@@ -172,24 +175,21 @@ check "gem detail page"   http://127.0.0.1:3000/gems/rubygem0             200 "r
 
 # ---------------------------------------------------------------------------
 # 4. screenshots
+#
+# bin/playwright is the Node CLI pinned to the playwright-ruby-client gem;
+# `playwright screenshot` knows where its own bundled Chromium lives, so we
+# don't have to. If the CLI isn't usable here (e.g. no node), skip rather
+# than fail — screenshots are nice-to-have, not load-bearing.
 # ---------------------------------------------------------------------------
-step "screenshots via headless chrome"
-CHROME=""
-# Prefer playwright-cached chromium (the one bin/setup installs); fall back to /Applications.
-for c in "$HOME"/Library/Caches/ms-playwright/chromium-*/chrome-mac-arm64/"Google Chrome for Testing.app"/Contents/MacOS/"Google Chrome for Testing"; do
-  [[ -x "$c" ]] && CHROME="$c"
-done
-if [[ -z "$CHROME" && -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]]; then
-  CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-fi
-if [[ -z "$CHROME" ]]; then
-  echo "  no chromium found (run: bin/playwright install --with-deps chromium); skipping screenshots"
+step "screenshots via playwright"
+if ! command -v node >/dev/null || ! [[ -x bin/playwright ]]; then
+  echo "  bin/playwright unavailable (need node + bin/playwright); skipping screenshots"
 else
   shoot() {
     local name=$1 url=$2 wh=${3:-1280,1400}
-    "$CHROME" --headless=new --disable-gpu --no-sandbox --hide-scrollbars \
-      --window-size="$wh" --screenshot="$OUT_DIR/$name.png" "$url" \
-      >/dev/null 2>&1
+    bin/playwright screenshot --browser=chromium --viewport-size="$wh" \
+      "$url" "$OUT_DIR/$name.png" >/dev/null 2>&1 \
+      || fail "screenshot $name failed (try: bin/playwright install --with-deps chromium)"
     [[ -s "$OUT_DIR/$name.png" ]] || fail "screenshot $name produced empty file"
     printf '  %-12s -> %s\n' "$name" "$OUT_DIR/$name.png"
   }

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,52 @@
+name: "Copilot Setup Steps"
+
+# Workflow consumed by GitHub Copilot's cloud agent to provision its
+# environment before it starts working on an issue or pull request.
+# See: https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/customize-the-agent-environment
+#
+# The job MUST be named `copilot-setup-steps` for Copilot to pick it up.
+# Only `steps`, `permissions`, `runs-on`, `services`, `snapshot`, and
+# `timeout-minutes` are honored on that job.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - .github/actions/setup-rubygems.org/**
+      - .ruby-version
+      - Gemfile.lock
+      - docker-compose.yml
+      - config/database.yml.sample
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - .github/actions/setup-rubygems.org/**
+      - .ruby-version
+      - Gemfile.lock
+      - docker-compose.yml
+      - config/database.yml.sample
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup rubygems.org
+        uses: ./.github/actions/setup-rubygems.org
+        with:
+          ruby-version: .ruby-version
+          # Keep in sync with RUBYGEMS_VERSION in .github/workflows/test.yml
+          rubygems-version: "4.0.12"
+          install-avo-pro: "false"
+          install-playwright: "true"


### PR DESCRIPTION
This builds on top of #6543 by adding setup instructions for agents on how to setup a development environment with or without docker.