### PR TITLE
Recompute compact index info on cache deserialization failure

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -7,7 +7,7 @@ class GemInfo
   end
 
   def compact_index_info
-    if @cached && (info = Rails.cache.read("info/#{@rubygem_name}"))
+    if @cached && (info = read_cache("info/#{@rubygem_name}"))
       StatsD.increment "compact_index.memcached.info.hit"
       info
     else
@@ -95,6 +95,13 @@ class GemInfo
   DEPENDENCY_NAMES_INDEX = 8
 
   DEPENDENCY_REQUIREMENTS_INDEX = 7
+
+  # Marshal.load of pre-deploy cache entries fails when GemVersion changes number of Struct fields.
+  def read_cache(cache_key)
+    Rails.cache.read(cache_key)
+  rescue TypeError
+    nil
+  end
 
   def compute_compact_index_info
     requirements_and_dependencies.map do |r|

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -50,6 +50,15 @@ class GemInfoTest < ActiveSupport::TestCase
 
       assert_equal @expected_info, info
     end
+
+    should "recompute when cache deserialization fails" do
+      Rails.cache.expects(:read).with("info/example").raises(TypeError, "struct size differs")
+
+      info = nil
+      assert_nothing_raised { info = GemInfo.new("example").compact_index_info }
+
+      assert_equal @expected_info, info
+    end
   end
 
   context ".ordered_names" do


### PR DESCRIPTION
`GemInfo#compact_index_info` caches arrays of `CompactIndex::GemVersion` structs in Memcached via `Marshal.dump`/`Marshal.load`. If the struct definition changes (e.g. adding a field),         
 `Marshal.load` raises `TypeError` when it encounters a cached entry with a different field count.                                                                                                  
                                                                                                                                                                                                    
   During a rolling deploy where old and new servers coexist, this means any cache entry written by one side will 500 when read by the other. Since these cache entries have no TTL, the problem persists until the entry is overwritten or Memcached is flushed.                                                                                                                                   
                                                                                                                                                                                                    
   This PR wraps `Rails.cache.read` in a `read_cache` helper that rescues `TypeError` and returns `nil`, treating deserialization failures as cache misses. The info is then recomputed from the    
 database and re-cached.                                                                                                                                                                            
                                                                                                                                                                                                    
   This is a prerequisite for [#6504](https://github.com/rubygems/rubygems.org/pull/6504), which adds a `created_at` field to the `GemVersion` struct for the v2 compact index. It should be deployed before that PR to ensure the rescue is on all servers before the struct changes roll out.  