### PR TITLE
test: remove duplicate "with" in versions controller test context

### DIFF
--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -185,7 +185,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
     end
   end
 
-  context "on GET to show a gem with with lots of versions" do
+  context "on GET to show a gem with lots of versions" do
     setup do
       @rubygem = create(:rubygem)
       12.times do |n|


### PR DESCRIPTION
## Summary

`test/functional/api/v2/versions_controller_test.rb:188` had `"on GET to show a gem with with lots of versions"` — removes the duplicate "with".

Test context description only; no behavior change.