### PR TITLE
Add `info_checksum_v2` and `yanked_info_checksum_v2` to versions table

### DIFF
--- a/db/migrate/20260526195603_add_info_checksum_v2_and_yanked_info_checksum_v2_to_versions.rb
+++ b/db/migrate/20260526195603_add_info_checksum_v2_and_yanked_info_checksum_v2_to_versions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddInfoChecksumV2AndYankedInfoChecksumV2ToVersions < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      change_table :versions, bulk: true do |t|
+        t.string :info_checksum_v2
+        t.string :yanked_info_checksum_v2
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_235942) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -701,6 +701,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_235942) do
     t.string "gem_platform"
     t.boolean "indexed", default: true
     t.string "info_checksum"
+    t.string "info_checksum_v2"
     t.boolean "latest"
     t.string "licenses"
     t.hstore "metadata", default: {}, null: false
@@ -721,6 +722,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_235942) do
     t.datetime "updated_at", precision: nil
     t.datetime "yanked_at", precision: nil
     t.string "yanked_info_checksum"
+    t.string "yanked_info_checksum_v2"
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"


### PR DESCRIPTION
Separating the migration from https://github.com/rubygems/rubygems.org/pull/6504 in case we need to rollback the double write.