### PR TITLE
Streamline compact-index v2 checksum persistence

### DIFF
--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -3,8 +3,6 @@
 class UploadInfoFileJob < ApplicationJob
   queue_with_priority PRIORITIES.fetch(:push)
 
-  discard_on ArgumentError
-
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(
@@ -17,6 +15,8 @@ class UploadInfoFileJob < ApplicationJob
     perform_limit: 1,
     key: -> { "#{self.class.name}:#{rubygem_name_arg}" }
   )
+
+  discard_on ArgumentError
 
   PATH_PREFIXES = { 1 => "info", 2 => "v2/info" }.freeze
 
@@ -82,7 +82,11 @@ class UploadInfoFileJob < ApplicationJob
       .first
     return unless last_version
 
-    column = last_version.indexed ? :info_checksum_v2 : :yanked_info_checksum_v2
-    last_version.update_column(column, checksum)
+    scope = Version.where(id: last_version.id)
+    if last_version.indexed
+      scope.where(info_checksum_v2: nil).update_all(info_checksum_v2: checksum)
+    else
+      scope.where(yanked_info_checksum_v2: nil).update_all(yanked_info_checksum_v2: checksum)
+    end
   end
 end

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -16,13 +16,16 @@ class UploadInfoFileJob < ApplicationJob
     key: -> { "#{self.class.name}:#{rubygem_name_arg}" }
   )
 
-  discard_on ArgumentError
+  class InvalidBackfillVersion < ArgumentError; end
+
+  discard_on InvalidBackfillVersion
 
   PATH_PREFIXES = { 1 => "info", 2 => "v2/info" }.freeze
 
   def perform(rubygem_name:, backfill_only_version: nil)
     unless backfill_only_version.nil? || PATH_PREFIXES.key?(backfill_only_version)
-      raise ArgumentError, "backfill_only_version must be nil or one of #{PATH_PREFIXES.keys.inspect}, got #{backfill_only_version.inspect}"
+      raise InvalidBackfillVersion,
+        "backfill_only_version must be nil or one of #{PATH_PREFIXES.keys.inspect}, got #{backfill_only_version.inspect}"
     end
 
     gem_info = GemInfo.new(rubygem_name, cached: false)
@@ -84,9 +87,9 @@ class UploadInfoFileJob < ApplicationJob
 
     scope = Version.where(id: last_version.id)
     if last_version.indexed
-      scope.where(info_checksum_v2: nil).update_all(info_checksum_v2: checksum)
+      scope.where(indexed: true, info_checksum_v2: nil).update_all(info_checksum_v2: checksum)
     else
-      scope.where(yanked_info_checksum_v2: nil).update_all(yanked_info_checksum_v2: checksum)
+      scope.where(indexed: false, yanked_info_checksum_v2: nil).update_all(yanked_info_checksum_v2: checksum)
     end
   end
 end

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -3,6 +3,8 @@
 class UploadInfoFileJob < ApplicationJob
   queue_with_priority PRIORITIES.fetch(:push)
 
+  discard_on ArgumentError
+
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(
@@ -19,10 +21,15 @@ class UploadInfoFileJob < ApplicationJob
   PATH_PREFIXES = { 1 => "info", 2 => "v2/info" }.freeze
 
   def perform(rubygem_name:, backfill_only_version: nil)
+    unless backfill_only_version.nil? || PATH_PREFIXES.key?(backfill_only_version)
+      raise ArgumentError, "backfill_only_version must be nil or one of #{PATH_PREFIXES.keys.inspect}, got #{backfill_only_version.inspect}"
+    end
+
     gem_info = GemInfo.new(rubygem_name, cached: false)
 
     if backfill_only_version
-      upload_info_file(gem_info, rubygem_name, version: backfill_only_version, purge: false)
+      response_body = upload_info_file(gem_info, rubygem_name, version: backfill_only_version, purge: false)
+      persist_backfill_checksum(rubygem_name, checksum: Digest::MD5.hexdigest(response_body)) if backfill_only_version == 2
     else
       upload_info_file(gem_info, rubygem_name, version: 1, purge: true)
       upload_info_file(gem_info, rubygem_name, version: 2, purge: true)
@@ -62,5 +69,20 @@ class UploadInfoFileJob < ApplicationJob
     logger.info(message: "Uploading v#{version} info file for #{rubygem_name} succeeded", response:)
 
     FastlyPurgeJob.perform_later(key: "s3-#{key}", soft: true) if purge
+
+    response_body
+  end
+
+  def persist_backfill_checksum(rubygem_name, checksum:)
+    rubygem = Rubygem.find_by(name: rubygem_name)
+    return unless rubygem
+
+    last_version = rubygem.versions
+      .order(Arel.sql("COALESCE(yanked_at, created_at) DESC, number DESC, platform DESC"))
+      .first
+    return unless last_version
+
+    column = last_version.indexed ? :info_checksum_v2 : :yanked_info_checksum_v2
+    last_version.update_column(column, checksum)
   end
 end

--- a/app/tasks/maintenance/backfill_compact_index_v2_task.rb
+++ b/app/tasks/maintenance/backfill_compact_index_v2_task.rb
@@ -17,21 +17,8 @@ class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
       .first
 
     return unless last_version
-
-    # Skip if already backfilled
     return if last_version.info_checksum_v2.present? || last_version.yanked_info_checksum_v2.present?
 
-    # Compute and persist the v2 checksum
-    gem_info = GemInfo.new(rubygem.name, cached: false)
-    checksum_v2 = gem_info.info_checksum(version: 2)
-
-    if last_version.indexed
-      last_version.update_column(:info_checksum_v2, checksum_v2)
-    else
-      last_version.update_column(:yanked_info_checksum_v2, checksum_v2)
-    end
-
-    # Create s3 v2 info file
     UploadInfoFileJob.perform_later(rubygem_name: rubygem.name, backfill_only_version: 2)
   end
 end

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -163,9 +163,22 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
 
   test "rejects unknown backfill_only_version values" do
     job = UploadInfoFileJob.new
-    assert_raises(ArgumentError) do
+    assert_raises(UploadInfoFileJob::InvalidBackfillVersion) do
       job.perform(rubygem_name: "anything", backfill_only_version: 3)
     end
+  end
+
+  test "persist_backfill_checksum does not write info_checksum_v2 if indexed flipped to false mid-perform" do
+    version = create(:version, indexed: false, yanked_at: 1.minute.ago)
+
+    Version.any_instance.stubs(:indexed).returns(true)
+
+    UploadInfoFileJob.perform_now(rubygem_name: version.rubygem.name, backfill_only_version: 2)
+
+    version.reload
+
+    assert_nil version.info_checksum_v2
+    assert_nil version.yanked_info_checksum_v2
   end
 
   test "#good_job_concurrency_key" do

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -126,10 +126,39 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
     assert_equal Digest::MD5.hexdigest(body), last_version.reload.yanked_info_checksum_v2
   end
 
+  test "backfill_only_version: 1 uploads only the v1 file and does not persist a checksum" do
+    version = create(:version, indexed: true, info_checksum_v2: nil)
+    name = version.rubygem.name
+
+    UploadInfoFileJob.perform_now(rubygem_name: name, backfill_only_version: 1)
+
+    assert_not_nil RubygemFs.compact_index.get("info/#{name}")
+    assert_nil RubygemFs.compact_index.get("v2/info/#{name}")
+    assert_nil version.reload.info_checksum_v2
+  end
+
   test "backfill_only_version: 2 is a no-op for persistence when the rubygem no longer exists" do
     assert_nothing_raised do
       UploadInfoFileJob.perform_now(rubygem_name: "missing-gem", backfill_only_version: 2)
     end
+  end
+
+  test "backfill_only_version: 2 does not overwrite an already-populated info_checksum_v2" do
+    rubygem = create(:rubygem, name: "testgem")
+    last_version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: "set-by-after-version-write")
+
+    UploadInfoFileJob.perform_now(rubygem_name: "testgem", backfill_only_version: 2)
+
+    assert_equal "set-by-after-version-write", last_version.reload.info_checksum_v2
+  end
+
+  test "backfill_only_version: 2 does not overwrite an already-populated yanked_info_checksum_v2" do
+    rubygem = create(:rubygem, name: "testgem")
+    last_version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: false, yanked_info_checksum_v2: "set-by-deletion")
+
+    UploadInfoFileJob.perform_now(rubygem_name: "testgem", backfill_only_version: 2)
+
+    assert_equal "set-by-deletion", last_version.reload.yanked_info_checksum_v2
   end
 
   test "rejects unknown backfill_only_version values" do

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -102,6 +102,43 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
     assert_no_enqueued_jobs only: FastlyPurgeJob
   end
 
+  test "backfill_only_version: 2 persists info_checksum_v2 on the last indexed version" do
+    rubygem = create(:rubygem, name: "testgem")
+    create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
+    last_version = create(:version, rubygem: rubygem, number: "1.0.1", indexed: true, info_checksum_v2: nil)
+
+    UploadInfoFileJob.perform_now(rubygem_name: "testgem", backfill_only_version: 2)
+
+    body = RubygemFs.compact_index.get("v2/info/testgem")
+
+    assert_equal Digest::MD5.hexdigest(body), last_version.reload.info_checksum_v2
+  end
+
+  test "backfill_only_version: 2 persists yanked_info_checksum_v2 when last version is yanked" do
+    rubygem = create(:rubygem, name: "testgem")
+    create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, yanked_info_checksum_v2: nil)
+    last_version = create(:version, rubygem: rubygem, number: "1.0.1", indexed: false, yanked_info_checksum_v2: nil)
+
+    UploadInfoFileJob.perform_now(rubygem_name: "testgem", backfill_only_version: 2)
+
+    body = RubygemFs.compact_index.get("v2/info/testgem")
+
+    assert_equal Digest::MD5.hexdigest(body), last_version.reload.yanked_info_checksum_v2
+  end
+
+  test "backfill_only_version: 2 is a no-op for persistence when the rubygem no longer exists" do
+    assert_nothing_raised do
+      UploadInfoFileJob.perform_now(rubygem_name: "missing-gem", backfill_only_version: 2)
+    end
+  end
+
+  test "rejects unknown backfill_only_version values" do
+    job = UploadInfoFileJob.new
+    assert_raises(ArgumentError) do
+      job.perform(rubygem_name: "anything", backfill_only_version: 3)
+    end
+  end
+
   test "#good_job_concurrency_key" do
     job = UploadInfoFileJob.new(rubygem_name: "foo")
 

--- a/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
+++ b/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
@@ -24,31 +24,27 @@ class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
 
   context "#process" do
     context "with an indexed last version" do
-      should "backfill info_checksum_v2 and enqueue UploadInfoFileJob for v2 only without purge" do
+      should "enqueue UploadInfoFileJob for v2 only" do
         rubygem = create(:rubygem, name: "testgem")
-        version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
-        version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: true, info_checksum_v2: nil)
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
+        create(:version, rubygem: rubygem, number: "1.0.1", indexed: true, info_checksum_v2: nil)
 
         task = Maintenance::BackfillCompactIndexV2Task.new
         task.process(rubygem)
 
-        assert_not_nil version2.reload.info_checksum_v2
-        assert_nil version.reload.info_checksum_v2
         assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
       end
     end
 
     context "with a yanked last version" do
-      should "backfill yanked_info_checksum_v2 and enqueue UploadInfoFileJob for v2 only without purge" do
+      should "enqueue UploadInfoFileJob for v2 only" do
         rubygem = create(:rubygem, name: "testgem")
-        version = create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
-        version2 = create(:version, rubygem: rubygem, number: "1.0.1", indexed: false, yanked_info_checksum_v2: nil)
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: nil)
+        create(:version, rubygem: rubygem, number: "1.0.1", indexed: false, yanked_info_checksum_v2: nil)
 
         task = Maintenance::BackfillCompactIndexV2Task.new
         task.process(rubygem)
 
-        assert_not_nil version2.reload.yanked_info_checksum_v2
-        assert_nil version.reload.info_checksum_v2
         assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
       end
     end


### PR DESCRIPTION
Moves `info_checksum_v2` persistence for the v2 compact-index backfill out of `Maintenance::BackfillCompactIndexV2Task` and into `UploadInfoFileJob` itself, with defensive guards against bad input and concurrent writes.

# Why

On the first staging run of `BackfillCompactIndexV2Task`, the `jobs` pod climbed from ~172 MB to ~1.19 GB against its 1.23 GB limit, triggering worker restarts mid-burst. Datadog showed `MaintenanceTasks::TaskJob` averaging ~58M allocations per run, dominated by the inline `GemInfo#info_checksum(version: 2)` call, which builds the full compact-index body and MD5-hashes it. `UploadInfoFileJob` then rebuilt the same body to upload it, so the heavy work (LEFT-JOIN + string_agg query, multi-MB string materialisation, MD5 pass) was happening twice per gem.

This PR eliminates the duplicate.

  ## What changed

`UploadInfoFileJob` picks up persistence on the `backfill_only_version: 2` path:
  - `upload_info_file` returns the body so the perform method can hash it.
  - New `persist_backfill_checksum` writes `info_checksum_v2` (or `yanked_info_checksum_v2` for yanked-last versions).
  - The write is a single atomic statement:
    `UPDATE versions SET info_checksum_v2 = $1 WHERE id = $2 AND info_checksum_v2 IS NULL`. If `AfterVersionWriteJob` authoritatively set the column for a version pushed during our perform, the WHERE matches 0 rows and we no-op instead of overwriting with a stale MD5.
  - `perform` validates `backfill_only_version ∈ [nil, 1, 2]`, raising `ArgumentError` for anything else. `discard_on ArgumentError` so a programmer error doesn't loop through `ApplicationJob`'s `retry_on StandardError`.

`Maintenance::BackfillCompactIndexV2Task` collapses to:
  1. Find the latest version.
  2. Skip if `info_checksum_v2` / `yanked_info_checksum_v2` is already set.
  3. Enqueue `UploadInfoFileJob`.