### PR TITLE
Add option to force creating s3 info files in backfill compact index task

### DIFF
--- a/app/tasks/maintenance/backfill_compact_index_v2_task.rb
+++ b/app/tasks/maintenance/backfill_compact_index_v2_task.rb
@@ -3,6 +3,7 @@
 class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
   attribute :min_rubygem_id, :integer
   attribute :max_rubygem_id, :integer
+  attribute :force_upload_info_file_job, :boolean, default: false
 
   def collection
     scope = Rubygem.with_versions
@@ -17,7 +18,7 @@ class Maintenance::BackfillCompactIndexV2Task < MaintenanceTasks::Task
       .first
 
     return unless last_version
-    return if last_version.info_checksum_v2.present? || last_version.yanked_info_checksum_v2.present?
+    return if !force_upload_info_file_job && (last_version.info_checksum_v2.present? || last_version.yanked_info_checksum_v2.present?)
 
     UploadInfoFileJob.perform_later(rubygem_name: rubygem.name, backfill_only_version: 2)
   end

--- a/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
+++ b/test/tasks/maintenance/backfill_compact_index_v2_task_test.rb
@@ -80,6 +80,28 @@ class Maintenance::BackfillCompactIndexV2TaskTest < ActiveSupport::TestCase
 
         assert_no_enqueued_jobs only: UploadInfoFileJob
       end
+
+      should "enqueue UploadInfoFileJob when forced and info_checksum_v2 is already set" do
+        rubygem = create(:rubygem, name: "testgem")
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: true, info_checksum_v2: "already_set")
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.force_upload_info_file_job = true
+        task.process(rubygem)
+
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
+      end
+
+      should "enqueue UploadInfoFileJob when forced and yanked_info_checksum_v2 is already set" do
+        rubygem = create(:rubygem, name: "testgem")
+        create(:version, rubygem: rubygem, number: "1.0.0", indexed: false, yanked_info_checksum_v2: "already_set")
+
+        task = Maintenance::BackfillCompactIndexV2Task.new
+        task.force_upload_info_file_job = true
+        task.process(rubygem)
+
+        assert_enqueued_with(job: UploadInfoFileJob, args: [rubygem_name: "testgem", backfill_only_version: 2])
+      end
     end
   end
 end


### PR DESCRIPTION
When testing the backfill task on staging there were 2 gems that had their columns backfilled but the s3 file wasn't created. Adding an option to bypass the early return so we can force enqueuing `UploadInfoFileJob` for those gems.