### PR TITLE
Add gssencmode disable flag to test database conf

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -22,6 +22,7 @@ test:
     password: testpassword
     pool: 5
     timeout: 5000
+    gssencmode: disable
 
 staging:
   primary:


### PR DESCRIPTION
Why this change is being made:
- On MacOS I ran into a Segfault running the tests using `bin/rails test` with multiple workers while running against the docker-compose version of the database
- The Segfault was caused by a "Fork after Thread" error which happened when the new test workers were spun up. The workers attempt to connect to the database which triggers a GSSAPI call in Kerberos to look for an existing token. I'm not 100% up on how this all works but the gist of it is that you aren't allowed to do that from multiple threads because of how the inter-process communication protocol works.
-  Conveniently, the database is set to "trust" mode locally and we don't use this GSSAPI for connecting to local postgres so we can set the flag in our database.yml.sample (and individually in our database.yml) to skip that auth check entirely for our test database.

What were the changes made to support this:
- set the GSS Encoding Mode to disabled in database.yml