### PR TITLE
Upgrade `multi_json` from `1.17.0` to `1.21.1` and address deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,7 +497,7 @@ GEM
     mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.1)
-    multi_json (1.17.0)
+    multi_json (1.21.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
@@ -1217,7 +1217,7 @@ CHECKSUMS
   minitest-retry (0.3.1) sha256=9b8282c5c1684a04b330526b90f39e42b7cec1b91abf70af6526e64131df186f
   mocha (3.1.0) sha256=75f42d69ebfb1f10b32489dff8f8431d37a418120ecdfc07afe3bc183d4e1d56
   msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
-  multi_json (1.17.0) sha256=76581f6c96aebf2e85f8a8b9854829e0988f335e8671cd1a56a1036eb75e4a1b
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751

--- a/config/initializers/opensearch_multi_json_serializer_patch.rb
+++ b/config/initializers/opensearch_multi_json_serializer_patch.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# TODO: Remove this patch when we upgrade to opensearch-ruby 4.0.0+
+# because once we do we will no longer have multi_json as a dependency.
+
+require "opensearch/transport/transport/serializer/multi_json"
+
+module OpenSearchMultiJsonSerializerPatch
+  def load(string, options = {})
+    ::MultiJSON.parse(string, options)
+  end
+
+  def dump(object, options = {})
+    ::MultiJSON.generate(object, options)
+  end
+end
+
+OpenSearch::Transport::Transport::Serializer::MultiJson.prepend(OpenSearchMultiJsonSerializerPatch)

--- a/config/initializers/sawyer_multi_json_serializer_patch.rb
+++ b/config/initializers/sawyer_multi_json_serializer_patch.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# TODO: Remove this patch when we upgrade to opensearch-ruby 4.0.0+
+# because once we do we will no longer have multi_json as a dependency.
+
+require "sawyer/serializer"
+
+module SawyerMultiJsonSerializerPatch
+  def multi_json
+    require "multi_json"
+    new(::MultiJSON, :generate, :parse)
+  end
+end
+
+Sawyer::Serializer.singleton_class.prepend(SawyerMultiJsonSerializerPatch)

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -584,7 +584,7 @@ class RubygemTest < ActiveSupport::TestCase
           }
         )
 
-        hash = MultiJson.load(@rubygem.to_json)
+        hash = MultiJSON.parse(@rubygem.to_json)
 
         assert_equal "http://example.com/home", hash["homepage_uri"]
         assert_equal "http://example.com/wiki", hash["wiki_uri"]


### PR DESCRIPTION
### Description (short)

Proposing we upgrade `multi_json` from `1.17.0` to `1.21.1` (latest) and address its deprecation warnings. Note that we only have `multi_json` due to `opensearch-ruby` which is planning to _remove_ `multi_json` in its next major release. Though we do not know when that will be. Explorartory PR for that upgrade: https://github.com/rubygems/rubygems.org/pull/6567.

Extracted from https://github.com/rubygems/rubygems.org/pull/6564

### Description (long)

Due to `v1.21.0` of `MultiJson` [deprecating a bunch of stuff](https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/CHANGELOG.md#deprecated) including but not limited to its entire namespace and most of primary methods in order to align with the stdlib `json` gem

<img width="2170" height="684" alt="Screenshot From 2026-05-29 23-12-21" src="https://github.com/user-attachments/assets/6920fe0a-70bd-462d-bc3d-5610c2b87f67" />

we now have the following deprecation warnings:

```
The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.
MultiJSON.load is deprecated and will be removed in v2.0. Use MultiJSON.parse instead.
MultiJSON.dump is deprecated and will be removed in v2.0. Use MultiJSON.generate instead.
```

The sources of these are the following:
- `test/models/rubygem_test.rb` (already fixed in this branch)
- [opensearch-project/opensearch-ruby](https://github.com/opensearch-project/opensearch-ruby) gem, issue: https://github.com/opensearch-project/opensearch-ruby/issues/329
  - Deprecation was already addressed in https://github.com/opensearch-project/opensearch-ruby/pull/290 but there hasn't been a stable release since July 2024. Maybe we'll see v4.0.0 with the required changes soon. :crossed_fingers: 
  - Added a small patch as mentioned by https://github.com/opensearch-project/opensearch-ruby/issues/329 to prevent the deprecation warnings.
- [lostisland/sawyer](https://github.com/lostisland/sawyer) gem
  - Opened a fix PR: https://github.com/lostisland/sawyer/pull/83
  - Added a small patch like above to prevent the deprecation warnings.