### PR TITLE
Stabilize `/info v2 cache expires on gem yank` test with `travel_to`

### DIFF
--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -265,21 +265,23 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
   test "/info v2 cache expires on gem yank" do
     with_compact_index_v2_enabled do
-      rubygem = create(:rubygem, name: "v2yank")
-      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
+      travel_to(Time.utc(2026, 5, 31, 12, 0, 0)) do
+        rubygem = create(:rubygem, name: "v2yank")
+        version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
 
-      get info_path(gem_name: "v2yank")
+        get info_path(gem_name: "v2yank")
 
-      assert_response :success
-      assert_includes @response.body, "1.0.0"
+        assert_response :success
+        assert_includes @response.body, "1.0.0"
 
-      Deletion.create!(version:, user: create(:user))
+        Deletion.create!(version:, user: create(:user))
 
-      get info_path(gem_name: "v2yank")
+        get info_path(gem_name: "v2yank")
 
-      assert_response :success
-      assert_not_includes @response.body, "1.0.0"
-      assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
+        assert_response :success
+        assert_not_includes @response.body, "1.0.0"
+        assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
+      end
     end
   end
 


### PR DESCRIPTION
### Description

Proposing a flake fix for the `/info v2 cache expires on gem yank` test that was introduced a few days ago in https://github.com/rubygems/rubygems.org/pull/6558. The flake stems from the 30 day limit and months with 31 days, it appears, as it started failing on the 31st of May. Thus, I believe we can ensure this test runs reliably by utilizing Rails' time helpers, specifically `travel_to` ([docs](https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel_to)) to set the test into a reliable timeframe.

See this unrelated PR's CI failure: 🙅‍♂️❌

https://github.com/rubygems/rubygems.org/actions/runs/26714036210/job/78729307775?pr=6567

### How?

Wrapped the whole test in a `travel_to`. Hence the diff is mostly indentation change whitespace. Hence I recommend reviewing the changes with whitespace diff turned off.

https://github.com/rubygems/rubygems.org/pull/6568/changes?w=1

### Testing

**master** 🙅‍♂️❌

```console
vscode ➜ /workspaces/rubygems.org (master) $ bundle exec rails test test/integration/api/compact_index_test.rb
Running 23 tests in a single process (parallelization threshold is 50)
Run options: --seed 13957

# Running:

...............E

Error:
Api::CompactIndexTest#test_/info_v2_cache_expires_on_gem_yank:
ActiveRecord::RecordInvalid: Validation failed: Versions published more than 30 days ago cannot be deleted.
    test/integration/api/compact_index_test.rb:276:in 'block (2 levels) in <class:CompactIndexTest>'
    test/integration/api/compact_index_test.rb:16:in 'Api::CompactIndexTest#with_compact_index_v2_enabled'
    test/integration/api/compact_index_test.rb:267:in 'block in <class:CompactIndexTest>'


bin/rails test test/integration/api/compact_index_test.rb:266

.......

Finished in 4.073244s, 5.6466 runs/s, 29.4605 assertions/s.
23 runs, 120 assertions, 0 failures, 1 errors, 0 skips
Coverage report generated for Minitest to /workspaces/rubygems.org/coverage.
Line Coverage: 17.65% (2483 / 14069)
```

**this branch** 🙆‍♂️✅️

```console
vscode ➜ /workspaces/rubygems.org (fix/compact-index-yank-travel-to) $ bundle exec rails test test/integration
/api/compact_index_test.rb
Running 23 tests in a single process (parallelization threshold is 50)
Run options: --seed 46926

# Running:

.......................

Finished in 3.905758s, 5.8887 runs/s, 31.7480 assertions/s.
23 runs, 124 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Minitest to /workspaces/rubygems.org/coverage.
Line Coverage: 17.64% (2482 / 14069)
```