### PR TITLE
Add Compact Index V2 Rake tasks to version yaml

### DIFF
--- a/config/deploy/versions-list-update-monthly.yaml.erb
+++ b/config/deploy/versions-list-update-monthly.yaml.erb
@@ -21,7 +21,7 @@ spec:
           containers:
           - name: versions-list-update-monthly
             image: 048268392960.dkr.ecr.us-west-2.amazonaws.com/rubygems/rubygems.org:<%= current_sha %>
-            args: ["rake", "compact_index:update_versions_file"]
+            args: ["rake", "compact_index:update_versions_file", "compact_index_v2:update_versions_file"]
             resources:
               <% if environment == 'production' %>
               requests:


### PR DESCRIPTION
## What

- Adds monthly regeneration for the compact index v2 versions list.
- Adds `compact_index_v2:update_versions_file` alongside the existing v1 task.
- Runs both tasks from the monthly versions list update job.

## Why

The v2 baseline file needs to stay fresh. This keeps v1 and v2 regenerated on the same schedule. It avoids manually running the v2 task in a container.