### PR TITLE
Add manual compact index versions list update job

### DIFF
--- a/app/avo/actions/update_versions_list.rb
+++ b/app/avo/actions/update_versions_list.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Avo::Actions::UpdateVersionsList < Avo::Actions::ApplicationAction
+  VERSION_SELECTIONS = {
+    "1" => [1],
+    "2" => [2],
+    "both" => [1, 2]
+  }.freeze
+
+  self.name = "Update Versions List"
+  self.message = "Regenerate and upload the compact index versions file used by the /versions endpoint."
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :index
+  }
+  self.standalone = true
+  self.confirm_button_label = "Update"
+
+  def fields
+    field :version, as: :select,
+      options: {
+        "Both" => "both",
+        "V1" => "1",
+        "V2" => "2"
+      },
+      default: "both",
+      required: true
+
+    super
+  end
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_standalone
+      versions.each do |version|
+        UpdateVersionsListJob.perform_later(version:)
+      end
+
+      succeed("Versions list update job scheduled")
+
+      nil
+    end
+
+    private
+
+    def versions
+      selected = fields["version"]
+      normalized = selected&.to_s
+
+      VERSION_SELECTIONS.fetch(normalized) do
+        raise ArgumentError, "Unsupported compact index version: #{selected}"
+      end
+    end
+  end
+end

--- a/app/avo/actions/update_versions_list.rb
+++ b/app/avo/actions/update_versions_list.rb
@@ -36,7 +36,7 @@ class Avo::Actions::UpdateVersionsList < Avo::Actions::ApplicationAction
 
       succeed("Versions list update job scheduled")
 
-      nil
+      Version.last
     end
 
     private

--- a/app/avo/resources/rubygem.rb
+++ b/app/avo/resources/rubygem.rb
@@ -16,6 +16,7 @@ class Avo::Resources::Rubygem < Avo::BaseResource
     action Avo::Actions::UploadInfoFile
     action Avo::Actions::UploadNamesFile
     action Avo::Actions::UploadVersionsFile
+    action Avo::Actions::UpdateVersionsList
   end
 
   class IndexedFilter < Avo::Filters::ScopeBooleanFilter; end

--- a/app/jobs/update_versions_list_job.rb
+++ b/app/jobs/update_versions_list_job.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class UpdateVersionsListJob < ApplicationJob
+  class UnsupportedVersionError < ArgumentError; end
+
+  queue_with_priority PRIORITIES.fetch(:push)
+  discard_on UnsupportedVersionError do |job, exception|
+    job.log_discarded_unsupported_version(exception)
+  end
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    perform_limit: 1,
+    key: -> { "#{self.class.name}-v#{version_arg}" }
+  )
+
+  VERSION_CONFIG = {
+    1 => {
+      config_key: "versions_file_location",
+      store_key: "versions/versions.list"
+    },
+    2 => {
+      config_key: "versions_file_location_v2",
+      store_key: "versions/versions_v2.list"
+    }
+  }.freeze
+
+  def perform(version:)
+    version = normalize_version(version)
+    config = VERSION_CONFIG[version]
+    raise UnsupportedVersionError, "Unsupported compact index version: #{version}" unless config
+
+    timestamp = Time.now.utc.iso8601
+    file_path = Rails.application.config.rubygems[config.fetch(:config_key)]
+    versions_file = CompactIndex::VersionsFile.new(file_path)
+    gems = GemInfo.compact_index_public_versions(timestamp, version:)
+
+    versions_file.create(gems, timestamp)
+    RubygemFs.instance.store(config.fetch(:store_key), File.read(file_path))
+  end
+
+  def log_discarded_unsupported_version(exception)
+    logger.info(
+      message: "Discarding update versions list job",
+      error: exception.message,
+      version: version_arg
+    )
+  end
+
+  private
+
+  def version_arg
+    arguments.first.fetch(:version)
+  end
+
+  def normalize_version(version)
+    Integer(version)
+  rescue ArgumentError, TypeError
+    raise UnsupportedVersionError, "Unsupported compact index version: #{version}"
+  end
+end

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpdateVersionsListJobTest < ActiveJob::TestCase
+  test "updates the v1 baseline versions list" do
+    v1_file = Tempfile.new("versions_file")
+    original_v1_path = Rails.application.config.rubygems["versions_file_location"]
+    Rails.application.config.rubygems["versions_file_location"] = v1_file.path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+
+    rubygem = create(:rubygem, name: "rubyrubyruby")
+    create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum: "v1_checksum")
+
+    freeze_time do
+      UpdateVersionsListJob.perform_now(version: 1)
+    end
+
+    expected_line = "rubyrubyruby 0.0.1 v1_checksum\n"
+
+    assert_equal expected_line, File.readlines(v1_file.path)[2]
+    assert_includes RubygemFs.instance.get("versions/versions.list"), expected_line
+    assert_nil RubygemFs.instance.get("versions/versions_v2.list")
+  ensure
+    Rails.application.config.rubygems["versions_file_location"] = original_v1_path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+    v1_file&.unlink
+  end
+
+  test "updates the v2 baseline versions list" do
+    v2_file = Tempfile.new("versions_v2_file")
+    original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    Rails.application.config.rubygems["versions_file_location_v2"] = v2_file.path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+
+    rubygem = create(:rubygem, name: "rubyrubyruby")
+    create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum_v2: "v2_checksum")
+
+    freeze_time do
+      UpdateVersionsListJob.perform_now(version: 2)
+    end
+
+    expected_line = "rubyrubyruby 0.0.1 v2_checksum\n"
+
+    assert_equal expected_line, File.readlines(v2_file.path)[2]
+    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), expected_line
+    assert_nil RubygemFs.instance.get("versions/versions.list")
+  ensure
+    Rails.application.config.rubygems["versions_file_location_v2"] = original_v2_path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+    v2_file&.unlink
+  end
+
+  test "discards unsupported versions" do
+    assert_nothing_raised do
+      UpdateVersionsListJob.perform_now(version: 3)
+    end
+  end
+
+  test "discards invalid versions" do
+    assert_nothing_raised do
+      UpdateVersionsListJob.perform_now(version: "not-a-version")
+    end
+  end
+
+  test "logs when discarding unsupported versions" do
+    logger = mock
+    logger.expects(:info).with(
+      message: "Discarding update versions list job",
+      error: "Unsupported compact index version: 3",
+      version: 3
+    )
+
+    job = UpdateVersionsListJob.new(version: 3)
+    job.stubs(:logger).returns(logger)
+
+    assert_nothing_raised do
+      job.perform_now
+    end
+  end
+end

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -337,6 +337,25 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     assert_not_nil Audit.last
   end
 
+  test "update versions list" do
+    admin_user = create(:admin_github_user, :is_admin)
+    avo_sign_in_as admin_user
+
+    visit avo.resources_rubygems_path
+
+    create(:version)
+
+    click_button "Actions"
+    click_on "Update Versions List"
+    fill_in "Comment", with: "A nice long comment"
+
+    assert_enqueued_jobs 2, only: UpdateVersionsListJob do
+      click_button "Update"
+
+      page.assert_text "Versions list update job scheduled"
+    end
+  end
+
   test "upload names file" do
     admin_user = create(:admin_github_user, :is_admin)
     avo_sign_in_as admin_user

--- a/test/unit/avo/actions/update_versions_list_test.rb
+++ b/test/unit/avo/actions/update_versions_list_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpdateVersionsListTest < ActiveJob::TestCase
+  setup do
+    @current_user = create(:admin_github_user, :is_admin)
+    @action = Avo::Actions::UpdateVersionsList.new
+
+    view_context = mock
+    avo = mock
+    view_context.stubs(:avo).returns(avo)
+    avo.stubs(:resources_audit_path).returns("resources_audit_path")
+    Avo::Current.stubs(:view_context).returns(view_context)
+  end
+
+  test "enqueues a v1 versions list update" do
+    perform_action("1")
+
+    assert_enqueued_jobs 1, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 1])
+  end
+
+  test "enqueues a v2 versions list update" do
+    perform_action("2")
+
+    assert_enqueued_jobs 1, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 2])
+  end
+
+  test "enqueues v1 and v2 versions list updates" do
+    perform_action("both")
+
+    assert_enqueued_jobs 2, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 1])
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 2])
+  end
+
+  test "shows an error for unsupported versions" do
+    perform_action("3")
+
+    assert_no_enqueued_jobs only: UpdateVersionsListJob
+    assert_equal [type: :error, body: "Unsupported compact index version: 3", timeout: nil], @action.response[:messages]
+  end
+
+  private
+
+  def perform_action(version)
+    @action.handle(
+      fields: {
+        comment: "Regenerating versions list",
+        "version" => version
+      },
+      current_user: @current_user,
+      resource: nil,
+      records: [],
+      query: nil
+    )
+  end
+end


### PR DESCRIPTION
## What

- Add `UpdateVersionsListJob` to regenerate and upload compact index v1/v2 versions lists.
- Add an Avo action on the Rubygems index to manually enqueue v1, v2, or both update jobs.

## Why

- Let admins verify the new job path in production before changing the existing monthly schedule.
- Keep the current rake tasks and deploy CronJob schedule unchanged for now.

## Testing

Automated:

```sh
bin/rails test test/jobs/update_versions_list_job_test.rb
```

Manual verification plan with a production DB dump:

```sh
script/load-pg-dump -c -d rubygems_development ~/Downloads/public_postgresql.tar
bin/rails runner 'UpdateVersionsListJob.perform_now(version: 1)'
bin/rails runner 'UpdateVersionsListJob.perform_now(version: 2)'
bin/rails runner 'puts File.readlines(Rails.application.config.rubygems["versions_file_location"]).first(5)'
bin/rails runner 'puts File.readlines(Rails.application.config.rubygems["versions_file_location_v2"]).first(5)'
```

Avo UI verification:

1. Visit `/admin/rubygems`.
2. Open `Actions` → `Update Versions List`.
3. Select `Both`, `V1`, or `V2`.
4. Submit with an audit comment.
5. Verify the expected `UpdateVersionsListJob` job(s) are enqueued.

Screenshots to add after local UI verification.
