### PR TITLE
Fix GitHub Actions Dependabot grouping configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,8 +26,8 @@ updates:
     github-actions-patch-minor:
       patterns: ["*"]
       update-types:
-        - version-update:semver-patch
-        - version-update:semver-minor
+        - patch
+        - minor
 - package-ecosystem: devcontainers
   directory: "/"
   schedule:


### PR DESCRIPTION
Just noticed we're still getting multiple minor/patch GitHub Actions Dependabot update PRs despite having added grouping in https://github.com/rubygems/rubygems.org/pull/6542 as part of addressing https://github.com/rubygems/rubygems.org/issues/6538.
- https://github.com/rubygems/rubygems.org/pull/6582
- https://github.com/rubygems/rubygems.org/pull/6583

Turns out Dependabot has multiple `update-types` configs, `allow` and `group`, and I read the wrong one.

- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#update-types-allow 🙅‍♂️ (ex. `version-update:semver-patch`)
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#update-types-groups 🙆‍♂️ (ex. `patch`)

I believe once we have this merged in we'll start receiving grouped patch/minor GitHub Actions Dependabot PRs.