### PR TITLE
Compact index v1 cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,6 @@ RUN apk update && apk add postgresql17-client && rm -rf /var/cache/apk/*
 # Copy built application from previous stage
 COPY --link --from=build /app/ /app/
 
-ADD --link https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions.list /app/config/versions.list
 ADD --link https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/versions/versions_v2.list /app/config/versions_v2.list
 ADD --link https://s3-us-west-2.amazonaws.com/oregon.production.s3.rubygems.org/stopforumspam/toxic_domains_whole.txt /app/vendor/toxic_domains_whole.txt
 

--- a/app/avo/actions/update_versions_list.rb
+++ b/app/avo/actions/update_versions_list.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Avo::Actions::UpdateVersionsList < Avo::Actions::ApplicationAction
+  VERSION_SELECTIONS = {
+    "1" => [1],
+    "2" => [2],
+    "both" => [1, 2]
+  }.freeze
+
+  self.name = "Update Versions List"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :index
+  }
+  self.standalone = true
+  self.confirm_button_label = "Update"
+
+  def fields
+    field :version, as: :select,
+      options: {
+        "Both" => "both",
+        "V1" => "1",
+        "V2" => "2"
+      },
+      default: "both",
+      required: true
+
+    super
+  end
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_standalone
+      versions.each do |version|
+        UpdateVersionsListJob.perform_later(version:)
+      end
+
+      succeed("Versions list update job scheduled")
+
+      nil
+    end
+
+    private
+
+    def versions
+      selected = fields["version"]
+      normalized = selected&.to_s
+
+      VERSION_SELECTIONS.fetch(normalized) do
+        raise ArgumentError, "Unsupported compact index version: #{selected}"
+      end
+    end
+  end
+end

--- a/app/avo/resources/rubygem.rb
+++ b/app/avo/resources/rubygem.rb
@@ -16,6 +16,7 @@ class Avo::Resources::Rubygem < Avo::BaseResource
     action Avo::Actions::UploadInfoFile
     action Avo::Actions::UploadNamesFile
     action Avo::Actions::UploadVersionsFile
+    action Avo::Actions::UpdateVersionsList
   end
 
   class IndexedFilter < Avo::Filters::ScopeBooleanFilter; end

--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -72,8 +72,8 @@ class Avo::Resources::Version < Avo::BaseResource
 
       tab "API" do
         panel do
-          field :info_checksum, as: :text
-          field :yanked_info_checksum, as: :text
+          field :info_checksum_v2, as: :text
+          field :yanked_info_checksum_v2, as: :text
         end
       end
 

--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -3,8 +3,6 @@
 class Api::CompactIndexController < Api::BaseController
   CURRENT_COMPACT_INDEX_VERSION = 2
 
-  # Compact index v1 was decommissioned after the v2 rollout.
-  # Keep only actively served or actively migrating formats in this registry.
   COMPACT_INDEX_VERSIONS = {
     2 => {
       info_prefix: "v2/info",

--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class Api::CompactIndexController < Api::BaseController
+  CURRENT_COMPACT_INDEX_VERSION = 2
+
+  # Compact index v1 was decommissioned after the v2 rollout.
+  # Keep only actively served or actively migrating formats in this registry.
   COMPACT_INDEX_VERSIONS = {
-    1 => {
-      info_prefix: "info",
-      versions_file_location_key: "versions_file_location",
-      versions_surrogate_key: "versions"
-    }.freeze,
     2 => {
       info_prefix: "v2/info",
       versions_file_location_key: "versions_file_location_v2",
@@ -45,8 +44,7 @@ class Api::CompactIndexController < Api::BaseController
   private
 
   def compact_index_serving_version
-    # Compact index responses are cached by URL, so this flag must only be toggled globally.
-    @compact_index_serving_version ||= FeatureFlag.enabled?(FeatureFlag::SERVE_COMPACT_INDEX_V2) ? 2 : 1
+    CURRENT_COMPACT_INDEX_VERSION
   end
 
   def compact_index_config

--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -18,8 +18,7 @@ class AfterVersionWriteJob < ApplicationJob
       version.update!(indexed: true)
       gem_info = GemInfo.new(rubygem.name, cached: false)
 
-      version.info_checksum = gem_info.info_checksum(version: 1)
-      version.info_checksum_v2 = gem_info.info_checksum(version: 2)
+      version.info_checksum_v2 = gem_info.info_checksum
       version.save(validate: false)
 
       SetLinksetHomeJob.perform_later(version:)

--- a/app/jobs/update_versions_list_job.rb
+++ b/app/jobs/update_versions_list_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class UpdateVersionsListJob < ApplicationJob
+  queue_with_priority PRIORITIES.fetch(:push)
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    perform_limit: 1,
+    key: -> { "#{self.class.name}-v#{version_arg}" }
+  )
+
+  VERSION_CONFIG = {
+    1 => {
+      config_key: "versions_file_location",
+      store_key: "versions/versions.list"
+    },
+    2 => {
+      config_key: "versions_file_location_v2",
+      store_key: "versions/versions_v2.list"
+    }
+  }.freeze
+
+  def version_arg
+    args = arguments.first
+    args[:version] || args["version"] if args.respond_to?(:[])
+  end
+
+  def perform(version:)
+    version = Integer(version)
+    config = VERSION_CONFIG[version]
+    raise ArgumentError, "Unsupported compact index version: #{version}" unless config
+
+    timestamp = Time.now.utc.iso8601
+    file_path = Rails.application.config.rubygems[config.fetch(:config_key)]
+    versions_file = CompactIndex::VersionsFile.new(file_path)
+    gems = GemInfo.compact_index_public_versions(timestamp, version:)
+
+    versions_file.create(gems, timestamp)
+    RubygemFs.instance.store(config.fetch(:store_key), File.read(file_path))
+  end
+end

--- a/app/jobs/update_versions_list_job.rb
+++ b/app/jobs/update_versions_list_job.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class UpdateVersionsListJob < ApplicationJob
+  class UnsupportedVersionError < ArgumentError; end
+
   queue_with_priority PRIORITIES.fetch(:push)
+  discard_on UnsupportedVersionError
 
   include GoodJob::ActiveJobExtensions::Concurrency
 
@@ -22,15 +25,10 @@ class UpdateVersionsListJob < ApplicationJob
     }
   }.freeze
 
-  def version_arg
-    args = arguments.first
-    args[:version] || args["version"] if args.respond_to?(:[])
-  end
-
   def perform(version:)
-    version = Integer(version)
+    version = normalize_version(version)
     config = VERSION_CONFIG[version]
-    raise ArgumentError, "Unsupported compact index version: #{version}" unless config
+    raise UnsupportedVersionError, "Unsupported compact index version: #{version}" unless config
 
     timestamp = Time.now.utc.iso8601
     file_path = Rails.application.config.rubygems[config.fetch(:config_key)]
@@ -39,5 +37,17 @@ class UpdateVersionsListJob < ApplicationJob
 
     versions_file.create(gems, timestamp)
     RubygemFs.instance.store(config.fetch(:store_key), File.read(file_path))
+  end
+
+  private
+
+  def version_arg
+    arguments.first.fetch(:version)
+  end
+
+  def normalize_version(version)
+    Integer(version)
+  rescue ArgumentError, TypeError
+    raise UnsupportedVersionError, "Unsupported compact index version: #{version}"
   end
 end

--- a/app/jobs/update_versions_list_job.rb
+++ b/app/jobs/update_versions_list_job.rb
@@ -15,10 +15,6 @@ class UpdateVersionsListJob < ApplicationJob
   )
 
   VERSION_CONFIG = {
-    1 => {
-      config_key: "versions_file_location",
-      store_key: "versions/versions.list"
-    },
     2 => {
       config_key: "versions_file_location_v2",
       store_key: "versions/versions_v2.list"

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -20,7 +20,7 @@ class UploadInfoFileJob < ApplicationJob
 
   discard_on InvalidBackfillVersion
 
-  PATH_PREFIXES = { 1 => "info", 2 => "v2/info" }.freeze
+  PATH_PREFIXES = { 2 => "v2/info" }.freeze
 
   def perform(rubygem_name:, backfill_only_version: nil)
     unless backfill_only_version.nil? || PATH_PREFIXES.key?(backfill_only_version)
@@ -32,10 +32,9 @@ class UploadInfoFileJob < ApplicationJob
 
     if backfill_only_version
       response_body = upload_info_file(gem_info, rubygem_name, version: backfill_only_version, purge: false)
-      persist_backfill_checksum(rubygem_name, checksum: Digest::MD5.hexdigest(response_body)) if backfill_only_version == 2
+      persist_backfill_checksum(rubygem_name, checksum: Digest::MD5.hexdigest(response_body))
     else
-      upload_info_file(gem_info, rubygem_name, version: 1, purge: true)
-      upload_info_file(gem_info, rubygem_name, version: 2, purge: true)
+      upload_info_file(gem_info, rubygem_name, version: GemInfo::CURRENT_VERSION, purge: true)
     end
   end
 

--- a/app/jobs/upload_info_file_job.rb
+++ b/app/jobs/upload_info_file_job.rb
@@ -32,7 +32,7 @@ class UploadInfoFileJob < ApplicationJob
 
     if backfill_only_version
       response_body = upload_info_file(gem_info, rubygem_name, version: backfill_only_version, purge: false)
-      persist_backfill_checksum(rubygem_name, checksum: Digest::MD5.hexdigest(response_body))
+      persist_backfill_checksum(rubygem_name, version: backfill_only_version, checksum: Digest::MD5.hexdigest(response_body))
     else
       upload_info_file(gem_info, rubygem_name, version: GemInfo::CURRENT_VERSION, purge: true)
     end
@@ -75,7 +75,7 @@ class UploadInfoFileJob < ApplicationJob
     response_body
   end
 
-  def persist_backfill_checksum(rubygem_name, checksum:)
+  def persist_backfill_checksum(rubygem_name, version:, checksum:)
     rubygem = Rubygem.find_by(name: rubygem_name)
     return unless rubygem
 
@@ -84,11 +84,15 @@ class UploadInfoFileJob < ApplicationJob
       .first
     return unless last_version
 
+    config = GemInfo::VERSIONS.fetch(version)
+    checksum_column = config.fetch(:checksum_column)
+    yanked_checksum_column = config.fetch(:yanked_checksum_column)
+
     scope = Version.where(id: last_version.id)
     if last_version.indexed
-      scope.where(indexed: true, info_checksum_v2: nil).update_all(info_checksum_v2: checksum)
+      scope.where(indexed: true, checksum_column => nil).update_all(checksum_column => checksum)
     else
-      scope.where(indexed: false, yanked_info_checksum_v2: nil).update_all(yanked_info_checksum_v2: checksum)
+      scope.where(indexed: false, yanked_checksum_column => nil).update_all(yanked_checksum_column => checksum)
     end
   end
 end

--- a/app/jobs/upload_names_file_job.rb
+++ b/app/jobs/upload_names_file_job.rb
@@ -20,7 +20,6 @@ class UploadNamesFileJob < ApplicationJob
     names = GemInfo.ordered_names(cached: false)
     response_body = CompactIndex.names(names)
 
-    upload_names_file(response_body, key: "names", surrogate_key: "names s3-compact-index s3-names")
     upload_names_file(response_body, key: "v2/names", surrogate_key: "v2/names s3-compact-index s3-v2/names")
   end
 

--- a/app/jobs/upload_versions_file_job.rb
+++ b/app/jobs/upload_versions_file_job.rb
@@ -17,20 +17,12 @@ class UploadVersionsFileJob < ApplicationJob
   )
 
   def perform
-    upload_versions_file(
-      versions_file_location: Rails.application.config.rubygems["versions_file_location"],
-      extra_gems: GemInfo.compact_index_versions(versions_file_updated_at("versions_file_location")),
-      key: "versions",
-      surrogate_key: "versions s3-compact-index s3-versions"
-    )
-
-    # V2 dual-write: only update v2/versions once the bootstrap rake task has seeded the local file.
     v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
     return unless v2_path && File.exist?(v2_path)
 
     upload_versions_file(
       versions_file_location: v2_path,
-      extra_gems: GemInfo.compact_index_versions(versions_file_updated_at("versions_file_location_v2"), version: 2),
+      extra_gems: GemInfo.compact_index_versions(versions_file_updated_at("versions_file_location_v2")),
       key: "v2/versions",
       surrogate_key: "v2/versions s3-compact-index s3-v2/versions"
     )

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -96,7 +96,7 @@ class Deletion < ApplicationRecord
   end
 
   def restore_to_index
-    version.update!(indexed: true, yanked_at: nil, yanked_info_checksum: nil, yanked_info_checksum_v2: nil)
+    version.update!(indexed: true, yanked_at: nil, yanked_info_checksum_v2: nil)
     reindex
     Rstuf::AddJob.perform_later(version:)
   end
@@ -140,8 +140,7 @@ class Deletion < ApplicationRecord
   def set_yanked_info_checksum
     gem_info = GemInfo.new(version.rubygem.name)
 
-    version.yanked_info_checksum = gem_info.info_checksum(version: 1)
-    version.yanked_info_checksum_v2 = gem_info.info_checksum(version: 2)
+    version.yanked_info_checksum_v2 = gem_info.info_checksum
     version.save(validate: false)
   end
 

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -2,7 +2,6 @@
 
 class FeatureFlag
   ORGANIZATIONS = :organizations
-  SERVE_COMPACT_INDEX_V2 = :serve_compact_index_v2
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -3,8 +3,6 @@
 class GemInfo
   CURRENT_VERSION = 2
 
-  # Compact index v1 was decommissioned after the v2 rollout.
-  # Keep only actively served or actively migrating formats in this registry.
   VERSIONS = {
     2 => { cache_prefix: "info_v2", stats_prefix: "compact_index.memcached.info_v2", klass: CompactIndex::GemVersionV2,
            checksum_column: "info_checksum_v2", yanked_checksum_column: "yanked_info_checksum_v2" }
@@ -125,7 +123,7 @@ class GemInfo
   end
 
   def compute_compact_index_info(version:)
-    requirements_and_dependencies.map do |row|
+    requirements_and_dependencies(version:).map do |row|
       dependencies = []
       if row[DEPENDENCY_REQUIREMENTS_INDEX]
         reqs = row[DEPENDENCY_REQUIREMENTS_INDEX].split("@")
@@ -146,12 +144,14 @@ class GemInfo
     end
   end
 
-  def requirements_and_dependencies
-    @requirements_and_dependencies ||= fetch_requirements_and_dependencies
+  def requirements_and_dependencies(version:)
+    @requirements_and_dependencies ||= {}
+    @requirements_and_dependencies[version] ||= fetch_requirements_and_dependencies(version)
   end
 
-  def fetch_requirements_and_dependencies
-    group_by_columns = "number, platform, sha256, info_checksum_v2, required_ruby_version, required_rubygems_version, versions.created_at"
+  def fetch_requirements_and_dependencies(version)
+    checksum_column = VERSIONS.fetch(version).fetch(:checksum_column)
+    group_by_columns = "number, platform, sha256, #{checksum_column}, required_ruby_version, required_rubygems_version, versions.created_at"
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
 

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class GemInfo
+  CURRENT_VERSION = 2
+
+  # Compact index v1 was decommissioned after the v2 rollout.
+  # Keep only actively served or actively migrating formats in this registry.
   VERSIONS = {
-    1 => { cache_prefix: "info", stats_prefix: "compact_index.memcached.info", klass: CompactIndex::GemVersion,
-           checksum_column: "info_checksum", yanked_checksum_column: "yanked_info_checksum" },
     2 => { cache_prefix: "info_v2", stats_prefix: "compact_index.memcached.info_v2", klass: CompactIndex::GemVersionV2,
            checksum_column: "info_checksum_v2", yanked_checksum_column: "yanked_info_checksum_v2" }
   }.freeze
@@ -13,7 +15,7 @@ class GemInfo
     @cached = cached
   end
 
-  def compact_index_info(version: 1)
+  def compact_index_info(version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     cache_key = "#{config[:cache_prefix]}/#{@rubygem_name}"
     stats_key = config[:stats_prefix]
@@ -29,7 +31,7 @@ class GemInfo
     end
   end
 
-  def info_checksum(version: 1)
+  def info_checksum(version: CURRENT_VERSION)
     compact_index_info = CompactIndex.info(compute_compact_index_info(version:))
     Digest::MD5.hexdigest(compact_index_info)
   end
@@ -45,7 +47,7 @@ class GemInfo
     names
   end
 
-  def self.compact_index_versions(date, version: 1)
+  def self.compact_index_versions(date, version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     checksum_column = config[:checksum_column]
     yanked_checksum_column = config[:yanked_checksum_column]
@@ -65,7 +67,7 @@ class GemInfo
     map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] })
   end
 
-  def self.compact_index_public_versions(updated_at, version: 1)
+  def self.compact_index_public_versions(updated_at, version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     checksum_column = config[:checksum_column]
     yanked_checksum_column = config[:yanked_checksum_column]
@@ -149,7 +151,7 @@ class GemInfo
   end
 
   def fetch_requirements_and_dependencies
-    group_by_columns = "number, platform, sha256, info_checksum, required_ruby_version, required_rubygems_version, versions.created_at"
+    group_by_columns = "number, platform, sha256, info_checksum_v2, required_ruby_version, required_rubygems_version, versions.created_at"
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,6 +5,8 @@ require "digest/sha2"
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
 
+  self.ignored_columns += %w[info_checksum yanked_info_checksum]
+
   belongs_to :rubygem, touch: true
   has_many :dependencies, lambda {
                             order(Rubygem.arel_table["name"].asc).includes(:rubygem).references(:rubygem)

--- a/config/deploy/versions-list-update-monthly.yaml.erb
+++ b/config/deploy/versions-list-update-monthly.yaml.erb
@@ -21,7 +21,7 @@ spec:
           containers:
           - name: versions-list-update-monthly
             image: 048268392960.dkr.ecr.us-west-2.amazonaws.com/rubygems/rubygems.org:<%= current_sha %>
-            args: ["rake", "compact_index:update_versions_file"]
+            args: ["rake", "compact_index_v2:update_versions_file"]
             resources:
               <% if environment == 'production' %>
               requests:

--- a/config/rubygems.yml
+++ b/config/rubygems.yml
@@ -7,7 +7,6 @@ development:
   s3_compact_index_bucket: compact-index
   s3_region: us-east-1
   s3_endpoint: s3.amazonaws.com
-  versions_file_location: "./config/versions.list"
   versions_file_location_v2: "./config/versions_v2.list"
 
 test:
@@ -19,7 +18,6 @@ test:
   s3_compact_index_bucket: compact-index.test.s3.rubygems.org
   s3_region: us-east-1
   s3_endpoint: s3.amazonaws.com
-  versions_file_location: "./test/helpers/versions.list"
   versions_file_location_v2: "./test/helpers/versions_v2.list"
 
 staging:
@@ -31,7 +29,6 @@ staging:
   s3_endpoint: s3-us-west-2.amazonaws.com
   s3_contents_bucket: contents.oregon.staging.s3.rubygems.org
   s3_compact_index_bucket: compact-index.oregon.staging.s3.rubygems.org
-  versions_file_location: "./config/versions.list"
   versions_file_location_v2: "./config/versions_v2.list"
 
 production:
@@ -43,6 +40,5 @@ production:
   s3_endpoint: s3-us-west-2.amazonaws.com
   s3_contents_bucket: contents.oregon.production.s3.rubygems.org
   s3_compact_index_bucket: compact-index.oregon.production.s3.rubygems.org
-  versions_file_location: "./config/versions.list"
   versions_file_location_v2: "./config/versions_v2.list"
   separate_admin_host: rubygems.team

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,7 +66,7 @@ Version.create_with(
   indexed: true,
   pusher: author,
   sha256: Digest::SHA256.base64digest("abc123"),
-  info_checksum: Digest::MD5.base64digest("abc123")
+  info_checksum_v2: Digest::MD5.base64digest("abc123")
 ).find_or_create_by!(rubygem: rubygem0, number: "0.0.1", platform: "ruby", gem_platform: "ruby") do |version|
   author.deletions.find_or_create_by!(version: version)
 end

--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -77,17 +77,9 @@ namespace :compact_index do
     puts "Done."
   end
 
-  desc "Generate/update the versions.list file"
+  desc "Generate/update the current compact index versions file"
   task update_versions_file: :environment do
-    ts            = Time.now.utc.iso8601
-    file_path     = Rails.application.config.rubygems["versions_file_location"]
-    versions_file = CompactIndex::VersionsFile.new file_path
-    gems          = GemInfo.compact_index_public_versions ts
-
-    versions_file.create gems, ts
-
-    version_file_content = File.read(file_path)
-    RubygemFs.instance.store("versions/versions.list", version_file_content)
+    Rake::Task["compact_index_v2:update_versions_file"].invoke
   end
 
   desc "Update info checksum for multiple ruby or rubygems requirements"

--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -79,15 +79,7 @@ namespace :compact_index do
 
   desc "Generate/update the versions.list file"
   task update_versions_file: :environment do
-    ts            = Time.now.utc.iso8601
-    file_path     = Rails.application.config.rubygems["versions_file_location"]
-    versions_file = CompactIndex::VersionsFile.new file_path
-    gems          = GemInfo.compact_index_public_versions ts
-
-    versions_file.create gems, ts
-
-    version_file_content = File.read(file_path)
-    RubygemFs.instance.store("versions/versions.list", version_file_content)
+    UpdateVersionsListJob.perform_now(version: 1)
   end
 
   desc "Update info checksum for multiple ruby or rubygems requirements"

--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -58,9 +58,9 @@ namespace :compact_index do
     Rails.logger.info("[compact_index:correct_info_checksum] #{mismatch}/#{total} gems had info mismatch")
   end
 
-  desc "Fill Versions' yanked_info_checksum attributes for compact index format"
+  desc "Fill Versions' yanked_info_checksum_v2 attributes for compact index format"
   task backfill_yanked_info_checksum: :environment do
-    without_yanked_info_checksum = Version.where(indexed: false, yanked_info_checksum: nil)
+    without_yanked_info_checksum = Version.where(indexed: false, yanked_info_checksum_v2: nil)
     mod = ENV["shard"]
     without_yanked_info_checksum = without_yanked_info_checksum.where("id % 4 = ?", mod.to_i) if mod
 
@@ -69,7 +69,7 @@ namespace :compact_index do
     puts "Total: #{total}"
     without_yanked_info_checksum.find_each do |version|
       cs = GemInfo.new(version.rubygem.name).info_checksum
-      version.update_attribute :yanked_info_checksum, cs
+      version.update_attribute :yanked_info_checksum_v2, cs
       i += 1
       print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
     end

--- a/lib/tasks/compact_index.rake
+++ b/lib/tasks/compact_index.rake
@@ -79,7 +79,15 @@ namespace :compact_index do
 
   desc "Generate/update the versions.list file"
   task update_versions_file: :environment do
-    UpdateVersionsListJob.perform_now(version: 1)
+    ts            = Time.now.utc.iso8601
+    file_path     = Rails.application.config.rubygems["versions_file_location"]
+    versions_file = CompactIndex::VersionsFile.new file_path
+    gems          = GemInfo.compact_index_public_versions ts
+
+    versions_file.create gems, ts
+
+    version_file_content = File.read(file_path)
+    RubygemFs.instance.store("versions/versions.list", version_file_content)
   end
 
   desc "Update info checksum for multiple ruby or rubygems requirements"

--- a/lib/tasks/compact_index_v2.rake
+++ b/lib/tasks/compact_index_v2.rake
@@ -3,6 +3,14 @@
 namespace :compact_index_v2 do
   desc "Generate/update the baseline v2 versions.list file"
   task update_versions_file: :environment do
-    UpdateVersionsListJob.perform_now(version: 2)
+    ts = Time.now.utc.iso8601
+    file_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    versions_file = CompactIndex::VersionsFile.new(file_path)
+    gems = GemInfo.compact_index_public_versions(ts, version: 2)
+
+    versions_file.create(gems, ts)
+    version_file_content = File.read(file_path)
+
+    RubygemFs.instance.store("versions/versions_v2.list", version_file_content)
   end
 end

--- a/lib/tasks/compact_index_v2.rake
+++ b/lib/tasks/compact_index_v2.rake
@@ -3,14 +3,6 @@
 namespace :compact_index_v2 do
   desc "Generate/update the baseline v2 versions.list file"
   task update_versions_file: :environment do
-    ts = Time.now.utc.iso8601
-    file_path = Rails.application.config.rubygems["versions_file_location_v2"]
-    versions_file = CompactIndex::VersionsFile.new(file_path)
-    gems = GemInfo.compact_index_public_versions(ts, version: 2)
-
-    versions_file.create(gems, ts)
-    version_file_content = File.read(file_path)
-
-    RubygemFs.instance.store("versions/versions_v2.list", version_file_content)
+    UpdateVersionsListJob.perform_now(version: 2)
   end
 end

--- a/lib/tasks/helpers/compact_index_tasks_helper.rb
+++ b/lib/tasks/helpers/compact_index_tasks_helper.rb
@@ -8,11 +8,11 @@ module CompactIndexTasksHelper
     cs = GemInfo.new(last_version.rubygem.name).info_checksum
 
     if last_version.indexed
-      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.info_checksum} new_checksum: #{cs}")
-      last_version.update_attribute :info_checksum, cs
+      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.info_checksum_v2} new_checksum: #{cs}")
+      last_version.update_attribute :info_checksum_v2, cs
     else
-      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.yanked_info_checksum} new_checksum: #{cs}")
-      last_version.update_attribute :yanked_info_checksum, cs
+      Rails.logger.info("[#{task}] version: #{last_version.full_name} old_checksum: #{last_version.yanked_info_checksum_v2} new_checksum: #{cs}")
+      last_version.update_attribute :yanked_info_checksum_v2, cs
     end
   end
 end

--- a/test/factories/version.rb
+++ b/test/factories/version.rb
@@ -37,9 +37,9 @@ FactoryBot.define do
     end
 
     after(:create) do |version|
-      if version.info_checksum.blank?
+      if version.info_checksum_v2.blank?
         checksum = GemInfo.new(version.rubygem.name).info_checksum
-        version.update_attribute :info_checksum, checksum
+        version.update_attribute :info_checksum_v2, checksum
       end
     end
   end

--- a/test/helpers/rake_task_helper.rb
+++ b/test/helpers/rake_task_helper.rb
@@ -4,10 +4,12 @@ require "rake"
 
 # Run Rake tasks without loading them and introducing constant redefinition warnings
 module RakeTaskHelper
-  def setup_rake_tasks(task_file)
+  def setup_rake_tasks(*task_files)
     Rake::Task.clear
     # :environment is already loaded when running tests, so stub it
     Rake::Task.define_task(:environment)
-    load Rails.root.join("lib", "tasks", task_file)
+    task_files.each do |task_file|
+      load Rails.root.join("lib", "tasks", task_file)
+    end
   end
 end

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -11,31 +11,51 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     Digest::SHA256.base64digest(body)
   end
 
+  def current_compact_index_version
+    GemInfo::CURRENT_VERSION
+  end
+
+  def current_compact_index_config
+    Api::CompactIndexController::COMPACT_INDEX_VERSIONS.fetch(current_compact_index_version)
+  end
+
+  def current_versions_surrogate_key
+    current_compact_index_config.fetch(:versions_surrogate_key)
+  end
+
+  def current_info_prefix
+    current_compact_index_config.fetch(:info_prefix)
+  end
+
+  def checksum_attributes(checksum)
+    { GemInfo::VERSIONS.fetch(current_compact_index_version).fetch(:checksum_column) => checksum }
+  end
+
   setup do
     @rubygem2 = create(:rubygem, name: "gemB")
-    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum_v2: "v2qw2dwe")
+    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", **checksum_attributes("v2qw2dwe"))
 
     rubygem = create(:rubygem, name: "gemA")
     dep1 = create(:rubygem, name: "gemA1", indexed: true)
     dep2 = create(:rubygem, name: "gemA2", indexed: true)
 
-    create(:version, rubygem: rubygem, number: "1.0.0", info_checksum_v2: "v2013we2", required_ruby_version: nil)
+    create(:version, rubygem: rubygem, number: "1.0.0", required_ruby_version: nil, **checksum_attributes("v2013we2"))
 
-    version = create(:version, rubygem: rubygem, number: "2.0.0", info_checksum_v2: "v21cf94r", required_ruby_version: nil)
+    version = create(:version, rubygem: rubygem, number: "2.0.0", required_ruby_version: nil, **checksum_attributes("v21cf94r"))
     create(:dependency, rubygem: dep1, version: version)
 
     create(:version,
       rubygem: rubygem,
       number: "1.2.0",
-      info_checksum_v2: "v213q4es",
+      **checksum_attributes("v213q4es"),
       required_rubygems_version: ">1.9",
       required_ruby_version: ">= 2.0.0")
 
     version = create(:version,
       rubygem: rubygem,
       number: "2.1.0",
-      info_checksum_v2: "v2e217fz",
-      required_rubygems_version: ">=2.0")
+      required_rubygems_version: ">=2.0",
+      **checksum_attributes("v2e217fz"))
 
     create(:dependency, rubygem: dep1, version: version)
     create(:dependency, rubygem: dep2, version: version)
@@ -82,7 +102,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match file_contents, @response.body
     assert_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
-    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
+    assert_equal current_versions_surrogate_key, @response.headers["Surrogate-Key"]
   end
 
   test "/versions partial response" do
@@ -98,7 +118,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(full_response_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
+    assert_equal current_versions_surrogate_key, @response.headers["Surrogate-Key"]
   end
 
   test "/versions updates on gem yank" do
@@ -108,13 +128,13 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes @response.body, "gemB -1.0.0 #{@version.reload.yanked_info_checksum_v2}"
-    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
+    assert_equal current_versions_surrogate_key, @response.headers["Surrogate-Key"]
   end
 
   test "/version has surrogate key header" do
     get versions_path
 
-    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
+    assert_equal current_versions_surrogate_key, @response.headers["Surrogate-Key"]
     assert_equal "max-age=3600, stale-while-revalidate=1800, stale-if-error=1800", @response.headers["Surrogate-Control"]
   end
 
@@ -136,7 +156,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(expected), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-    assert_equal "v2/info/* gem/v2gem v2/info/v2gem", @response.headers["Surrogate-Key"]
+    assert_equal "#{current_info_prefix}/* gem/v2gem #{current_info_prefix}/v2gem", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do
@@ -157,7 +177,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(full_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-    assert_equal "v2/info/* gem/v2partial v2/info/v2partial", @response.headers["Surrogate-Key"]
+    assert_equal "#{current_info_prefix}/* gem/v2partial #{current_info_prefix}/v2partial", @response.headers["Surrogate-Key"]
   end
 
   test "/info cache expires on gem yank" do
@@ -176,7 +196,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_not_includes @response.body, "1.0.0"
-      assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
+      assert_equal "#{current_info_prefix}/* gem/v2yank #{current_info_prefix}/v2yank", @response.headers["Surrogate-Key"]
     end
   end
 
@@ -189,7 +209,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_includes @response.headers["Cache-Control"], "public"
     assert_match(/max-age=60/, @response.headers["Cache-Control"])
     assert_match(/max-age=600/, @response.headers["Surrogate-Control"])
-    assert_equal "v2/info/404 v2/info/donotexist", @response.headers["Surrogate-Key"]
+    assert_equal "#{current_info_prefix}/404 #{current_info_prefix}/donotexist", @response.headers["Surrogate-Key"]
   end
 
   test "/info with gzip" do

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -11,50 +11,30 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     Digest::SHA256.base64digest(body)
   end
 
-  def with_compact_index_v2_enabled
-    FeatureFlag.enable_globally(:serve_compact_index_v2)
-    yield
-  ensure
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-  end
-
   setup do
     @rubygem2 = create(:rubygem, name: "gemB")
-    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum: "qw2dwe")
+    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum_v2: "v2qw2dwe")
 
-    # another gem
     rubygem = create(:rubygem, name: "gemA")
     dep1 = create(:rubygem, name: "gemA1", indexed: true)
     dep2 = create(:rubygem, name: "gemA2", indexed: true)
 
-    # minimal version
-    create(:version,
-      rubygem: rubygem,
-      number: "1.0.0",
-      info_checksum: "013we2",
-      required_ruby_version: nil)
+    create(:version, rubygem: rubygem, number: "1.0.0", info_checksum_v2: "v2013we2", required_ruby_version: nil)
 
-    # version with deps but no ruby or rubygems requirements
-    version = create(:version,
-      rubygem: rubygem,
-      number: "2.0.0",
-      info_checksum: "1cf94r",
-      required_ruby_version: nil)
+    version = create(:version, rubygem: rubygem, number: "2.0.0", info_checksum_v2: "v21cf94r", required_ruby_version: nil)
     create(:dependency, rubygem: dep1, version: version)
 
-    # version with required ruby and rubygems version
     create(:version,
       rubygem: rubygem,
       number: "1.2.0",
-      info_checksum: "13q4es",
+      info_checksum_v2: "v213q4es",
       required_rubygems_version: ">1.9",
       required_ruby_version: ">= 2.0.0")
 
-    # version with everything
     version = create(:version,
       rubygem: rubygem,
       number: "2.1.0",
-      info_checksum: "e217fz",
+      info_checksum_v2: "v2e217fz",
       required_rubygems_version: ">=2.0")
 
     create(:dependency, rubygem: dep1, version: version)
@@ -94,73 +74,15 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal full_body.byteslice(15..), @response.body
   end
 
-  test "/versions serves v2 checksums when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      file_contents = File.read(Rails.application.config.rubygems["versions_file_location_v2"])
-
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-
-      get versions_path
-
-      assert_response :success
-      assert_match file_contents, @response.body
-      assert_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/versions partial response uses v2 response body when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-      get versions_path
-      full_response_body = @response.body
-      expected_digest = digest(full_response_body)
-      byte_offset = full_response_body.bytesize / 2
-
-      get versions_path, env: { range: "bytes=#{byte_offset}-" }
-
-      assert_response :partial_content
-      assert_equal full_response_body.byteslice(byte_offset..), @response.body
-      assert_equal etag(full_response_body), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-      assert_includes full_response_body, "gemB 1.0.0 v2qw2dwe"
-    end
-  end
-
-  test "/versions serves v1 checksums when compact index v2 flag is disabled" do
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-
-    @version.update!(info_checksum: "qw2dwe", info_checksum_v2: "v2qw2dwe")
-
-    versions_file_location = Rails.application.config.rubygems["versions_file_location"]
-    file_contents = File.read(versions_file_location)
+  test "/versions serves current v2 checksums" do
+    file_contents = File.read(Rails.application.config.rubygems["versions_file_location_v2"])
 
     get versions_path
 
     assert_response :success
     assert_match file_contents, @response.body
-    assert_match(/gemB 1.0.0 qw2dwe/, @response.body)
-    assert_no_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
-    assert_equal "versions", @response.headers["Surrogate-Key"]
-  end
-
-  test "/versions includes pre-built file and new gems" do
-    versions_file_location = Rails.application.config.rubygems["versions_file_location"]
-    file_contents = File.read(versions_file_location)
-    gem_a_match = "gemA 1.0.0 013we2\ngemA 2.0.0 1cf94r\ngemA 1.2.0 13q4es\ngemA 2.1.0 e217fz\n"
-    gem_b_match = "gemB 1.0.0 qw2dwe\n"
-
-    get versions_path
-    expected_digest = digest(@response.body)
-
-    assert_response :success
-    assert_match file_contents, @response.body
-    assert_match(/#{gem_b_match}#{gem_a_match}/, @response.body)
-    assert_equal etag(@response.body), @response.headers["ETag"]
-    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/versions partial response" do
@@ -176,211 +98,86 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(full_response_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/versions updates on gem yank" do
     Deletion.create!(version: @version, user: create(:user))
 
     get versions_path
-    full_response_body = @response.body
-    expected_digest = digest(full_response_body)
 
-    assert_includes full_response_body, "gemB -1.0.0 6105347ebb9825ac754615ca55ff3b0c"
-
-    byte_offset = full_response_body.bytesize / 2
-
-    get versions_path, env: { range: "bytes=#{byte_offset}-" }
-
-    assert_equal etag(full_response_body), @response.headers["ETag"]
-    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-    assert_equal full_response_body.byteslice(byte_offset..), @response.body
-  end
-
-  test "/versions updates on gem yank when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-      Deletion.create!(version: @version, user: create(:user))
-
-      get versions_path
-
-      assert_response :success
-      assert_includes @response.body, "gemB -1.0.0 #{@version.reload.yanked_info_checksum_v2}"
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-    end
+    assert_response :success
+    assert_includes @response.body, "gemB -1.0.0 #{@version.reload.yanked_info_checksum_v2}"
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/version has surrogate key header" do
     get versions_path
 
-    assert_equal "versions", @response.headers["Surrogate-Key"]
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
     assert_equal "max-age=3600, stale-while-revalidate=1800, stale-if-error=1800", @response.headers["Surrogate-Control"]
   end
 
-  test "/info serves v2 format when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      rubygem = create(:rubygem, name: "v2gem")
-      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-      expected = <<~VERSIONS_FILE
-        ---
-        1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
-      VERSIONS_FILE
-
-      expected_digest = digest(expected)
-
-      get info_path(gem_name: "v2gem")
-
-      assert_response :success
-      assert_equal expected, @response.body
-      assert_equal etag(expected), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/info/* gem/v2gem v2/info/v2gem", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info partial response when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      rubygem = create(:rubygem, name: "v2partial")
-      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-      full_body = <<~VERSIONS_FILE
-        ---
-        1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
-      VERSIONS_FILE
-      byte_offset = full_body.bytesize / 2
-      expected_digest = digest(full_body)
-
-      get info_path(gem_name: "v2partial"), env: { range: "bytes=#{byte_offset}-" }
-
-      assert_response :partial_content
-      assert_equal full_body.byteslice(byte_offset..), @response.body
-      assert_equal etag(full_body), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/info/* gem/v2partial v2/info/v2partial", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info v2 cache expires on gem yank" do
-    with_compact_index_v2_enabled do
-      travel_to(Time.utc(2026, 5, 31, 12, 0, 0)) do
-        rubygem = create(:rubygem, name: "v2yank")
-        version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-        get info_path(gem_name: "v2yank")
-
-        assert_response :success
-        assert_includes @response.body, "1.0.0"
-
-        Deletion.create!(version:, user: create(:user))
-
-        get info_path(gem_name: "v2yank")
-
-        assert_response :success
-        assert_not_includes @response.body, "1.0.0"
-        assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
-      end
-    end
-  end
-
-  test "/info serves v1 format when compact index v2 flag is disabled" do
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-
-    rubygem = create(:rubygem, name: "v1gem")
+  test "/info serves current v2 format" do
+    rubygem = create(:rubygem, name: "v2gem")
     version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
 
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
     VERSIONS_FILE
 
-    get info_path(gem_name: "v1gem")
-
-    assert_response :success
-    assert_equal expected, @response.body
-    assert_equal "info/* gem/v1gem info/v1gem", @response.headers["Surrogate-Key"]
-  end
-
-  test "/info does not return not modified for v1 validators after v2 flag is enabled" do
-    rubygem = create(:rubygem, name: "conditionalv2")
-    version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-    get info_path(gem_name: "conditionalv2")
-
-    assert_response :success
-    v1_etag = @response.headers["ETag"]
-
-    with_compact_index_v2_enabled do
-      get info_path(gem_name: "conditionalv2"), headers: {
-        "If-Modified-Since" => rubygem.updated_at.httpdate
-      }
-
-      assert_response :success
-      assert_includes @response.body, "created_at:#{version.created_at.utc.iso8601}"
-      assert_not_equal v1_etag, @response.headers["ETag"]
-      assert_equal "v2/info/* gem/conditionalv2 v2/info/conditionalv2", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info with existing gem" do
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-    VERSIONS_FILE
     expected_digest = digest(expected)
 
-    get info_path(gem_name: "gemA")
+    get info_path(gem_name: "v2gem")
 
     assert_response :success
     assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-  end
-
-  test "/info has surrogate key header" do
-    get info_path(gem_name: "gemA")
-
-    assert_equal "info/* gem/gemA info/gemA", @response.headers["Surrogate-Key"]
+    assert_equal "v2/info/* gem/v2gem v2/info/v2gem", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-    VERSIONS_FILE
+    rubygem = create(:rubygem, name: "v2partial")
+    version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
 
-    get info_path(gem_name: "gemA"), env: { range: "bytes=159-" }
+    full_body = <<~VERSIONS_FILE
+      ---
+      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+    byte_offset = full_body.bytesize / 2
+    expected_digest = digest(full_body)
+
+    get info_path(gem_name: "v2partial"), env: { range: "bytes=#{byte_offset}-" }
 
     assert_response :partial_content
-    assert_equal expected[159..], @response.body
-  end
-
-  test "/info with new gem" do
-    rubygem = create(:rubygem, name: "gemC")
-    version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "65ea0d")
-    create(:dependency, :development, version: version, rubygem: @rubygem2)
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-    VERSIONS_FILE
-    expected_digest = digest(expected)
-
-    get info_path(gem_name: "gemC")
-
-    assert_response :success
-    assert_equal(expected, @response.body)
-    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal full_body.byteslice(byte_offset..), @response.body
+    assert_equal etag(full_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "v2/info/* gem/v2partial v2/info/v2partial", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info cache expires on gem yank" do
+    travel_to(Time.utc(2026, 5, 31, 12, 0, 0)) do
+      rubygem = create(:rubygem, name: "v2yank")
+      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
+
+      get info_path(gem_name: "v2yank")
+
+      assert_response :success
+      assert_includes @response.body, "1.0.0"
+
+      Deletion.create!(version:, user: create(:user))
+
+      get info_path(gem_name: "v2yank")
+
+      assert_response :success
+      assert_not_includes @response.body, "1.0.0"
+      assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
+    end
   end
 
   test "/info with nonexistent gem" do
@@ -392,16 +189,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_includes @response.headers["Cache-Control"], "public"
     assert_match(/max-age=60/, @response.headers["Cache-Control"])
     assert_match(/max-age=600/, @response.headers["Surrogate-Control"])
-    assert_equal "info/404 info/donotexist", @response.headers["Surrogate-Key"]
-  end
-
-  test "/info with nonexistent gem uses v2 surrogate key when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      get info_path(gem_name: "donotexist")
-
-      assert_response :not_found
-      assert_equal "v2/info/404 v2/info/donotexist", @response.headers["Surrogate-Key"]
-    end
+    assert_equal "v2/info/404 v2/info/donotexist", @response.headers["Surrogate-Key"]
   end
 
   test "/info with gzip" do
@@ -421,14 +209,14 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{@version.created_at.utc.iso8601}
     VERSIONS_FILE
     expected_digest = digest(expected)
 
     get info_path(gem_name: "gemB")
 
     assert_response :success
-    assert_equal(expected, @response.body)
+    assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -55,10 +55,10 @@ class PushTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal <<~INFO, info_file
       ---
-      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))}
+      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{Version.find_by!(full_name: "sigstore-0.0.1").created_at.utc.iso8601}
+      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))},created_at:#{Rubygem.find_by!(name: "sigstore").versions.find_by!(number: "1.0.0").created_at.utc.iso8601}
     INFO
-    assert_equal Digest::MD5.hexdigest(info_file), Rubygem.find_by!(name: "sigstore").versions.find_by(number: "1.0.0").info_checksum
+    assert_equal Digest::MD5.hexdigest(info_file), Rubygem.find_by!(name: "sigstore").versions.find_by(number: "1.0.0").info_checksum_v2
 
     get api_v2_rubygem_version_path("sigstore", "1.0.0", format: "json")
 
@@ -95,15 +95,10 @@ class PushTest < ActionDispatch::IntegrationTest
     version = Rubygem.find_by!(name: "sandworm").versions.sole
     sha256 = Digest::SHA256.hexdigest gem_io.string
 
-    assert_equal Digest::MD5.hexdigest(<<~INFO), version.info_checksum
-      ---
-      1.0.0 |checksum:#{sha256}
-    INFO
     assert_equal Digest::MD5.hexdigest(<<~INFO), version.info_checksum_v2
       ---
       1.0.0 |checksum:#{sha256},created_at:#{version.created_at.utc.iso8601}
     INFO
-    refute_equal version.info_checksum, version.info_checksum_v2
   end
 
   test "push a new version of a gem" do

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -53,12 +53,16 @@ class PushTest < ActionDispatch::IntegrationTest
     info_file = response.body
 
     assert_response :success
+    rubygem = Rubygem.find_by!(name: "sigstore")
+    existing_version_created_at = Version.find_by!(full_name: "sigstore-0.0.1").created_at.utc.iso8601
+    pushed_version = rubygem.versions.find_by!(number: "1.0.0")
+
     assert_equal <<~INFO, info_file
       ---
-      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{Version.find_by!(full_name: "sigstore-0.0.1").created_at.utc.iso8601}
-      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))},created_at:#{Rubygem.find_by!(name: "sigstore").versions.find_by!(number: "1.0.0").created_at.utc.iso8601}
+      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{existing_version_created_at}
+      1.0.0 |checksum:#{Digest::SHA256.hexdigest File.binread(gem_file('sigstore-1.0.0.gem'))},created_at:#{pushed_version.created_at.utc.iso8601}
     INFO
-    assert_equal Digest::MD5.hexdigest(info_file), Rubygem.find_by!(name: "sigstore").versions.find_by(number: "1.0.0").info_checksum_v2
+    assert_equal Digest::MD5.hexdigest(info_file), pushed_version.info_checksum_v2
 
     get api_v2_rubygem_version_path("sigstore", "1.0.0", format: "json")
 

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -339,8 +339,8 @@ class PusherIntegrationTest < ActiveSupport::TestCase
         assert_equal 200, @cutter.code
       end
 
-      should "set info_checksum" do
-        assert_not_nil @rubygem.versions.last.info_checksum
+      should "set info_checksum_v2" do
+        assert_not_nil @rubygem.versions.last.info_checksum_v2
       end
 
       should "indexe rubygem and version" do

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpdateVersionsListJobTest < ActiveJob::TestCase
+  setup do
+    @v1_file = Tempfile.new("versions_file")
+    @v2_file = Tempfile.new("versions_v2_file")
+    @original_v1_path = Rails.application.config.rubygems["versions_file_location"]
+    @original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    Rails.application.config.rubygems["versions_file_location"] = @v1_file.path
+    Rails.application.config.rubygems["versions_file_location_v2"] = @v2_file.path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+  end
+
+  teardown do
+    Rails.application.config.rubygems["versions_file_location"] = @original_v1_path
+    Rails.application.config.rubygems["versions_file_location_v2"] = @original_v2_path
+    @v1_file.unlink
+    @v2_file.unlink
+  end
+
+  test "updates the v1 baseline versions list" do
+    rubygem = create(:rubygem, name: "rubyrubyruby")
+    create(:version, rubygem:, number: "0.0.1", info_checksum: "v1_checksum")
+
+    freeze_time do
+      UpdateVersionsListJob.perform_now(version: 1)
+    end
+
+    expected_line = "rubyrubyruby 0.0.1 v1_checksum\n"
+    assert_equal expected_line, @v1_file.readlines[2]
+    assert_includes RubygemFs.instance.get("versions/versions.list"), expected_line
+    assert_nil RubygemFs.instance.get("versions/versions_v2.list")
+  end
+
+  test "updates the v2 baseline versions list" do
+    rubygem = create(:rubygem, name: "rubyrubyruby")
+    create(:version, rubygem:, number: "0.0.1", info_checksum_v2: "v2_checksum")
+
+    freeze_time do
+      UpdateVersionsListJob.perform_now(version: 2)
+    end
+
+    expected_line = "rubyrubyruby 0.0.1 v2_checksum\n"
+    assert_equal expected_line, @v2_file.readlines[2]
+    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), expected_line
+    assert_nil RubygemFs.instance.get("versions/versions.list")
+  end
+end

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -3,29 +3,6 @@
 require "test_helper"
 
 class UpdateVersionsListJobTest < ActiveJob::TestCase
-  test "updates the v1 baseline versions list" do
-    v1_file = Tempfile.new("versions_file")
-    original_v1_path = Rails.application.config.rubygems["versions_file_location"]
-    Rails.application.config.rubygems["versions_file_location"] = v1_file.path
-    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
-
-    rubygem = create(:rubygem, name: "rubyrubyruby")
-    create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum: "v1_checksum")
-
-    freeze_time do
-      UpdateVersionsListJob.perform_now(version: 1)
-    end
-
-    expected_line = "rubyrubyruby 0.0.1 v1_checksum\n"
-
-    assert_equal expected_line, File.readlines(v1_file.path)[2]
-    assert_includes RubygemFs.instance.get("versions/versions.list"), expected_line
-    assert_nil RubygemFs.instance.get("versions/versions_v2.list")
-  ensure
-    Rails.application.config.rubygems["versions_file_location"] = original_v1_path
-    v1_file&.unlink
-  end
-
   test "updates the v2 baseline versions list" do
     v2_file = Tempfile.new("versions_v2_file")
     original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
@@ -51,7 +28,7 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
 
   test "discards unsupported versions" do
     assert_nothing_raised do
-      UpdateVersionsListJob.perform_now(version: 3)
+      UpdateVersionsListJob.perform_now(version: 1)
     end
   end
 end

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -48,4 +48,10 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
     Rails.application.config.rubygems["versions_file_location_v2"] = original_v2_path
     v2_file&.unlink
   end
+
+  test "discards unsupported versions" do
+    assert_nothing_raised do
+      UpdateVersionsListJob.perform_now(version: 3)
+    end
+  end
 end

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -3,13 +3,10 @@
 require "test_helper"
 
 class UpdateVersionsListJobTest < ActiveJob::TestCase
-  setup do
-    @v1_file = Tempfile.new("versions_file")
-    @v2_file = Tempfile.new("versions_v2_file")
-    @original_v1_path = Rails.application.config.rubygems["versions_file_location"]
-    @original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
-    Rails.application.config.rubygems["versions_file_location"] = @v1_file.path
-    Rails.application.config.rubygems["versions_file_location_v2"] = @v2_file.path
+  test "updates the v1 baseline versions list" do
+    v1_file = Tempfile.new("versions_file")
+    original_v1_path = Rails.application.config.rubygems["versions_file_location"]
+    Rails.application.config.rubygems["versions_file_location"] = v1_file.path
     RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
   end
 
@@ -22,29 +19,40 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
 
   test "updates the v1 baseline versions list" do
     rubygem = create(:rubygem, name: "rubyrubyruby")
-    create(:version, rubygem:, number: "0.0.1", info_checksum: "v1_checksum")
+    create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum: "v1_checksum")
 
     freeze_time do
       UpdateVersionsListJob.perform_now(version: 1)
     end
 
     expected_line = "rubyrubyruby 0.0.1 v1_checksum\n"
-    assert_equal expected_line, @v1_file.readlines[2]
+    assert_equal expected_line, File.readlines(v1_file.path)[2]
     assert_includes RubygemFs.instance.get("versions/versions.list"), expected_line
     assert_nil RubygemFs.instance.get("versions/versions_v2.list")
+  ensure
+    Rails.application.config.rubygems["versions_file_location"] = original_v1_path
+    v1_file&.unlink
   end
 
   test "updates the v2 baseline versions list" do
+    v2_file = Tempfile.new("versions_v2_file")
+    original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    Rails.application.config.rubygems["versions_file_location_v2"] = v2_file.path
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+
     rubygem = create(:rubygem, name: "rubyrubyruby")
-    create(:version, rubygem:, number: "0.0.1", info_checksum_v2: "v2_checksum")
+    create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum_v2: "v2_checksum")
 
     freeze_time do
       UpdateVersionsListJob.perform_now(version: 2)
     end
 
     expected_line = "rubyrubyruby 0.0.1 v2_checksum\n"
-    assert_equal expected_line, @v2_file.readlines[2]
+    assert_equal expected_line, File.readlines(v2_file.path)[2]
     assert_includes RubygemFs.instance.get("versions/versions_v2.list"), expected_line
     assert_nil RubygemFs.instance.get("versions/versions.list")
+  ensure
+    Rails.application.config.rubygems["versions_file_location_v2"] = original_v2_path
+    v2_file&.unlink
   end
 end

--- a/test/jobs/update_versions_list_job_test.rb
+++ b/test/jobs/update_versions_list_job_test.rb
@@ -8,16 +8,7 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
     original_v1_path = Rails.application.config.rubygems["versions_file_location"]
     Rails.application.config.rubygems["versions_file_location"] = v1_file.path
     RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
-  end
 
-  teardown do
-    Rails.application.config.rubygems["versions_file_location"] = @original_v1_path
-    Rails.application.config.rubygems["versions_file_location_v2"] = @original_v2_path
-    @v1_file.unlink
-    @v2_file.unlink
-  end
-
-  test "updates the v1 baseline versions list" do
     rubygem = create(:rubygem, name: "rubyrubyruby")
     create(:version, rubygem:, number: "0.0.1", created_at: 1.minute.ago, info_checksum: "v1_checksum")
 
@@ -26,6 +17,7 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
     end
 
     expected_line = "rubyrubyruby 0.0.1 v1_checksum\n"
+
     assert_equal expected_line, File.readlines(v1_file.path)[2]
     assert_includes RubygemFs.instance.get("versions/versions.list"), expected_line
     assert_nil RubygemFs.instance.get("versions/versions_v2.list")
@@ -48,6 +40,7 @@ class UpdateVersionsListJobTest < ActiveJob::TestCase
     end
 
     expected_line = "rubyrubyruby 0.0.1 v2_checksum\n"
+
     assert_equal expected_line, File.readlines(v2_file.path)[2]
     assert_includes RubygemFs.instance.get("versions/versions_v2.list"), expected_line
     assert_nil RubygemFs.instance.get("versions/versions.list")

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -131,6 +131,7 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
 
   test "persist_backfill_checksum does not write info_checksum_v2 if indexed flipped to false mid-perform" do
     version = create(:version, indexed: false, yanked_at: 1.minute.ago)
+    version.update_column(:info_checksum_v2, nil)
 
     Version.any_instance.stubs(:indexed).returns(true)
 

--- a/test/jobs/upload_info_file_job_test.rb
+++ b/test/jobs/upload_info_file_job_test.rb
@@ -9,49 +9,24 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
     version = create(:version, number: "0.0.1", required_ruby_version: ">= 2.0.0", required_rubygems_version: ">= 2.6.3")
     version.reload
     checksum = "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78"
-    compact_index_info = [CompactIndex::GemVersion.new(
-      "0.0.1", "ruby", checksum, version.info_checksum, [], ">= 2.0.0", ">= 2.6.3"
-    )]
     compact_index_info_v2 = [CompactIndex::GemVersionV2.new(
-      "0.0.1", "ruby", checksum, version.info_checksum, [], ">= 2.0.0", ">= 2.6.3",
+      "0.0.1", "ruby", checksum, GemInfo.new(version.rubygem.name).info_checksum, [], ">= 2.0.0", ">= 2.6.3",
       version.created_at.utc.iso8601
     )]
 
-    Rails.cache.expects(:write).with("info/#{version.rubygem.name}", compact_index_info)
     Rails.cache.expects(:write).with("info_v2/#{version.rubygem.name}", compact_index_info_v2)
 
     perform_enqueued_jobs only: [UploadInfoFileJob] do
       UploadInfoFileJob.perform_now(rubygem_name: version.rubygem.name)
     end
 
-    content = <<~INFO
-      ---
-      0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-    INFO
-
     v2_content = <<~INFO
       ---
       0.0.1 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
     INFO
 
-    assert_equal content, RubygemFs.compact_index.get("info/#{version.rubygem.name}")
+    assert_nil RubygemFs.compact_index.get("info/#{version.rubygem.name}")
     assert_equal v2_content, RubygemFs.compact_index.get("v2/info/#{version.rubygem.name}")
-
-    assert_equal_hash(
-      { metadata: {
-          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
-          "surrogate-key" =>
-            "info/* info/#{version.rubygem.name} gem/#{version.rubygem.name} s3-compact-index s3-info/* s3-info/#{version.rubygem.name}",
-          "sha256" => Digest::SHA256.base64digest(content),
-          "md5" => Digest::MD5.base64digest(content)
-        },
-        cache_control: "max-age=60, public",
-        content_type: "text/plain; charset=utf-8",
-        checksum_sha256: Digest::SHA256.base64digest(content),
-        content_md5: Digest::MD5.base64digest(content),
-        key: "info/#{version.rubygem.name}" },
-      RubygemFs.compact_index.head("info/#{version.rubygem.name}")
-    )
 
     assert_equal_hash(
       { metadata: {
@@ -70,23 +45,20 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
       RubygemFs.compact_index.head("v2/info/#{version.rubygem.name}")
     )
 
-    assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-info/#{version.rubygem.name}", soft: true])
     assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-v2/info/#{version.rubygem.name}", soft: true])
   end
 
-  test "info_checksum columns match the MD5 of uploaded info file bodies" do
-    # /versions advertises the MD5 of /info/<gem>; if they diverge Bundler rejects on hash mismatch.
+  test "info_checksum_v2 matches the MD5 of uploaded v2 info file body" do
+    # /versions advertises the MD5 of /v2/info/<gem>; if they diverge Bundler rejects on hash mismatch.
     version = create(:version)
     rubygem_name = version.rubygem.name
-    version.update!(info_checksum_v2: GemInfo.new(rubygem_name).info_checksum(version: 2))
+    version.update!(info_checksum_v2: GemInfo.new(rubygem_name).info_checksum)
 
     UploadInfoFileJob.perform_now(rubygem_name: rubygem_name)
 
-    v1_body = RubygemFs.compact_index.get("info/#{rubygem_name}")
     v2_body = RubygemFs.compact_index.get("v2/info/#{rubygem_name}")
     version.reload
 
-    assert_equal Digest::MD5.hexdigest(v1_body), version.info_checksum
     assert_equal Digest::MD5.hexdigest(v2_body), version.info_checksum_v2
   end
 
@@ -124,17 +96,6 @@ class UploadInfoFileJobTest < ActiveJob::TestCase
     body = RubygemFs.compact_index.get("v2/info/testgem")
 
     assert_equal Digest::MD5.hexdigest(body), last_version.reload.yanked_info_checksum_v2
-  end
-
-  test "backfill_only_version: 1 uploads only the v1 file and does not persist a checksum" do
-    version = create(:version, indexed: true, info_checksum_v2: nil)
-    name = version.rubygem.name
-
-    UploadInfoFileJob.perform_now(rubygem_name: name, backfill_only_version: 1)
-
-    assert_not_nil RubygemFs.compact_index.get("info/#{name}")
-    assert_nil RubygemFs.compact_index.get("v2/info/#{name}")
-    assert_nil version.reload.info_checksum_v2
   end
 
   test "backfill_only_version: 2 is a no-op for persistence when the rubygem no longer exists" do

--- a/test/jobs/upload_names_file_job_test.rb
+++ b/test/jobs/upload_names_file_job_test.rb
@@ -17,24 +17,8 @@ class UploadNamesFileJobTest < ActiveJob::TestCase
       #{version.rubygem.name}
     INFO
 
-    assert_equal content, RubygemFs.compact_index.get("names")
+    assert_nil RubygemFs.compact_index.get("names")
     assert_equal content, RubygemFs.compact_index.get("v2/names")
-
-    assert_equal_hash(
-      { metadata: {
-          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
-          "surrogate-key" =>
-            "names s3-compact-index s3-names",
-          "sha256" => Digest::SHA256.base64digest(content),
-          "md5" => Digest::MD5.base64digest(content)
-        },
-        cache_control: "max-age=60, public",
-        content_type: "text/plain; charset=utf-8",
-        checksum_sha256: Digest::SHA256.base64digest(content),
-        content_md5: Digest::MD5.base64digest(content),
-        key: "names" },
-      RubygemFs.compact_index.head("names")
-    )
 
     assert_equal_hash(
       { metadata: {
@@ -52,7 +36,6 @@ class UploadNamesFileJobTest < ActiveJob::TestCase
       RubygemFs.compact_index.head("v2/names")
     )
 
-    assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-names", soft: true])
     assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-v2/names", soft: true])
   end
 

--- a/test/jobs/upload_versions_file_job_test.rb
+++ b/test/jobs/upload_versions_file_job_test.rb
@@ -7,63 +7,25 @@ class UploadVersionsFileJobTest < ActiveJob::TestCase
     RubygemFs.compact_index.remove("versions", "v2/versions")
   end
 
-  test "uploads the v1 versions file but skips v2 if the local v2 file does not exist" do
-    version = create(:version)
-    info_checksum = GemInfo.new(version.rubygem.name).info_checksum
-    version.update!(info_checksum:)
-
+  test "skips upload if the local v2 versions file does not exist" do
     original_v2_path = Rails.application.config.rubygems["versions_file_location_v2"]
     Rails.application.config.rubygems["versions_file_location_v2"] = "./test/helpers/missing_versions_v2.list"
 
     UploadVersionsFileJob.perform_now
 
-    content = <<~VERSIONS
-      created_at: 2015-08-23T17:22:53-07:00
-      ---
-      old_gem_one 1 e63fe62df0f1f459d2f70986f79745c6
-      old_gem_two 0.1.0,0.1.1,0.1.2,0.2.0,0.2.1,0.3.0,0.4.0,0.4.1,0.5.0,0.5.1,0.5.2,0.5.3 c54e4b7e14861a5d8c225283b75075f4
-      #{version.rubygem.name} #{version.number} #{info_checksum}
-    VERSIONS
-
-    assert_equal content, RubygemFs.compact_index.get("versions")
+    assert_nil RubygemFs.compact_index.get("versions")
     assert_nil RubygemFs.compact_index.get("v2/versions")
-
-    assert_equal_hash(
-      { metadata: {
-          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
-          "surrogate-key" => "versions s3-compact-index s3-versions",
-          "sha256" => Digest::SHA256.base64digest(content),
-          "md5" => Digest::MD5.base64digest(content)
-        },
-        cache_control: "max-age=60, public",
-        content_type: "text/plain; charset=utf-8",
-        checksum_sha256: Digest::SHA256.base64digest(content),
-        content_md5: Digest::MD5.base64digest(content),
-        key: "versions" },
-      RubygemFs.compact_index.head("versions")
-    )
-
-    assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-versions", soft: true])
-    assert_enqueued_jobs 1, only: FastlyPurgeJob
+    assert_no_enqueued_jobs only: FastlyPurgeJob
   ensure
     Rails.application.config.rubygems["versions_file_location_v2"] = original_v2_path
   end
 
-  test "uploads the v1 and v2 versions files" do
+  test "uploads the v2 versions file" do
     version = create(:version)
-    info_checksum = GemInfo.new(version.rubygem.name).info_checksum
-    info_checksum_v2 = GemInfo.new(version.rubygem.name).info_checksum(version: 2)
-    version.update!(info_checksum:, info_checksum_v2:)
+    info_checksum_v2 = GemInfo.new(version.rubygem.name).info_checksum
+    version.update!(info_checksum_v2:)
 
     UploadVersionsFileJob.perform_now
-
-    content = <<~VERSIONS
-      created_at: 2015-08-23T17:22:53-07:00
-      ---
-      old_gem_one 1 e63fe62df0f1f459d2f70986f79745c6
-      old_gem_two 0.1.0,0.1.1,0.1.2,0.2.0,0.2.1,0.3.0,0.4.0,0.4.1,0.5.0,0.5.1,0.5.2,0.5.3 c54e4b7e14861a5d8c225283b75075f4
-      #{version.rubygem.name} #{version.number} #{info_checksum}
-    VERSIONS
 
     v2_content = <<~VERSIONS
       created_at: 2015-08-23T17:22:53-07:00
@@ -71,23 +33,8 @@ class UploadVersionsFileJobTest < ActiveJob::TestCase
       #{version.rubygem.name} #{version.number} #{info_checksum_v2}
     VERSIONS
 
-    assert_equal content, RubygemFs.compact_index.get("versions")
+    assert_nil RubygemFs.compact_index.get("versions")
     assert_equal v2_content, RubygemFs.compact_index.get("v2/versions")
-
-    assert_equal_hash(
-      { metadata: {
-          "surrogate-control" => "max-age=3600, stale-while-revalidate=1800",
-          "surrogate-key" => "versions s3-compact-index s3-versions",
-          "sha256" => Digest::SHA256.base64digest(content),
-          "md5" => Digest::MD5.base64digest(content)
-        },
-        cache_control: "max-age=60, public",
-        content_type: "text/plain; charset=utf-8",
-        checksum_sha256: Digest::SHA256.base64digest(content),
-        content_md5: Digest::MD5.base64digest(content),
-        key: "versions" },
-      RubygemFs.compact_index.head("versions")
-    )
 
     assert_equal_hash(
       { metadata: {
@@ -104,7 +51,6 @@ class UploadVersionsFileJobTest < ActiveJob::TestCase
       RubygemFs.compact_index.head("v2/versions")
     )
 
-    assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-versions", soft: true])
     assert_enqueued_with(job: FastlyPurgeJob, args: [key: "s3-v2/versions", soft: true])
   end
 end

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -97,9 +97,8 @@ class DeletionTest < ActiveSupport::TestCase
         assert @version.reload.yanked_at
       end
 
-      should "set the yanked info checksums" do
-        refute_nil @version.reload.yanked_info_checksum
-        refute_nil @version.yanked_info_checksum_v2
+      should "set the yanked info checksum" do
+        refute_nil @version.reload.yanked_info_checksum_v2
       end
 
       should "delete the .gem file" do
@@ -132,12 +131,9 @@ class DeletionTest < ActiveSupport::TestCase
       delete_gem
       @version.reload
       checksum = Version._sha256_hex(other_version.sha256)
-      expected_v1_line = "0.0.1 |checksum:#{checksum},ruby:>= 2.0.0,rubygems:>= 2.6.3"
-      expected_v2_line = "#{expected_v1_line},created_at:#{other_version.created_at.utc.iso8601}"
+      expected_line = "0.0.1 |checksum:#{checksum},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{other_version.created_at.utc.iso8601}"
 
-      assert_equal Digest::MD5.hexdigest("---\n#{expected_v1_line}\n"), @version.yanked_info_checksum
-      assert_equal Digest::MD5.hexdigest("---\n#{expected_v2_line}\n"), @version.yanked_info_checksum_v2
-      refute_equal @version.yanked_info_checksum, @version.yanked_info_checksum_v2
+      assert_equal Digest::MD5.hexdigest("---\n#{expected_line}\n"), @version.yanked_info_checksum_v2
     end
   end
 
@@ -220,9 +216,8 @@ class DeletionTest < ActiveSupport::TestCase
         assert_predicate @version.reload, :latest?
       end
 
-      should "remove the yanked time and yanked_info_checksum" do
+      should "remove the yanked time and yanked_info_checksum_v2" do
         assert_nil @version.yanked_at
-        assert_nil @version.yanked_info_checksum
         assert_nil @version.yanked_info_checksum_v2
       end
 

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -5,34 +5,22 @@ require "test_helper"
 class GemInfoTest < ActiveSupport::TestCase
   setup do
     Rails.cache.delete("names")
-    Rails.cache.delete("info/example")
     Rails.cache.delete("info_v2/example")
   end
 
   teardown do
     Rails.cache.delete("names")
-    Rails.cache.delete("info/example")
     Rails.cache.delete("info_v2/example")
   end
 
   context "#compact_index_info" do
     setup do
       rubygem = create(:rubygem, name: "example")
-      @version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "qw2dwe")
+      @version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum_v2: "qw2dwe")
       dep = create(:rubygem, name: "exmaple_dep")
       create(:dependency, rubygem: dep, version: @version)
 
-      @expected_info = [CompactIndex::GemVersion.new(
-        "1.0.0",
-        "ruby",
-        "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
-        "qw2dwe",
-        [CompactIndex::Dependency.new("exmaple_dep", "= 1.0.0")],
-        ">= 2.0.0",
-        ">= 2.6.3"
-      )]
-
-      @expected_info_v2 = [CompactIndex::GemVersionV2.new(
+      @expected_info = [CompactIndex::GemVersionV2.new(
         "1.0.0",
         "ruby",
         "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
@@ -44,59 +32,28 @@ class GemInfoTest < ActiveSupport::TestCase
       )]
 
       @expected_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(@expected_info))
-      @expected_info_checksum_v2 = Digest::MD5.hexdigest(CompactIndex.info(@expected_info_v2))
-    end
-
-    should "return gem version and dependency" do
-      info = GemInfo.new("example").compact_index_info
-
-      assert_equal @expected_info, info
     end
 
     should "return v2 gem version and dependency with created_at" do
-      info = GemInfo.new("example").compact_index_info(version: 2)
-
-      assert_equal @expected_info_v2, info
-    end
-
-    should "compute v2 info checksum with created_at" do
-      assert_equal @expected_info_checksum_v2, GemInfo.new("example").info_checksum(version: 2)
-      refute_equal GemInfo.new("example").info_checksum, GemInfo.new("example").info_checksum(version: 2)
-    end
-
-    should "write cache" do
-      Rails.cache.expects(:write).with("info/example", @expected_info)
-
-      GemInfo.new("example").compact_index_info
-    end
-
-    should "read from cache when cache exists" do
-      Rails.cache.expects(:read).with("info/example")
-
       info = GemInfo.new("example").compact_index_info
 
       assert_equal @expected_info, info
     end
 
-    should "write v2 cache" do
-      Rails.cache.expects(:write).with("info_v2/example", @expected_info_v2)
+    should "compute v2 info checksum with created_at" do
+      assert_equal @expected_info_checksum, GemInfo.new("example").info_checksum
+    end
 
-      GemInfo.new("example").compact_index_info(version: 2)
+    should "write v2 cache" do
+      Rails.cache.expects(:write).with("info_v2/example", @expected_info)
+
+      GemInfo.new("example").compact_index_info
     end
 
     should "read v2 from cache when cache exists" do
       Rails.cache.expects(:read).with("info_v2/example")
 
-      info = GemInfo.new("example").compact_index_info(version: 2)
-
-      assert_equal @expected_info_v2, info
-    end
-
-    should "recompute when v1 cache deserialization fails" do
-      Rails.cache.expects(:read).with("info/example").raises(TypeError, "struct size differs")
-
-      info = nil
-      assert_nothing_raised { info = GemInfo.new("example").compact_index_info }
+      info = GemInfo.new("example").compact_index_info
 
       assert_equal @expected_info, info
     end
@@ -105,9 +62,9 @@ class GemInfoTest < ActiveSupport::TestCase
       Rails.cache.expects(:read).with("info_v2/example").raises(TypeError, "struct size differs")
 
       info = nil
-      assert_nothing_raised { info = GemInfo.new("example").compact_index_info(version: 2) }
+      assert_nothing_raised { info = GemInfo.new("example").compact_index_info }
 
-      assert_equal @expected_info_v2, info
+      assert_equal @expected_info, info
     end
   end
 
@@ -145,29 +102,8 @@ class GemInfoTest < ActiveSupport::TestCase
     setup do
       create(:version, number: "0.0.1", created_at: 10.days.ago)
       rubygem = create(:rubygem, name: "foo")
-      create(:version, rubygem: rubygem, number: "2.0.0", created_at: 2.days.ago, info_checksum: "qw2dwe")
-      create(:version, rubygem: rubygem, number: "1.0.1", created_at: 3.days.ago, info_checksum: "32ddwe")
-
-      @expected_versions =
-        [CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("1.0.1", "ruby", nil, "32ddwe")]),
-         CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("2.0.0", "ruby", nil, "qw2dwe")])]
-    end
-
-    should "return all versions created after given date and ordered by created_at" do
-      versions = GemInfo.compact_index_versions(4.days.ago)
-
-      assert_equal @expected_versions, versions
-    end
-  end
-
-  context ".compact_index_versions version: 2" do
-    setup do
-      create(:version, number: "0.0.1", created_at: 10.days.ago)
-      rubygem = create(:rubygem, name: "foo")
-      create(:version, rubygem: rubygem, number: "2.0.0", created_at: 2.days.ago,
-                       info_checksum: "qw2dwe", info_checksum_v2: "v2qw2dwe")
-      create(:version, rubygem: rubygem, number: "1.0.1", created_at: 3.days.ago,
-                       info_checksum: "32ddwe", info_checksum_v2: "v232ddwe")
+      create(:version, rubygem: rubygem, number: "2.0.0", created_at: 2.days.ago, info_checksum_v2: "v2qw2dwe")
+      create(:version, rubygem: rubygem, number: "1.0.1", created_at: 3.days.ago, info_checksum_v2: "v232ddwe")
 
       @expected_versions =
         [CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("1.0.1", "ruby", nil, "v232ddwe")]),
@@ -175,7 +111,7 @@ class GemInfoTest < ActiveSupport::TestCase
     end
 
     should "return all versions created after given date using v2 checksum" do
-      versions = GemInfo.compact_index_versions(4.days.ago, version: 2)
+      versions = GemInfo.compact_index_versions(4.days.ago)
 
       assert_equal @expected_versions, versions
     end
@@ -185,7 +121,7 @@ class GemInfoTest < ActiveSupport::TestCase
       create(:version, :yanked, rubygem: rubygem, number: "1.0.0", created_at: 10.days.ago,
                                 yanked_at: 1.day.ago, yanked_info_checksum_v2: "v2yanked")
 
-      versions = GemInfo.compact_index_versions(4.days.ago, version: 2)
+      versions = GemInfo.compact_index_versions(4.days.ago)
 
       assert_includes versions,
         CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("-1.0.0", "ruby", nil, "v2yanked")])
@@ -195,33 +131,13 @@ class GemInfoTest < ActiveSupport::TestCase
   context ".compact_index_public_versions" do
     setup do
       @ts               = 5.minutes.ago
-      @version          = create(:version, number: "0.0.1", created_at: @ts, info_checksum: "qw2dwe")
-
-      _updated_after_ts = create(:version, number: "2.0.0", created_at: @ts + 1.second)
-    end
-
-    should "not return version updated after ts" do
-      versions = GemInfo.compact_index_public_versions(@ts)
-
-      expected_versions = [CompactIndex::Gem.new(
-        @version.rubygem.name,
-        [CompactIndex::GemVersion.new(@version.number, @version.platform, @version.sha256, @version.info_checksum)]
-      )]
-
-      assert_equal expected_versions, versions
-    end
-  end
-
-  context ".compact_index_public_versions version: 2" do
-    setup do
-      @ts               = 5.minutes.ago
       @version          = create(:version, number: "0.0.1", created_at: @ts, info_checksum_v2: "v2qw2dwe")
 
       _updated_after_ts = create(:version, number: "2.0.0", created_at: @ts + 1.second, info_checksum_v2: "v2qw2dwe")
     end
 
     should "not return version updated after ts" do
-      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+      versions = GemInfo.compact_index_public_versions(@ts)
 
       expected_versions = [CompactIndex::Gem.new(
         @version.rubygem.name,
@@ -237,7 +153,7 @@ class GemInfoTest < ActiveSupport::TestCase
       create(:version, :yanked, rubygem: rubygem, number: "2.0.0", created_at: 9.minutes.ago,
                                 yanked_at: 8.minutes.ago, yanked_info_checksum_v2: "v2yanked")
 
-      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+      versions = GemInfo.compact_index_public_versions(@ts)
 
       assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
     end
@@ -249,7 +165,7 @@ class GemInfoTest < ActiveSupport::TestCase
                                 yanked_at: 8.minutes.ago, info_checksum_v2: "v2qw2dwe",
                                 yanked_info_checksum_v2: nil)
 
-      versions = GemInfo.compact_index_public_versions(@ts, version: 2)
+      versions = GemInfo.compact_index_public_versions(@ts)
 
       assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2qw2dwe")])
     end

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -233,13 +233,13 @@ class RubygemTest < ActiveSupport::TestCase
           number: "1.0.0",
           platform: "ruby",
           licenses: "MIT",
-          info_checksum: "1234567890")
+          info_checksum_v2: "1234567890")
         @jruby_version = create(:version,
           rubygem: @rubygem,
           number: "1.0.0",
           platform: "jruby",
           licenses: "MIT",
-          info_checksum: "1234567890")
+          info_checksum_v2: "1234567890")
       end
 
       should "return the most recently created version without platform" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1109,10 +1109,10 @@ class VersionTest < ActiveSupport::TestCase
         end
       end
 
-      context "info checksum is updated" do
+      context "info checksum v2 is updated" do
         should "not reorder versions" do
           @version.expects(:reorder_versions).times(0)
-          @version.update(info_checksum: "lala")
+          @version.update(info_checksum_v2: "lala")
         end
       end
     end

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -101,7 +101,7 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     version.reload
 
     assert_not_nil version.yanked_at
-    assert_not_nil version.yanked_info_checksum
+    assert_not_nil version.yanked_info_checksum_v2
 
     audit = rubygem.audits.sole
     deletion = security_user.deletions.first
@@ -179,9 +179,9 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     version2.reload
 
     assert_not_nil version1.yanked_at
-    assert_not_nil version1.yanked_info_checksum
+    assert_not_nil version1.yanked_info_checksum_v2
     assert_not_nil version2.yanked_at
-    assert_not_nil version2.yanked_info_checksum
+    assert_not_nil version2.yanked_info_checksum_v2
 
     audit = rubygem.audits.sole
     deletion1 = security_user.deletions.first

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -337,6 +337,27 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
     assert_not_nil Audit.last
   end
 
+  test "update versions list" do
+    admin_user = create(:admin_github_user, :is_admin)
+    avo_sign_in_as admin_user
+
+    visit avo.resources_rubygems_path
+
+    _ = create(:version)
+
+    click_button "Actions"
+    click_on "Update Versions List"
+    fill_in "Comment", with: "A nice long comment"
+
+    assert_enqueued_jobs 2, only: UpdateVersionsListJob do
+      click_button "Update"
+
+      page.assert_text "Versions list update job scheduled"
+    end
+
+    assert_not_nil Audit.last
+  end
+
   test "upload names file" do
     admin_user = create(:admin_github_user, :is_admin)
     avo_sign_in_as admin_user

--- a/test/system/avo/rubygems_test.rb
+++ b/test/system/avo/rubygems_test.rb
@@ -354,8 +354,6 @@ class Avo::RubygemsSystemTest < ApplicationSystemTestCase
 
       page.assert_text "Versions list update job scheduled"
     end
-
-    assert_not_nil Audit.last
   end
 
   test "upload names file" do

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -44,7 +44,7 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
 
     assert deletion.version.indexed
     assert_nil version.yanked_at
-    assert_nil version.yanked_info_checksum
+    assert_nil version.yanked_info_checksum_v2
 
     audit = version.audits.sole
 
@@ -69,12 +69,11 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
             {
               "indexed" => [false, true],
               "yanked_at" => [version_attributes[:yanked_at].as_json, nil],
-              "yanked_info_checksum" => [version_attributes[:yanked_info_checksum], nil],
               "yanked_info_checksum_v2" => [version_attributes[:yanked_info_checksum_v2], nil],
               "updated_at" => [version_attributes[:updated_at].as_json, version.updated_at.as_json]
             },
             "unchanged" => version_attributes
-              .except("updated_at", "yanked_info_checksum", "yanked_info_checksum_v2", "yanked_at", "indexed")
+              .except("updated_at", "yanked_info_checksum_v2", "yanked_at", "indexed")
               .merge("position" => 0, "latest" => false)
               .transform_values(&:as_json)
           },

--- a/test/unit/avo/actions/update_versions_list_test.rb
+++ b/test/unit/avo/actions/update_versions_list_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UpdateVersionsListTest < ActiveJob::TestCase
+  setup do
+    @current_user = create(:admin_github_user, :is_admin)
+    @action = Avo::Actions::UpdateVersionsList.new
+
+    view_context = mock
+    avo = mock
+    view_context.stubs(:avo).returns(avo)
+    avo.stubs(:resources_audit_path).returns("resources_audit_path")
+    Avo::Current.stubs(:view_context).returns(view_context)
+  end
+
+  test "enqueues a v1 versions list update" do
+    perform_action("1")
+
+    assert_enqueued_jobs 1, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 1])
+  end
+
+  test "enqueues a v2 versions list update" do
+    perform_action("2")
+
+    assert_enqueued_jobs 1, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 2])
+  end
+
+  test "enqueues v1 and v2 versions list updates" do
+    perform_action("both")
+
+    assert_enqueued_jobs 2, only: UpdateVersionsListJob
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 1])
+    assert_enqueued_with(job: UpdateVersionsListJob, args: [version: 2])
+  end
+
+  test "shows an error for unsupported versions" do
+    perform_action("3")
+
+    assert_no_enqueued_jobs only: UpdateVersionsListJob
+    assert_equal [type: :error, body: "Unsupported compact index version: 3", timeout: nil], @action.response[:messages]
+  end
+
+  private
+
+  def perform_action(version)
+    @action.handle(
+      fields: {
+        comment: "Regenerating versions list",
+        "version" => version
+      },
+      current_user: @current_user,
+      resource: nil,
+      records: [],
+      query: nil
+    )
+  end
+end

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -1,184 +1,58 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "rake"
 
 class UpdateVersionsFileTest < ActiveSupport::TestCase
-  include RakeTaskHelper
-
   setup do
-    @tmp_versions_file = Tempfile.new("tmp_versions_file")
-    tmp_path = @tmp_versions_file.path
-    Rails.application.config.rubygems.stubs(:[]).with("versions_file_location").returns(tmp_path)
+    @tmp_versions_file = Tempfile.new("versions_v2.list")
+    @tmp_versions_file.write "created_at: 2015-08-23T17:22:53-07:00\n---\n"
+    @tmp_versions_file.close
 
-    setup_rake_tasks("compact_index.rake")
-  end
-
-  def update_versions_file
-    freeze_time do
-      @created_at = Time.now.utc.iso8601
-      Rake::Task["compact_index:update_versions_file"].invoke
-    end
+    @original_path = Rails.application.config.rubygems["versions_file_location_v2"]
+    Rails.application.config.rubygems["versions_file_location_v2"] = @tmp_versions_file.path
+    setup_rake_tasks("compact_index_v2.rake", "compact_index.rake")
   end
 
   teardown do
+    Rake::Task["compact_index:update_versions_file"].reenable
+    Rake::Task["compact_index_v2:update_versions_file"].reenable
+    Rails.application.config.rubygems["versions_file_location_v2"] = @original_path
     @tmp_versions_file.unlink
   end
 
-  context "file header" do
-    setup do
-      update_versions_file
-    end
+  should "delegate the default compact index versions file task to v2" do
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
 
-    should "use today's timestamp as header" do
-      expected_header = "created_at: #{@created_at}\n---\n"
+    rubygem = create(:rubygem, name: "foo")
+    create(:version, rubygem:, number: "1.0.0", info_checksum_v2: "v2_checksum")
 
-      assert_equal expected_header, @tmp_versions_file.read
-    end
+    Rake::Task["compact_index:update_versions_file"].invoke
+
+    content = File.read(@tmp_versions_file.path)
+
+    assert_includes content, "foo 1.0.0 v2_checksum"
+    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), "foo 1.0.0 v2_checksum"
+    assert_nil RubygemFs.instance.get("versions/versions.list")
   end
 
-  context "single gem" do
-    setup { @rubygem = create(:rubygem, name: "rubyrubyruby") }
+  should "use yanked_info_checksum_v2 for yanked versions" do
+    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
 
-    context "platform release" do
-      setup do
-        create(:version,
-          rubygem:       @rubygem,
-          created_at:    2.minutes.ago,
-          number:        "0.0.1",
-          info_checksum: "13q4e1")
-        create(:version,
-          rubygem:       @rubygem,
-          created_at:    1.minute.ago,
-          number:        "0.0.1",
-          info_checksum: "qw212r",
-          platform:      "jruby")
+    rubygem = create(:rubygem, name: "foo")
+    create(:version,
+      :yanked,
+      rubygem:,
+      number: "1.0.0",
+      info_checksum_v2: "v2_checksum",
+      yanked_info_checksum_v2: "v2_yanked_checksum")
 
-        update_versions_file
-      end
+    Rake::Task["compact_index:update_versions_file"].invoke
 
-      should "include platform release" do
-        expected_output = "rubyrubyruby 0.0.1,0.0.1-jruby qw212r\n"
+    content = File.read(@tmp_versions_file.path)
 
-        assert_equal expected_output, @tmp_versions_file.readlines[2]
-      end
-    end
-
-    context "order" do
-      setup do
-        1.upto(3) do |i|
-          create(:version,
-            rubygem:       @rubygem,
-            created_at:    i.minutes.ago,
-            number:        "0.0.#{4 - i}",
-            info_checksum: "13q4e#{i}")
-        end
-
-        update_versions_file
-      end
-
-      should "order by created_at and use last released version's info_checksum" do
-        expected_output = "rubyrubyruby 0.0.1,0.0.2,0.0.3 13q4e1\n"
-
-        assert_equal expected_output, @tmp_versions_file.readlines[2]
-      end
-    end
-
-    context "yanked version" do
-      setup do
-        create(:version,
-          rubygem:       @rubygem,
-          created_at:    5.minutes.ago,
-          number:        "0.0.1",
-          info_checksum: "qw212r")
-        create(:version,
-          indexed:              false,
-          rubygem:              @rubygem,
-          created_at:           3.minutes.ago,
-          yanked_at:            1.minute.ago,
-          number:               "0.0.2",
-          info_checksum:        "sd12q",
-          yanked_info_checksum: "qw212r")
-        Rake::Task["compact_index:update_versions_file"].invoke
-      end
-
-      should "not include yanked version" do
-        expected_output = "rubyrubyruby 0.0.1 qw212r\n"
-
-        assert_equal expected_output, @tmp_versions_file.readlines[2]
-      end
-    end
-
-    context "yanked version isn't the latest version" do
-      setup do
-        create(:version,
-          rubygem:       @rubygem,
-          created_at:    5.seconds.ago,
-          number:        "0.1.1",
-          info_checksum: "zqw212r")
-        create(:version,
-          indexed:       false,
-          rubygem:       @rubygem,
-          created_at:    4.seconds.ago,
-          yanked_at:     2.seconds.ago,
-          number:        "0.1.2",
-          info_checksum: "zsd12q",
-          yanked_info_checksum: "zab45d")
-        create(:version,
-          rubygem:       @rubygem,
-          created_at:    3.seconds.ago,
-          number:        "0.1.3",
-          info_checksum: "zrt13y")
-
-        update_versions_file
-      end
-
-      should "not include yanked version" do
-        expected_output = "rubyrubyruby 0.1.1,0.1.3 zab45d\n"
-
-        assert_equal expected_output, @tmp_versions_file.readlines[2]
-      end
-    end
-
-    context "no public versions" do
-      setup do
-        create(:version,
-          indexed:       false,
-          rubygem:       @rubygem,
-          created_at:    4.seconds.ago,
-          yanked_at:     2.seconds.ago,
-          number:        "0.1.2",
-          info_checksum: "zsd12q",
-          yanked_info_checksum: "zab45d")
-
-        update_versions_file
-      end
-
-      should "not include yanked version" do
-        refute_includes "rubyrubyruby", @tmp_versions_file.read
-      end
-    end
-  end
-
-  context "multiple gems" do
-    setup do
-      3.times do |i|
-        create(:rubygem, name: "rubygem#{i}").tap do |gem|
-          create(:version, rubygem: gem, created_at: 4.seconds.ago, number: "0.0.1", info_checksum: "13q4e#{i}")
-        end
-      end
-
-      update_versions_file
-    end
-
-    should "put each gem on new line" do
-      expected_output = <<~VERSIONS_FILE
-        created_at: #{@created_at}
-        ---
-        rubygem0 0.0.1 13q4e0
-        rubygem1 0.0.1 13q4e1
-        rubygem2 0.0.1 13q4e2
-      VERSIONS_FILE
-      assert_equal expected_output, @tmp_versions_file.read
-    end
+    assert_includes content, "foo -1.0.0 v2_yanked_checksum"
+    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), "foo -1.0.0 v2_yanked_checksum"
+    assert_nil RubygemFs.instance.get("versions/versions.list")
   end
 end

--- a/test/unit/update_versions_file_test.rb
+++ b/test/unit/update_versions_file_test.rb
@@ -4,55 +4,119 @@ require "test_helper"
 require "rake"
 
 class UpdateVersionsFileTest < ActiveSupport::TestCase
-  setup do
-    @tmp_versions_file = Tempfile.new("versions_v2.list")
-    @tmp_versions_file.write "created_at: 2015-08-23T17:22:53-07:00\n---\n"
-    @tmp_versions_file.close
+  include RakeTaskHelper
 
-    @original_path = Rails.application.config.rubygems["versions_file_location_v2"]
-    Rails.application.config.rubygems["versions_file_location_v2"] = @tmp_versions_file.path
+  COMPACT_INDEX_VERSION_TESTS = {
+    2 => {
+      config_key: "versions_file_location_v2",
+      rake_task: "compact_index_v2:update_versions_file",
+      store_key: "versions/versions_v2.list",
+      absent_store_keys: ["versions/versions.list"],
+      checksum_column: :info_checksum_v2,
+      yanked_checksum_column: :yanked_info_checksum_v2
+    }
+  }.freeze
+
+  setup do
+    @tmp_versions_files = {}
+    @original_paths = {}
+
+    COMPACT_INDEX_VERSION_TESTS.each do |version, config|
+      tmp_versions_file = Tempfile.new("versions_v#{version}.list")
+      tmp_versions_file.write "created_at: 2015-08-23T17:22:53-07:00\n---\n"
+      tmp_versions_file.close
+
+      @tmp_versions_files[version] = tmp_versions_file
+      @original_paths[config.fetch(:config_key)] = Rails.application.config.rubygems[config.fetch(:config_key)]
+      Rails.application.config.rubygems[config.fetch(:config_key)] = tmp_versions_file.path
+    end
+
+    cleanup_compact_index_files
     setup_rake_tasks("compact_index_v2.rake", "compact_index.rake")
   end
 
   teardown do
-    Rake::Task["compact_index:update_versions_file"].reenable
-    Rake::Task["compact_index_v2:update_versions_file"].reenable
-    Rails.application.config.rubygems["versions_file_location_v2"] = @original_path
-    @tmp_versions_file.unlink
+    COMPACT_INDEX_VERSION_TESTS.each_value do |config|
+      Rails.application.config.rubygems[config.fetch(:config_key)] = @original_paths.fetch(config.fetch(:config_key))
+    end
+    cleanup_compact_index_files
+    @tmp_versions_files.each_value(&:unlink)
   end
 
-  should "delegate the default compact index versions file task to v2" do
-    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
+  COMPACT_INDEX_VERSION_TESTS.each do |version, config|
+    should "update compact index v#{version} versions file" do
+      rubygem = create(:rubygem, name: "foo")
+      create(:version,
+        rubygem:,
+        number: "1.0.0",
+        created_at: 1.minute.ago,
+        config.fetch(:checksum_column) => "v#{version}_checksum")
 
-    rubygem = create(:rubygem, name: "foo")
-    create(:version, rubygem:, number: "1.0.0", info_checksum_v2: "v2_checksum")
+      Rake::Task[config.fetch(:rake_task)].invoke
 
-    Rake::Task["compact_index:update_versions_file"].invoke
+      content = File.read(@tmp_versions_files.fetch(version).path)
 
-    content = File.read(@tmp_versions_file.path)
+      assert_includes content, "foo 1.0.0 v#{version}_checksum"
+      assert_includes RubygemFs.instance.get(config.fetch(:store_key)), "foo 1.0.0 v#{version}_checksum"
+      config.fetch(:absent_store_keys).each do |store_key|
+        assert_nil RubygemFs.instance.get(store_key)
+      end
+    end
 
-    assert_includes content, "foo 1.0.0 v2_checksum"
-    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), "foo 1.0.0 v2_checksum"
-    assert_nil RubygemFs.instance.get("versions/versions.list")
+    should "use compact index v#{version} yanked checksum for latest yanked version" do
+      rubygem = create(:rubygem, name: "foo")
+      create(:version,
+        rubygem:,
+        number: "1.0.0",
+        created_at: 2.minutes.ago,
+        config.fetch(:checksum_column) => "v#{version}_checksum")
+      create(:version,
+        :yanked,
+        rubygem:,
+        number: "1.0.1",
+        created_at: 90.seconds.ago,
+        yanked_at: 1.minute.ago,
+        config.fetch(:checksum_column) => "v#{version}_checksum",
+        config.fetch(:yanked_checksum_column) => "v#{version}_yanked_checksum")
+
+      Rake::Task[config.fetch(:rake_task)].invoke
+
+      content = File.read(@tmp_versions_files.fetch(version).path)
+
+      assert_includes content, "foo 1.0.0 v#{version}_yanked_checksum"
+      assert_includes RubygemFs.instance.get(config.fetch(:store_key)), "foo 1.0.0 v#{version}_yanked_checksum"
+      config.fetch(:absent_store_keys).each do |store_key|
+        assert_nil RubygemFs.instance.get(store_key)
+      end
+    end
   end
 
-  should "use yanked_info_checksum_v2 for yanked versions" do
-    RubygemFs.instance.remove("versions/versions.list", "versions/versions_v2.list")
-
+  should "delegate the default compact index versions file task to the current version" do
+    current_version = GemInfo::CURRENT_VERSION
+    config = COMPACT_INDEX_VERSION_TESTS.fetch(current_version)
     rubygem = create(:rubygem, name: "foo")
     create(:version,
-      :yanked,
       rubygem:,
       number: "1.0.0",
-      info_checksum_v2: "v2_checksum",
-      yanked_info_checksum_v2: "v2_yanked_checksum")
+      created_at: 1.minute.ago,
+      config.fetch(:checksum_column) => "current_checksum")
 
     Rake::Task["compact_index:update_versions_file"].invoke
 
-    content = File.read(@tmp_versions_file.path)
+    content = File.read(@tmp_versions_files.fetch(current_version).path)
 
-    assert_includes content, "foo -1.0.0 v2_yanked_checksum"
-    assert_includes RubygemFs.instance.get("versions/versions_v2.list"), "foo -1.0.0 v2_yanked_checksum"
-    assert_nil RubygemFs.instance.get("versions/versions.list")
+    assert_includes content, "foo 1.0.0 current_checksum"
+    assert_includes RubygemFs.instance.get(config.fetch(:store_key)), "foo 1.0.0 current_checksum"
+    config.fetch(:absent_store_keys).each do |store_key|
+      assert_nil RubygemFs.instance.get(store_key)
+    end
+  end
+
+  private
+
+  def cleanup_compact_index_files
+    RubygemFs.instance.remove(*COMPACT_INDEX_VERSION_TESTS.values.flat_map do |config|
+      [config.fetch(:store_key), *config.fetch(:absent_store_keys)]
+    end.uniq)
   end
 end


### PR DESCRIPTION
Closing in favour of #6631 

## What

This PR removes compact index v1 runtime support and makes compact index v2 the only active serving/generation path.

It updates the compact index controller, jobs, rake tasks, deploy config, admin views, maintenance helpers, and tests to use v2-only behavior. It also stops writing legacy v1 compact index files and checksum data, and marks the legacy checksum columns as ignored before a later column-removal PR.

## Why

Compact index v2 has been rolled out and validated, so we no longer need to keep the v1 serving fallback, dual-write paths, or v1 checksum maintenance code around.

Removing the v1 runtime paths reduces production complexity, avoids keeping stale format logic alive, and prepares the app for safely removing the legacy checksum columns in a follow-up migration.