### PR TITLE
Switch Version#to_bundler to use optimistic versioning

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -387,16 +387,16 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def to_bundler(locked_version: false)
     if prerelease?
-      modifier = locked_version ? "" : "~> "
+      modifier = locked_version ? "" : ">= "
       %(gem '#{rubygem.name}', '#{modifier}#{number}')
     elsif number[0] == "0"
-      %(gem '#{rubygem.name}', '~> #{number}')
+      %(gem '#{rubygem.name}', '>= #{number}')
     else
       release = feature_release
       if release == Gem::Version.new(number)
-        %(gem '#{rubygem.name}', '~> #{release}')
+        %(gem '#{rubygem.name}', '>= #{release}')
       else
-        %(gem '#{rubygem.name}', '~> #{release}', '>= #{number}')
+        %(gem '#{rubygem.name}', '>= #{number}')
       end
     end
   end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -565,7 +565,7 @@ class VersionTest < ActiveSupport::TestCase
         patched_version = build(:version, number: "1.0.3")
         name = patched_version.rubygem.name
         actual = patched_version.to_bundler
-        expected = %(gem '#{name}', '~> 1.0', '>= 1.0.3')
+        expected = %(gem '#{name}', '>= 1.0.3')
 
         assert_equal expected, actual
       end
@@ -574,7 +574,7 @@ class VersionTest < ActiveSupport::TestCase
         no_bugfix = build(:version, number: "1.0")
         name = no_bugfix.rubygem.name
         actual = no_bugfix.to_bundler
-        expected = %(gem '#{name}', '~> 1.0')
+        expected = %(gem '#{name}', '>= 1.0')
 
         assert_equal expected, actual
       end
@@ -583,7 +583,7 @@ class VersionTest < ActiveSupport::TestCase
         long_version = build(:version, number: "1.0.0.0")
         name = long_version.rubygem.name
         actual = long_version.to_bundler
-        expected = %(gem '#{name}', '~> 1.0')
+        expected = %(gem '#{name}', '>= 1.0')
 
         assert_equal expected, actual
       end
@@ -592,7 +592,7 @@ class VersionTest < ActiveSupport::TestCase
         long_version = build(:version, number: "1.0.3.0")
         name = long_version.rubygem.name
         actual = long_version.to_bundler
-        expected = %(gem '#{name}', '~> 1.0', '>= 1.0.3.0')
+        expected = %(gem '#{name}', '>= 1.0.3.0')
 
         assert_equal expected, actual
       end
@@ -601,7 +601,7 @@ class VersionTest < ActiveSupport::TestCase
         early_version = build(:version, number: "0.1.2")
         name = early_version.rubygem.name
         actual = early_version.to_bundler
-        expected = %(gem '#{name}', '~> 0.1.2')
+        expected = %(gem '#{name}', '>= 0.1.2')
 
         assert_equal expected, actual
       end
@@ -610,7 +610,7 @@ class VersionTest < ActiveSupport::TestCase
         prerelease_version = create(:version, number: "4.0.0.pre")
         name = prerelease_version.rubygem.name
         actual = prerelease_version.to_bundler
-        expected = %(gem '#{name}', '~> 4.0.0.pre')
+        expected = %(gem '#{name}', '>= 4.0.0.pre')
 
         assert_equal expected, actual
       end


### PR DESCRIPTION
At the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default. This changes the version on the gem show page to use optimistic versioning, to encourage optimistic versioning instead of pessimistic versioning.