### PR TITLE
[codex] Update security bounty policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,6 @@ We deeply appreciate any effort to discover and disclose security vulnerabilitie
 
 For any security bug or issue with the RubyGems client or RubyGems.org service, please email security@rubygems.org with details about the problem or submit a report using [HackerOne](https://hackerone.com/rubygems).
 
+RubyGems no longer offers monetary rewards for bug bounty reports.
+
 For additional information about RubyGems security, please see https://rubygems.org/pages/security.

--- a/app/views/pages/security.html.erb
+++ b/app/views/pages/security.html.erb
@@ -23,9 +23,7 @@
       RubyGems.org service, please email <a href="mailto:security@rubygems.org">
         security@rubygems.org</a> with details about the problem or submit a report
       using <a href="https://hackerone.com/rubygems">HackerOne</a>.
-      The <a href="https://github.com/rubygems/rubygems">RubyGems</a> client library
-      is in scope for bounty reward. You can read the details of the bounty
-      program on the <a href="https://hackerone.com/rubygems">RubyGems HackerOne page</a>.
+      RubyGems no longer offers monetary rewards for bug bounty reports.
     </strong>
   </p>
 
@@ -34,7 +32,6 @@
       If you find a compromised or malicious gem, please consider it as a security issue:
       please email <a href="mailto:security@rubygems.org">security@rubygems.org</a> with
       the gem name or submit a report using <a href="https://hackerone.com/rubygems">HackerOne</a>.
-      Note that it is not in scope for bounty reward.
     </strong>
   </p>
 


### PR DESCRIPTION
## What changed

- State that RubyGems no longer offers monetary rewards for bug bounty reports in `SECURITY.md`.
- Update the public security page to remove the old bounty reward scope language and use the same current policy language.

## Why

RubyGems is no longer offering monetary rewards for bug bounty programs, so the policy and website copy should not imply reward eligibility.

## Validation

- `git diff --check`

`bin/herb analyze app/views/pages/security.html.erb` could not run in this checkout because the bundle is not installed locally.