### PR TITLE
Redesign: Add profiles/:user shows dashboard layout

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,7 +14,7 @@ class ProfilesController < ApplicationController
   def show
     @user = User.confirmed.find_by_slug!(params[:id])
     return render_not_found unless @user
-    @rubygems = @user.rubygems_downloaded.includes(%i[most_recent_version gem_download]).strict_loading
+    @rubygems = @user.rubygems_downloaded.includes(%i[latest_version most_recent_version gem_download]).strict_loading
     add_breadcrumb @user.display_handle
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,10 +9,13 @@ class ProfilesController < ApplicationController
   before_action :verify_password, only: %i[update destroy]
   before_action :disable_cache, only: :edit
 
+  layout "subject", only: :show
+
   def show
     @user = User.confirmed.find_by_slug!(params[:id])
     return render_not_found unless @user
-    @rubygems = @user.rubygems_downloaded.includes(%i[latest_version gem_download]).strict_loading
+    @rubygems = @user.rubygems_downloaded.includes(%i[most_recent_version gem_download]).strict_loading
+    add_breadcrumb @user.display_handle
   end
 
   def me

--- a/app/views/profiles/_subject.html.erb
+++ b/app/views/profiles/_subject.html.erb
@@ -1,0 +1,52 @@
+<%# locals: (user:) -%>
+
+<div class="mb-8 space-y-4">
+  <div class="flex flex-wrap lg:flex-col items-start mb-6 lg:mb-10">
+    <%= avatar 328, "profile_gravatar", user, theme: :dark, class: "h-24 w-24 lg:h-40 lg:w-40 rounded-lg object-cover mr-4" %>
+
+    <div class="lg:w-full lg:mt-2">
+      <h2 class="font-bold text-h4"><%= user.display_handle %></h2>
+      <% if user.full_name.present? %>
+        <p class="text-neutral-500 text-b3"><%= user.full_name %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <% if user.public_email? || user == current_user %>
+    <div class="flex items-center mb-4 text-b3 lg:text-b2">
+      <%= icon_tag("mail", color: :primary, class: "h-6 w-6 text-orange mr-3") %>
+      <p class="text-neutral-800 dark:text-white"><%= mail_to(user.email, encode: "hex") %></p>
+    </div>
+  <% end %>
+
+  <% if user.twitter_username.present? %>
+    <div class="flex items-center mb-4 text-b3 lg:text-b2">
+      <%= icon_tag("x-twitter", color: :primary, class: "w-6 text-orange mr-3") %>
+      <p class="text-neutral-800 dark:text-white"><%= link_to(twitter_username(user), twitter_url(user)) %></p>
+    </div>
+  <% end %>
+
+  <% if user == current_user %>
+    <div class="flex items-center mb-4 text-b3 lg:text-b2">
+      <%= icon_tag("account-box", color: :primary, class: "h-6 w-6 text-orange mr-3") %>
+      <%= link_to t("profiles.show.edit_profile"), edit_profile_path, id: "edit-profile", class: "text-neutral-800 dark:text-white" %>
+    </div>
+    <div class="flex items-center mb-4 text-b3 lg:text-b2">
+      <%= icon_tag("settings", color: :primary, class: "h-6 w-6 text-orange mr-3") %>
+      <%= link_to t("layouts.application.header.settings"), edit_settings_path, id: "edit-settings", class: "text-neutral-800 dark:text-white" %>
+    </div>
+  <% end %>
+</div>
+
+<hr class="hidden lg:block lg:mb-6 border-neutral-400 dark:border-neutral-600" />
+
+<dl class="flex lg:flex-col gap-8 lg:gap-4">
+  <div>
+    <dt class="text-b4 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"><%= t("stats.index.total_gems") %></dt>
+    <dd class="text-h4 font-semibold text-neutral-900 dark:text-white"><%= number_with_delimiter(user.total_rubygems_count) %></dd>
+  </div>
+  <div>
+    <dt class="text-b4 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"><%= t("total_downloads") %></dt>
+    <dd class="text-h4 font-semibold text-neutral-900 dark:text-white"><%= number_with_delimiter(user.total_downloads_count) %></dd>
+  </div>
+</dl>

--- a/app/views/profiles/_subject.html.erb
+++ b/app/views/profiles/_subject.html.erb
@@ -15,7 +15,7 @@
   <% if user.public_email? || user == current_user %>
     <div class="flex items-center mb-4 text-b3 lg:text-b2">
       <%= icon_tag("mail", color: :primary, class: "h-6 w-6 text-orange mr-3") %>
-      <p class="text-neutral-800 dark:text-white"><%= mail_to(user.email, encode: "hex") %></p>
+      <p class="text-neutral-800 dark:text-white"><%= mail_to(user.email, t("profiles.show.email_me"), encode: "hex") %></p>
     </div>
   <% end %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -19,18 +19,19 @@
   <% else %>
     <%= c.divided_list do %>
       <% @rubygems.each do |rubygem| %>
+        <% version = rubygem.latest_version || rubygem.most_recent_version %>
         <%= c.list_item_to(
           rubygem_path(rubygem.slug),
-          title: short_info(rubygem.most_recent_version),
+          title: short_info(version),
         ) do %>
           <div class="flex flex-col w-full justify-between">
             <div class="flex flex-row w-full items-center justify-between">
               <h4 class="text-b1 flex"><%= rubygem.name %></h4>
-              <%= version_number(rubygem.most_recent_version) %>
+              <span data-testid="rubygem-version"><%= version_number(version) %></span>
             </div>
             <div class="flex flex-row w-full items-center justify-between">
-              <%= download_count_component(rubygem, class: "flex") %>
-              <div class="flex text-neutral-600"><%= version_date_component(rubygem.most_recent_version) %></div>
+              <%= download_count_component(rubygem, class: "flex", data: { testid: "rubygem-downloads" }) %>
+              <div class="flex text-neutral-600"><%= version_date_component(version) %></div>
             </div>
           </div>
         <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,114 +1,40 @@
-<% @title_for_header_only = t('.title', username: @user.display_id) %>
+<% @title = t(".title", username: @user.display_id) %>
 
-<% content_for :title do %>
-  <header class="profile__header">
-    <div class="profile__header__name-wrap">
-      <div id="avatar-frame">
-        <%= avatar(300, 'profile_gravatar', @user, class: 'profile__header__avatar') %>
-      </div>
-
-      <% if @user.full_name.present? %>
-        <h1 id="profile-full-name" class="profile__header__name t-display-full-name">
-          <%= link_to(@user.full_name, profile_path(@user.display_id), class: "t-link--black") %>
-        </h1>
-
-        <h1 id="profile-name" class="profile__header__username t-display-username">
-          <%= link_to(@user.display_handle, profile_path(@user.display_id), class: "t-link--black") %>
-        </h1>
-      <% else %>
-        <h1 id="profile-name" class="profile__header__name t-display">
-          <%=
-            link_to(
-              @user.display_handle, profile_path(@user.display_id),
-              class: "t-link--black"
-            )
-          %>
-        </h1>
-      <% end %>
-
-      <% if @user == current_user %>
-        <div id="profile-settings">
-          <%=
-            link_to(
-              t("layouts.application.header.settings"),
-              edit_settings_path,
-              id: "edit-settings",
-              class: "profile__header__attribute t-link--black",
-              "data-icon": "★"
-            )
-          %>
-        </div>
-
-        <div id="downloads-ego">
-          <%=
-            link_to(
-              "Edit Profile",
-              edit_profile_path,
-              id: "edit-profile",
-              class: "profile__header__attribute t-link--black",
-              "data-icon": "☺"
-            )
-          %>
-        </div>
-      <% else %>
-        <% if @user.public_email? %>
-          <p id="profile-email">
-            <%=
-              mail_to(
-                @user.email,
-                "Email Me",
-                encode: "hex",
-                class: "profile__header__attribute t-link--black",
-                "data-icon" => "✉"
-              )
-            %>
-          </p>
-        <% end %>
-
-        <% if @user.twitter_username.present? %>
-          <%=
-            image_tag(
-              "/images/x_icon.png",
-              alt: "X icon",
-              class: "profile__header__icon"
-            )
-          %>
-
-          <%=
-            link_to(
-              twitter_username(@user),
-              twitter_url(@user),
-              class: "profile__header__attribute t-link--black"
-            )
-          %>
-        <% end %>
-      <% end %>
-    </div>
-
-    <div class="profile__downloads-wrap">
-      <h4 class="gem__downloads__heading t-text--s">
-        <%= t('stats.index.total_gems') %>
-      </h4>
-
-      <h2 id="profile-gems-count" class="gem__downloads">
-        <%= @user.total_rubygems_count.to_s %>
-      </h2>
-
-      <h4 id="downloads" class="gem__downloads__heading t-text--s">
-        <%= t('total_downloads') %>
-      </h4>
-
-      <h2 id="downloads_count" class="gem__downloads">
-        <%= number_with_delimiter(@user.total_downloads_count) %>
-      </h2>
-    </div>
-  </header>
+<% content_for :subject do %>
+  <%= render "profiles/subject", user: @user %>
 <% end %>
 
-<div id="profile">
-  <div class="profile-list">
-    <ul>
-      <%= render partial: 'rubygem', collection: @rubygems %>
-    </ul>
-  </div>
-</div>
+<!-- Main Content -->
+<h1 class="text-h2 mb-10"><%= t(".title", username: @user.display_handle) %></h1>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title t(".gems"), icon: "gems", count: @user.total_rubygems_count %>
+  <% end %>
+
+  <% if @rubygems.empty? %>
+    <%= prose do %>
+      <i><%= t(".no_gems") %></i>
+    <% end %>
+  <% else %>
+    <%= c.divided_list do %>
+      <% @rubygems.each do |rubygem| %>
+        <%= c.list_item_to(
+          rubygem_path(rubygem.slug),
+          title: short_info(rubygem.most_recent_version),
+        ) do %>
+          <div class="flex flex-col w-full justify-between">
+            <div class="flex flex-row w-full items-center justify-between">
+              <h4 class="text-b1 flex"><%= rubygem.name %></h4>
+              <%= version_number(rubygem.most_recent_version) %>
+            </div>
+            <div class="flex flex-row w-full items-center justify-between">
+              <%= download_count_component(rubygem, class: "flex") %>
+              <div class="flex text-neutral-600"><%= version_date_component(rubygem.most_recent_version) %></div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -829,6 +829,7 @@ de:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -826,6 +826,9 @@ de:
     request_denied:
     show:
       title: Profil von %{username}
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,6 +748,7 @@ en:
       gems: Gems
       no_gems: This user has not pushed any gems yet.
       edit_profile: Edit Profile
+      email_me: Email Me
     security_events:
       title: Security Events
       description_html: "This page shows the security events that have occurred on your account. If you see any suspicious activity, please <a href='mailto:support@rubygems.org'>contact support</a>."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -745,6 +745,9 @@ en:
     request_denied: This request was denied. We could not verify your password.
     show:
       title: Profile of %{username}
+      gems: Gems
+      no_gems: This user has not pushed any gems yet.
+      edit_profile: Edit Profile
     security_events:
       title: Security Events
       description_html: "This page shows the security events that have occurred on your account. If you see any suspicious activity, please <a href='mailto:support@rubygems.org'>contact support</a>."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -836,6 +836,9 @@ es:
     request_denied: La solicitud fue denegada. No pudimos verificar tu contraseña.
     show:
       title: Perfil de %{username}
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -839,6 +839,7 @@ es:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -768,6 +768,9 @@ fr:
       mot de passe.
     show:
       title: Profil de %{username}
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -771,6 +771,7 @@ fr:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -754,6 +754,7 @@ ja:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title: セキュリティ事象
       description_html: |-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -751,6 +751,9 @@ ja:
     request_denied: このリクエストは拒否されました。パスワードを検証できませんでした。
     show:
       title: "%{username} のプロフィール"
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title: セキュリティ事象
       description_html: |-

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -738,6 +738,9 @@ nl:
     request_denied:
     show:
       title: Profiel van %{username}
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -741,6 +741,7 @@ nl:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -749,6 +749,9 @@ pt-BR:
     request_denied:
     show:
       title: Perfil de %{username}
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -752,6 +752,7 @@ pt-BR:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -750,6 +750,7 @@ zh-CN:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -747,6 +747,9 @@ zh-CN:
     request_denied: 请求被驳回，您的密码无法被我们验证通过。
     show:
       title: "%{username} 的个人资料"
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -739,6 +739,9 @@ zh-TW:
     request_denied: 此請求遭拒。我們無法驗證您的密碼。
     show:
       title: "%{username} 的個人檔案"
+      gems:
+      no_gems:
+      edit_profile:
     security_events:
       title:
       description_html:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -742,6 +742,7 @@ zh-TW:
       gems:
       no_gems:
       edit_profile:
+      email_me:
     security_events:
       title:
       description_html:

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -197,11 +197,11 @@ class ProfileTest < ApplicationSystemTestCase
     sign_in
     visit profile_path("nick1")
 
-    downloads = page.all(".gems__gem__downloads__count")
+    downloads = page.all("[data-testid='rubygem-downloads']")
 
-    assert_equal("7\nDOWNLOADS", downloads[0].text)
-    assert_equal("5\nDOWNLOADS", downloads[1].text)
-    assert_equal("2\nDOWNLOADS", downloads[2].text)
+    assert_equal("7", downloads[0].text)
+    assert_equal("5", downloads[1].text)
+    assert_equal("2", downloads[2].text)
   end
 
   test "seeing the latest version when there is a newer previous version" do
@@ -211,7 +211,7 @@ class ProfileTest < ApplicationSystemTestCase
     sign_in
     visit profile_path("nick1")
 
-    version = page.find(".gems__gem__version").text
+    version = page.find("[data-testid='rubygem-version']").text
 
     assert_equal("1.0.1", version)
   end


### PR DESCRIPTION
Why this change is being made:
- We want to match the dashboard design to show the new redesign layout for our /profile/:user path

What were the changes made to support this:
- use the subject layout matching the dashboard layout
- use a new partial for subject
- Add some new translation points

For the current user
<img width="1477" height="1167" alt="image" src="https://github.com/user-attachments/assets/6b6d0ad0-80a9-43ce-8fae-cacd75f3206b" />

For different users 
<img width="1676" height="975" alt="image" src="https://github.com/user-attachments/assets/a6e58962-b868-47fe-9b7e-dad1876a1592" />

<img width="1676" height="975" alt="image" src="https://github.com/user-attachments/assets/2ee31c1b-f97c-4520-ba9a-847ab297ba59" />

