### PR TITLE
Fix business logic events signup tracking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,11 @@ class ApplicationController < ActionController::Base
     set_tag "gemcutter.user.id", current_user.id
 
     trace = Datadog::Tracing.active_trace
-    Datadog::Kit::Identity.set_user(trace, id: current_user.id.to_s) if trace
+    Datadog::Kit::Identity.set_user(
+      trace,
+      id: current_user.id.to_s,
+      login: Digest::SHA256.hexdigest(current_user.handle || current_user.email)
+    ) if trace
   end
 
   rescue_from(ActionController::ParameterMissing) do |e|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,11 +55,12 @@ class ApplicationController < ActionController::Base
     set_tag "gemcutter.user.id", current_user.id
 
     trace = Datadog::Tracing.active_trace
+    return unless trace
     Datadog::Kit::Identity.set_user(
       trace,
       id: current_user.id.to_s,
       login: Digest::SHA256.hexdigest(current_user.handle || current_user.email)
-    ) if trace
+    )
   end
 
   rescue_from(ActionController::ParameterMissing) do |e|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -116,8 +116,11 @@ class SessionsController < Clearance::SessionsController
         rescue Encoding::UndefinedConversionError
           nil
         end
-        login_id = attempted_user&.id&.to_s || Digest::SHA256.hexdigest(who.to_s)
-        Datadog::Kit::AppSec::Events::V2.track_user_login_failure(login_id, attempted_user.present?)
+        login = attempted_user ? (attempted_user.handle || attempted_user.email) : who.to_s
+        metadata = attempted_user ? { "usr.id": attempted_user.id.to_s } : {}
+        Datadog::Kit::AppSec::Events::V2.track_user_login_failure(
+          Digest::SHA256.hexdigest(login), attempted_user.present?, metadata
+        )
         login_failure(status.failure_message)
       end
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -104,7 +104,10 @@ class SessionsController < Clearance::SessionsController
         StatsD.increment "login.success"
         current_user.record_event!(Events::UserEvent::LOGIN_SUCCESS, request:,
           two_factor_method:, two_factor_label:, authentication_method:)
-        Datadog::Kit::AppSec::Events::V2.track_user_login_success(current_user.id.to_s)
+        Datadog::Kit::AppSec::Events::V2.track_user_login_success(
+          Digest::SHA256.hexdigest(current_user.handle || current_user.email),
+          current_user.id.to_s
+        )
         set_login_flash
         redirect_to(url_after_create)
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,9 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     @user.policies_acknowledged_at = Time.zone.now
     if @user.save
-      Datadog::Kit::AppSec::Events.track("users.signup", "usr.id": @user.id.to_s)
+      Datadog::Kit::AppSec::Events.track_signup(
+        user: { id: @user.id.to_s, login: Digest::SHA256.hexdigest(@user.handle || @user.email) }
+      )
       Mailer.email_confirmation(@user).deliver_later
       flash[:notice] = t(".email_sent")
       redirect_back_or_to root_path

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -72,7 +72,7 @@ class DashboardsControllerTest < ActionController::TestCase
         span = with_appsec_trace { get :show, format: "atom" }
 
         assert_equal @user.id.to_s, span.get_tag("usr.id")
-        assert_equal "eed7fe63e132770e8d8049f9272905a4c3e3adc8fcd327ac2fb904c659cbaf0e", span.get_tag("usr.login")
+        assert_match(/eed7fe63e132.*cbaf0e/, span.get_tag("usr.login"))
       end
     end
 

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -62,6 +62,20 @@ class DashboardsControllerTest < ActionController::TestCase
       end
     end
 
+    context "on GET to show with Datadog AppSec" do
+      setup do
+        @user = create(:user, handle: "appsec_dashboard")
+        sign_in_as(@user)
+      end
+
+      should "set hashed usr.login and usr.id tags" do
+        span = with_appsec_trace { get :show, format: "atom" }
+
+        assert_equal @user.id.to_s, span.get_tag("usr.id")
+        assert_equal "eed7fe63e132770e8d8049f9272905a4c3e3adc8fcd327ac2fb904c659cbaf0e", span.get_tag("usr.login")
+      end
+    end
+
     context "On GET to show as an atom feed" do
       setup do
         @subscribed_versions = (1..2).map { |n| create(:version, created_at: n.hours.ago) }

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -224,7 +224,8 @@ class SessionsControllerTest < ActionController::TestCase
           end
 
           assert_equal "true", span.get_tag("appsec.events.users.login.success.track")
-          assert_equal @user.id.to_s, span.get_tag("appsec.events.users.login.success.usr.login")
+          assert_equal "428821350e9691491f616b754cd8315fb86d797ab35d843479e732ef90665324", span.get_tag("appsec.events.users.login.success.usr.login")
+          assert_equal @user.id.to_s, span.get_tag("usr.id")
         end
 
         should "set security device notice" do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -224,7 +224,7 @@ class SessionsControllerTest < ActionController::TestCase
           end
 
           assert_equal "true", span.get_tag("appsec.events.users.login.success.track")
-          assert_equal "428821350e9691491f616b754cd8315fb86d797ab35d843479e732ef90665324", span.get_tag("appsec.events.users.login.success.usr.login")
+          assert_match(/428821350e96.*665324/, span.get_tag("appsec.events.users.login.success.usr.login"))
           assert_equal @user.id.to_s, span.get_tag("usr.id")
         end
 
@@ -331,8 +331,9 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         assert_equal "true", span.get_tag("appsec.events.users.login.failure.track")
-        assert_equal user.id.to_s, span.get_tag("appsec.events.users.login.failure.usr.login")
+        assert_match(/4041d06f2aec.*fb5368/, span.get_tag("appsec.events.users.login.failure.usr.login"))
         assert_equal "true", span.get_tag("appsec.events.users.login.failure.usr.exists")
+        assert_equal user.id.to_s, span.get_tag("appsec.events.users.login.failure.usr.id")
       end
 
       should "track login failure with Datadog AppSec for an unknown user" do
@@ -341,7 +342,7 @@ class SessionsControllerTest < ActionController::TestCase
         end
 
         assert_equal "true", span.get_tag("appsec.events.users.login.failure.track")
-        assert_equal Digest::SHA256.hexdigest("nobody"), span.get_tag("appsec.events.users.login.failure.usr.login")
+        assert_match(/6382b3cc8814.*51462a/, span.get_tag("appsec.events.users.login.failure.usr.login"))
         assert_equal "false", span.get_tag("appsec.events.users.login.failure.usr.exists")
       end
     end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -87,7 +87,7 @@ class UsersControllerTest < ActionController::TestCase
 
         assert_equal "true", span.get_tag("appsec.events.users.signup.track")
         assert_equal user.id.to_s, span.get_tag("usr.id")
-        assert_equal "0c7e6a405862e402eb76a70f8a26fc732d07c32931e9fae9ab1582911d2e8a3b", span.get_tag("appsec.events.users.signup.usr.login")
+        assert_match(/0c7e6a405862.*2e8a3b/, span.get_tag("appsec.events.users.signup.usr.login"))
       end
     end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -86,7 +86,8 @@ class UsersControllerTest < ActionController::TestCase
         user = User.find_by!(email: "foo@bar.com")
 
         assert_equal "true", span.get_tag("appsec.events.users.signup.track")
-        assert_equal user.id.to_s, span.get_tag("appsec.events.users.signup.usr.id")
+        assert_equal user.id.to_s, span.get_tag("usr.id")
+        assert_equal "0c7e6a405862e402eb76a70f8a26fc732d07c32931e9fae9ab1582911d2e8a3b", span.get_tag("appsec.events.users.signup.usr.login")
       end
     end
 


### PR DESCRIPTION
Hey Rubygems, after discussion with @colby-swandale I went through the setup and pick up few low-hanging fruits to better configure AppSec.

**Motivation**

This change will fix signup events to be displayed properly and add the right correlation tags to the login events via distinct login/id values

**Changes**

1. I've adjusted signup tracking to use SDK method instead of `track` method as `track` will not generate necessary tags required by the injection
2. I've supplied most of the calls with a set of 2 distinct values, user `login` and `id`
3. Corresponding tests are updated

**Notes**

The `login` consists of `handle` or `email` and is anonymized ahead of time, even tho tracking mode set to `anon` and SDK will do it for you. But to avoid PII crossing boundary between Rubygems and dd-trace-rb (noticed it in another place), I decided to pick that style. If that was not an intention, I can remove hashing

_P.S this PR is opened for edits, feel free to change it_