### PR TITLE
Make compact index v2 the only served format

### DIFF
--- a/app/controllers/api/compact_index_controller.rb
+++ b/app/controllers/api/compact_index_controller.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class Api::CompactIndexController < Api::BaseController
+  CURRENT_COMPACT_INDEX_VERSION = 2
+
+  # Compact index v1 was decommissioned after the v2 rollout.
+  # Keep only actively served or actively migrating formats in this registry.
   COMPACT_INDEX_VERSIONS = {
-    1 => {
-      info_prefix: "info",
-      versions_file_location_key: "versions_file_location",
-      versions_surrogate_key: "versions"
-    }.freeze,
     2 => {
       info_prefix: "v2/info",
       versions_file_location_key: "versions_file_location_v2",
@@ -45,8 +44,7 @@ class Api::CompactIndexController < Api::BaseController
   private
 
   def compact_index_serving_version
-    # Compact index responses are cached by URL, so this flag must only be toggled globally.
-    @compact_index_serving_version ||= FeatureFlag.enabled?(FeatureFlag::SERVE_COMPACT_INDEX_V2) ? 2 : 1
+    CURRENT_COMPACT_INDEX_VERSION
   end
 
   def compact_index_config

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -2,7 +2,6 @@
 
 class FeatureFlag
   ORGANIZATIONS = :organizations
-  SERVE_COMPACT_INDEX_V2 = :serve_compact_index_v2
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class GemInfo
+  CURRENT_VERSION = 2
+
+  # Compact index v1 was decommissioned after the v2 rollout.
+  # Keep only actively served or actively migrating formats in this registry.
   VERSIONS = {
-    1 => { cache_prefix: "info", stats_prefix: "compact_index.memcached.info", klass: CompactIndex::GemVersion,
-           checksum_column: "info_checksum", yanked_checksum_column: "yanked_info_checksum" },
     2 => { cache_prefix: "info_v2", stats_prefix: "compact_index.memcached.info_v2", klass: CompactIndex::GemVersionV2,
            checksum_column: "info_checksum_v2", yanked_checksum_column: "yanked_info_checksum_v2" }
   }.freeze
@@ -13,7 +15,7 @@ class GemInfo
     @cached = cached
   end
 
-  def compact_index_info(version: 1)
+  def compact_index_info(version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     cache_key = "#{config[:cache_prefix]}/#{@rubygem_name}"
     stats_key = config[:stats_prefix]
@@ -29,7 +31,7 @@ class GemInfo
     end
   end
 
-  def info_checksum(version: 1)
+  def info_checksum(version: CURRENT_VERSION)
     compact_index_info = CompactIndex.info(compute_compact_index_info(version:))
     Digest::MD5.hexdigest(compact_index_info)
   end
@@ -45,7 +47,7 @@ class GemInfo
     names
   end
 
-  def self.compact_index_versions(date, version: 1)
+  def self.compact_index_versions(date, version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     checksum_column = config[:checksum_column]
     yanked_checksum_column = config[:yanked_checksum_column]
@@ -65,7 +67,7 @@ class GemInfo
     map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] })
   end
 
-  def self.compact_index_public_versions(updated_at, version: 1)
+  def self.compact_index_public_versions(updated_at, version: CURRENT_VERSION)
     config = VERSIONS.fetch(version)
     checksum_column = config[:checksum_column]
     yanked_checksum_column = config[:yanked_checksum_column]
@@ -149,7 +151,7 @@ class GemInfo
   end
 
   def fetch_requirements_and_dependencies
-    group_by_columns = "number, platform, sha256, info_checksum, required_ruby_version, required_rubygems_version, versions.created_at"
+    group_by_columns = "number, platform, sha256, info_checksum_v2, required_ruby_version, required_rubygems_version, versions.created_at"
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
 

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -11,50 +11,30 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     Digest::SHA256.base64digest(body)
   end
 
-  def with_compact_index_v2_enabled
-    FeatureFlag.enable_globally(:serve_compact_index_v2)
-    yield
-  ensure
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-  end
-
   setup do
     @rubygem2 = create(:rubygem, name: "gemB")
-    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum: "qw2dwe")
+    @version = create(:version, rubygem: @rubygem2, number: "1.0.0", info_checksum_v2: "v2qw2dwe")
 
-    # another gem
     rubygem = create(:rubygem, name: "gemA")
     dep1 = create(:rubygem, name: "gemA1", indexed: true)
     dep2 = create(:rubygem, name: "gemA2", indexed: true)
 
-    # minimal version
-    create(:version,
-      rubygem: rubygem,
-      number: "1.0.0",
-      info_checksum: "013we2",
-      required_ruby_version: nil)
+    create(:version, rubygem: rubygem, number: "1.0.0", info_checksum_v2: "v2013we2", required_ruby_version: nil)
 
-    # version with deps but no ruby or rubygems requirements
-    version = create(:version,
-      rubygem: rubygem,
-      number: "2.0.0",
-      info_checksum: "1cf94r",
-      required_ruby_version: nil)
+    version = create(:version, rubygem: rubygem, number: "2.0.0", info_checksum_v2: "v21cf94r", required_ruby_version: nil)
     create(:dependency, rubygem: dep1, version: version)
 
-    # version with required ruby and rubygems version
     create(:version,
       rubygem: rubygem,
       number: "1.2.0",
-      info_checksum: "13q4es",
+      info_checksum_v2: "v213q4es",
       required_rubygems_version: ">1.9",
       required_ruby_version: ">= 2.0.0")
 
-    # version with everything
     version = create(:version,
       rubygem: rubygem,
       number: "2.1.0",
-      info_checksum: "e217fz",
+      info_checksum_v2: "v2e217fz",
       required_rubygems_version: ">=2.0")
 
     create(:dependency, rubygem: dep1, version: version)
@@ -94,73 +74,15 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal full_body.byteslice(15..), @response.body
   end
 
-  test "/versions serves v2 checksums when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      file_contents = File.read(Rails.application.config.rubygems["versions_file_location_v2"])
-
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-
-      get versions_path
-
-      assert_response :success
-      assert_match file_contents, @response.body
-      assert_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/versions partial response uses v2 response body when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-      get versions_path
-      full_response_body = @response.body
-      expected_digest = digest(full_response_body)
-      byte_offset = full_response_body.bytesize / 2
-
-      get versions_path, env: { range: "bytes=#{byte_offset}-" }
-
-      assert_response :partial_content
-      assert_equal full_response_body.byteslice(byte_offset..), @response.body
-      assert_equal etag(full_response_body), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-      assert_includes full_response_body, "gemB 1.0.0 v2qw2dwe"
-    end
-  end
-
-  test "/versions serves v1 checksums when compact index v2 flag is disabled" do
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-
-    @version.update!(info_checksum: "qw2dwe", info_checksum_v2: "v2qw2dwe")
-
-    versions_file_location = Rails.application.config.rubygems["versions_file_location"]
-    file_contents = File.read(versions_file_location)
+  test "/versions serves current v2 checksums" do
+    file_contents = File.read(Rails.application.config.rubygems["versions_file_location_v2"])
 
     get versions_path
 
     assert_response :success
     assert_match file_contents, @response.body
-    assert_match(/gemB 1.0.0 qw2dwe/, @response.body)
-    assert_no_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
-    assert_equal "versions", @response.headers["Surrogate-Key"]
-  end
-
-  test "/versions includes pre-built file and new gems" do
-    versions_file_location = Rails.application.config.rubygems["versions_file_location"]
-    file_contents = File.read(versions_file_location)
-    gem_a_match = "gemA 1.0.0 013we2\ngemA 2.0.0 1cf94r\ngemA 1.2.0 13q4es\ngemA 2.1.0 e217fz\n"
-    gem_b_match = "gemB 1.0.0 qw2dwe\n"
-
-    get versions_path
-    expected_digest = digest(@response.body)
-
-    assert_response :success
-    assert_match file_contents, @response.body
-    assert_match(/#{gem_b_match}#{gem_a_match}/, @response.body)
-    assert_equal etag(@response.body), @response.headers["ETag"]
-    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_match(/gemB 1.0.0 v2qw2dwe/, @response.body)
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/versions partial response" do
@@ -176,211 +98,86 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal etag(full_response_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/versions updates on gem yank" do
     Deletion.create!(version: @version, user: create(:user))
 
     get versions_path
-    full_response_body = @response.body
-    expected_digest = digest(full_response_body)
 
-    assert_includes full_response_body, "gemB -1.0.0 6105347ebb9825ac754615ca55ff3b0c"
-
-    byte_offset = full_response_body.bytesize / 2
-
-    get versions_path, env: { range: "bytes=#{byte_offset}-" }
-
-    assert_equal etag(full_response_body), @response.headers["ETag"]
-    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-    assert_equal full_response_body.byteslice(byte_offset..), @response.body
-  end
-
-  test "/versions updates on gem yank when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      @version.update!(info_checksum_v2: "v2qw2dwe")
-      Deletion.create!(version: @version, user: create(:user))
-
-      get versions_path
-
-      assert_response :success
-      assert_includes @response.body, "gemB -1.0.0 #{@version.reload.yanked_info_checksum_v2}"
-      assert_equal "v2/versions", @response.headers["Surrogate-Key"]
-    end
+    assert_response :success
+    assert_includes @response.body, "gemB -1.0.0 #{@version.reload.yanked_info_checksum_v2}"
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
   end
 
   test "/version has surrogate key header" do
     get versions_path
 
-    assert_equal "versions", @response.headers["Surrogate-Key"]
+    assert_equal "v2/versions", @response.headers["Surrogate-Key"]
     assert_equal "max-age=3600, stale-while-revalidate=1800, stale-if-error=1800", @response.headers["Surrogate-Control"]
   end
 
-  test "/info serves v2 format when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      rubygem = create(:rubygem, name: "v2gem")
-      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-      expected = <<~VERSIONS_FILE
-        ---
-        1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
-      VERSIONS_FILE
-
-      expected_digest = digest(expected)
-
-      get info_path(gem_name: "v2gem")
-
-      assert_response :success
-      assert_equal expected, @response.body
-      assert_equal etag(expected), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/info/* gem/v2gem v2/info/v2gem", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info partial response when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      rubygem = create(:rubygem, name: "v2partial")
-      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-      full_body = <<~VERSIONS_FILE
-        ---
-        1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
-      VERSIONS_FILE
-      byte_offset = full_body.bytesize / 2
-      expected_digest = digest(full_body)
-
-      get info_path(gem_name: "v2partial"), env: { range: "bytes=#{byte_offset}-" }
-
-      assert_response :partial_content
-      assert_equal full_body.byteslice(byte_offset..), @response.body
-      assert_equal etag(full_body), @response.headers["ETag"]
-      assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
-      assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-      assert_equal "v2/info/* gem/v2partial v2/info/v2partial", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info v2 cache expires on gem yank" do
-    with_compact_index_v2_enabled do
-      travel_to(Time.utc(2026, 5, 31, 12, 0, 0)) do
-        rubygem = create(:rubygem, name: "v2yank")
-        version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-        get info_path(gem_name: "v2yank")
-
-        assert_response :success
-        assert_includes @response.body, "1.0.0"
-
-        Deletion.create!(version:, user: create(:user))
-
-        get info_path(gem_name: "v2yank")
-
-        assert_response :success
-        assert_not_includes @response.body, "1.0.0"
-        assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
-      end
-    end
-  end
-
-  test "/info serves v1 format when compact index v2 flag is disabled" do
-    FeatureFlag.disable_globally(:serve_compact_index_v2)
-
-    rubygem = create(:rubygem, name: "v1gem")
+  test "/info serves current v2 format" do
+    rubygem = create(:rubygem, name: "v2gem")
     version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
 
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
     VERSIONS_FILE
 
-    get info_path(gem_name: "v1gem")
-
-    assert_response :success
-    assert_equal expected, @response.body
-    assert_equal "info/* gem/v1gem info/v1gem", @response.headers["Surrogate-Key"]
-  end
-
-  test "/info does not return not modified for v1 validators after v2 flag is enabled" do
-    rubygem = create(:rubygem, name: "conditionalv2")
-    version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
-
-    get info_path(gem_name: "conditionalv2")
-
-    assert_response :success
-    v1_etag = @response.headers["ETag"]
-
-    with_compact_index_v2_enabled do
-      get info_path(gem_name: "conditionalv2"), headers: {
-        "If-Modified-Since" => rubygem.updated_at.httpdate
-      }
-
-      assert_response :success
-      assert_includes @response.body, "created_at:#{version.created_at.utc.iso8601}"
-      assert_not_equal v1_etag, @response.headers["ETag"]
-      assert_equal "v2/info/* gem/conditionalv2 v2/info/conditionalv2", @response.headers["Surrogate-Key"]
-    end
-  end
-
-  test "/info with existing gem" do
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-    VERSIONS_FILE
     expected_digest = digest(expected)
 
-    get info_path(gem_name: "gemA")
+    get info_path(gem_name: "v2gem")
 
     assert_response :success
     assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
-  end
-
-  test "/info has surrogate key header" do
-    get info_path(gem_name: "gemA")
-
-    assert_equal "info/* gem/gemA info/gemA", @response.headers["Surrogate-Key"]
+    assert_equal "v2/info/* gem/v2gem v2/info/v2gem", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      2.0.0 gemA1:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,rubygems:>= 2.6.3
-      1.2.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>1.9
-      2.1.0 gemA1:= 1.0.0,gemA2:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>=2.0
-    VERSIONS_FILE
+    rubygem = create(:rubygem, name: "v2partial")
+    version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
 
-    get info_path(gem_name: "gemA"), env: { range: "bytes=159-" }
+    full_body = <<~VERSIONS_FILE
+      ---
+      1.0.0 |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+    byte_offset = full_body.bytesize / 2
+    expected_digest = digest(full_body)
+
+    get info_path(gem_name: "v2partial"), env: { range: "bytes=#{byte_offset}-" }
 
     assert_response :partial_content
-    assert_equal expected[159..], @response.body
-  end
-
-  test "/info with new gem" do
-    rubygem = create(:rubygem, name: "gemC")
-    version = create(:version, rubygem: rubygem, number: "1.0.0", info_checksum: "65ea0d")
-    create(:dependency, :development, version: version, rubygem: @rubygem2)
-    expected = <<~VERSIONS_FILE
-      ---
-      1.0.0 |checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
-    VERSIONS_FILE
-    expected_digest = digest(expected)
-
-    get info_path(gem_name: "gemC")
-
-    assert_response :success
-    assert_equal(expected, @response.body)
-    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal full_body.byteslice(byte_offset..), @response.body
+    assert_equal etag(full_body), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "v2/info/* gem/v2partial v2/info/v2partial", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info cache expires on gem yank" do
+    travel_to(Time.utc(2026, 5, 31, 12, 0, 0)) do
+      rubygem = create(:rubygem, name: "v2yank")
+      version = create(:version, rubygem:, number: "1.0.0", created_at: Time.utc(2026, 5, 1, 12, 0, 0))
+
+      get info_path(gem_name: "v2yank")
+
+      assert_response :success
+      assert_includes @response.body, "1.0.0"
+
+      Deletion.create!(version:, user: create(:user))
+
+      get info_path(gem_name: "v2yank")
+
+      assert_response :success
+      assert_not_includes @response.body, "1.0.0"
+      assert_equal "v2/info/* gem/v2yank v2/info/v2yank", @response.headers["Surrogate-Key"]
+    end
   end
 
   test "/info with nonexistent gem" do
@@ -392,16 +189,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_includes @response.headers["Cache-Control"], "public"
     assert_match(/max-age=60/, @response.headers["Cache-Control"])
     assert_match(/max-age=600/, @response.headers["Surrogate-Control"])
-    assert_equal "info/404 info/donotexist", @response.headers["Surrogate-Key"]
-  end
-
-  test "/info with nonexistent gem uses v2 surrogate key when compact index v2 flag is enabled" do
-    with_compact_index_v2_enabled do
-      get info_path(gem_name: "donotexist")
-
-      assert_response :not_found
-      assert_equal "v2/info/404 v2/info/donotexist", @response.headers["Surrogate-Key"]
-    end
+    assert_equal "v2/info/404 v2/info/donotexist", @response.headers["Surrogate-Key"]
   end
 
   test "/info with gzip" do
@@ -421,14 +209,14 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
     expected = <<~VERSIONS_FILE
       ---
-      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3
+      1.0.0 aaab:>= 0,aaab:~> 0.2,bbcc:= 1.0.0|checksum:b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78,ruby:>= 2.0.0,rubygems:>= 2.6.3,created_at:#{@version.created_at.utc.iso8601}
     VERSIONS_FILE
     expected_digest = digest(expected)
 
     get info_path(gem_name: "gemB")
 
     assert_response :success
-    assert_equal(expected, @response.body)
+    assert_equal expected, @response.body
     assert_equal etag(expected), @response.headers["ETag"]
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]


### PR DESCRIPTION
### What                                                                                                                               
                                                                                                                                    
 Makes compact index v2 the only served compact index format for the public compact index endpoints.                                
                                                                                                                                    
This removes the compact index v2 serving feature flag and the v1 serving fallback, so /versions, /info/:gem_name, and related compact index responses consistently use the v2 format and v2 surrogate keys.                                                      
                                                                                                                                    
### Why                                                                                                                                
                                                                                                                                    
Compact index v2 has been rolled out and validated, so we no longer need runtime logic for switching between v1 and v2 responses. Removing the serving flag and fallback path simplifies the compact index controller/model behavior and makes the active compact index format explicit before the follow-up cleanup PRs remove v1 generation, file writes, and checksum data.    