### PR TITLE
docs: remove HackerOne bug bounty channel from security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 This issue tracker for bug reports and feature requests only.
 
   * Please open a support ticket by sending mail to support@rubygems.org if your issue is related your rubygems.org account or you need help using the site.
-  * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
+  * Please email security@rubygems.org if you are reporting a security vulnerability.
 --->
 
 <!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 This issue tracker for bug reports and feature requests only.
 
   * Please open a support ticket by sending mail to support@rubygems.org  if your issue is related your rubygems.org account or you need help using the site.
-  * Please submit a report using https://hackerone.com/rubygems if you are reporting a security vulnerability.
+  * Please email security@rubygems.org if you are reporting a security vulnerability.
 --->
 
 ## Is your feature request related to a problem?

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
-For any security bug or issue with the RubyGems client or RubyGems.org service, please email security@rubygems.org with details about the problem or submit a report using [HackerOne](https://hackerone.com/rubygems).
+For any security bug or issue with the RubyGems client or RubyGems.org service, please email security@rubygems.org with details about the problem.
 
 RubyGems no longer offers monetary rewards for bug bounty reports.
 

--- a/app/views/pages/security.html.erb
+++ b/app/views/pages/security.html.erb
@@ -21,8 +21,7 @@
     <strong>
       For any security bug or issue with the RubyGems client or
       RubyGems.org service, please email <a href="mailto:security@rubygems.org">
-        security@rubygems.org</a> with details about the problem or submit a report
-      using <a href="https://hackerone.com/rubygems">HackerOne</a>.
+        security@rubygems.org</a> with details about the problem.
       RubyGems no longer offers monetary rewards for bug bounty reports.
     </strong>
   </p>
@@ -31,7 +30,7 @@
     <strong>
       If you find a compromised or malicious gem, please consider it as a security issue:
       please email <a href="mailto:security@rubygems.org">security@rubygems.org</a> with
-      the gem name or submit a report using <a href="https://hackerone.com/rubygems">HackerOne</a>.
+      the gem name.
     </strong>
   </p>
 

--- a/test/functional/pages_controller_test.rb
+++ b/test/functional/pages_controller_test.rb
@@ -11,6 +11,23 @@ class PagesControllerTest < ActionController::TestCase
     should respond_with :ok
   end
 
+  context "when the security page is requested" do
+    setup do
+      get :show, params: { id: "security" }
+    end
+
+    should respond_with :ok
+
+    should "direct security reports to the security email" do
+      assert_select "a[href='mailto:security@rubygems.org']"
+    end
+
+    should "no longer present HackerOne as a reporting channel" do
+      assert_select "a[href='https://hackerone.com/rubygems']", false
+      assert_no_match(/HackerOne/, @response.body)
+    end
+  end
+
   context "when invalid page is requested" do
     should "error" do
       assert_raises(ActionController::UrlGenerationError) do


### PR DESCRIPTION
## Summary

The Internet Bug Bounty is closing, so RubyGems.org can no longer offer bug bounties through its HackerOne program. This updates the security-reporting instructions to direct reporters to `security@rubygems.org` as the single disclosure channel and removes the HackerOne submission option everywhere it appeared.

Changes:
- `app/views/pages/security.html.erb`: drop the "submit a report using HackerOne" clause from both the general-issue and compromised/malicious-gem report paths, leaving email as the only channel. The existing "no longer offers monetary rewards" note is retained.
- `SECURITY.md`: remove the HackerOne link from the GitHub security-policy entry point, which links back to this page.
- `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`: point security-vulnerability reporters to `security@rubygems.org` instead of HackerOne.

## Why this matters

The security policy page (and the other official reporting surfaces) still send vulnerability reporters to a HackerOne program that is being retired. Leaving these in place would route reporters to a channel that no longer accepts submissions, leaving the security-reporting instructions inconsistent across the page, `SECURITY.md`, and the issue templates. See #6575.

## Testing

Added functional coverage in `test/functional/pages_controller_test.rb` asserting that `GET /pages/security` returns 200, still surfaces the `security@rubygems.org` mailto, and no longer presents HackerOne as a reporting channel.

Fixes #6575
