### PR TITLE
Compact index v1 drop columns

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,8 +5,6 @@ require "digest/sha2"
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
 
-  self.ignored_columns += %w[info_checksum yanked_info_checksum]
-
   belongs_to :rubygem, touch: true
   has_many :dependencies, lambda {
                             order(Rubygem.arel_table["name"].asc).includes(:rubygem).references(:rubygem)

--- a/db/migrate/20260617144510_remove_info_checksum_v1_columns_from_versions.rb
+++ b/db/migrate/20260617144510_remove_info_checksum_v1_columns_from_versions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemoveInfoChecksumV1ColumnsFromVersions < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      change_table :versions, bulk: true do |t|
+        t.remove :info_checksum, type: :string
+        t.remove :yanked_info_checksum, type: :string
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_144510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -700,7 +700,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.string "gem_full_name"
     t.string "gem_platform"
     t.boolean "indexed", default: true
-    t.string "info_checksum"
     t.string "info_checksum_v2"
     t.boolean "latest"
     t.string "licenses"
@@ -721,7 +720,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.text "summary"
     t.datetime "updated_at", precision: nil
     t.datetime "yanked_at", precision: nil
-    t.string "yanked_info_checksum"
     t.string "yanked_info_checksum_v2"
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"


### PR DESCRIPTION
## What

- References: https://github.com/rubygems/rubygems.org/issues/6572

Drops the legacy `info_checksum` and `yanked_info_checksum` columns from the `versions` table now that they're no longer referenced by application code.

This PR is stacked on top of #6631 and **must merge after** it.

## Changes

- New migration `RemoveInfoChecksumV1ColumnsFromVersions` (`db/migrate/20260617144510_*`) — uses `change_table` with `bulk: true` and `safety_assured` to drop both columns in a single `ALTER TABLE` statement.
- Removes the `self.ignored_columns += %w[info_checksum yanked_info_checksum]` line from `Version` — no longer needed once the columns are gone.
- Regenerates `db/schema.rb`.

## Why

The compact index v1 cleanup (#6631) marked these columns as `ignored_columns` and removed all reads/writes. That deployment makes it safe to drop them at the database level. Removing them reclaims storage and keeps the schema honest about what the app actually uses.
