### PR TITLE
Allow gem owners to bypass typo protection for their own gems

### DIFF
--- a/app/models/gem_typo.rb
+++ b/app/models/gem_typo.rb
@@ -6,19 +6,26 @@ class GemTypo
 
   attr_reader :protected_gem
 
-  def initialize(rubygem_name)
+  def initialize(rubygem_name, pushed_by: nil)
     @rubygem_name = rubygem_name
+    @pushed_by = pushed_by
   end
 
+  # `pushed_by` is the gem's owner for this push (a User or a trusted publisher).
+  # Both respond to `owns_gem?`, matching the ownership check in Pusher#authorize.
   def protected_typo?
     return false if GemTypoException.where("upper(name) = upper(?)", @rubygem_name).any?
 
     return false if published_exact_name_matches.any?
 
-    match = matched_protected_gem_name
-    return false if not_protected?(match)
+    # Only gems that are themselves protected (popular/recent enough) can block a
+    # too-similar push. Allow an author to publish a too-similar name when every
+    # colliding protected gem is one they already own (e.g. a renamed/consolidated
+    # variant of their own gem) -- there is no impersonation risk in that case.
+    protected_match = protected_matches.find { |gem| !owned_by_pusher?(gem) }
+    return false unless protected_match
 
-    @protected_gem = match.name
+    @protected_gem = protected_match.name
     true
   end
 
@@ -28,11 +35,19 @@ class GemTypo
     Rubygem.with_versions.where("upper(name) = upper(?)", @rubygem_name)
   end
 
-  def matched_protected_gem_name
-    Rubygem.with_versions.find_by(
+  def matched_protected_gem_names
+    Rubygem.with_versions.where(
       "regexp_replace(upper(name), '[_-]', '', 'g') = regexp_replace(upper(?), '[_-]', '', 'g')",
       @rubygem_name
     )
+  end
+
+  def protected_matches
+    matched_protected_gem_names.reject { |gem| not_protected?(gem) }
+  end
+
+  def owned_by_pusher?(rubygem)
+    @pushed_by.present? && @pushed_by.owns_gem?(rubygem)
   end
 
   def not_protected?(rubygem)

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -112,6 +112,7 @@ class Pusher
     set_tag "gemcutter.rubygem.name", name
 
     @rubygem = Rubygem.name_is(name).first || Rubygem.new(name: name)
+    @rubygem.pushed_by = owner
 
     sha256 = Digest::SHA2.base64digest(body.string)
     spec_sha256 = Digest::SHA2.base64digest(spec_contents)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -4,6 +4,10 @@ class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
 
+  # The user pushing this gem, when available (set by Pusher). Used to let an
+  # existing owner bypass the typo protection for their own gems. Not persisted.
+  attr_accessor :pushed_by
+
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :rubygem
   has_many :ownerships_including_unconfirmed, dependent: :destroy, class_name: "Ownership"
   has_many :owners, through: :ownerships, source: :user
@@ -412,7 +416,7 @@ class Rubygem < ApplicationRecord
   end
 
   def protected_gem_typo
-    gem_typo = GemTypo.new(name)
+    gem_typo = GemTypo.new(name, pushed_by: pushed_by)
 
     return unless gem_typo.protected_typo?
     errors.add :name, "'#{name}' is too similar to an existing gem named '#{gem_typo.protected_gem}'"

--- a/test/models/gem_typo_test.rb
+++ b/test/models/gem_typo_test.rb
@@ -77,6 +77,42 @@ class GemTypoTest < ActiveSupport::TestCase
     end
   end
 
+  context "the pushing user owns the colliding protected gem" do
+    setup do
+      @owner = create(:user)
+      create(:ownership, rubygem: @existing, user: @owner)
+    end
+
+    should "return false so the owner can publish a too-similar name for their own gem" do
+      gem_typo = GemTypo.new("delayed-job_active_record", pushed_by: @owner)
+
+      refute_predicate gem_typo, :protected_typo?
+    end
+
+    should "still return true for a different user pushing a too-similar name" do
+      other_user = create(:user)
+      gem_typo = GemTypo.new("delayed-job_active_record", pushed_by: other_user)
+
+      assert_predicate gem_typo, :protected_typo?
+    end
+
+    should "still return true when no pushing user is provided" do
+      gem_typo = GemTypo.new("delayed-job_active_record")
+
+      assert_predicate gem_typo, :protected_typo?
+    end
+
+    should "still return true when another protected gem the user does not own also collides" do
+      other_gem = build(:rubygem, name: "delayed-job-active-record")
+      other_gem.save(validate: false)
+      create(:version, rubygem: other_gem, created_at: Time.now.utc)
+
+      gem_typo = GemTypo.new("delayed-job_active_record", pushed_by: @owner)
+
+      assert_predicate gem_typo, :protected_typo?
+    end
+  end
+
   context "gem has less than GemTypo::DOWNLOADS_THRESHOLD downloads" do
     setup do
       @existing.gem_download.update_attribute(:count, 9999)


### PR DESCRIPTION
## Summary

Lets a gem author bypass the "too similar to an existing gem" typo guard when they already own the gem they would be colliding with. Pushing `lowtype` while you own `low_type`, or `low_load` while you own `lowload`, now succeeds. Anyone else pushing a too-similar name is still blocked exactly as before.

The push pipeline already knows who is pushing (`Pusher#owner`, the API-key user or trusted publisher), so this threads that owner into the `protected_gem_typo` validation:

- `Pusher#find` sets a new non-persisted `Rubygem#pushed_by` accessor to `owner`.
- `Rubygem#protected_gem_typo` passes `pushed_by` to `GemTypo`.
- `GemTypo#protected_typo?` skips a colliding protected gem only when `pushed_by.owns_gem?` is true for it. The bypass uses `owns_gem?`, the same ownership check `Pusher#authorize` already uses, so it works for both User and trusted-publisher pushes.

The check now looks at all colliding protected gems, not just one: the bypass applies only when every protected collision is owned by the pusher. If a different, unowned protected gem also collides, the push stays blocked. All other protections (download/recency thresholds, exact-name short-circuit, `GemTypoException`) are unchanged, and when there is no pushing user (`pushed_by` nil) behavior is identical to today.

## Why this matters

Fixes #6484. The reporter owns a family of `low_*` gems and wants to consolidate them by adding/removing `_`/`-` (e.g. renaming `lowload` to `low_load`). There is no rename feature, so they re-publish under the new spelling, but their own existing gem trips the typo guard. Since the name is interchangeable and reserved to them anyway, there is no impersonation risk when the pusher owns the colliding gem.

## Testing

Added cases to `test/models/gem_typo_test.rb`:

- Owner pushing a too-similar name for a gem they own -> `protected_typo?` returns false (push allowed).
- A different user pushing the same name -> still returns true (blocked), confirming the bypass is owner-scoped.
- No pushing user provided -> still returns true (web/anonymous path unchanged).
- Owner owns one colliding gem but another protected gem they do not own also collides -> still returns true (blocked).

Existing `GemTypo` tests continue to pass unchanged.

Fixes #6484
