### PR TITLE
Redesign: Update profile link pages (all the pages on the side in the profile view) 

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -4,11 +4,9 @@ class ApiKeysController < ApplicationController
   before_action :disable_cache, only: :index
   before_action :set_page, only: :index
 
-  # create/update re-render new/edit on validation failure, so they share the layout
   layout "subject", only: %i[index new edit create update]
 
   include ApiKeyable
-
   include SessionVerifiable
 
   verify_session_before

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -4,7 +4,8 @@ class ApiKeysController < ApplicationController
   before_action :disable_cache, only: :index
   before_action :set_page, only: :index
 
-  layout "subject", only: :index
+  # create/update re-render new/edit on validation failure, so they share the layout
+  layout "subject", only: %i[index new edit create update]
 
   include ApiKeyable
 

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -4,6 +4,8 @@ class ApiKeysController < ApplicationController
   before_action :disable_cache, only: :index
   before_action :set_page, only: :index
 
+  layout "subject", only: :index
+
   include ApiKeyable
 
   include SessionVerifiable

--- a/app/controllers/concerns/require_mfa.rb
+++ b/app/controllers/concerns/require_mfa.rb
@@ -21,7 +21,7 @@ module RequireMfa
     @otp_verification_url = otp_verification_url
     setup_webauthn_authentication form_url: webauthn_verification_url
     flash.now.alert = alert if alert
-    render template: "multifactor_auths/prompt", layout: "application", status:
+    render template: "multifactor_auths/prompt", layout: "hammy", status:
   end
 
   def otp_param

--- a/app/controllers/oidc/pending_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/pending_trusted_publishers_controller.rb
@@ -5,12 +5,15 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
 
   before_action :find_pending_trusted_publisher, only: %i[destroy]
 
-  layout "subject", only: :index
+  layout "subject"
 
   def index
     trusted_publishers = policy_scope(OIDC::PendingTrustedPublisher)
       .unexpired.includes(:trusted_publisher)
       .order(:rubygem_name, :created_at).page(@page).strict_loading
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t(".title"))
+
     render OIDC::PendingTrustedPublishers::IndexView.new(
       trusted_publishers:
     )
@@ -18,6 +21,8 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
 
   def new
     pending_trusted_publisher = current_user.oidc_pending_trusted_publishers.new(trusted_publisher: OIDC::TrustedPublisher::GitHubAction.new)
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t(".title"))
     render OIDC::PendingTrustedPublishers::NewView.new(
       pending_trusted_publisher:
     )

--- a/app/controllers/oidc/pending_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/pending_trusted_publishers_controller.rb
@@ -5,6 +5,8 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
 
   before_action :find_pending_trusted_publisher, only: %i[destroy]
 
+  layout "subject", only: :index
+
   def index
     trusted_publishers = policy_scope(OIDC::PendingTrustedPublisher)
       .unexpired.includes(:trusted_publisher)

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -5,7 +5,7 @@ class PasswordsController < ApplicationController
   include RequireMfa
   include WebauthnVerifiable
 
-  layout "hammy", only: %i[edit]
+  layout "hammy"
 
   before_action :ensure_email_present, only: %i[create]
 
@@ -21,6 +21,7 @@ class PasswordsController < ApplicationController
   before_action :validate_password_reset_session, only: :update
 
   def new
+    render :new
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
   before_action :verify_password, only: %i[update destroy]
   before_action :disable_cache, only: :edit
 
-  layout "subject", only: :show
+  layout "subject", only: %i[show edit update]
 
   def show
     @user = User.confirmed.find_by_slug!(params[:id])

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,6 +24,7 @@ class ProfilesController < ApplicationController
 
   def edit
     @user = current_user
+    add_breadcrumb(current_user.handle)
   end
 
   def update

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -130,7 +130,7 @@ class SessionsController < Clearance::SessionsController
 
   def login_failure(message)
     StatsD.increment "login.failure"
-    flash.now.notice = message
+    flash.now.alert = message
     webauthn_new_setup
     render "sessions/new", status: :unauthorized
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,9 @@ class SessionsController < Clearance::SessionsController
   include WebauthnVerifiable
   include SessionVerifiable
 
+  # authenticate/webauthn_authenticate re-render :verify on failure, so they share the layout
+  layout "hammy", only: %i[verify authenticate webauthn_authenticate]
+
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify webauthn_authenticate authenticate]
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: %i[verify webauthn_authenticate authenticate]
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?, only: %i[verify webauthn_authenticate authenticate]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,7 @@ class SessionsController < Clearance::SessionsController
   include WebauthnVerifiable
   include SessionVerifiable
 
-  # authenticate/webauthn_authenticate re-render :verify on failure, so they share the layout
-  layout "hammy", only: %i[verify authenticate webauthn_authenticate]
+  layout "hammy"
 
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify webauthn_authenticate authenticate]
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?, only: %i[verify webauthn_authenticate authenticate]

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -5,6 +5,8 @@ class SettingsController < ApplicationController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :disable_cache
 
+  layout "subject"
+
   def edit
     @user = current_user
     @webauthn_credential = WebauthnCredential.new(user: @user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@
 class UsersController < ApplicationController
   before_action :redirect_to_root, if: :signed_in?
   before_action :reject_disabled_signup, only: :create
+  layout "hammy"
 
   def new
     @user = User.new

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -15,9 +15,11 @@ module ApiKeysHelper
     data[:exclusive_checkbox_target] = exclusive ? "exclusive" : "inclusive"
     data[:gem_scope_target] = "checkbox" if gem_scope
 
-    html_options = { class: "form__checkbox__input", id: api_scope, data: }
+    html_options = { class: CHECKBOX_CLASSES, id: api_scope, data: }
     form.check_box api_scope, html_options, "true", "false"
   end
+
+  CHECKBOX_CLASSES = "h-4 w-4 rounded border-neutral-300 dark:border-neutral-700 text-orange-500 focus:ring-0"
 
   def self.api_key_params(params, existing_api_key = nil)
     scopes = params.fetch(:scopes, existing_api_key&.scopes || []).to_set

--- a/app/views/api_keys/_form.html.erb
+++ b/app/views/api_keys/_form.html.erb
@@ -1,46 +1,68 @@
-<%= form_with model: [:profile, @api_key], data: { controller: "exclusive-checkbox gem-scope" } do |f| %>
-  <%= label_tag :name, t("api_keys.index.name"), class: "form__label" %>
-  <%= f.text_field :name, class: "form__input", autocomplete: :off, disabled: f.object.persisted? %>
+<%
+  label_class = "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  field_class = "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+                "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+                "outline-none focus:border-neutral-500 focus:ring-0 " \
+                "disabled:bg-neutral-100 disabled:text-neutral-500 dark:disabled:bg-neutral-800 dark:disabled:text-neutral-500"
+  check_label = "text-b3 text-neutral-800 dark:text-neutral-200"
+  scope_grid  = "grid grid-cols-1 gap-2 sm:grid-cols-2"
+  submit_btn  = "inline-flex items-center justify-center rounded text-white bg-orange-500 px-4 h-12 min-h-12 " \
+                "text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
+                "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none"
+%>
 
-  <div class="form__group">
-    <%= label_tag :scope, t(".exclusive_scopes"), class: "form__label" %>
-    <% ApiKey::EXCLUSIVE_SCOPES.each do |api_scope| %>
-      <div class = "form__checkbox__item">
-        <%= api_key_checkbox(f, api_scope) %>
-        <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
-      </div>
-    <% end %>
-  </div>
-  <div class="form__group">
-    <%= label_tag :scope, t("api_keys.index.scopes"), class: "form__label" %>
-    <% (ApiKey::API_SCOPES - ApiKey::EXCLUSIVE_SCOPES).each do |api_scope| %>
-      <div class = "form__checkbox__item">
-        <%= api_key_checkbox(f, api_scope) %>
-        <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: "form__checkbox__label" %>
-      </div>
-    <% end %>
+<%= form_with model: [:profile, @api_key], data: { controller: "exclusive-checkbox gem-scope" }, class: "flex flex-col gap-8" do |f| %>
+  <div>
+    <%= f.label :name, t("api_keys.index.name"), class: label_class %>
+    <%= f.text_field :name, class: field_class, autocomplete: :off, disabled: f.object.persisted? %>
   </div>
 
-  <div class="form__group api_key_rubygem_id_form">
-    <%= label_tag :rubygem_id, t(".rubygem_scope"), class: "form__label" %>
-    <p><%= t(".rubygem_scope_info") %></p>
-    <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, selected: :rubygem_id, class: "form__input form__select", data: { gem_scope_target: "selector" } %>
+  <fieldset>
+    <legend class="<%= label_class %>"><%= t(".exclusive_scopes") %></legend>
+    <div class="<%= scope_grid %>">
+      <% ApiKey::EXCLUSIVE_SCOPES.each do |api_scope| %>
+        <div class="flex items-center gap-2">
+          <%= api_key_checkbox(f, api_scope) %>
+          <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: check_label %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend class="<%= label_class %>"><%= t("api_keys.index.scopes") %></legend>
+    <div class="<%= scope_grid %>">
+      <% (ApiKey::API_SCOPES - ApiKey::EXCLUSIVE_SCOPES).each do |api_scope| %>
+        <div class="flex items-center gap-2">
+          <%= api_key_checkbox(f, api_scope) %>
+          <%= label_tag api_scope, t("api_keys.index.#{api_scope}"), class: check_label %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+
+  <div>
+    <%= f.label :rubygem_id, t(".rubygem_scope"), class: label_class %>
+    <p class="mb-2 text-b4 text-neutral-600 dark:text-neutral-400"><%= t(".rubygem_scope_info") %></p>
+    <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, selected: :rubygem_id, class: field_class, data: { gem_scope_target: "selector" } %>
   </div>
 
-  <div class="form__group">
-    <%= label_tag :expires_at, t(".expiration"), class: "form__label" %>
-    <%= f.datetime_field :expires_at, min: 5.minutes.from_now, include_seconds: false, class: "form__input", disabled: f.object.persisted?  %>
+  <div>
+    <%= f.label :expires_at, t(".expiration"), class: label_class %>
+    <%= f.datetime_field :expires_at, min: 5.minutes.from_now, include_seconds: false, class: field_class, disabled: f.object.persisted? %>
   </div>
 
   <% unless current_user.mfa_disabled? || current_user.mfa_ui_and_api? %>
-    <div class="form__group">
-      <%= label_tag :mfa, t(".multifactor_auth"), class: "form__label" %>
-      <div class="form__checkbox__item">
-        <%= f.check_box :mfa, { class: "form__checkbox__input", id: :mfa, checked: true } , "true", "false" %>
-        <%= label_tag :mfa, t(".enable_mfa"), class: "form__checkbox__label" %>
+    <fieldset>
+      <legend class="<%= label_class %>"><%= t(".multifactor_auth") %></legend>
+      <div class="flex items-center gap-2">
+        <%= f.check_box :mfa, { class: ApiKeysHelper::CHECKBOX_CLASSES, id: :mfa, checked: true }, "true", "false" %>
+        <%= label_tag :mfa, t(".enable_mfa"), class: check_label %>
       </div>
-    </div>
+    </fieldset>
   <% end %>
 
-  <%= f.submit class: "form__submit" %>
+  <div>
+    <%= f.submit class: submit_btn %>
+  </div>
 <% end %>

--- a/app/views/api_keys/edit.html.erb
+++ b/app/views/api_keys/edit.html.erb
@@ -1,5 +1,11 @@
 <% @title = t(".edit_api_key") %>
 
-<div class="t-body">
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :settings %>
+<% end %>
+
+<h1 class="text-h2 mb-10"><%= t(".edit_api_key") %></h1>
+
+<%= render CardComponent.new do %>
   <%= render "form", api_key: @api_key %>
-</div>
+<% end %>

--- a/app/views/api_keys/edit.html.erb
+++ b/app/views/api_keys/edit.html.erb
@@ -1,4 +1,5 @@
 <% @title = t(".edit_api_key") %>
+<% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>
   <%= render "dashboards/subject", user: current_user, current: :settings %>

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -1,130 +1,106 @@
 <% @title = t(".api_keys") %>
 
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :settings %>
+<% end %>
+
+<%
+  th_class    = "py-2 pr-4 text-b4 font-semibold text-neutral-900 dark:text-white"
+  cell_class  = "block md:table-cell py-1 md:py-3 pr-4 align-top " \
+                "before:content-[attr(data-title)] before:block before:text-c4 before:font-semibold " \
+                "before:uppercase before:tracking-wide before:text-neutral-500 md:before:content-none"
+  edit_btn    = "inline-flex items-center justify-center rounded border-2 border-orange-500 text-orange-500 " \
+                "px-4 h-9 min-h-9 text-b3 hover:bg-orange-500/5 active:bg-orange-500/10 " \
+                "dark:hover:bg-orange-500/15 dark:active:bg-orange-500/25 transition focus:outline-none"
+  danger_btn  = "inline-flex items-center justify-center rounded border-2 border-red-500 text-red-500 " \
+                "px-4 h-9 min-h-9 text-b3 hover:bg-red-500/5 active:bg-red-500/10 " \
+                "dark:hover:bg-red-500/15 dark:active:bg-red-500/25 transition focus:outline-none"
+%>
+
+<h1 class="text-h2 mb-10"><%= t(".api_keys") %></h1>
+
 <% if @api_key %>
-  <div class="t-body push--bottom-s">
-    <p>
-      <%= t(".save_key") %>
-      <span> <code><%= @api_key %></code> </span>
-    </p>
+  <div class="mb-10 rounded-md border border-green-300 bg-green-50 p-4 text-b3 text-neutral-900 dark:border-green-800 dark:bg-green-900/20 dark:text-white">
+    <p class="mb-2"><%= t(".save_key") %></p>
+    <code class="block break-all rounded bg-neutral-100 px-3 py-2 font-mono text-b3 dark:bg-neutral-800"><%= @api_key %></code>
   </div>
 <% end %>
 
-<header class="gems__header">
-  <p class="gems__meter">
-    <%= page_entries_info @api_keys, entry_name: 'API keys' %>
-  </p>
-</header>
-
-<div class="t-body">
-  <table class="owners__table">
-    <tr class="owners__row owners__header">
-      <th class="owners__cell">
-        <%= t(".name") %>
-      </th>
-      <th class="owners__cell">
-        <%= t(".scopes") %>
-      </th>
-      <th class="owners__cell">
-        <%= t(".gem") %>
-      </th>
-      <th class="owners__cell">
-        <%= t(".age") %>
-      </th>
-      <% if current_user.mfa_enabled? %>
-        <th class="owners__cell">
-          <%= t(".mfa") %>
-        </th>
-      <% end %>
-      <th class="owners__cell">
-        <%= t(".last_access") %>
-      </th>
-      <th class="owners__cell">
-        <%= t(".expiration") %>
-      </th>
-      <th class="owners__cell">
-      </th>
-      <th class="owners__cell">
-      </th>
-    </tr>
-
-    <% for api_key in @api_keys do %>
-      <tr class="owners__row <%= 'owners__row__invalid' if api_key.soft_deleted? %>">
-        <td class="owners__cell" data-title="Name">
-          <%= api_key.name %>
-        </td>
-        <td class="owners__cell" data-title="Scopes">
-          <% api_key.scopes.each do |scope| %>
-            <ul class="scopes__list"><%= t(".#{scope}") %></ul>
-          <% end %>
-        </td>
-        <td class="owners__cell" data-title="Gem">
-          <%= gem_scope(api_key) %>
-        </td>
-        <td class="owners__cell" data-title="Age">
-          <%= time_ago_in_words(api_key.created_at) %>
-        </td>
-        <% if current_user.mfa_enabled? %>
-          <td class="owners__cell" data-title="MFA">
-            <%= image_tag("/images/check.svg") if api_key.mfa? %>
-          </td>
-        <% end %>
-        <td class="owners__cell" data-title="Last access">
-          <%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %>
-        </td>
-        <td class="owners__cell" data-title="Expiration">
-          <%= api_key.expires_at&.strftime("%Y-%m-%d %H:%M %Z") %>
-        </td>
-        <td class="owners__cell">
-          <% unless api_key.soft_deleted? %>
-            <%= button_to t("edit"),
-                        edit_profile_api_key_path(id: api_key.id),
-                        method: :get,
-                        class: "form__submit form__submit--small" %>
-          <% end %>
-        </td>
-        <td class="owners__cell">
-          <%= button_to t(".delete"),
-                      profile_api_key_path(id: api_key.id),
-                      method: :delete,
-                      class: "form__submit form__submit--small",
-                      data: { confirm: t(".confirm")} %>
-        </td>
-      </tr>
-    <% end %>
-
-    <tr class="owners__row">
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <td class="owners__cell">
-      </td>
-      <% if current_user.mfa_enabled? %>
-        <td class="owners__cell">
-        </td>
-      <% end %>
-      <td class="owners__cell">
-        <%= button_to t(".reset"),
-                    reset_profile_api_keys_path,
-                    method: :delete,
-                    class: "form__submit form__submit--small",
-                    data: { confirm: t(".confirm_all")} %>
-      </td>
-    </tr>
-  </table>
-
-  <%= paginate @api_keys %>
-
-  <p><%= button_to t(".new_key"), new_profile_api_key_path, method: "get", class: "form__submit" %></p>
-  <% if current_user.oidc_api_key_roles.any? %>
-    <h2 class="t-display"><%= link_to t("oidc.api_key_roles.index.api_key_roles"), profile_oidc_api_key_roles_path, class: "t-link t-underline" %> →</h2>
+<%= render CardComponent.new do |c| %>
+  <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>
+    <%= c.section_title t(".api_keys"), icon: "settings" %>
   <% end %>
-</div>
+
+  <div class="flex">
+    <div class="grow mt-8 mb-4 pr-4">
+      <p class="text-b4 text-neutral-600 dark:text-neutral-400"><%= page_entries_info @api_keys, entry_name: "API keys" %></p>
+    </div>
+    <div class="flex-initial mt-6 mb-4">
+      <%= button_to t(".reset"), reset_profile_api_keys_path, method: :delete, class: "#{danger_btn} right", data: { confirm: t(".confirm_all") } %>
+    </div>
+  </div>
+
+  <div class="overflow-x-auto">
+    <table class="w-full text-left text-b3">
+      <thead class="hidden md:table-header-group border-b-2 border-neutral-300 dark:border-neutral-700">
+        <tr>
+          <th scope="col" class="<%= th_class %>"><%= t(".name") %></th>
+          <th scope="col" class="<%= th_class %>"><%= t(".scopes") %></th>
+          <th scope="col" class="<%= th_class %>"><%= t(".gem") %></th>
+          <th scope="col" class="<%= th_class %>"><%= t(".age") %></th>
+          <% if current_user.mfa_enabled? %>
+            <th scope="col" class="<%= th_class %>"><%= t(".mfa") %></th>
+          <% end %>
+          <th scope="col" class="<%= th_class %>"><%= t(".last_access") %></th>
+          <th scope="col" class="<%= th_class %>"><%= t(".expiration") %></th>
+          <th scope="col" class="<%= th_class %>"><span class="sr-only"><%= t(".action") %></span></th>
+        </tr>
+      </thead>
+      <tbody class="md:divide-y md:divide-neutral-200 md:dark:divide-neutral-800">
+        <% @api_keys.each do |api_key| %>
+          <tr class="block md:table-row border-b border-neutral-200 py-4 dark:border-neutral-800 md:border-0 md:py-0 <%= "owners__row__invalid opacity-60" if api_key.soft_deleted? %>">
+            <td data-title="<%= t('.name') %>" class="<%= cell_class %> font-medium text-neutral-900 dark:text-white"><%= api_key.name %></td>
+            <td data-title="<%= t('.scopes') %>" class="<%= cell_class %>">
+              <span class="flex flex-wrap gap-1">
+                <% api_key.scopes.each do |scope| %>
+                  <span class="inline-block rounded bg-neutral-100 px-2 py-0.5 text-c4 dark:bg-neutral-800"><%= t(".#{scope}") %></span>
+                <% end %>
+              </span>
+            </td>
+            <td data-title="<%= t('.gem') %>" class="<%= cell_class %>"><%= gem_scope(api_key) %></td>
+            <td data-title="<%= t('.age') %>" class="<%= cell_class %> text-neutral-700 dark:text-neutral-300"><%= time_ago_in_words(api_key.created_at) %></td>
+            <% if current_user.mfa_enabled? %>
+              <td data-title="<%= t('.mfa') %>" class="<%= cell_class %>">
+                <%= icon_tag("check-circle", size: 5, class: "text-green-600 dark:text-green-400") if api_key.mfa? %>
+              </td>
+            <% end %>
+            <td data-title="<%= t('.last_access') %>" class="<%= cell_class %> text-nowrap text-neutral-700 dark:text-neutral-300"><%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %></td>
+            <td data-title="<%= t('.expiration') %>" class="<%= cell_class %> text-nowrap text-neutral-700 dark:text-neutral-300"><%= api_key.expires_at&.strftime("%Y-%m-%d %H:%M %Z") %></td>
+            <td class="block py-2 align-top md:table-cell md:py-3">
+              <div class="flex gap-2">
+                <% unless api_key.soft_deleted? %>
+                  <%= button_to t("edit"), edit_profile_api_key_path(id: api_key.id), method: :get, class: edit_btn %>
+                <% end %>
+                <%= button_to t(".delete"), profile_api_key_path(id: api_key.id), method: :delete, class: danger_btn, data: { confirm: t(".confirm") } %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="mt-4"><%= paginate @api_keys %></div>
+
+  <div class="mt-8 flex flex-wrap items-center gap-4">
+    <%= render ButtonComponent.new(t(".new_key"), new_profile_api_key_path) %>
+  </div>
+
+  <% if current_user.oidc_api_key_roles.any? %>
+    <p class="mt-6">
+      <%= link_to profile_oidc_api_key_roles_path, class: "text-b3 text-orange-700 underline dark:text-orange-400" do %>
+        <%= t("oidc.api_key_roles.index.api_key_roles") %> &rarr;
+      <% end %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -98,7 +98,7 @@
 
   <% if current_user.oidc_api_key_roles.any? %>
     <p class="mt-6">
-      <%= link_to profile_oidc_api_key_roles_path, class: "text-b3 text-orange-700 underline dark:text-orange-400" do %>
+      <%= link_to profile_oidc_api_key_roles_path, class: "text-b3 text-orange-500 underline dark:text-orange-400" do %>
         <%= t("oidc.api_key_roles.index.api_key_roles") %> &rarr;
       <% end %>
     </p>

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -1,4 +1,5 @@
 <% @title = t(".api_keys") %>
+<% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>
   <%= render "dashboards/subject", user: current_user, current: :settings %>

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -1,4 +1,5 @@
 <% @title = t(".new_api_key") %>
+<% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>
   <%= render "dashboards/subject", user: current_user, current: :settings %>

--- a/app/views/api_keys/new.html.erb
+++ b/app/views/api_keys/new.html.erb
@@ -1,5 +1,11 @@
 <% @title = t(".new_api_key") %>
 
-<div class="t-body">
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :settings %>
+<% end %>
+
+<h1 class="text-h2 mb-10"><%= t(".new_api_key") %></h1>
+
+<%= render CardComponent.new do %>
   <%= render "form", api_key: @api_key %>
-</div>
+<% end %>

--- a/app/views/components/button_component.rb
+++ b/app/views/components/button_component.rb
@@ -22,7 +22,8 @@ class ButtonComponent < ApplicationComponent
           "rounded inline-flex border-box " \
           "justify-content-center items-center hover:shadow-md " \
           "#{DISABLED} disabled:cursor-default disabled:hover:shadow-none " \
-          "transition duration-200 ease-in-out focus:outline-none " \
+          "transition duration-200 ease-in-out " \
+          "focus:outline-2 focus:outline-offset-2 " \
           "#{button_color(color, style)} #{button_size(size)} #{options.delete(:class)}"
 
     if type == :link
@@ -41,7 +42,7 @@ class ButtonComponent < ApplicationComponent
     color = color.to_sym
     color = :orange if color == :primary
     color = :hammy if color == :secondary
-    STYLES[style][color]
+    "#{STYLES[style][color]} #{FOCUS_OUTLINE_COLOR[color]}"
   end
 
   def button_size(size)
@@ -55,6 +56,17 @@ class ButtonComponent < ApplicationComponent
 
   DISABLED = "disabled:bg-neutral-200 disabled:border-neutral-200 disabled:text-neutral-600 " \
              "dark:disabled:bg-neutral-800 dark:disabled:border-neutral-800 dark:disabled:text-neutral-600"
+
+  # Focus outline color matches the button's color (used with focus:outline-2 focus:outline-offset-2)
+  FOCUS_OUTLINE_COLOR = {
+    red:     "focus:outline-red-500",
+    orange:  "focus:outline-orange-500",
+    hammy:   "focus:outline-orange-800 dark:focus:outline-orange-200",
+    yellow:  "focus:outline-yellow-500",
+    green:   "focus:outline-green-500",
+    blue:    "focus:outline-blue-500",
+    neutral: "focus:outline-neutral-700 dark:focus:outline-white"
+  }.freeze
 
   FILL_BUTTON_COLOR = {
     red:     "text-white bg-red-500 hover:bg-red-600 active:bg-red-600 " \

--- a/app/views/components/card_component.rb
+++ b/app/views/components/card_component.rb
@@ -19,12 +19,13 @@ class CardComponent < ApplicationComponent
   end
 
   def title(title, icon: nil, count: nil)
-    h3(class: "flex items-center text-lg space-x-2") do
-      render_icon(icon, class: "fill-orange") if icon
-      span(class: "font-semibold") { title }
-      # when count is 0, don't show the count because it's more confusing than helpful
-      span(class: "font-light text-neutral-600") { count } unless count.to_i.zero?
-    end
+    h3(class: TITLE_CLASSES) { title_content(title, icon:, count:) }
+  end
+
+  # Same visual treatment as #title, rendered as an <h2> for cards that are a
+  # top-level section of the page (keeps the heading outline valid under an <h1>).
+  def section_title(title, icon: nil, count: nil)
+    h2(class: TITLE_CLASSES) { title_content(title, icon:, count:) }
   end
 
   def list(**options, &)
@@ -68,9 +69,17 @@ class CardComponent < ApplicationComponent
 
   private
 
+  TITLE_CLASSES = "flex items-center text-lg space-x-2"
   LIST_ITEM_CLASSES = "flex w-full px-4 py-3 " \
                       "items-center md:rounded " \
                       "hover:bg-neutral-100 dark:hover:bg-neutral-800"
+
+  def title_content(title, icon:, count:)
+    render_icon(icon, class: "fill-orange") if icon
+    span(class: "font-semibold") { title }
+    # when count is 0, don't show the count because it's more confusing than helpful
+    span(class: "font-light text-neutral-600") { count } unless count.to_i.zero?
+  end
 
   def render_icon(name, size: 8, **)
     icon_tag(name, size: size, **)

--- a/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/form_component.rb
@@ -17,11 +17,28 @@ class OIDC::TrustedPublisher::GitHubAction::FormComponent < ApplicationComponent
   private
 
   def field(form, type, name, optional: false, **)
-    form.label name, class: "form__label" do
-      plain form.object.class.human_attribute_name(name)
-      span(class: "t-text--s") { " (#{t('form.optional')})" } if optional
+    div class: "py-4" do
+      form.label name, class: label_class do
+        plain form.object.class.human_attribute_name(name)
+        span(class: "t-text--s") { " (#{t('form.optional')})" } if optional
+      end
+      form.send(type, name, class: class_names(field_class, "tw-border tw-border-red-500" => form.object.errors.include?(name)), **)
+      p(class: note_class) { t("oidc.trusted_publisher.github_actions.#{name}_help_html") }
     end
-    form.send(type, name, class: class_names("form__input", "tw-border tw-border-red-500" => form.object.errors.include?(name)), **)
-    p(class: "form__field__instructions") { t("oidc.trusted_publisher.github_actions.#{name}_help_html") }
+  end
+
+  def label_class
+    "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  end
+
+  def field_class
+    "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+      "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+      "outline-none focus:border-neutral-500 focus:ring-0"
+  end
+
+  def note_class
+    "mt-1 text-b4 text-neutral-600 dark:text-neutral-400 " \
+      "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400"
   end
 end

--- a/app/views/components/settings/mfa_status_badge_component.rb
+++ b/app/views/components/settings/mfa_status_badge_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# A small enabled/disabled status pill used by the MFA sections on the settings page.
+class Settings::MfaStatusBadgeComponent < ApplicationComponent
+  def initialize(enabled:)
+    @enabled = enabled
+    super()
+  end
+
+  def view_template
+    span(class: "#{BASE} #{@enabled ? ENABLED : DISABLED}") do
+      @enabled ? t("settings.edit.mfa.enabled") : t("settings.edit.mfa.disabled")
+    end
+  end
+
+  BASE = "inline-flex items-center rounded-full px-3 py-0.5 text-b4 font-semibold"
+  ENABLED = "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200"
+  DISABLED = "bg-neutral-200 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+end

--- a/app/views/dashboards/_subject.html.erb
+++ b/app/views/dashboards/_subject.html.erb
@@ -5,7 +5,9 @@
     <%= avatar 328, "user_gravatar", theme: :dark, class: "h-24 w-24 lg:h-40 lg:w-40 rounded-lg object-cover mr-4" %>
 
     <div class="lg:w-full lg:mt-2">
-      <h2 class="font-bold text-h4"><%= user.display_handle %></h2>
+      <h2 class="font-bold text-h4">
+        <%= link_to user.display_handle, profile_path(user.display_id), class: "hover:underline" %>
+      </h2>
       <% if user.full_name.present? %>
         <p class="text-neutral-500 text-b3"><%= user.full_name %></p>
       <% end %>

--- a/app/views/multifactor_auths/_webauthn_prompt.html.erb
+++ b/app/views/multifactor_auths/_webauthn_prompt.html.erb
@@ -5,8 +5,8 @@
   <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
     <p hidden class="js-webauthn-session--error mb-3 text-b3 text-red-600 dark:text-red-400"></p>
     <%= submit_tag t("multifactor_auths.prompt.sign_in_with_webauthn_credential"),
-      class: "js-webauthn-session--submit inline-flex items-center justify-center rounded text-white bg-orange-500 " \
-      "px-4 h-12 min-h-12 text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
-      "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none" %>
+      class: "js-webauthn-session--submit inline-flex items-center justify-center w-full rounded text-white bg-orange-500 " \
+      "px-4 sm:px-2 min-h-12 text-sm:text-b4 text-lg:text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
+      "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none whitespace-normal" %>
   <% end %>
 </div>

--- a/app/views/multifactor_auths/_webauthn_prompt.html.erb
+++ b/app/views/multifactor_auths/_webauthn_prompt.html.erb
@@ -1,13 +1,12 @@
-<div class="mfa__option">
-  <h2 class="page__subheading--block"> <%= t("multifactor_auths.prompt.security_device") %></h2>
-  <div class="t-body">
-    <p><%= t("multifactor_auths.prompt.webauthn_credential_note") %></p>
-  </div>
-  <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
-    <div class="form_bottom">
-      <p hidden class="l-text-red-600 js-webauthn-session--error"></p>
+<div class="mt-8 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+  <h2 class="text-b1 font-semibold text-neutral-900 dark:text-white mb-2"><%= t("multifactor_auths.prompt.security_device") %></h2>
+  <p class="mb-4 text-b3 text-neutral-700 dark:text-neutral-300"><%= t("multifactor_auths.prompt.webauthn_credential_note") %></p>
 
-      <%= submit_tag t("multifactor_auths.prompt.sign_in_with_webauthn_credential"), class: 'js-webauthn-session--submit form__submit form__submit--no-hover' %>
-    </div>
+  <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session--form", data: { options: @webauthn_options.to_json } do %>
+    <p hidden class="js-webauthn-session--error mb-3 text-b3 text-red-600 dark:text-red-400"></p>
+    <%= submit_tag t("multifactor_auths.prompt.sign_in_with_webauthn_credential"),
+      class: "js-webauthn-session--submit inline-flex items-center justify-center rounded text-white bg-orange-500 " \
+      "px-4 h-12 min-h-12 text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
+      "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none" %>
   <% end %>
 </div>

--- a/app/views/multifactor_auths/_webauthn_prompt.html.erb
+++ b/app/views/multifactor_auths/_webauthn_prompt.html.erb
@@ -7,6 +7,7 @@
     <%= submit_tag t("multifactor_auths.prompt.sign_in_with_webauthn_credential"),
       class: "js-webauthn-session--submit inline-flex items-center justify-center w-full rounded text-white bg-orange-500 " \
       "px-4 sm:px-2 min-h-12 text-sm:text-b4 text-lg:text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
-      "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none whitespace-normal" %>
+      "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition whitespace-normal " \
+      "focus:outline-2 focus:outline-offset-2 focus:outline-orange-500" %>
   <% end %>
 </div>

--- a/app/views/multifactor_auths/prompt.html.erb
+++ b/app/views/multifactor_auths/prompt.html.erb
@@ -1,39 +1,43 @@
 <% @title = t("multifactor_authentication") %>
 
-<div class="mfa__container">
-  <% if @user.webauthn_enabled?%>
-    <%= render "multifactor_auths/webauthn_prompt" %>
-  <% end %>
+<%
+  label_class = "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
+  field_class = "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg " \
+                "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white " \
+                "focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition"
+  submit_class = "inline-flex items-center justify-center rounded text-white bg-orange-500 px-4 h-12 min-h-12 " \
+                 "text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
+                 "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition focus:outline-none"
+%>
 
-  <% if @user.totp_enabled? || @user.webauthn_only_with_recovery? %>
-    <div class="mfa__option">
-      <% if @user.totp_enabled? %>
-        <h2 class="page__subheading--block"> <%= t(".otp_code") %></h2>
-      <% elsif @user.webauthn_only_with_recovery? %>
-        <h2 class="page__subheading--block"> <%= t(".recovery_code") %></h2>
-      <% end %>
-      <div class="t-body">
-        <p><%= t(".recovery_code_html") %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t("multifactor_authentication") %></h1>
+
+    <% if @user.webauthn_enabled? %>
+      <%= render "multifactor_auths/webauthn_prompt" %>
+    <% end %>
+
+    <% if @user.totp_enabled? || @user.webauthn_only_with_recovery? %>
+      <div class="<%= "mt-8 pt-8 border-t border-neutral-200 dark:border-neutral-800" if @user.webauthn_enabled? %>">
+        <h2 class="text-b1 font-semibold text-neutral-900 dark:text-white mb-2">
+          <%= @user.totp_enabled? ? t(".otp_code") : t(".recovery_code") %>
+        </h2>
+        <p class="mb-4 text-b3 text-neutral-700 dark:text-neutral-300"><%= t(".recovery_code_html") %></p>
+
+        <%= form_tag @otp_verification_url, method: :post do %>
+          <div class="mb-6">
+            <% if @user.totp_enabled? %>
+              <%= label_tag :otp, t(".otp_or_recovery"), class: label_class %>
+              <%= text_field_tag :otp, "", class: field_class, autofocus: true, autocomplete: "one-time-code" %>
+            <% else %>
+              <%= label_tag :otp, t(".recovery_code"), class: label_class %>
+              <%= text_field_tag :otp, "", class: field_class, autofocus: true, autocomplete: :off %>
+            <% end %>
+          </div>
+          <%= submit_tag t("authenticate"), data: { disable_with: t("form_disable_with") }, class: submit_class %>
+        <% end %>
       </div>
-      <%= form_tag @otp_verification_url, method: :post do %>
-        <div class="text_field">
-          <% if @user.totp_enabled? %>
-            <%= label_tag :otp, t(".otp_or_recovery"), class: 'form__label' %>
-            <%= text_field_tag :otp, '', class: 'form__input', autofocus: true, autocomplete: "one-time-code" %>
-          <% elsif @user.webauthn_only_with_recovery? %>
-            <%= text_field_tag :otp,
-              '',
-              class: 'form__input',
-              autofocus: true,
-              autocomplete: :off,
-              aria: { label: t(".recovery_code") }
-            %>
-          <% end %>
-        </div>
-        <div class="form_bottom">
-          <%= submit_tag t("authenticate"), data: { disable_with: t("form_disable_with")}, class: "form__submit" %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -9,58 +9,81 @@ class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
   prop :trusted_publishers, reader: :public
 
   def view_template
-    title_content
+    self.title = t(".title")
+    content_for(:subject) { raw(subject_sidebar) } # rubocop:disable Rails/OutputSafety -- trusted Rails partial
 
-    div(class: "tw-space-y-2 t-body") do
-      p do
-        t(".description_html")
+    h1(class: "text-h2 mb-10") { t(".title") }
+
+    p(class: "mb-8 max-w-2xl text-b3 text-neutral-700 dark:text-neutral-300 " \
+             "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400") do
+      raw t(".description_html")
+    end
+
+    div(class: "mb-8") do
+      render ButtonComponent.new(t(".create"), new_profile_oidc_pending_trusted_publisher_path)
+    end
+
+    render CardComponent.new do
+      p(class: "mb-2 text-b4 text-neutral-600 dark:text-neutral-400") { page_entries_info(trusted_publishers) }
+
+      div(class: "divide-y divide-neutral-200 dark:divide-neutral-800") do
+        trusted_publishers.each { |pending_trusted_publisher| publisher_section(pending_trusted_publisher) }
       end
 
-      p do
-        button_to t(".create"), new_profile_oidc_pending_trusted_publisher_path, class: "form__submit", method: :get
-      end
-
-      header(class: "gems__header push--s") do
-        p(class: "gems__meter l-mb-0") { page_entries_info(trusted_publishers) }
-      end
-
-      div(class: "tw-divide-y") do
-        trusted_publishers.each do |pending_trusted_publisher|
-          trusted_publisher_section(pending_trusted_publisher)
-        end
-      end
-
-      paginate(trusted_publishers)
+      div(class: "mt-4") { paginate(trusted_publishers) }
     end
   end
 
-  def title_content
-    self.title_for_header_only = t(".title")
-    content_for :title do
-      h1(class: "t-display page__heading page__heading-small") do
-        plain t(".title")
-      end
-    end
+  private
+
+  DANGER_BTN = "inline-flex items-center justify-center rounded border-2 border-red-500 text-red-500 " \
+               "px-4 h-9 min-h-9 text-b3 hover:bg-red-500/5 active:bg-red-500/10 " \
+               "dark:hover:bg-red-500/15 dark:active:bg-red-500/25 transition focus:outline-none"
+
+  def subject_sidebar
+    view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :settings })
   end
 
-  def trusted_publisher_section(pending_trusted_publisher)
-    div(class: "tw-border-solid tw-my-4 tw-space-y-2 tw-flex tw-flex-col") do
-      div(class: "sm:tw-flex sm:tw-flex-row tw-gap-4 tw-mt-2") do
-        h3(class: "!tw-mb-0") { pending_trusted_publisher.rubygem_name }
+  def publisher_section(pending_trusted_publisher)
+    div(class: "py-6 first:pt-0 last:pb-0") do
+      div(class: "flex flex-wrap items-center justify-between gap-3") do
+        h2(class: "text-b1 font-semibold text-neutral-900 dark:text-white") { pending_trusted_publisher.rubygem_name }
         button_to(t(".delete"), profile_oidc_pending_trusted_publisher_path(pending_trusted_publisher),
-          method: :delete, class: "form__submit form__submit--small")
+          method: :delete, class: DANGER_BTN)
       end
 
-      div(class: "sm:tw-flex sm:tw-flex-row tw-gap-4") do
-        p(class: "!tw-mb-0") { pending_trusted_publisher.trusted_publisher.class.publisher_name }
-        p(class: "!tw-mb-0") do
-          raw t(".valid_for_html",
-            time_html: view_context.time_tag(pending_trusted_publisher.expires_at,
-view_context.distance_of_time_in_words_to_now(pending_trusted_publisher.expires_at)))
-        end
+      p(class: "mt-1 text-b3 text-neutral-700 dark:text-neutral-300") do
+        plain pending_trusted_publisher.trusted_publisher.class.publisher_name
+        whitespace
+        plain "·"
+        whitespace
+        raw t(".valid_for_html",
+          time_html: view_context.time_tag(pending_trusted_publisher.expires_at,
+            view_context.distance_of_time_in_words_to_now(pending_trusted_publisher.expires_at)))
       end
 
-      render pending_trusted_publisher.trusted_publisher
+      publisher_details(pending_trusted_publisher.trusted_publisher)
+    end
+  end
+
+  # Rendered inline (rather than the shared tw-prefixed TableComponent) so the
+  # details are styled under the new hammy layout. GitHub Actions is currently
+  # the only trusted publisher type.
+  def publisher_details(github_action)
+    dl(class: "mt-4 grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2") do
+      detail_row("GitHub Repository", github_action.repository)
+      detail_row("Workflow Filename", github_action.workflow_filename)
+      detail_row("Workflow Repository", github_action.workflow_repository) if github_action.workflow_repository_owner.present?
+      detail_row("Environment", github_action.environment) if github_action.environment?
+    end
+  end
+
+  def detail_row(label, value)
+    div do
+      dt(class: "text-b4 font-semibold text-neutral-800 dark:text-neutral-200") { label }
+      dd(class: "mt-0.5 break-all") do
+        code(class: "font-mono text-c4 text-neutral-900 dark:text-white") { value }
+      end
     end
   end
 end

--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -1,35 +1,67 @@
 # frozen_string_literal: true
 
 class OIDC::PendingTrustedPublishers::NewView < ApplicationView
-  include Phlex::Rails::Helpers::LinkTo
-  include Phlex::Rails::Helpers::SelectTag
-  include Phlex::Rails::Helpers::OptionsForSelect
+  include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::FormWith
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::OptionsForSelect
+  include Phlex::Rails::Helpers::SelectTag
 
   prop :pending_trusted_publisher, reader: :public
 
   def view_template
     self.title = t(".title")
+    content_for(:subject) { raw(subject_sidebar) } # rubocop:disable Rails/OutputSafety -- trusted Rails partial
 
-    div(class: "t-body") do
+    h1(class: "text-h2 mb-10") { t(".title") }
+
+    render CardComponent.new do
       form_with(
         model: pending_trusted_publisher,
         url: profile_oidc_pending_trusted_publishers_path
       ) do |f|
-        f.label :rubygem_name, class: "form__label"
-        f.text_field :rubygem_name, class: "form__input", autocomplete: :off
-        p(class: "form__field__instructions") { t("oidc.trusted_publisher.pending.rubygem_name_help_html") }
+        div class: "py-4" do
+          f.label :rubygem_name, class: label_class
+          f.text_field :rubygem_name, class: field_class, autocomplete: :off
+          p(class: note_class) { t("oidc.trusted_publisher.pending.rubygem_name_help_html") }
+        end
 
-        f.label :trusted_publisher_type, class: "form__label"
-        f.select :trusted_publisher_type, OIDC::TrustedPublisher.all.map { |type|
-                                            [type.publisher_name, type.polymorphic_name]
-                                          }, {}, class: "form__input form__select"
+        div class: "py-4" do
+          f.label :trusted_publisher_type, class: label_class
+          f.select :trusted_publisher_type,
+            OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
+            {}
+        end
 
         render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
           github_action_form: f
         )
-        f.submit class: "form__submit"
+
+        render ButtonComponent.new do
+          f.submit
+        end
       end
     end
+  end
+
+  private
+
+  def label_class
+    "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  end
+
+  def field_class
+    "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+      "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+      "outline-none focus:border-neutral-500 focus:ring-0"
+  end
+
+  def note_class
+    "mt-1 text-b4 text-neutral-600 dark:text-neutral-400 " \
+      "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400"
+  end
+
+  def subject_sidebar
+    view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :settings })
   end
 end

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,3 +1,7 @@
-<div id="clearance" class="password-reset">
-  <p><%= t(".success") %></p>
+<div class="flex items-center justify-center">
+  <div class="w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10 password-reset" id="clearance">
+    <p class="text-sm font-semibold text-neutral-900 dark:text-white">
+      <%= t(".success") %>
+    </p>
+  </div>
 </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,15 +1,25 @@
 <% @title = t('.title') %>
+<% add_breadcrumb @title %>
 
-<div class="t-body">
-  <p><%= t '.will_email_notice' %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6">
+      <%= t('.title') %>
+    </h1>
+    <div class="mb-4">
+      <p><%= t '.will_email_notice' %></p>
+    </div>
+
+    <%= form_for :password, url: password_path do |form| %>
+      <div class="mb-6">
+        <%= form.label :email, t('activerecord.attributes.user.email'),
+          class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+        <%= form.email_field :email, :size => '25',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+      </div>
+      <div class="submit_field">
+        <%= render ButtonComponent.new(t(".submit"), type: :submit, color: :primary) %>
+      </div>
+    <% end %>
+  </div>
 </div>
-
-<%= form_for :password, url: password_path do |form| %>
-  <div class="text_field">
-    <%= form.label :email, t('activerecord.attributes.user.email'), :class => 'form__label' %>
-    <%= form.email_field :email, :size => '25', :class => 'form__input' %>
-  </div>
-  <div class="submit_field">
-    <%= form.submit t('.submit'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
-  </div>
-<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,87 +1,95 @@
 <% @title = t('.title') %>
 
-<%= form_for @user, :url => {:controller => 'profiles', :action => 'update'} do |form| %>
-  <%= error_messages_for(@user) %>
-
-  <div class="avatar_field">
-    <%= form.label :avatar, :class => 'form__label'  %>
-    <div class="l-overflow">
-      <%= avatar(160) %>
-      <% if @user.public_email? %>
-        <%= link_to t('.change_avatar'), 'https://www.gravatar.com', :class => 't-text t-link' %>
-      <% else %>
-        <%= content_tag 'i', t('.disabled_avatar_html'), :class => 't-text' %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="text_field">
-    <%= form.label :handle, :class => 'form__label' %>
-    <%= form.text_field :handle, :class => 'form__input' %>
-  </div>
-
-  <div class="text_field">
-    <%= form.label :twitter_username, class: 'form__label form__label__icon-container' do %>
-      <%=
-        image_tag("/images/x_icon.png", alt: 'X icon', class: 'form__label__icon')
-      %>
-
-      <span class='form__label__text'><%= t('.twitter_username') %></span>
-    <% end %>
-
-    <p class='form__field__instructions'>
-      <%= t('.optional_twitter_username') %>
-    </p>
-
-    <div class="form__input__addon-container form__input__addon-left">
-      <span class="form__input__addon">@</span>
-      <%= form.text_field(:twitter_username, class: 'form__input') %>
-    </div>
-  </div>
-
-  <% if current_user.unconfirmed_email %>
-    <div class="push--bottom-s">
-      <p class='form__field__instructions'>
-        <%= t('.email_awaiting_confirmation', unconfirmed_email: current_user.unconfirmed_email) %>
-      </p>
-      <%= link_to "Resend confirmation", unconfirmed_email_confirmations_path, method: :patch, class: 'form__field__instructions t-link' %>
-    </div>
-  <% end %>
-
-  <div class="text_field">
-    <%= form.label :email, :class => 'form__label' %>
-    <%= form.email_field :email, name: 'user[unconfirmed_email]', class: 'form__input' %>
-  </div>
-
-  <div class="text_field">
-    <%= form.label :full_name, :class => 'form__label' %>
-    <p class='form__field__instructions'>
-      <%= t('.optional_full_name') %>
-    </p>
-    <%= form.text_field :full_name, :class => 'form__input' %>
-  </div>
-
-  <div class="password_field">
-    <%= form.label :password, t("activerecord.attributes.user.password"), :class => 'form__label' %>
-    <p class='form__field__instructions'>
-      <%= t('.enter_password') %>
-    </p>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input', required: true %>
-  </div>
-
-
-  <div class="profile-checkbox form__checkbox">
-    <%= form.check_box :public_email, :class => 'form__checkbox__input' %>
-    <%= form.label :public_email, t('profiles.public_email'), :class => 'form__checkbox__label' %>
-  </div>
-
-  <div class="submit_field">
-    <%= form.submit t("update"), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
-  </div>
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :profile %>
 <% end %>
 
-<div class="t-body">
-  <h2><%= t '.delete.delete_profile' %></h2>
-  <p><%= t '.delete.warning' %></p>
-  <%= button_to t('.delete.delete'), delete_profile_path, method: 'get', class: 'form__submit' %>
-</div>
+<%
+  label_class = "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  field_class = "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+                "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+                "outline-none focus:border-neutral-500 focus:ring-0"
+  note_class  = "mt-1 text-b4 text-neutral-600 dark:text-neutral-400 " \
+                "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400"
+  link_class  = "text-b4 text-orange-700 underline dark:text-orange-400"
+%>
+
+<h1 class="text-h2 mb-10"><%= t('.title') %></h1>
+
+<%= render CardComponent.new do %>
+  <%= form_for @user, url: { controller: 'profiles', action: 'update' }, html: { class: "flex flex-col gap-6" } do |form| %>
+    <%= error_messages_for(@user) %>
+
+    <div>
+      <%= form.label :avatar, class: label_class %>
+      <div class="flex items-center gap-4">
+        <%= avatar(160, "profile_avatar", class: "h-20 w-20 rounded-lg object-cover", alt: @user.display_handle) %>
+        <% if @user.public_email? %>
+          <%= link_to t('.change_avatar'), 'https://www.gravatar.com', class: link_class %>
+        <% else %>
+          <p class="<%= note_class %> mt-0"><%= t('.disabled_avatar_html') %></p>
+        <% end %>
+      </div>
+    </div>
+
+    <div>
+      <%= form.label :handle, class: label_class %>
+      <%= form.text_field :handle, class: field_class %>
+    </div>
+
+    <div>
+      <%= form.label :twitter_username, class: "#{label_class} flex items-center gap-2" do %>
+        <%= icon_tag "x-twitter", size: 4 %>
+        <span><%= t('.twitter_username') %></span>
+      <% end %>
+      <p class="<%= note_class %> mb-2"><%= t('.optional_twitter_username') %></p>
+      <div class="flex">
+        <span class="inline-flex items-center px-3 rounded-l border border-r-0 border-neutral-300 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">@</span>
+        <%= form.text_field :twitter_username, class: "#{field_class} rounded-l-none" %>
+      </div>
+    </div>
+
+    <% if current_user.unconfirmed_email %>
+      <div>
+        <p class="<%= note_class %> mt-0"><%= t('.email_awaiting_confirmation', unconfirmed_email: current_user.unconfirmed_email) %></p>
+        <%= link_to "Resend confirmation", unconfirmed_email_confirmations_path, method: :patch, class: link_class %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= form.label :email, class: label_class %>
+      <%= form.email_field :email, name: 'user[unconfirmed_email]', class: field_class %>
+    </div>
+
+    <div>
+      <%= form.label :full_name, class: label_class %>
+      <p class="<%= note_class %> mb-2"><%= t('.optional_full_name') %></p>
+      <%= form.text_field :full_name, class: field_class %>
+    </div>
+
+    <div>
+      <%= form.label :password, t("activerecord.attributes.user.password"), class: label_class %>
+      <p class="<%= note_class %> mb-2"><%= t('.enter_password') %></p>
+      <%= form.password_field :password, autocomplete: 'current-password', class: field_class, required: true %>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <%= form.check_box :public_email, class: "h-4 w-4 rounded border-neutral-300 dark:border-neutral-700 text-orange-500 focus:ring-0" %>
+      <%= form.label :public_email, t('profiles.public_email'), class: "text-b3 text-neutral-800 dark:text-neutral-200" %>
+    </div>
+
+    <div>
+      <%= render ButtonComponent.new(t("update"), type: :submit, data: { disable_with: t('form_disable_with') }) %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>
+    <%= c.section_title t('.delete.delete_profile') %>
+  <% end %>
+  <p class="mt-6 text-b3 text-neutral-700 dark:text-neutral-300"><%= t('.delete.warning') %></p>
+  <div class="mt-6">
+    <%= render ButtonComponent.new(t('.delete.delete'), delete_profile_path, color: :red, style: :outline) %>
+  </div>
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,38 +1,48 @@
 <% @title = t('sign_in') %>
+<% add_breadcrumb @title %>
 
-<% if Gemcutter::ENABLE_DEVELOPMENT_LOG_IN %>
-<div class="t-body">
-  <h2 class="page__subheading--block">Development Login</h2>
-  <ul>
-    <% User.all.order(id: :asc).each do |user| %>
-    <li>
-      <%= link_to "login as #{user.handle}", controller: :sessions, action: "development_log_in_as", user_id: user.id %>
-    </li>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t(".title") %></h1>
+    <% if Gemcutter::ENABLE_DEVELOPMENT_LOG_IN %>
+      <div class="mb-8">
+      <ul>
+        <% User.all.order(id: :asc).each do |user| %>
+          <li>
+            <span class="text-b3 text-orange-500 underline dark:text-orange-400">
+              <%= link_to "login as #{user.handle}", controller: :sessions, action: "development_log_in_as", user_id: user.id %>
+            </span>
+          </li>
+        <% end %>
+      </ul>
+      </div>
     <% end %>
-  </ul>
-  <hr/>
+
+    <div class="mb-8">
+      <div>
+        <%= link_to t('.forgot_password'), new_password_path, class: "text-b3 text-orange-500 underline dark:text-orange-400"%>
+      </div>
+      <div>
+        <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: "text-b3 text-orange-500 underline dark:text-orange-400"%>
+      </div>
+    </div>
+
+    <%= form_for :session, :url => session_path do |form| %>
+    <div class="mb-8">
+      <%= form.label :who, t('activerecord.attributes.session.who'),
+        class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+      <%= form.text_field :who, :autofocus => true,
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition mb-2" %>
+      <%= form.label :password, t('activerecord.attributes.session.password'),
+        class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+      <%= form.password_field :password, autocomplete: 'current-password',
+        class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+
+    </div>
+      <%= render ButtonComponent.new(t(".confirm"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
+    <% end %>
+
+    <%= render "multifactor_auths/webauthn_prompt" %>
+
+  </div>
 </div>
-<% end %>
-
-<div class="t-body">
-  <p>
-    <%= link_to t('.forgot_password'), new_password_path, class: 't-list__item' %>
-    <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: 't-list__item' %>
-  </p>
-</div>
-
-<%= form_for :session, :url => session_path do |form| %>
-  <div class="text_field">
-    <%= form.label :who, t('activerecord.attributes.session.who'), :class => 'form__label' %>
-    <%= form.text_field :who, :autofocus => true, :class => 'form__input' %>
-  </div>
-  <div class="password_field">
-    <%= form.label :password, t('activerecord.attributes.session.password'), :class => 'form__label' %>
-    <%= form.password_field :password, autocomplete: 'current-password', class: 'form__input' %>
-  </div>
-  <div class="form_bottom">
-    <%= form.submit t('sign_in'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
-  </div>
-<% end %>
-
-<%= render "multifactor_auths/webauthn_prompt" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <%= form_for :session, :url => session_path do |form| %>
+    <%= form_for :session, url: session_path do |form| %>
     <div class="mb-8">
       <%= form.label :who, t('activerecord.attributes.session.who'),
         class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
@@ -39,7 +39,7 @@
         class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
 
     </div>
-      <%= render ButtonComponent.new(t(".confirm"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
+      <%= render ButtonComponent.new(t(".sign_in"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
     <% end %>
 
     <%= render "multifactor_auths/webauthn_prompt" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -39,7 +39,7 @@
         class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
 
     </div>
-      <%= render ButtonComponent.new(t(".sign_in"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
+      <%= render ButtonComponent.new(t("sign_in"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
     <% end %>
 
     <%= render "multifactor_auths/webauthn_prompt" %>

--- a/app/views/sessions/verify.html.erb
+++ b/app/views/sessions/verify.html.erb
@@ -10,18 +10,16 @@
     <%= form_for :verify_password, url: authenticate_session_path, method: :post do |form| %>
       <div class="mb-8">
         <%= form.label :password, t("activerecord.attributes.session.password"),
-              class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+          class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
         <%= form.password_field :password, autocomplete: "current-password",
-              class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
       </div>
 
       <%= render ButtonComponent.new(t(".confirm"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
     <% end %>
 
     <% if @user.webauthn_enabled? %>
-      <div class="mt-8 pt-8 border-t border-neutral-200 dark:border-neutral-800">
         <%= render "multifactor_auths/webauthn_prompt" %>
-      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/sessions/verify.html.erb
+++ b/app/views/sessions/verify.html.erb
@@ -1,18 +1,27 @@
 <% @title = t(".title") %>
+<% add_breadcrumb @title %>
 
-<div class="t-body">
-  <p><%= t(".notice") %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t(".title") %></h1>
+
+    <p class="mb-6 text-b3 text-neutral-700 dark:text-neutral-300"><%= t(".notice") %></p>
+
+    <%= form_for :verify_password, url: authenticate_session_path, method: :post do |form| %>
+      <div class="mb-8">
+        <%= form.label :password, t("activerecord.attributes.session.password"),
+              class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+        <%= form.password_field :password, autocomplete: "current-password",
+              class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+      </div>
+
+      <%= render ButtonComponent.new(t(".confirm"), type: :submit, color: :primary, data: { disable_with: t("form_disable_with") }) %>
+    <% end %>
+
+    <% if @user.webauthn_enabled? %>
+      <div class="mt-8 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+        <%= render "multifactor_auths/webauthn_prompt" %>
+      </div>
+    <% end %>
+  </div>
 </div>
-
-<%= form_for :verify_password, url: authenticate_session_path, method: :post do |form| %>
-  <div class="password_field">
-    <%= form.label :password, t("activerecord.attributes.session.password"), class: "form__label" %>
-    <%= form.password_field :password, autocomplete: "current-password", class: "form__input" %>
-  </div>
-  <div class="form_bottom">
-    <%= form.submit t(".confirm"), data: {disable_with: t("form_disable_with")}, class: "form__submit" %>
-  </div>
-<% end %>
-<% if @user.webauthn_enabled?%>
-    <%= render "multifactor_auths/webauthn_prompt" %>
-<% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -24,12 +24,12 @@
 
   <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
     <% if @user.mfa_enabled? %>
-      <section class="py-8">
+      <section class="py-4">
         <h3 class="<%= sub_heading %> pt-8"><%= t(".mfa.level.title") %></h3>
         <p class="<%= note_class %>"><%= t(".mfa.level_html") %></p>
 
         <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit",
-              class: "mt-4 flex flex-col gap-4 sm:flex-row sm:items-end" do %>
+              class: "my-4 flex flex-col gap-4 sm:flex-row sm:items-end" do %>
           <div class="flex-1">
             <%= label_tag :level, t(".mfa.level.title"), class: "sr-only" %>
             <%= select_tag :level, options_for_select(@mfa_options, @user.mfa_level), class: field_class %>
@@ -39,7 +39,7 @@
       </section>
     <% end %>
 
-    <section class="py-8">
+    <section class="py-4">
       <div class="flex items-center gap-3">
         <h3 class="<%= sub_heading %>"><%= t(".webauthn_credentials") %></h3>
         <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.webauthn_enabled?) %>
@@ -54,7 +54,9 @@
         </ul>
       <% end %>
 
-      <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
+      <div class="pb-4">
+        <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
+      </div>
     </section>
 
     <section class="py-8 first:pt-0 last:pb-0">

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,87 +1,112 @@
 <% @title = t(".title") %>
 
-<div class="t-body">
-  <h2 class="page__subheading"><%= t ".mfa.multifactor_auth" %></h2>
-  <% if @user.mfa_enabled? %>
-    <div class="mfa__header-wrapper">
-      <h2 class="mfa__header mfa__header--compact"><%= t(".mfa.level.title")%></h2>
-    </div>
-    <p><%= t(".mfa.level_html") %></p>
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :settings %>
+<% end %>
 
-    <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
-      <%= select_tag :level, options_for_select(@mfa_options, @user.mfa_level), class: "form__input form__select" %>
+<%# TODO, ¿Should these exist in a component somewhere? %>
+<%
+  sub_heading = "text-b2 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"
+  note_class  = "mt-2 text-b3 text-neutral-700 dark:text-neutral-300 " \
+                "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400"
+  label_class = "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  field_class = "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+                "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+                "outline-none focus:border-neutral-500 focus:ring-0"
+%>
 
-      <%= submit_tag t(".mfa.update"), class: "form__submit" %>
-    <% end %>
+<h1 class="text-h2 mb-10"><%= t(".title") %></h1>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>
+    <%= c.section_title t(".mfa.multifactor_auth"), icon: "settings" %>
   <% end %>
 
-  <div class="mfa__header-wrapper">
-    <h2 class="mfa__header mfa__header--compact"><%= t(".webauthn_credentials") %></h2>
-    <% if @user.webauthn_enabled? %>
-      <span class="badge badge--success"><%= t(".mfa.enabled") %></span>
-    <% else %>
-      <span class="badge badge--warning"><%= t(".mfa.disabled") %></span>
+  <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
+    <% if @user.mfa_enabled? %>
+      <section class="py-8 first:pt-0">
+        <h3 class="<%= sub_heading %> pt-8"><%= t(".mfa.level.title") %></h3>
+        <p class="<%= note_class %>"><%= t(".mfa.level_html") %></p>
+
+        <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit",
+              class: "mt-4 flex flex-col gap-4 sm:flex-row sm:items-end" do %>
+          <div class="flex-1">
+            <%= label_tag :level, t(".mfa.level.title"), class: "sr-only" %>
+            <%= select_tag :level, options_for_select(@mfa_options, @user.mfa_level), class: field_class %>
+          </div>
+          <%= render ButtonComponent.new(t(".mfa.update"), type: :submit) %>
+        <% end %>
+      </section>
     <% end %>
-  </div>
 
-  <p><%= t(".webauthn_credential_note")%></p>
-
-  <% if @user.webauthn_credentials.none? %>
-    <p><i><%= t(".no_webauthn_credentials") %></i></p>
-  <% else %>
-    <div class="l-mb-8">
-      <%= render @user.webauthn_credentials %>
-    </div>
-  <% end %>
-
-  <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
-
-  <% if @user.totp_enabled? %>
-    <div class="mfa__header-wrapper">
-      <h2 class="mfa__header mfa__header--compact"><%= t(".mfa.otp") %></h2>
-      <span class="badge badge--success"><%= t(".mfa.enabled") %></span>
-    </div>
-    <p><%= t(".mfa.enabled_note") %></p>
-    <%= form_tag totp_path, method: :delete, id: "mfa-delete" do %>
-      <div class="text_field">
-        <%= label_tag :otp, t(".otp_code"), class: "form__label" %>
-        <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>
+    <section class="py-8 first:pt-0">
+      <div class="flex items-center gap-3">
+        <h3 class="<%= sub_heading %>"><%= t(".webauthn_credentials") %></h3>
+        <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.webauthn_enabled?) %>
       </div>
-      <%= submit_tag t(".mfa.disable"), class: "form__submit" %>
-    <% end %>
-  <% else %>
-    <div class="mfa__header-wrapper">
-      <h2 class="mfa__header mfa__header--compact"><%= t(".mfa.otp") %></h2>
-      <span class="badge badge--warning"><%= t(".mfa.disabled") %></span>
-    </div>
-    <p>
-      <%= t(".mfa.disabled_html") %>
-      <%= button_to t(".mfa.go_settings"), new_totp_path, method: "get", class: "form__submit" %>
-    </p>
-  <% end %>
-</div>
+      <p class="<%= note_class %>"><%= t(".webauthn_credential_note") %></p>
 
-<div class="t-body">
-  <h2><%= link_to t('.reset_password.title'), new_password_path %></h2>
-</div>
+      <% if @user.webauthn_credentials.none? %>
+        <p class="mt-4 text-b3 italic text-neutral-600 dark:text-neutral-400"><%= t(".no_webauthn_credentials") %></p>
+      <% else %>
+        <ul class="mt-4 divide-y divide-neutral-200 dark:divide-neutral-800 border-y border-neutral-200 dark:border-neutral-800">
+          <%= render @user.webauthn_credentials %>
+        </ul>
+      <% end %>
 
-<div class="t-body">
-  <h2><%= link_to t('api_keys.index.api_keys'), profile_api_keys_path %></h2>
-</div>
+      <%= render "webauthn_credentials/form", webauthn_credential: @webauthn_credential %>
+    </section>
 
-<div class="t-body">
-  <h2><%= link_to t('oidc.pending_trusted_publishers.index.title'), profile_oidc_pending_trusted_publishers_path %></h2>
-  <span><%= t("oidc.pending_trusted_publishers.index.description_html") %></span>
-</div>
+    <section class="py-8 first:pt-0 last:pb-0">
+      <div class="flex items-center gap-3">
+        <h3 class="<%= sub_heading %>"><%= t(".mfa.otp") %></h3>
+        <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.totp_enabled?) %>
+      </div>
 
-<% if @user.oidc_api_key_roles.any? %>
-  <div class="t-body">
-    <h2><%= link_to t('oidc.api_key_roles.index.api_key_roles'), profile_oidc_api_key_roles_path %></h2>
+      <% if @user.totp_enabled? %>
+        <p class="<%= note_class %>"><%= t(".mfa.enabled_note") %></p>
+        <%= form_tag totp_path, method: :delete, id: "mfa-delete",
+              class: "mt-4 flex flex-col gap-4 sm:flex-row sm:items-end" do %>
+          <div class="flex-1">
+            <%= label_tag :otp, t(".otp_code"), class: label_class %>
+            <%= text_field_tag :otp, "", class: field_class, autocomplete: :off %>
+          </div>
+          <%= render ButtonComponent.new(t(".mfa.disable"), type: :submit, color: :red) %>
+        <% end %>
+      <% else %>
+        <p class="<%= note_class %>"><%= t(".mfa.disabled_html") %></p>
+        <div class="mt-4">
+          <%= render ButtonComponent.new(t(".mfa.go_settings"), new_totp_path, style: :outline) %>
+        </div>
+      <% end %>
+    </section>
   </div>
 <% end %>
 
-<% if @user.ownerships.any? %>
-  <div class="t-body">
-    <h2><%= link_to t("notifiers.show.title"), notifier_path %></h2>
-  </div>
+<%= render CardComponent.new do |c| %>
+  <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>
+    <%= c.section_title t(".account_header"), icon: "settings" %>
+  <% end %>
+
+  <%= c.divided_list do %>
+    <%= c.list_item_to(new_password_path) do %>
+      <%= t(".reset_password.title") %>
+    <% end %>
+    <%= c.list_item_to(profile_api_keys_path) do %>
+      <%= t("api_keys.index.api_keys") %>
+    <% end %>
+    <%= c.list_item_to(profile_oidc_pending_trusted_publishers_path) do %>
+      <span class="block"><%= t("oidc.pending_trusted_publishers.index.title") %></span>
+    <% end %>
+    <% if @user.oidc_api_key_roles.any? %>
+      <%= c.list_item_to(profile_oidc_api_key_roles_path) do %>
+        <%= t("oidc.api_key_roles.index.api_key_roles") %>
+      <% end %>
+    <% end %>
+    <% if @user.ownerships.any? %>
+      <%= c.list_item_to(notifier_path) do %>
+        <%= t("notifiers.show.title") %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,10 +1,10 @@
 <% @title = t(".title") %>
+<% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>
   <%= render "dashboards/subject", user: current_user, current: :settings %>
 <% end %>
 
-<%# TODO, ¿Should these exist in a component somewhere? %>
 <%
   sub_heading = "text-b2 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"
   note_class  = "mt-2 text-b3 text-neutral-700 dark:text-neutral-300 " \
@@ -24,7 +24,7 @@
 
   <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
     <% if @user.mfa_enabled? %>
-      <section class="py-8 first:pt-0">
+      <section class="py-8">
         <h3 class="<%= sub_heading %> pt-8"><%= t(".mfa.level.title") %></h3>
         <p class="<%= note_class %>"><%= t(".mfa.level_html") %></p>
 
@@ -39,7 +39,7 @@
       </section>
     <% end %>
 
-    <section class="py-8 first:pt-0">
+    <section class="py-8">
       <div class="flex items-center gap-3">
         <h3 class="<%= sub_heading %>"><%= t(".webauthn_credentials") %></h3>
         <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.webauthn_enabled?) %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,26 +1,30 @@
-<%= error_messages_for(@user) %>
+<%= error_messages_for(@user,
+  class: "mb-6 p-4 border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950 rounded-lg text-red-700 dark:text-red-400 text-sm") %>
 
-<div class="text_field">
-  <%= form.label :full_name, :class => 'form__label' %>
-  <p class='form__field__instructions'>
-    <%= t('profiles.edit.optional_full_name') %>
-  </p>
-  <%= form.text_field :full_name, :class => 'form__input' %>
-</div>
+<div class="flex flex-col gap-6">
+  <div>
+    <%= form.label :full_name, class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+    <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-2"><%= t('profiles.edit.optional_full_name') %></p>
+    <%= form.text_field :full_name, class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+  </div>
 
-<div class="text_field">
-  <%= form.label :email, :class => 'form__label' %>
-  <%= form.email_field :email, :class => 'form__input' %>
-</div>
-<div class="text_field">
-  <%= form.label :handle, :class => 'form__label' %>
-  <%= form.text_field :handle, :class => 'form__input' %>
-</div>
-<div class="password_field">
-  <%= form.label :password, t('activerecord.attributes.user.password'), :class => 'form__label' %>
-  <%= form.password_field :password, autocomplete: "new-password", class: 'form__input' %>
-</div>
-<div class="profile-checkbox form__checkbox">
-  <%= form.check_box :public_email, :class => 'form__checkbox__input' %>
-  <%= form.label :public_email, t('profiles.public_email'), :class => 'form__checkbox__label' %>
+  <div>
+    <%= form.label :email, class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+    <%= form.email_field :email, class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+  </div>
+
+  <div>
+    <%= form.label :handle, class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+    <%= form.text_field :handle, class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+  </div>
+
+  <div>
+    <%= form.label :password, t('activerecord.attributes.user.password'), class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+    <%= form.password_field :password, autocomplete: "new-password", class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= form.check_box :public_email, class: "h-4 w-4 rounded border-neutral-300 dark:border-neutral-700 text-orange-500 focus:ring-0" %>
+    <%= form.label :public_email, t('profiles.public_email'), class: "text-sm text-neutral-800 dark:text-neutral-200" %>
+  </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,13 +1,26 @@
 <% @title = t('sign_up') %>
+<% add_breadcrumb @title %>
 
-<div class="form_links sign_up_links t-body">
-  <p><%= link_to t('.have_account'), sign_in_path %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t('sign_up') %></h1>
+
+    <div class="mb-6">
+      <%= link_to t('.have_account'), sign_in_path, class: "text-b3 text-orange-500 underline dark:text-orange-400" %>
+    </div>
+
+    <% if signup_enabled? %>
+      <%= form_for @user do |form| %>
+        <%= render partial: '/users/form', object: form %>
+
+        <p class="mt-4 text-sm text-neutral-600 dark:text-neutral-400">
+          <%= t('by_signing_up') %> <%= link_to t('sign_up_terms'), policy_path('terms-of-service'), class: "text-orange-500 underline dark:text-orange-400" %>
+        </p>
+
+        <div class="mt-6">
+          <%= render ButtonComponent.new(t('sign_up'), type: :submit, color: :primary, data: { disable_with: t('form_disable_with') }) %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
 </div>
-
-<% if signup_enabled? %>
-  <%= form_for @user do |form| %>
-    <%= render :partial => '/users/form', :object => form %>
-    <p class="form__legend"><%= t('by_signing_up')%> <%= link_to t('sign_up_terms'), policy_path('terms-of-service') %></p>
-    <%= form.submit t('sign_up'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
-  <% end %>
-<% end %>

--- a/app/views/webauthn_credentials/_form.html.erb
+++ b/app/views/webauthn_credentials/_form.html.erb
@@ -1,12 +1,19 @@
 <% callback_csrf_token = form_authenticity_token(form_options: { action: callback_webauthn_credentials_path, method: "post" }) %>
-<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form", data: { callback_csrf_token: callback_csrf_token } } do |f| %>
-  <h3><%= t('.new_device') %></h3>
-  <div class="text_field">
-    <%= f.label :nickname, t('.nickname'), class: 'form__label' %>
-    <%= f.text_field :nickname, class: 'form__input js-new-webauthn-credential--nickname', required: true, pattern: '.*\S+.*' %>
+<%= form_for webauthn_credential, html: { class: "js-new-webauthn-credential--form mt-6", data: { callback_csrf_token: callback_csrf_token } } do |f| %>
+  <h4 class="text-b3 font-semibold text-neutral-900 dark:text-white"><%= t('.new_device') %></h4>
+  <div class="mt-4">
+    <%= f.label :nickname, t('.nickname'), class: 'block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2' %>
+    <%= f.text_field :nickname,
+          class: 'js-new-webauthn-credential--nickname block w-full rounded border border-neutral-300 dark:border-neutral-700 ' \
+                 'bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 outline-none focus:border-neutral-500 focus:ring-0',
+          required: true, pattern: '.*\S+.*' %>
   </div>
 
-  <p hidden class="l-text-red-600 js-new-webauthn-credential--error"></p>
+  <p hidden class="js-new-webauthn-credential--error mt-2 text-b3 text-red-600 dark:text-red-400"></p>
 
-  <%= f.submit t('.submit'), class: 'form__submit js-new-webauthn-credential--submit' %>
+  <%= f.submit t('.submit'),
+        class: 'js-new-webauthn-credential--submit mt-4 inline-flex items-center justify-center rounded ' \
+               'text-white bg-orange-500 px-4 h-12 min-h-12 text-b2 cursor-pointer ' \
+               'hover:bg-orange-600 active:bg-orange-600 dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 ' \
+               'transition focus:outline-none' %>
 <% end %>

--- a/app/views/webauthn_credentials/_webauthn_credential.html.erb
+++ b/app/views/webauthn_credentials/_webauthn_credential.html.erb
@@ -1,8 +1,10 @@
-<div class="l-flex l-mb-4 l-items-center l-gap-2">
-  <div class="t-text"><%= webauthn_credential.nickname %></div>
+<li class="flex items-center justify-between gap-2 px-4 py-3">
+  <span class="text-b3 text-neutral-900 dark:text-white"><%= webauthn_credential.nickname %></span>
   <%= button_to t(".delete"),
-    webauthn_credential,
-    method: :delete,
-    class: "form__submit form__submit--small",
-    data: { confirm: t(".confirm")} %>
-</div>
+        webauthn_credential,
+        method: :delete,
+        class: "inline-flex items-center justify-center rounded border-2 border-red-500 text-red-500 " \
+               "px-4 h-9 min-h-9 text-b3 hover:bg-red-500/5 active:bg-red-500/10 " \
+               "dark:hover:bg-red-500/15 dark:active:bg-red-500/25 transition focus:outline-none",
+        data: { confirm: t(".confirm") } %>
+</li>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -777,6 +777,7 @@ de:
   settings:
     edit:
       title:
+      account_header:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -981,6 +981,7 @@ de:
     new:
       forgot_password: Passwort vergessen?
       resend_confirmation:
+      confirm:
     verify:
       title:
       confirm:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -900,6 +900,7 @@ en:
     new:
       forgot_password: Forgot password?
       resend_confirmation: Didn't receive confirmation mail?
+      confirm: Confirm
     verify:
       title: Confirm Password
       confirm: Confirm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -696,6 +696,7 @@ en:
   settings:
     edit:
       title: Edit settings
+      account_header: Account
       webauthn_credentials: Security device
       no_webauthn_credentials: You don't have any security devices
       webauthn_credential_note: A security device can be any device that complies with the FIDO2 standard such as security and biometric keys.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -768,6 +768,7 @@ es:
   settings:
     edit:
       title: Editar configuración
+      account_header:
       webauthn_credentials: Dispositivo de seguridad
       no_webauthn_credentials: No tienes dispositivos de seguridad
       webauthn_credential_note: Un dispositivo de seguridad puede ser cualquier dispositivo

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1006,6 +1006,7 @@ es:
     new:
       forgot_password: "¿Olvidaste tu contraseña?"
       resend_confirmation: "¿No recibiste tu correo electrónico de confirmación?"
+      confirm:
     verify:
       title:
       confirm: Confirmar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -936,6 +936,7 @@ fr:
     new:
       forgot_password: Mot de passe oublié ?
       resend_confirmation: Vous n'avez pas reçu l'email de confirmation ?
+      confirm:
     verify:
       title:
       confirm:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -706,6 +706,7 @@ fr:
   settings:
     edit:
       title:
+      account_header:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -913,6 +913,7 @@ ja:
     new:
       forgot_password: パスワードをお忘れですか？
       resend_confirmation: 確認メールを受け取っていませんか？
+      confirm:
     verify:
       title:
       confirm: 確定

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -702,6 +702,7 @@ ja:
   settings:
     edit:
       title: 設定を編集
+      account_header:
       webauthn_credentials: セキュリティ機器
       no_webauthn_credentials: セキュリティ機器がありません
       webauthn_credential_note: セキュリティ機器とは、セキュリティキーや生体認証キーといった、FIDO2規格に準じた任意の機器です。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -689,6 +689,7 @@ nl:
   settings:
     edit:
       title:
+      account_header:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -893,6 +893,7 @@ nl:
     new:
       forgot_password: Wachtwoord vergeten?
       resend_confirmation: Geen bevestigingsemail ontvangen?
+      confirm:
     verify:
       title:
       confirm:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -916,6 +916,7 @@ pt-BR:
     new:
       forgot_password: Esqueceu sua Senha?
       resend_confirmation: Não recebeu o email de confirmação?
+      confirm:
     verify:
       title:
       confirm:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -700,6 +700,7 @@ pt-BR:
   settings:
     edit:
       title:
+      account_header:
       webauthn_credentials:
       no_webauthn_credentials:
       webauthn_credential_note:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -694,6 +694,7 @@ zh-CN:
   settings:
     edit:
       title: 编辑设置
+      account_header:
       webauthn_credentials: 安全设备
       no_webauthn_credentials: 您还没有任何安全设备
       webauthn_credential_note: 安全设备可以是任何符合 FIDO2 标准的设备，比如安全密钥、生物密钥等。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -906,6 +906,7 @@ zh-CN:
     new:
       forgot_password: 忘了密码？
       resend_confirmation: 没有收到确认邮件？
+      confirm:
     verify:
       title:
       confirm: 确认

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -894,6 +894,7 @@ zh-TW:
     new:
       forgot_password: 忘記密碼？
       resend_confirmation: 沒收到確認信？
+      confirm:
     verify:
       title:
       confirm: 確認

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -688,6 +688,7 @@ zh-TW:
   settings:
     edit:
       title: 編輯設定
+      account_header:
       webauthn_credentials: 安全裝置
       no_webauthn_credentials: 您沒有任何安全裝置
       webauthn_credential_note: 安全裝置可以是任何遵循 FIDO2 標準的裝置，例如安全或生物特徵金鑰。

--- a/test/components/previews/settings/mfa_status_badge_component_preview.rb
+++ b/test/components/previews/settings/mfa_status_badge_component_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Settings::MfaStatusBadgeComponentPreview < Lookbook::Preview
+  layout "hammy_component_preview"
+
+  # @param enabled toggle "enabled"
+  def default(enabled: true)
+    render Settings::MfaStatusBadgeComponent.new(enabled: enabled)
+  end
+end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -196,7 +196,7 @@ class ApiKeysControllerTest < ActionController::TestCase
 
       should "render edit api key form" do
         assert page.has_content? "Edit API key"
-        assert_select "form > input.form__input", value: "ci-key"
+        assert_select "form input#api_key_name[value=?]", "ci-key"
       end
 
       should "redirect to index with soft deleted key" do

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -82,6 +82,11 @@ class ApiKeysControllerTest < ActionController::TestCase
         should "render api key of user" do
           assert page.has_content? @api_key.name
         end
+
+        should "render on the subject layout with settings active" do
+          assert_select "h1", text: "API keys"
+          assert_select "nav a[href=?].bg-orange-100", edit_settings_path
+        end
       end
     end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -87,7 +87,7 @@ class SessionsControllerTest < ActionController::TestCase
           post :otp_create, params: { otp: wrong_otp }
         end
 
-        should set_flash.now[:notice]
+        should set_flash.now[:alert]
         should respond_with :unauthorized
 
         should "render sign in page" do
@@ -142,7 +142,7 @@ class SessionsControllerTest < ActionController::TestCase
         post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
       end
 
-      should set_flash.now[:notice]
+      should set_flash.now[:alert]
       should respond_with :unauthorized
 
       should "clear mfa_expires_at" do
@@ -314,7 +314,7 @@ class SessionsControllerTest < ActionController::TestCase
       end
 
       should respond_with :unauthorized
-      should set_flash.now[:notice]
+      should set_flash.now[:alert]
 
       should "render sign in page" do
         assert page.has_content? "Sign in"
@@ -645,8 +645,8 @@ class SessionsControllerTest < ActionController::TestCase
 
       should respond_with :unauthorized
 
-      should "set flash notice" do
-        assert_equal "Credentials required", flash[:notice]
+      should "set flash alert" do
+        assert_equal "Credentials required", flash[:alert]
       end
 
       should "render sign in page" do
@@ -681,8 +681,8 @@ class SessionsControllerTest < ActionController::TestCase
 
       should respond_with :unauthorized
 
-      should "set flash notice" do
-        assert_equal "WebAuthn::ChallengeVerificationError", flash[:notice]
+      should "set flash alert" do
+        assert_equal "WebAuthn::ChallengeVerificationError", flash[:alert]
       end
 
       should "render sign in page" do
@@ -728,8 +728,8 @@ class SessionsControllerTest < ActionController::TestCase
         refute_predicate @controller.request.env[:clearance], :signed_in?
       end
 
-      should "set flash notice" do
-        assert_equal "Your login page session has expired.", flash[:notice]
+      should "set flash alert" do
+        assert_equal "Your login page session has expired.", flash[:alert]
       end
 
       should "render sign in page" do

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -17,6 +17,33 @@ class SettingsControllerTest < ActionController::TestCase
       sign_in_as(@user)
     end
 
+    context "on the redesigned settings page" do
+      setup { get :edit }
+
+      should respond_with :success
+
+      should "render the page heading" do
+        assert_select "h1", text: "Edit settings"
+      end
+
+      should "render the subject sidebar with settings marked active" do
+        assert_select "nav a[href=?]", edit_settings_path, text: /Settings/
+        assert_select "nav a[href=?].bg-orange-100", edit_settings_path
+      end
+
+      should "group the multi-factor authentication controls in a card" do
+        assert_select "h2", text: /Multi-factor authentication/
+        assert_select "h3", text: "Security device"
+        assert_select "h3", text: "Authentication app"
+      end
+
+      should "list the account links" do
+        assert_select "a[href=?]", new_password_path
+        assert_select "a[href=?]", profile_api_keys_path
+        assert_select "a[href=?]", profile_oidc_pending_trusted_publishers_path
+      end
+    end
+
     context "when user owns a gem with more than MFA_REQUIRED_THRESHOLD downloads" do
       setup do
         @rubygem = create(:rubygem)

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -140,7 +140,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     @ownership.destroy!
     click_button "Create API Key"
 
-    assert page.has_css? ".flash"
+    assert page.has_css? "#flash_error"
     assert_text "Rubygem must be a gem that you are an owner of"
     assert_empty @user.api_keys
   end
@@ -270,7 +270,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     @another_ownership.destroy!
     click_button "Update API Key"
 
-    assert page.has_css? ".flash"
+    assert page.has_css? "#flash_error"
     assert_text "Rubygem must be a gem that you are an owner of"
     assert_equal @ownership.rubygem, api_key.reload.rubygem
   end

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -72,7 +72,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     click_button "Create API Key"
 
     assert_text "Note that we won't be able to show the key to you again. New API key:"
-    assert_equal @ownership.rubygem.name, page.find('.owners__cell[data-title="Gem"]').text
+    assert_equal @ownership.rubygem.name, page.find('td[data-title="Gem"]').text
     assert_equal @ownership.rubygem, @user.api_keys.last.rubygem
   end
 
@@ -170,7 +170,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     click_button "Create API Key"
 
     assert_text "Note that we won't be able to show the key to you again. New API key:"
-    assert_equal expiration.strftime("%Y-%m-%d %H:%M %Z"), page.find('.owners__cell[data-title="Expiration"]').text
+    assert_equal expiration.strftime("%Y-%m-%d %H:%M %Z"), page.find('td[data-title="Expiration"]').text
     assert_equal expiration, @user.api_keys.last.expires_at
   end
 
@@ -216,7 +216,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     click_button "Update API Key"
 
     assert_text("Successfully updated API key")
-    assert_equal "All Gems", page.find('.owners__cell[data-title="Gem"]').text
+    assert_equal "All Gems", page.find('td[data-title="Gem"]').text
     assert_nil api_key.reload.rubygem
   end
 
@@ -363,7 +363,7 @@ class ApiKeysTest < ApplicationSystemTestCase
     assert_predicate api_key.reload, :soft_deleted?
 
     refute page.has_button? "Edit"
-    assert_equal "#{@ownership.rubygem.name} [?]", page.find('.owners__cell[data-title="Gem"]').text
+    assert_equal "#{@ownership.rubygem.name} [?]", page.find('td[data-title="Gem"]').text
     visit_edit_profile_api_key_path(api_key)
 
     assert_text "An invalid API key cannot be edited. Please delete it and create a new one."

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -467,18 +467,16 @@ class OIDCTest < ApplicationSystemTestCase
 
     page.assert_text "Pending Trusted Publisher created"
     page.assert_selector "h1", text: "Pending Trusted Publishers"
-    page.assert_text <<~TEXT
-      rubygem1
-      Delete
-      GitHub Actions
-      Valid for about 12 hours
-      GitHub Repository
-      example/rubygem1
-      Workflow Filename
-      push_rubygem.yml
-      Environment
-      prod
-    TEXT
+    page.assert_text "rubygem1"
+    page.assert_text "Delete"
+    page.assert_text "GitHub Actions"
+    page.assert_text "Valid for about 12 hours"
+    page.assert_text "GitHub Repository"
+    page.assert_text "example/rubygem1"
+    page.assert_text "Workflow Filename"
+    page.assert_text "push_rubygem.yml"
+    page.assert_text "Environment"
+    page.assert_text "prod"
   end
 
   test "deleting pending trusted publishers" do
@@ -491,6 +489,6 @@ class OIDCTest < ApplicationSystemTestCase
     click_button "Delete"
 
     assert_content "Pending Trusted Publisher deleted"
-    assert_content "NO PENDING TRUSTED PUBLISHERS FOUND"
+    assert_content "No pending trusted publishers found"
   end
 end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -14,7 +14,7 @@ class SettingsTest < ApplicationSystemTestCase
 
   def change_auth_level(type)
     page.select type
-    find("#mfa-edit input[type=submit]").click
+    within("#mfa-edit") { click_button "Update" }
   end
 
   def otp_key

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -105,7 +105,7 @@ class SignInTest < ApplicationSystemTestCase
       assert_text "Sign in"
       expected_notice = "Your login page session has expired."
 
-      assert page.has_selector? "#flash_notice", text: expected_notice
+      assert page.has_selector? "#flash_alert", text: expected_notice
     end
   end
 

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -38,7 +38,7 @@ class ApiKeysHelperTest < ActionView::TestCase
 
     [
       scope,
-      { class: "form__checkbox__input", id: scope, data: },
+      { class: ApiKeysHelper::CHECKBOX_CLASSES, id: scope, data: },
       "true",
       "false"
     ]

--- a/test/views/card_component_test.rb
+++ b/test/views/card_component_test.rb
@@ -43,4 +43,15 @@ class CardComponentTest < ComponentTest
     assert_text "content"
     refute_text "View all"
   end
+
+  should "render a section title as an h2" do
+    render_page CardComponent.new do |c|
+      c.head do
+        c.section_title("Account")
+      end
+    end
+
+    assert_selector "h2", text: "Account"
+    refute_selector "h3", text: "Account"
+  end
 end

--- a/test/views/settings/mfa_status_badge_component_test.rb
+++ b/test/views/settings/mfa_status_badge_component_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Settings::MfaStatusBadgeComponentTest < ComponentTest
+  def render_page(component)
+    Capybara.string(render(component))
+  end
+
+  should "render an enabled badge" do
+    page = render_page Settings::MfaStatusBadgeComponent.new(enabled: true)
+
+    assert page.has_text?("Enabled")
+    assert page.has_selector?("span.bg-green-100")
+  end
+
+  should "render a disabled badge" do
+    page = render_page Settings::MfaStatusBadgeComponent.new(enabled: false)
+
+    assert page.has_text?("Disabled")
+    assert page.has_selector?("span.bg-neutral-200")
+  end
+end


### PR DESCRIPTION
Updates all the views associated with the "profile" view 

(Screenshots are zoomed out a bit to fit)

Pages:


profile edit/update
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/20dc181e-a950-45f3-8a95-dfe6251d4abb" />

Pending trusted publishers 
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/ebc8574d-298c-4c7d-a27b-772396a7ebd2" />

<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/23951752-676d-4e1f-adaa-2e8fc64b4d3b" />


API keys 
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/1aaf9468-cf9c-4745-95c3-4c748ab6b4d7" />

<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/bbd951f7-d16e-4824-b0ee-5541ad9314c9" />

<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/2fae8463-4dba-4035-b361-a6bb6a5aeddc" />

session verify 
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/d4e6c548-5948-4a33-a850-f50725cf521c" />

passwords reset
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/23c255a4-7eff-4c8f-a304-d5af8e787e9d" />


login sessions
(the login as section doesn't show on production)
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/c6ff9598-b29b-4cf5-a203-8edfa0d6385f" />

sign up
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/33dbe196-1fb7-4920-aef9-690019ed9695" />


settings
<img width="1371" height="1168" alt="image" src="https://github.com/user-attachments/assets/1c60770b-7fd7-4cb4-847f-e54942e8234f" />




