### PR TITLE
Handle Locales in URL Paths

### DIFF
--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -27,7 +27,7 @@ class Avo::Resources::Version < Avo::BaseResource
   def fields # rubocop:disable Metrics
     field :full_name, as: :text, link_to_resource: true
     field :id, as: :id, hide_on: :index, as_html: true do |_id, *_args|
-      link_to record.id, main_app.rubygem_version_url(record.rubygem.slug, record.slug)
+      link_to record.id, main_app.rubygem_version_url(rubygem_id: record.rubygem.slug, id: record.slug)
     end
 
     field :rubygem, as: :belongs_to

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
   def create
     if @user.webauthn_enabled?
       verification = @user.refresh_webauthn_verification
-      webauthn_path = webauthn_verification_url(verification.path_token)
+      webauthn_path = webauthn_verification_url(webauthn_token: verification.path_token)
       respond_to do |format|
         format.any(:all) { render plain: webauthn_path }
         format.yaml { render yaml: { path: webauthn_path, expiry: verification.path_token_expires_at.utc } }

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -96,7 +96,7 @@ class ApiKeysController < ApplicationController
     when "create"
       new_profile_api_key_path
     when "update"
-      edit_profile_api_key_path(params[:id])
+      edit_profile_api_key_path(id: params[:id])
     else
       super
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :reject_null_char_param
   before_action :reject_path_params_param
   before_action :reject_null_char_cookie
+  before_action :strip_default_locale
   before_action :set_error_context_user
   before_action :set_user_tag
   before_action :set_current_request
@@ -48,6 +49,17 @@ class ApplicationController < ActionController::Base
 
   def default_url_options
     { path_params: { locale: LocaleRouting.default_locale?(I18n.locale) ? nil : I18n.locale } }
+  end
+
+  def strip_default_locale
+    return unless request.get? || request.head?
+    return unless LocaleRouting.default_locale?(request.path_parameters[:locale])
+
+    canonical = url_for(request.path_parameters.merge(locale: nil, only_path: true))
+    canonical = "#{canonical}?#{request.query_string}" if request.query_string.present?
+    redirect_to canonical, status: :moved_permanently
+  rescue ActionController::UrlGenerationError
+    nil
   end
 
   def set_user_tag

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,7 @@ class ApplicationController < ActionController::Base
     render_forbidden(e.policy.error)
   end
 
-  # TODO: Separate locales by path and re-enable
-  # before_action :set_locale
+  around_action :switch_locale
   before_action :reject_null_char_param
   before_action :reject_path_params_param
   before_action :reject_null_char_cookie
@@ -41,13 +40,14 @@ class ApplicationController < ActionController::Base
     )
   end
 
-  def set_locale
-    I18n.locale = user_locale
-
-    # after store current locale
-    session[:locale] = params[:locale] if params[:locale]
+  def switch_locale(&action)
+    I18n.with_locale(request.path_parameters[:locale] || I18n.default_locale, &action)
   rescue I18n::InvalidLocale
-    I18n.locale = I18n.default_locale
+    I18n.with_locale(I18n.default_locale, &action)
+  end
+
+  def default_url_options
+    { path_params: { locale: LocaleRouting.default_locale?(I18n.locale) ? nil : I18n.locale } }
   end
 
   def set_user_tag
@@ -143,14 +143,6 @@ class ApplicationController < ActionController::Base
     redirect_to_page_with_error && return unless valid_page_param?(max_page)
 
     @page = params[:page].to_i
-  end
-
-  def user_locale
-    params[:locale] || session[:locale] || http_head_locale || I18n.default_locale
-  end
-
-  def http_head_locale
-    http_accept_language.language_region_compatible_from(I18n.available_locales)
   end
 
   def render_not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    { path_params: { locale: LocaleRouting.default_locale?(I18n.locale) ? nil : I18n.locale } }
+    { path_params: { locale: LocaleRouting.locale_param(I18n.locale) } }
   end
 
   def strip_default_locale

--- a/app/controllers/oidc/api_key_roles_controller.rb
+++ b/app/controllers/oidc/api_key_roles_controller.rb
@@ -65,7 +65,7 @@ class OIDC::ApiKeyRolesController < ApplicationController
   def create
     @api_key_role = current_user.oidc_api_key_roles.build(api_key_role_params)
     if @api_key_role.save
-      redirect_to profile_oidc_api_key_role_path(@api_key_role.token), flash: { notice: t(".success") }
+      redirect_to profile_oidc_api_key_role_path(token: @api_key_role.token), flash: { notice: t(".success") }
     else
       flash.now[:error] = @api_key_role.errors.full_messages.to_sentence
       render :new
@@ -74,7 +74,7 @@ class OIDC::ApiKeyRolesController < ApplicationController
 
   def update
     if @api_key_role.update(api_key_role_params)
-      redirect_to profile_oidc_api_key_role_path(@api_key_role.token), flash: { notice: t(".success") }
+      redirect_to profile_oidc_api_key_role_path(token: @api_key_role.token), flash: { notice: t(".success") }
     else
       flash.now[:error] = @api_key_role.errors.full_messages.to_sentence
       render :edit
@@ -85,7 +85,7 @@ class OIDC::ApiKeyRolesController < ApplicationController
     if @api_key_role.update(deleted_at: Time.current)
       redirect_to profile_oidc_api_key_roles_path, flash: { notice: t(".success") }
     else
-      redirect_to profile_oidc_api_key_role_path(@api_key_role.token),
+      redirect_to profile_oidc_api_key_role_path(token: @api_key_role.token),
         flash: { error: @api_key_role.errors.full_messages.to_sentence }
     end
   end

--- a/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
@@ -22,7 +22,7 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
   def create
     trusted_publisher = authorize @rubygem.oidc_rubygem_trusted_publishers.new(create_params)
     if trusted_publisher.save
-      redirect_to rubygem_trusted_publishers_path(@rubygem.slug), flash: { notice: t(".success") }
+      redirect_to rubygem_trusted_publishers_path(rubygem_id: @rubygem.slug), flash: { notice: t(".success") }
     else
       flash.now[:error] = trusted_publisher.errors.full_messages.to_sentence
       render OIDC::RubygemTrustedPublishers::NewView.new(
@@ -33,9 +33,9 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
 
   def destroy
     if @rubygem_trusted_publisher.destroy
-      redirect_to rubygem_trusted_publishers_path(@rubygem.slug), flash: { notice: t(".success") }
+      redirect_to rubygem_trusted_publishers_path(rubygem_id: @rubygem.slug), flash: { notice: t(".success") }
     else
-      redirect_back_or_to(rubygem_trusted_publishers_path(@rubygem.slug),
+      redirect_back_or_to(rubygem_trusted_publishers_path(rubygem_id: @rubygem.slug),
 flash: { error: @rubygem_trusted_publisher.errors.full_messages.to_sentence })
     end
   end

--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -10,7 +10,7 @@ class Organizations::InvitationsController < Organizations::BaseController
 
   def update
     @membership.confirm!
-    redirect_to organization_path(@organization), notice: "You have successfully joined the #{@organization.handle} organization."
+    redirect_to organization_path(id: @organization), notice: "You have successfully joined the #{@organization.handle} organization."
   end
 
   private

--- a/app/controllers/organizations/members_controller.rb
+++ b/app/controllers/organizations/members_controller.rb
@@ -38,7 +38,7 @@ class Organizations::MembersController < Organizations::BaseController
 
     if @membership.save
       OrganizationMailer.user_invited(@membership).deliver_later
-      redirect_to organization_memberships_path(@organization), notice: t(".member_invited")
+      redirect_to organization_memberships_path(organization_id: @organization), notice: t(".member_invited")
     else
       render :new, status: :unprocessable_content
     end
@@ -48,7 +48,7 @@ class Organizations::MembersController < Organizations::BaseController
     @membership.assign_attributes(membership_params[:membership])
     authorize @membership, :update?
     if @membership.save
-      redirect_to organization_memberships_path(@organization), notice: t(".member_updated")
+      redirect_to organization_memberships_path(organization_id: @organization), notice: t(".member_updated")
     else
       render :edit, status: :unprocessable_content
     end
@@ -56,20 +56,23 @@ class Organizations::MembersController < Organizations::BaseController
 
   def destroy
     authorize @membership, :destroy?
-    return redirect_to organization_memberships_path(@organization), alert: t(".cannot_remove_self") if current_user == @membership.user
+    if current_user == @membership.user
+      return redirect_to organization_memberships_path(organization_id: @organization), alert: t(".cannot_remove_self")
+    end
+
     @membership.destroy!
 
-    redirect_to organization_memberships_path(@organization), notice: t(".member_removed")
+    redirect_to organization_memberships_path(organization_id: @organization), notice: t(".member_removed")
   end
 
   def resend_invitation
-    return redirect_to organization_memberships_path(@organization), alert: t(".already_confirmed") if @membership.confirmed?
+    return redirect_to organization_memberships_path(organization_id: @organization), alert: t(".already_confirmed") if @membership.confirmed?
 
     authorize @organization, :invite_member?
 
     @membership.refresh_invitation!
     OrganizationMailer.user_invited(@membership).deliver_later
-    redirect_to organization_memberships_path(@organization), notice: t(".invitation_resent")
+    redirect_to organization_memberships_path(organization_id: @organization), notice: t(".invitation_resent")
   end
 
   private

--- a/app/controllers/organizations/onboarding/confirm_controller.rb
+++ b/app/controllers/organizations/onboarding/confirm_controller.rb
@@ -8,7 +8,7 @@ class Organizations::Onboarding::ConfirmController < Organizations::Onboarding::
     @organization_onboarding.onboard!
 
     flash[:notice] = I18n.t("organization_onboardings.confirm.success")
-    redirect_to organization_path(@organization_onboarding.organization)
+    redirect_to organization_path(id: @organization_onboarding.organization)
   rescue ActiveRecord::ActiveRecordError
     flash.now[:error] = "Onboarding error: #{@organization_onboarding.error}"
     render :edit, status: :unprocessable_content

--- a/app/controllers/organizations/onboarding_controller.rb
+++ b/app/controllers/organizations/onboarding_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Organizations::OnboardingController < Organizations::Onboarding::BaseController
+  def new
+    redirect_to organization_onboarding_name_path, status: :moved_permanently
+  end
+
   def destroy
     OrganizationOnboarding.destroy_by(created_by: Current.user, status: %i[pending failed])
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -29,7 +29,7 @@ class OrganizationsController < Organizations::BaseController
   end
 
   def edit
-    add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(@organization)
+    add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(id: @organization)
     add_breadcrumb t("breadcrumbs.settings")
 
     authorize @organization
@@ -39,7 +39,7 @@ class OrganizationsController < Organizations::BaseController
     authorize @organization
 
     if @organization.update(organization_params)
-      redirect_to organization_path(@organization)
+      redirect_to organization_path(id: @organization)
     else
       render :edit
     end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -9,7 +9,7 @@ class OwnersController < ApplicationController
   before_action :find_ownership, only: %i[edit update destroy]
 
   rescue_from(Pundit::NotAuthorizedError) do |e|
-    redirect_to rubygem_path(@rubygem.slug), alert: e.policy.error
+    redirect_to rubygem_path(id: @rubygem.slug), alert: e.policy.error
   end
 
   def confirm
@@ -17,7 +17,7 @@ class OwnersController < ApplicationController
 
     if ownership.valid_confirmation_token? && ownership.confirm!
       notify_owner_added(ownership)
-      redirect_to rubygem_path(ownership.rubygem.slug), notice: t(".confirmed_email", gem: ownership.rubygem.name)
+      redirect_to rubygem_path(id: ownership.rubygem.slug), notice: t(".confirmed_email", gem: ownership.rubygem.name)
     else
       redirect_to root_path, alert: t(".token_expired")
     end
@@ -31,7 +31,7 @@ class OwnersController < ApplicationController
     else
       flash[:alert] = t("try_again")
     end
-    redirect_to rubygem_path(ownership.rubygem.slug)
+    redirect_to rubygem_path(id: ownership.rubygem.slug)
   end
 
   def index
@@ -49,7 +49,7 @@ class OwnersController < ApplicationController
     ownership = @rubygem.ownerships.new(user: owner, authorizer: current_user, role: params[:role])
     if ownership.save
       OwnersMailer.ownership_confirmation(ownership).deliver_later
-      redirect_to rubygem_owners_path(@rubygem.slug), notice: t(".success_notice", handle: owner.name)
+      redirect_to rubygem_owners_path(rubygem_id: @rubygem.slug), notice: t(".success_notice", handle: owner.name)
     else
       index_with_error ownership.errors.full_messages.to_sentence, :unprocessable_content
     end
@@ -61,7 +61,7 @@ class OwnersController < ApplicationController
   def update
     if @ownership.update(update_params)
       OwnersMailer.with(ownership: @ownership, authorizer: current_user).owner_updated.deliver_later
-      redirect_to rubygem_owners_path(@ownership.rubygem.slug), notice: t(".success_notice", handle: @ownership.user.name)
+      redirect_to rubygem_owners_path(rubygem_id: @ownership.rubygem.slug), notice: t(".success_notice", handle: @ownership.user.name)
     else
       index_with_error @ownership.errors.full_messages.to_sentence, :unprocessable_content
     end
@@ -70,7 +70,7 @@ class OwnersController < ApplicationController
   def destroy
     if @ownership.safe_destroy
       OwnersMailer.owner_removed(@ownership.user_id, current_user.id, @ownership.rubygem_id).deliver_later
-      redirect_to rubygem_owners_path(@ownership.rubygem.slug), notice: t(".removed_notice", owner_name: @ownership.owner_name)
+      redirect_to rubygem_owners_path(rubygem_id: @ownership.rubygem.slug), notice: t(".removed_notice", owner_name: @ownership.owner_name)
     else
       index_with_error t(".failed_notice"), :forbidden
     end
@@ -79,7 +79,7 @@ class OwnersController < ApplicationController
   private
 
   def verify_session_redirect_path
-    rubygem_owners_url(params[:rubygem_id])
+    rubygem_owners_url(rubygem_id: params[:rubygem_id])
   end
 
   def find_ownership

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,6 +10,10 @@ class PagesController < ApplicationController
     render @page
   end
 
+  def sponsors
+    redirect_to page_path(id: "supporters"), status: :moved_permanently
+  end
+
   private
 
   def find_page

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,7 +16,7 @@ class ProfilesController < ApplicationController
   end
 
   def me
-    redirect_to profile_path(current_user.display_id)
+    redirect_to profile_path(id: current_user.display_id)
   end
 
   def edit

--- a/app/controllers/rubygems/transfer/confirmations_controller.rb
+++ b/app/controllers/rubygems/transfer/confirmations_controller.rb
@@ -16,7 +16,7 @@ class Rubygems::Transfer::ConfirmationsController < Rubygems::Transfer::BaseCont
     flash[:notice] = I18n.t("rubygems.transfer.confirm.success",
                             organization: @rubygem_transfer.organization.name,
                             count: @rubygem_transfer.rubygems.size)
-    redirect_to organization_path(@rubygem_transfer.organization.handle)
+    redirect_to organization_path(id: @rubygem_transfer.organization.handle)
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = "Onboarding error: #{@rubygem_transfer.error}"
     render :edit, status: :unprocessable_content

--- a/app/controllers/rubygems/transfers_controller.rb
+++ b/app/controllers/rubygems/transfers_controller.rb
@@ -5,6 +5,10 @@ class Rubygems::TransfersController < ApplicationController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :find_rubygem
 
+  def new
+    redirect_to organization_transfer_rubygems_path, status: :moved_permanently
+  end
+
   def destroy
     @rubygem_transfer = RubygemTransfer.find_by(created_by: Current.user, status: %i[pending failed])
     @rubygem_transfer&.destroy!

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -35,6 +35,6 @@ class SubscriptionsController < ApplicationController
 
   def redirect_to_rubygem(success)
     flash[:error] = t("try_again") unless success
-    redirect_to rubygem_path(@rubygem.slug)
+    redirect_to rubygem_path(id: @rubygem.slug)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,10 @@ module ApplicationHelper
     "is-active" if request.path_info == path
   end
 
+  def home_page?
+    current_page?(root_path)
+  end
+
   # replacement for Kaminari::ActionViewExtension#paginate
   # only shows `next` and `prev` links and not page numbers, saving a COUNT(DISTINCT ..) query
   def plain_paginate(items)

--- a/app/helpers/locale_switch_helper.rb
+++ b/app/helpers/locale_switch_helper.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module LocaleSwitchHelper
+  def default_search_engine_tags
+    return if signed_in?
+    return unless request.get? || request.head?
+    return if request.query_string.present?
+
+    canonical_link_tags { |locale| localized_url_for_current_page(locale) }
+  end
+
+  def canonical_link_tags
+    canonical = tag.link(rel: "canonical", href: yield(I18n.locale))
+    alternates = I18n.available_locales.map do |locale|
+      tag.link(rel: "alternate", hreflang: locale, href: yield(locale))
+    end
+    x_default = tag.link(rel: "alternate", hreflang: "x-default", href: yield(I18n.default_locale))
+
+    safe_join([canonical, *alternates, x_default], "\n")
+  end
+
+  def locale_switch_path(locale)
+    url_for(
+      locale_switch_path_parameters.merge(
+        locale: LocaleRouting.locale_param(locale),
+        params: request.query_parameters.except(:locale, "locale"),
+        only_path: true
+      )
+    )
+  end
+
+  delegate :locale_param, to: :LocaleRouting
+
+  private
+
+  def localized_url_for_current_page(locale = I18n.locale)
+    url_for(request.path_parameters.merge(locale: LocaleRouting.locale_param(locale), only_path: false))
+  end
+
+  def locale_switch_path_parameters
+    return request.path_parameters if request.get? || request.head?
+
+    form_action = { "create" => "new", "update" => "edit" }[request.path_parameters[:action]]
+    if form_action
+      form_path_parameters = request.path_parameters.merge(action: form_action)
+      return form_path_parameters if locale_switch_path_routable?(form_path_parameters)
+    end
+
+    { controller: "home", action: "index" }
+  end
+
+  def locale_switch_path_routable?(path_parameters)
+    url_for(path_parameters.merge(only_path: true))
+    true
+  rescue ActionController::UrlGenerationError
+    false
+  end
+end

--- a/app/helpers/rubygems_helper.rb
+++ b/app/helpers/rubygems_helper.rb
@@ -38,11 +38,11 @@ module RubygemsHelper
   def subscribe_link(rubygem)
     if signed_in?
       if rubygem.subscribers.find_by_id(current_user.id)
-        link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem.slug),
+        link_to t(".links.unsubscribe"), rubygem_subscription_path(rubygem_id: rubygem.slug),
           class: [:toggler, "gem__link", "t-list__item"], id: "unsubscribe",
           method: :delete
       else
-        link_to t(".links.subscribe"), rubygem_subscription_path(rubygem.slug),
+        link_to t(".links.subscribe"), rubygem_subscription_path(rubygem_id: rubygem.slug),
           class: %w[toggler gem__link t-list__item], id: "subscribe",
           method: :post
       end
@@ -56,7 +56,7 @@ module RubygemsHelper
     return unless signed_in?
     style = "t-item--hidden" unless rubygem.subscribers.find_by_id(current_user.id)
 
-    link_to t("rubygems.aside.links.unsubscribe"), rubygem_subscription_path(rubygem.slug),
+    link_to t("rubygems.aside.links.unsubscribe"), rubygem_subscription_path(rubygem_id: rubygem.slug),
       class: [:toggler, "gem__link", "t-list__item", style], id: "unsubscribe",
       method: :delete
   end
@@ -71,12 +71,12 @@ module RubygemsHelper
   end
 
   def atom_link(rubygem)
-    link_to t(".links.rss"), rubygem_versions_path(rubygem.slug, format: "atom"),
+    link_to t(".links.rss"), rubygem_versions_path(rubygem_id: rubygem.slug, format: "atom"),
       class: "gem__link t-list__item", id: :rss
   end
 
   def reverse_dependencies_link(rubygem)
-    link_to_page :reverse_dependencies, rubygem_reverse_dependencies_path(rubygem.slug)
+    link_to_page :reverse_dependencies, rubygem_reverse_dependencies_path(rubygem_id: rubygem.slug)
   end
 
   def badge_link(rubygem)
@@ -92,11 +92,11 @@ module RubygemsHelper
   end
 
   def ownership_link(rubygem)
-    link_to I18n.t("rubygems.aside.links.ownership"), rubygem_owners_path(rubygem.slug), class: "gem__link t-list__item"
+    link_to I18n.t("rubygems.aside.links.ownership"), rubygem_owners_path(rubygem_id: rubygem.slug), class: "gem__link t-list__item"
   end
 
   def rubygem_trusted_publishers_link(rubygem)
-    link_to t("rubygems.aside.links.trusted_publishers"), rubygem_trusted_publishers_path(rubygem.slug), class: "gem__link t-list__item"
+    link_to t("rubygems.aside.links.trusted_publishers"), rubygem_trusted_publishers_path(rubygem_id: rubygem.slug), class: "gem__link t-list__item"
   end
 
   def oidc_api_key_role_links(rubygem)
@@ -105,7 +105,7 @@ module RubygemsHelper
     links = roles.map do |role|
       link_to(
         t("rubygems.aside.links.oidc.api_key_role.name", name: role.name),
-        profile_oidc_api_key_role_path(role.token),
+        profile_oidc_api_key_role_path(token: role.token),
         class: "gem__link t-list__item"
       )
     end
@@ -120,12 +120,12 @@ module RubygemsHelper
 
   def resend_owner_confirmation_link(rubygem)
     link_to I18n.t("rubygems.aside.links.resend_ownership_confirmation"),
-            resend_confirmation_rubygem_owners_path(rubygem.slug), class: "gem__link t-list__item"
+            resend_confirmation_rubygem_owners_path(rubygem_id: rubygem.slug), class: "gem__link t-list__item"
   end
 
   def rubygem_security_events_link(rubygem)
     link_to "Security Events",
-      security_events_rubygem_path(rubygem.slug), class: "gem__link t-list__item"
+      security_events_rubygem_path(id: rubygem.slug), class: "gem__link t-list__item"
   end
 
   def clickgems_analytics_link(rubygem)
@@ -143,7 +143,7 @@ module RubygemsHelper
   end
 
   def link_to_user(user)
-    link_to avatar(48, "gravatar-#{user.id}", user), profile_path(user.display_id),
+    link_to avatar(48, "gravatar-#{user.id}", user), profile_path(id: user.display_id),
       alt: user.display_handle, title: user.display_handle
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,6 +6,7 @@ class ApplicationMailer < ActionMailer::Base
 
   default from: Gemcutter::MAIL_SENDER
   default_url_options[:host] = Gemcutter::HOST
+  default_url_options[:locale] = nil
   default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   layout "mailer"

--- a/app/mailers/organization_mailer.rb
+++ b/app/mailers/organization_mailer.rb
@@ -6,7 +6,7 @@ class OrganizationMailer < ApplicationMailer
     @user = membership.user
     @invited_by = membership.invited_by
     @organization = membership.organization
-    @accept_url = organization_invitation_url(@organization, host: Gemcutter::HOST)
+    @accept_url = organization_invitation_url(organization_id: @organization, host: Gemcutter::HOST)
 
     mail(to: @user.email, subject: "You've been invited to join #{@organization.handle}")
   end

--- a/app/views/components/card/timeline_component.rb
+++ b/app/views/components/card/timeline_component.rb
@@ -32,7 +32,7 @@ class Card::TimelineComponent < ApplicationComponent
   end
 
   def link_to_user(user)
-    link_to(profile_path(user.display_id), alt: user.display_handle, title: user.display_handle, class: "flex items-center") do
+    link_to(profile_path(id: user.display_id), alt: user.display_handle, title: user.display_handle, class: "flex items-center") do
       span(class: "w-6 h-6 inline-block mr-2 rounded") { avatar(48, "gravatar-#{user.id}", user) }
       span { user.display_handle }
     end

--- a/app/views/components/events/table_details_component.rb
+++ b/app/views/components/events/table_details_component.rb
@@ -20,7 +20,7 @@ class Events::TableDetailsComponent < ApplicationComponent
     user = load_gid(gid, only: User)
 
     if user
-      view_context.link_to text, profile_path(user.display_id), alt: user.display_handle, title: user.display_handle
+      view_context.link_to text, profile_path(id: user.display_id), alt: user.display_handle, title: user.display_handle
     else
       text
     end
@@ -30,7 +30,7 @@ class Events::TableDetailsComponent < ApplicationComponent
     version = load_gid(gid, only: Version)
 
     if version
-      view_context.link_to version.to_title, rubygem_version_path(version.rubygem.slug, version.slug)
+      view_context.link_to version.to_title, rubygem_version_path(rubygem_id: version.rubygem.slug, id: version.slug)
     else
       "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'})"
     end

--- a/app/views/components/events/user_event/api_key/created_component.rb
+++ b/app/views/components/events/user_event/api_key/created_component.rb
@@ -6,7 +6,7 @@ class Events::UserEvent::ApiKey::CreatedComponent < Events::TableDetailsComponen
     div { t(".api_key_scopes", scopes: additional.scopes&.to_sentence) }
     if additional.gem.present?
       div do
-        t(".api_key_gem_html", gem: link_to(additional.gem, rubygem_path(additional.gem)))
+        t(".api_key_gem_html", gem: link_to(additional.gem, rubygem_path(id: additional.gem)))
       end
     end
     div { t(".api_key_mfa", mfa: additional.mfa ? t(".required") : t(".not_required")) } if additional.has_attribute?(:mfa)

--- a/app/views/components/oidc/api_key_role/table_component.rb
+++ b/app/views/components/oidc/api_key_role/table_component.rb
@@ -18,7 +18,7 @@ class OIDC::ApiKeyRole::TableComponent < ApplicationComponent
       tbody(class: "t-body") do
         api_key_roles.each do |api_key_role|
           tr(class: "owners__row") do
-            cell(title: "Name") { link_to api_key_role.name, profile_oidc_api_key_role_path(api_key_role.token) }
+            cell(title: "Name") { link_to api_key_role.name, profile_oidc_api_key_role_path(token: api_key_role.token) }
             cell(title: "Role Token") { code { api_key_role.token } }
             cell(title: "Provider") { link_to api_key_role.provider.issuer, api_key_role.provider.issuer }
           end

--- a/app/views/components/oidc/id_token/table_component.rb
+++ b/app/views/components/oidc/id_token/table_component.rb
@@ -33,8 +33,8 @@ class OIDC::IdToken::TableComponent < ApplicationComponent
     tr(class: row_classes.join(" ")) do
       td(class: "owners__cell") { time_tag token.created_at }
       td(class: "owners__cell") { time_tag token.api_key.expires_at }
-      td(class: "owners__cell") { link_to_unless_current token.api_key_role.name, profile_oidc_api_key_role_path(token.api_key_role.token) }
-      td(class: "owners__cell") { link_to_unless_current token.jti, profile_oidc_id_token_path(token), class: "recovery-code-list__item" }
+      td(class: "owners__cell") { link_to_unless_current token.api_key_role.name, profile_oidc_api_key_role_path(token: token.api_key_role.token) }
+      td(class: "owners__cell") { link_to_unless_current token.jti, profile_oidc_id_token_path(id: token), class: "recovery-code-list__item" }
     end
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -21,14 +21,14 @@
 
   <% if @latest_updates.empty? %>
     <%= prose do %>
-      <i><%= t('.no_subscriptions_html', :gem_link => link_to(t('.gem_link_text'), rubygem_path("rake"))) %></i>
+      <i><%= t('.no_subscriptions_html', :gem_link => link_to(t('.gem_link_text'), rubygem_path(id: "rake"))) %></i>
     <% end %>
   <% else %>
     <%= c.scrollable do %>
       <%= render Card::TimelineComponent.new do |t| %>
         <% @latest_updates.each do |version| %>
           <%= t.timeline_item(version.authored_at, t.link_to_pusher(version)) do %>
-              <div class="flex text-b1 text-neutral-800 dark:text-white"><%= link_to version.rubygem.name, rubygem_path(version.rubygem.slug) %></div>
+              <div class="flex text-b1 text-neutral-800 dark:text-white"><%= link_to version.rubygem.name, rubygem_path(id: version.rubygem.slug) %></div>
               <%= version_number(version) %>
           <% end %>
         <% end %>
@@ -49,7 +49,7 @@
     <%= c.divided_list do %>
       <% @my_gems.each do |rubygem| %>
         <%= c.list_item_to(
-          rubygem_path(rubygem.slug),
+          rubygem_path(id: rubygem.slug),
           title: short_info(rubygem.most_recent_version),
         ) do %>
           <div class="flex flex-col w-full justify-between">
@@ -76,7 +76,7 @@
     <% end %>
     <%= c.list do %>
       <% @subscribed_gems.each do |gem| %>
-        <%= c.list_item_to(rubygem_path(gem.slug), title: short_info(gem.most_recent_version)) do %>
+        <%= c.list_item_to(rubygem_path(id: gem.slug), title: short_info(gem.most_recent_version)) do %>
           <h3 class="text-b1"><%= gem.name %></h3>
           <p class="text-b3 text-neutral-600"><%= short_info(gem.most_recent_version) %></p>
         <% end %>
@@ -94,7 +94,7 @@
     <% end %>
     <%= c.divided_list do %>
       <% current_user.memberships.preload(:organization).each do |membership| %>
-        <%= c.list_item_to(organization_path(membership.organization)) do %>
+        <%= c.list_item_to(organization_path(id: membership.organization)) do %>
           <div class="flex flex-row w-full justify-between items-center">
             <div class="flex flex-col">
               <p class="text-neutral-800 dark:text-white"><%= membership.organization.name %></p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,7 +10,7 @@
       <span class="home__downloads__desc"><%= t('.downloads_counting_html') %></span>
     </h2>
   <% end %>
-  <%= link_to t('.learn.install_rubygems'), page_url("download"), :class => "home__join #{@downloads_count.nil? ? 'no-download-count' : ''}", "data-icon" => ">" %>
+  <%= link_to t('.learn.install_rubygems'), page_url(id: "download"), :class => "home__join #{@downloads_count.nil? ? 'no-download-count' : ''}", "data-icon" => ">" %>
 </div>
 <div class="home__links">
   <%= link_to t('layouts.application.footer.status'), "https://status.rubygems.org", class: "home__link", "data-icon" => "⌁" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
 
           <nav class="header__nav-links" data-controller="dropdown">
             <% if signed_in? %>
-              <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link mobile__header__nav-link">
+              <a href="<%= profile_path(id: current_user.display_id) %>" class="header__nav-link mobile__header__nav-link">
                 <span><%= current_user.name %></span>
                 <%= avatar 80, "user_gravatar", theme: :dark %>
               </a>
@@ -66,7 +66,7 @@
             <%= link_to t('.footer.guides'), "https://guides.rubygems.org", class: "header__nav-link" %>
 
             <% if signed_in? %>
-              <a href="<%= profile_path(current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
+              <a href="<%= profile_path(id: current_user.display_id) %>" class="header__nav-link desktop__header__nav-link">
                 <span><%= current_user.name %></span>
                 <%= avatar 80, "user_gravatar", theme: :dark %>
               </a>
@@ -129,22 +129,22 @@
             <%= link_to t('.footer.status'), "https://status.rubygems.org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.uptime'), "https://uptime.rubygems.org", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.source_code'), "https://github.com/rubygems/rubygems.org", class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.data'), page_path("data"), class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.data'), page_path(id: "data"), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.statistics'), stats_path, class: "nav--v__link--footer" %>
             <%= link_to t('.footer.contribute'), "https://guides.rubygems.org/contributing/", class: "nav--v__link--footer" %>
             <%- if current_page?(page_path(id: "about")) %>
-              <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer is-active" %>
+              <%= link_to t('.footer.about'), page_path(id: "about"), class: "nav--v__link--footer is-active" %>
             <%- else %>
-              <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer" %>
+              <%= link_to t('.footer.about'), page_path(id: "about"), class: "nav--v__link--footer" %>
             <%- end %>
             <%= mail_to "support@rubygems.org", t('.footer.help'), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.api'), "https://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.policies'), policies_path, class: "nav--v__link--footer" %>
-            <%= link_to t('.footer.support_us'), page_path("supporters"), class: "nav--v__link--footer" %>
+            <%= link_to t('.footer.support_us'), page_path(id: "supporters"), class: "nav--v__link--footer" %>
             <%- if current_page?(page_path(id: "security")) %>
-              <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer is-active" %>
+              <%= link_to t('.footer.security'), page_path(id: "security"), class: "nav--v__link--footer is-active" %>
             <%- else %>
-              <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer" %>
+              <%= link_to t('.footer.security'), page_path(id: "security"), class: "nav--v__link--footer" %>
             <%- end %>
           </div>
           <div class="l-colspan--l colspan--l--has-border">
@@ -159,7 +159,7 @@
                   ) %>
               </p>
               <p>
-                <%= t('footer_sponsors_html', supporters_page: page_path("supporters")) %>
+                <%= t('footer_sponsors_html', supporters_page: page_path(id: "supporters")) %>
               </p>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -200,7 +200,13 @@
           <span class="t-hidden">Mend.io</span>
         </a>
       </div>
-      <%# Locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
+      <div class="footer__language_selector">
+        <% I18n.available_locales.each do |language| %>
+          <div class="footer__language">
+            <%= link_to I18n.t(:locale_name, locale: language), locale_switch_path(language), class: "nav--v__link--footer" %>
+          </div>
+        <% end %>
+      </div>
     </footer>
     <%= yield :javascript %>
     <script type="text/javascript" defer src="https://www.fastly-insights.com/insights.js?k=3e63c3cd-fc37-4b19-80b9-65ce64af060a"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="<%= 'body--index' if request.path_info == '/' %>" data-controller="nav" data-nav-expanded-class="mobile-nav-is-expanded">
+  <body class="<%= 'body--index' if home_page? %>" data-controller="nav" data-nav-expanded-class="mobile-nav-is-expanded">
     <!-- Top banner -->
     <% if content_for?(:banner) %>
       <div class="banner">
@@ -33,7 +33,7 @@
     <!-- Policies acknowledgment banner -->
     <%= render "layouts/policies_acknowledgement" if show_policies_acknowledge_banner?(current_user) %>
 
-    <header class="header <%= 'header--interior' if request.path_info != '/' %>" data-nav-target="header collapse">
+    <header class="header <%= 'header--interior' unless home_page? %>" data-nav-target="header collapse">
       <div class="l-wrap--header">
         <%= link_to(root_path, title: 'RubyGems', class: 'header__logo-wrap', data: { nav_target: "logo" }) do %>
           <span class="header__logo" data-icon="⬡">⬢</span>
@@ -57,7 +57,7 @@
             <%= link_to t('.footer.releases'), news_url, class: "header__nav-link #{active_status(news_path)}" %>
             <%= link_to t('.footer.blog'), "https://blog.rubygems.org", class: "header__nav-link" %>
 
-            <%- if request.path_info == '/gems' %>
+            <%- if current_page?(rubygems_path) %>
               <%= link_to "Gems", rubygems_path, class: "header__nav-link is-active" %>
             <%- else %>
               <%= link_to "Gems", rubygems_path, class: "header__nav-link" %>
@@ -80,8 +80,8 @@
                 <%= link_to t('sign_out'), sign_out_path, method: :delete, class: "header__nav-link" %>
               </div>
             <% else %>
-              <%= link_to t('sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_in'}" %>
-              <%= link_to t('sign_up'), sign_up_path, class: "header__nav-link #{'is-active' if request.path_info == '/sign_up'}" %>
+              <%= link_to t('sign_in'), sign_in_path, class: "header__nav-link #{'is-active' if current_page?(sign_in_path)}" %>
+              <%= link_to t('sign_up'), sign_up_path, class: "header__nav-link #{'is-active' if current_page?(sign_up_path)}" %>
             <% end %>
           </nav>
         </div>
@@ -102,8 +102,8 @@
       </div>
     <% end %>
 
-    <main class="<%= 'main--interior' if request.path_info != '/' %>" data-nav-target="collapse">
-      <% if request.path_info != '/' %>
+    <main class="<%= 'main--interior' unless home_page? %>" data-nav-target="collapse">
+      <% unless home_page? %>
         <div class="l-wrap--b">
           <% if @title %>
             <h1 class="t-display page__heading">
@@ -132,7 +132,7 @@
             <%= link_to t('.footer.data'), page_path("data"), class: "nav--v__link--footer" %>
             <%= link_to t('.footer.statistics'), stats_path, class: "nav--v__link--footer" %>
             <%= link_to t('.footer.contribute'), "https://guides.rubygems.org/contributing/", class: "nav--v__link--footer" %>
-            <%- if request.path_info == '/pages/about' %>
+            <%- if current_page?(page_path(id: "about")) %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer is-active" %>
             <%- else %>
               <%= link_to t('.footer.about'), page_path("about"), class: "nav--v__link--footer" %>
@@ -141,7 +141,7 @@
             <%= link_to t('.footer.api'), "https://guides.rubygems.org/rubygems-org-api", class: "nav--v__link--footer" %>
             <%= link_to t('.footer.policies'), policies_path, class: "nav--v__link--footer" %>
             <%= link_to t('.footer.support_us'), page_path("supporters"), class: "nav--v__link--footer" %>
-            <%- if request.path_info == '/pages/security' %>
+            <%- if current_page?(page_path(id: "security")) %>
               <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer is-active" %>
             <%- else %>
               <%= link_to t('.footer.security'), page_path("security"), class: "nav--v__link--footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto:100&amp;subset=greek,latin,cyrillic,latin-ext' rel='stylesheet' type='text/css'>
     <%= render "layouts/feeds" %>
     <%= csrf_meta_tag if signed_in? %>
+    <%= content_for?(:search_engine_tags) ? yield(:search_engine_tags) : default_search_engine_tags %>
     <%= yield :head %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -57,10 +57,10 @@
 
                 <!-- About Dropdown Menu -->
                 <div data-dropdown-target="menu" class="z-50 hidden absolute -left-4 top-8 bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded shadow-lg text-b2 text-neutral-700 dark:text-neutral-300 divide-y divide-neutral-200 dark:divide-neutral-800">
-                  <%= link_to t('title'), page_path("about"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                  <%= link_to t('title'), page_path(id: "about"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                   <%= link_to t('layouts.application.footer.status'), "https://status.rubygems.org", data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
-                  <%= link_to t('layouts.application.footer.data'), page_path("data"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
-                  <%= link_to t('layouts.application.footer.security'), page_path("security"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                  <%= link_to t('layouts.application.footer.data'), page_path(id: "data"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                  <%= link_to t('layouts.application.footer.security'), page_path(id: "security"), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                   <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                 </div>
               </div>
@@ -99,10 +99,10 @@
                       <%= icon_tag "keyboard-arrow-down", class:"transition-transform transform", data: { reveal_target: "toggle" } %>
                     </button>
 
-                    <%= link_to t('title'), page_path("about"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                    <%= link_to t('title'), page_path(id: "about"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                     <%= link_to t('layouts.application.footer.status'), "https://status.rubygems.org", data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
-                    <%= link_to t('layouts.application.footer.data'), page_path("data"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
-                    <%= link_to t('layouts.application.footer.security'), page_path("security"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                    <%= link_to t('layouts.application.footer.data'), page_path(id: "data"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+                    <%= link_to t('layouts.application.footer.security'), page_path(id: "security"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                     <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "mb-4 hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                   </div>
 
@@ -180,11 +180,11 @@
         <div class="max-w-screen-xl mx-auto flex flex-col md:flex-row justify-between">
           <nav class="mb-4 md:mb-0 justify-start">
             <ul class="flex flex-col md:flex-row md:space-x-8 text-b1 md:text-b2">
-              <li><%= link_to t("layouts.application.footer.about"), page_path("about"), class: "hover:text-neutral-600" %></li>
+              <li><%= link_to t("layouts.application.footer.about"), page_path(id: "about"), class: "hover:text-neutral-600" %></li>
               <li><%= link_to t("layouts.application.footer.docs"), "https://guides.rubygems.org/command-reference/#gem-install", class: "hover:text-neutral-600" %></li>
               <li><%= link_to t("layouts.application.footer.policies"), policies_path, class: "hover:text-neutral-600" %></li>
               <li><%= link_to t("layouts.application.footer.status"), "https://status.rubygems.org", class: "hover:text-neutral-600" %></li>
-              <li><%= link_to t("layouts.application.footer.security"), page_path("security"), class: "hover:text-neutral-600" %></li>
+              <li><%= link_to t("layouts.application.footer.security"), page_path(id: "security"), class: "hover:text-neutral-600" %></li>
               <li><%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), class: "hover:text-neutral-600" %></li>
             </ul>
           </nav>

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -65,7 +65,6 @@
                   <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                 </div>
               </div>
-              <%# Locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
             </nav>
 
             <!-- Mobile Left Navigation Menu -->
@@ -106,8 +105,6 @@
                     <%= link_to t('layouts.application.footer.security'), page_path(id: "security"), data: { reveal_target: "item" }, class: "hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                     <%= mail_to "support@rubygems.org", t('layouts.application.footer.help'), data: { reveal_target: "item" }, class: "mb-4 hidden px-16 py-3 hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
                   </div>
-
-                  <%# Mobile locale switcher temporarily disabled to improve cacheability and mitigate bot abuse %>
                 </nav>
               </div>
             </dialog>
@@ -219,6 +216,11 @@
             <a href="https://mend.io/" class="col-start-2 p-1"><%= icon_tag "mend-io", size: 15 %></a>
           </div>
         </div>
+      </div>
+      <div class="footer__language_selector">
+        <% I18n.available_locales.each do |language| %>
+          <%= link_to I18n.t(:locale_name, locale: language), locale_switch_path(language), class: "hover:text-neutral-600" %>
+        <% end %>
       </div>
     </footer>
   </div>

--- a/app/views/layouts/hammy.html.erb
+++ b/app/views/layouts/hammy.html.erb
@@ -20,6 +20,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet" type="text/css">
   <%= render "layouts/feeds" %>
   <%= csrf_meta_tag if signed_in? %>
+  <%= content_for?(:search_engine_tags) ? yield(:search_engine_tags) : default_search_engine_tags %>
   <%= yield :head %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/mailer/api_key_created.html.erb
+++ b/app/views/mailer/api_key_created.html.erb
@@ -20,7 +20,7 @@
           Created at: <strong><%= @api_key.created_at.to_formatted_s(:rfc822) %></strong>
           <% if @api_key.oidc_id_token.present? %>
             <br>
-            <%= ApiKey.human_attribute_name(:oidc_api_key_role) %>: <strong><%= link_to(@api_key.oidc_api_key_role.name, profile_oidc_api_key_role_url(@api_key.oidc_api_key_role.token), target: :_blank) %></strong>
+            <%= ApiKey.human_attribute_name(:oidc_api_key_role) %>: <strong><%= link_to(@api_key.oidc_api_key_role.name, profile_oidc_api_key_role_url(token: @api_key.oidc_api_key_role.token), target: :_blank) %></strong>
           <% end %>
           <% if @api_key.expires_at.present? %>
             <br>

--- a/app/views/mailer/gem_pushed.html.erb
+++ b/app/views/mailer/gem_pushed.html.erb
@@ -13,18 +13,18 @@
           A gem you have push access to has recently released a new version.
         </p>
         <p>
-          Gem: <strong><%= link_to @version.to_title, rubygem_version_url(@version.rubygem.slug, @version.slug), target: "_blank" %></strong>
+          Gem: <strong><%= link_to @version.to_title, rubygem_version_url(rubygem_id: @version.rubygem.slug, id: @version.slug), target: "_blank" %></strong>
           <br>
           <% if @pushed_by_user %>
             <% if @pushed_by_user.is_a?(User) %>
               Pushed by user:
               <strong>
-                <%= link_to @pushed_by_user.handle, profile_url(@pushed_by_user.display_id), target: "_blank" %> <%= mail_to(@pushed_by_user.email) if @pushed_by_user.public_email? %>
+                <%= link_to @pushed_by_user.handle, profile_url(id: @pushed_by_user.display_id), target: "_blank" %> <%= mail_to(@pushed_by_user.email) if @pushed_by_user.public_email? %>
               </strong>
             <% else %>
               Pushed by trusted publisher:
               <strong>
-                <%= link_to @pushed_by_user.name, rubygem_trusted_publishers_url(@version.rubygem.slug), target: "_blank" %>
+                <%= link_to @pushed_by_user.name, rubygem_trusted_publishers_url(rubygem_id: @version.rubygem.slug), target: "_blank" %>
               </strong>
             <% end %>
             <br>

--- a/app/views/mailer/gem_trusted_publisher_added.html.erb
+++ b/app/views/mailer/gem_trusted_publisher_added.html.erb
@@ -13,13 +13,13 @@
           A gem you have push access to has recently added a new trusted publisher.
         </p>
         <p>
-          Gem: <strong><%= link_to @rubygem_trusted_publisher.rubygem.name, rubygem_url(@rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
+          Gem: <strong><%= link_to @rubygem_trusted_publisher.rubygem.name, rubygem_url(id: @rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
           <br>
-          Trusted publisher: <strong><%= link_to @rubygem_trusted_publisher.trusted_publisher.name, rubygem_trusted_publishers_url(@rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
+          Trusted publisher: <strong><%= link_to @rubygem_trusted_publisher.trusted_publisher.name, rubygem_trusted_publishers_url(rubygem_id: @rubygem_trusted_publisher.rubygem.slug), target: "_blank" %></strong>
           <br>
           Added by:
           <strong>
-            <%= link_to @created_by_user.display_handle, profile_url(@created_by_user.display_id), target: "_blank" %> <%= mail_to(@created_by_user.email) if @created_by_user.public_email? %>
+            <%= link_to @created_by_user.display_handle, profile_url(id: @created_by_user.display_id), target: "_blank" %> <%= mail_to(@created_by_user.email) if @created_by_user.public_email? %>
           </strong>
           <br>
           Added at: <strong><%= @rubygem_trusted_publisher.created_at.to_formatted_s(:rfc822) %></strong>

--- a/app/views/mailer/gem_yanked.html.erb
+++ b/app/views/mailer/gem_yanked.html.erb
@@ -13,11 +13,11 @@
           A version of a gem you are an owner of was recently yanked from <%= Gemcutter::HOST_DISPLAY %>.
         </p>
         <p>
-          Gem: <strong><%= link_to @version.to_title, rubygem_version_url(@version.rubygem.slug, @version.slug), target: "_blank" %></strong>
+          Gem: <strong><%= link_to @version.to_title, rubygem_version_url(rubygem_id: @version.rubygem.slug, id: @version.slug), target: "_blank" %></strong>
           <br>
           Yanked by user:
           <strong>
-            <%= link_to @yanked_by_user.handle, profile_url(@yanked_by_user.display_id), target: "_blank" %> <%= mail_to(@yanked_by_user.email) if @yanked_by_user.public_email? %>
+            <%= link_to @yanked_by_user.handle, profile_url(id: @yanked_by_user.display_id), target: "_blank" %> <%= mail_to(@yanked_by_user.email) if @yanked_by_user.public_email? %>
           </strong>
           <br>
           Yanked at: <strong><%= @version.yanked_at.to_formatted_s(:rfc822) %></strong>

--- a/app/views/news/_rubygem.html.erb
+++ b/app/views/news/_rubygem.html.erb
@@ -1,4 +1,4 @@
-<%= link_to rubygem_path(rubygem.slug), class: 'gems__gem' do %>
+<%= link_to rubygem_path(id: rubygem.slug), class: 'gems__gem' do %>
   <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= rubygem.name %>

--- a/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
+++ b/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
@@ -5,6 +5,6 @@
     <dt><%= api_key_permissions.class.human_attribute_name :valid_for %></dt>
     <dd><%= duration_string api_key_permissions.valid_for %></dd>
     <dt><%= api_key_permissions.class.human_attribute_name :gems %></dt>
-    <dd><%= to_sentence(api_key_permissions.gems.presence&.map { |gem| link_to(gem, rubygem_path(gem)) } || [t("api_keys.all_gems")])  %></dd>
+    <dd><%= to_sentence(api_key_permissions.gems.presence&.map { |gem| link_to(gem, rubygem_path(id: gem)) } || [t("api_keys.all_gems")])  %></dd>
   </dl>
 </div>

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -1,4 +1,4 @@
-<% url_attrs = @api_key_role.persisted? ? {url: profile_oidc_api_key_role_path(@api_key_role.token)} : {} %>
+<% url_attrs = @api_key_role.persisted? ? {url: profile_oidc_api_key_role_path(token: @api_key_role.token)} : {} %>
 <%= form_for [:profile, @api_key_role], **url_attrs do |f|%>
   <%= error_messages_for @api_key_role %>
   <%= f.label :name, class: "form__label" %>

--- a/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
+++ b/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
@@ -18,12 +18,12 @@ class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
     div(class: "t-body", data: { controller: "clipboard", clipboard_success_content_value: "✔" }) do
       p do
         t(".configured_for_html", link_html:
-          single_gem_role? ? link_to(gem_name, rubygem_path(gem_name)) : t(".a_gem"))
+          single_gem_role? ? link_to(gem_name, rubygem_path(id: gem_name)) : t(".a_gem"))
       end
 
       p do
         t(".to_automate_html", link_html:
-         single_gem_role? ? link_to(gem_name, rubygem_path(gem_name)) : t(".a_gem"))
+         single_gem_role? ? link_to(gem_name, rubygem_path(id: gem_name)) : t(".a_gem"))
       end
 
       p { t(".instructions_html") }

--- a/app/views/oidc/api_key_roles/index.html.erb
+++ b/app/views/oidc/api_key_roles/index.html.erb
@@ -24,13 +24,13 @@
       <% @api_key_roles.each do |api_key_role| %>
         <tr class="owners__row">
           <td class="owners__cell" data-title="Name">
-            <%= link_to api_key_role.name, profile_oidc_api_key_role_path(api_key_role.token) %>
+            <%= link_to api_key_role.name, profile_oidc_api_key_role_path(token: api_key_role.token) %>
           </td>
           <td class="owners__cell " data-title="Role Token">
             <code><%= api_key_role.token %></code>
           </td>
           <td class="owners__cell" data-title="Provider">
-            <%= link_to api_key_role.provider.issuer, profile_oidc_provider_path(api_key_role.provider) %>
+            <%= link_to api_key_role.provider.issuer, profile_oidc_provider_path(id: api_key_role.provider) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/oidc/api_key_roles/show.html.erb
+++ b/app/views/oidc/api_key_roles/show.html.erb
@@ -1,7 +1,7 @@
 <% @title = t(".api_key_role_name", name: @api_key_role.name) %>
 <div class="t-body">
   <% if @api_key_role.github_actions_push? && !@api_key_role.deleted_at? %>
-    <h2 class="t-display"><%= link_to t(".automate_gh_actions_publishing"), github_actions_workflow_profile_oidc_api_key_role_path(@api_key_role.token), class: "t-link t-underline" %> →</h2>
+    <h2 class="t-display"><%= link_to t(".automate_gh_actions_publishing"), github_actions_workflow_profile_oidc_api_key_role_path(token: @api_key_role.token), class: "t-link t-underline" %> →</h2>
   <% end %>
   <% if @api_key_role.deleted_at? %>
     <h2 class="t-display">
@@ -14,7 +14,7 @@
   </div>
   <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:provider) %></h3>
   <div class="push--s">
-    <%= link_to t(".view_provider", issuer: @api_key_role.provider.issuer), profile_oidc_provider_path(@api_key_role.provider) %> →
+    <%= link_to t(".view_provider", issuer: @api_key_role.provider.issuer), profile_oidc_provider_path(id: @api_key_role.provider) %> →
   </div>
   <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:api_key_permissions) %></h3>
   <div class="push--s">
@@ -26,8 +26,8 @@
   </div>
 
   <% unless @api_key_role.deleted_at? %>
-    <%= button_to t(".edit_role"), edit_profile_oidc_api_key_role_path(@api_key_role.token), method: "get", class: "form__submit" %>
-    <%= button_to t(".delete_role"), profile_oidc_api_key_role_path(@api_key_role.token), method: "delete", class: "form__submit", data: { confirm: t(".confirm_delete") } %>
+    <%= button_to t(".edit_role"), edit_profile_oidc_api_key_role_path(token: @api_key_role.token), method: "get", class: "form__submit" %>
+    <%= button_to t(".delete_role"), profile_oidc_api_key_role_path(token: @api_key_role.token), method: "delete", class: "form__submit", data: { confirm: t(".confirm_delete") } %>
   <% end %>
   <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:id_tokens) %></h3>
   <div class="push--s">

--- a/app/views/oidc/id_tokens/show_view.rb
+++ b/app/views/oidc/id_tokens/show_view.rb
@@ -13,8 +13,8 @@ class OIDC::IdTokens::ShowView < ApplicationView
       section(:created_at) { time_tag id_token.created_at }
       section(:expires_at) { time_tag id_token.api_key.expires_at }
       section(:jti) { code { id_token.jti } }
-      section(:api_key_role) { link_to id_token.api_key_role.name, profile_oidc_api_key_role_path(id_token.api_key_role.token) }
-      section(:provider) { link_to id_token.provider.issuer, profile_oidc_provider_path(id_token.provider) }
+      section(:api_key_role) { link_to id_token.api_key_role.name, profile_oidc_api_key_role_path(token: id_token.api_key_role.token) }
+      section(:provider) { link_to id_token.provider.issuer, profile_oidc_provider_path(id: id_token.provider) }
       section(:claims) { render OIDC::IdToken::KeyValuePairsComponent.new(pairs: id_token.claims) }
       section(:header) { render OIDC::IdToken::KeyValuePairsComponent.new(pairs: id_token.header) }
     end

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -47,7 +47,7 @@ class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
     div(class: "tw-border-solid tw-my-4 tw-space-y-2 tw-flex tw-flex-col") do
       div(class: "sm:tw-flex sm:tw-flex-row tw-gap-4 tw-mt-2") do
         h3(class: "!tw-mb-0") { pending_trusted_publisher.rubygem_name }
-        button_to(t(".delete"), profile_oidc_pending_trusted_publisher_path(pending_trusted_publisher),
+        button_to(t(".delete"), profile_oidc_pending_trusted_publisher_path(id: pending_trusted_publisher),
           method: :delete, class: "form__submit form__submit--small")
       end
 

--- a/app/views/oidc/providers/index_view.rb
+++ b/app/views/oidc/providers/index_view.rb
@@ -23,7 +23,7 @@ class OIDC::Providers::IndexView < ApplicationView
       end
       ul do
         providers.each do |provider|
-          li { link_to provider.issuer, profile_oidc_provider_path(provider) }
+          li { link_to provider.issuer, profile_oidc_provider_path(id: provider) }
         end
       end
       plain paginate(providers)

--- a/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
@@ -11,7 +11,7 @@ module OIDC::RubygemTrustedPublishers::Concerns::Title
           plain t(".title")
 
           i(class: "page__subheading page__subheading--block") do
-            raw t(".subtitle_owner_html", gem_html: view_context.link_to(rubygem.name, rubygem_path(rubygem.slug), class: "t-link t-underline"))
+            raw t(".subtitle_owner_html", gem_html: view_context.link_to(rubygem.name, rubygem_path(id: rubygem.slug), class: "t-link t-underline"))
           end
         end
       end

--- a/app/views/oidc/rubygem_trusted_publishers/index_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/index_view.rb
@@ -18,7 +18,7 @@ class OIDC::RubygemTrustedPublishers::IndexView < ApplicationView
       end
 
       p do
-        button_to t(".create"), new_rubygem_trusted_publisher_path(rubygem.slug), class: "form__submit", method: :get
+        button_to t(".create"), new_rubygem_trusted_publisher_path(rubygem_id: rubygem.slug), class: "form__submit", method: :get
       end
 
       header(class: "gems__header push--s") do
@@ -30,7 +30,7 @@ class OIDC::RubygemTrustedPublishers::IndexView < ApplicationView
           div(class: "tw-border-solid tw-my-4 tw-space-y-4 tw-flex tw-flex-col") do
             div(class: "sm:tw-flex sm:tw-items-baseline tw-mt-4 tw-gap-2") do
               h4 { rubygem_trusted_publisher.trusted_publisher.class.publisher_name }
-              button_to(t(".delete"), rubygem_trusted_publisher_path(rubygem.slug, rubygem_trusted_publisher),
+              button_to(t(".delete"), rubygem_trusted_publisher_path(rubygem_id: rubygem.slug, id: rubygem_trusted_publisher),
                         method: :delete, class: "form__submit form__submit--small")
             end
             render rubygem_trusted_publisher.trusted_publisher

--- a/app/views/oidc/rubygem_trusted_publishers/new_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/new_view.rb
@@ -16,7 +16,7 @@ class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
     div(class: "t-body") do
       form_with(
         model: rubygem_trusted_publisher,
-        url: rubygem_trusted_publishers_path(rubygem_trusted_publisher.rubygem.slug)
+        url: rubygem_trusted_publishers_path(rubygem_id: rubygem_trusted_publisher.rubygem.slug)
       ) do |f|
         f.label :trusted_publisher_type, class: "form__label"
         f.select :trusted_publisher_type, OIDC::TrustedPublisher.all.map { |type|

--- a/app/views/organizations/_subject.html.erb
+++ b/app/views/organizations/_subject.html.erb
@@ -15,11 +15,11 @@
 <hr class="hidden lg:block lg:mb-6 border-neutral-400 dark:border-neutral-600" />
 
 <%= render Subject::NavComponent.new(current:) do |nav| %>
-  <%= nav.link t("layouts.application.header.dashboard"), organization_path(@organization), name: :dashboard, icon: "space-dashboard" %>
-  <%= nav.link t("organizations.show.history"), organization_path(@organization), name: :subscriptions, icon: "notifications" %>
-  <%= nav.link t("organizations.show.gems"), organization_gems_path(@organization), name: :gems, icon: "gems" %>
-  <%= nav.link t("organizations.show.members"), organization_memberships_path(@organization), name: :members, icon: "organizations" %>
+  <%= nav.link t("layouts.application.header.dashboard"), organization_path(id: @organization), name: :dashboard, icon: "space-dashboard" %>
+  <%= nav.link t("organizations.show.history"), organization_path(id: @organization), name: :subscriptions, icon: "notifications" %>
+  <%= nav.link t("organizations.show.gems"), organization_gems_path(organization_id: @organization), name: :gems, icon: "gems" %>
+  <%= nav.link t("organizations.show.members"), organization_memberships_path(organization_id: @organization), name: :members, icon: "organizations" %>
   <% if policy(@organization).edit? %>
-    <%= nav.link t("layouts.application.header.settings"), edit_organization_path(@organization), name: :settings, icon: "settings" %>
+    <%= nav.link t("layouts.application.header.settings"), edit_organization_path(id: @organization), name: :settings, icon: "settings" %>
   <% end %>
 <% end %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -8,7 +8,7 @@
   <%= c.head do %>
     <%= c.title t("layouts.application.header.settings"), icon: "settings" %>
   <% end %>
-  <%= form_with model: @organization, url: organization_path(@organization), method: :patch do |form| %>
+  <%= form_with model: @organization, url: organization_path(id: @organization), method: :patch do |form| %>
     <div>
       <%= form.label :name, "Display Name", class: "block text-b2 font-semibold mb-2" %>
       <%= form.text_field(

--- a/app/views/organizations/gems/index.html.erb
+++ b/app/views/organizations/gems/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(@organization)
+  add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(id: @organization)
   add_breadcrumb t("breadcrumbs.gems")
 %>
 
@@ -21,7 +21,7 @@
     <%= c.divided_list do %>
       <% @gems.each do |rubygem| %>
         <%= c.list_item_to(
-          rubygem_path(rubygem.slug),
+          rubygem_path(id: rubygem.slug),
           title: short_info(rubygem.most_recent_version),
         ) do %>
           <div class="flex flex-col w-full justify-between">

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -25,7 +25,7 @@
       <% end %>
     <% else %>
       <% @memberships.each do |membership| %>
-        <%= c.list_item_to(organization_path(membership.organization.handle)) do %>
+        <%= c.list_item_to(organization_path(id: membership.organization.handle)) do %>
           <div class="flex flex-row w-full justify-between items-center">
             <div class="flex flex-col">
               <p class="text-neutral-800 dark:text-white"><%= membership.organization.name %></p>

--- a/app/views/organizations/invitations/show.html.erb
+++ b/app/views/organizations/invitations/show.html.erb
@@ -1,8 +1,8 @@
 <% 
 
     add_breadcrumb "Organizations", organizations_path
-    add_breadcrumb @organization.handle, organization_path(@organization)
-    add_breadcrumb "Invitation", organization_invitation_path(@organization)
+    add_breadcrumb @organization.handle, organization_path(id: @organization)
+    add_breadcrumb "Invitation", organization_invitation_path(organization_id: @organization)
 
 %>
 
@@ -15,10 +15,10 @@
       </div>
     </div>
     <div class="flex justify-center gap-3 mb-6">
-      <%= form_with model: @membership, url: organization_invitation_path(@organization), method: :patch, class: "inline" do |f| %>
+      <%= form_with model: @membership, url: organization_invitation_path(organization_id: @organization), method: :patch, class: "inline" do |f| %>
         <%= render ButtonComponent.new t(".accept"), type: :submit, class: "bg-orange-500 hover:bg-orange-600 text-white" %>
       <% end %>
-      <%= button_to t(".decline"), organization_invitation_path(@organization), method: :delete, class: "border border-slate-400 text-slate-700 px-4 py-2 rounded dark:text-white hover:bg-slate-100" %>
+      <%= button_to t(".decline"), organization_invitation_path(organization_id: @organization), method: :delete, class: "border border-slate-400 text-slate-700 px-4 py-2 rounded dark:text-white hover:bg-slate-100" %>
     </div>
     <hr class="my-6">
     <div class="text-xs text-slate-500 dark:text-white">

--- a/app/views/organizations/members/edit.html.erb
+++ b/app/views/organizations/members/edit.html.erb
@@ -1,8 +1,8 @@
 <%
   add_breadcrumb "Dashboard", dashboard_path
   add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle)
-  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(@organization)
-  add_breadcrumb @membership.user.handle, organization_membership_path(@organization, @membership)
+  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(organization_id: @organization)
+  add_breadcrumb @membership.user.handle, organization_membership_path(organization_id: @organization, id: @membership)
 %>
 
 <% content_for :subject do %>
@@ -23,7 +23,7 @@
     <% end %>
   <% end %>
 
-  <%= form_with(model: @membership, url: organization_membership_path(@organization, @membership), method: :patch) do |f| %>
+  <%= form_with(model: @membership, url: organization_membership_path(organization_id: @organization, id: @membership), method: :patch) do |f| %>
       <% if @membership.errors.any? %>
       <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
         <div class="flex">
@@ -55,7 +55,7 @@
       <% if !@membership.confirmed? %>
         <div class="flex flex-col">
           <% if policy(@organization).invite_member? %>
-            <%= render ButtonComponent.new t(".resend_invitation"), resend_invitation_organization_membership_path(@organization, @membership), type: :link, method: :patch, style: :outline, class: "text-xs px-3 py-1 mr-3" %>
+            <%= render ButtonComponent.new t(".resend_invitation"), resend_invitation_organization_membership_path(organization_id: @organization, id: @membership), type: :link, method: :patch, style: :outline, class: "text-xs px-3 py-1 mr-3" %>
           <% end %>
         </div>
       <% end %>
@@ -65,7 +65,7 @@
 
   <hr class="my-6 border-gray-200 dark:border-gray-700"/>
 
-  <%= form_with(url: organization_membership_path(@organization, @membership), method: :delete, confirm: "Are you sure?") do |f| %>
+  <%= form_with(url: organization_membership_path(organization_id: @organization, id: @membership), method: :delete, confirm: "Are you sure?") do |f| %>
     <div class="flex justify-end">
     <%= render ButtonComponent.new t(".delete"), type: :submit, style: :outline, disabled: @membership.user == current_user, class: "px-4 py-2 text-red-600 border-red-300 hover:bg-red-50 dark:text-red-400 dark:border-red-700 dark:hover:bg-red-900/20", data: { confirm: "Are you sure you want to remove this member?" } %>
     </div>

--- a/app/views/organizations/members/index.html.erb
+++ b/app/views/organizations/members/index.html.erb
@@ -1,7 +1,7 @@
 <%
   add_breadcrumb "Dashboard", dashboard_path
   add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle)
-  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(@organization)
+  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(organization_id: @organization)
 %>
 
 <% content_for :subject do %>
@@ -16,13 +16,13 @@
   <%= c.head do %>
     <%= c.title t("organizations.show.members"), icon: "organizations", count: @memberships_count %>
     <% if policy(@organization).invite_member? %>
-      <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
+      <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(organization_id: @organization), type: :link %>
     <% end %>
   <% end %>
   <%= c.divided_list do %>
     <% @memberships.each do |membership| %>
       <%= c.list_item_to(
-        policy(@organization).list_memberships? ? edit_organization_membership_path(@organization, membership) : profile_path(membership.user),
+        policy(@organization).list_memberships? ? edit_organization_membership_path(organization_id: @organization, id: membership) : profile_path(id: membership.user),
         title: membership.user.handle,
       ) do %>
         <div class="flex flex-col w-full justify-between">

--- a/app/views/organizations/members/new.html.erb
+++ b/app/views/organizations/members/new.html.erb
@@ -1,7 +1,7 @@
 <%
   add_breadcrumb "Dashboard", dashboard_path
   add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle)
-  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(@organization)
+  add_breadcrumb t("breadcrumbs.members"), organization_memberships_path(organization_id: @organization)
   add_breadcrumb t("breadcrumbs.invite_member")
 %>
 
@@ -18,7 +18,7 @@
     <%= c.title "Invite Member", icon: "organizations" %>
   <% end %>
 
-  <%= form_with(model: @membership, url: organization_memberships_path(@organization), method: :post, html: { class: "p-6" }) do |f| %>
+  <%= form_with(model: @membership, url: organization_memberships_path(organization_id: @organization), method: :post, html: { class: "p-6" }) do |f| %>
     <% if @membership.errors.any? %>
       <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
         <div class="flex">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -27,7 +27,7 @@
             end
           %>
           <%= t.timeline_item(version.authored_at, pusher_link) do %>
-            <div class="flex text-b1 text-neutral-800 dark:text-white"><%= link_to version.rubygem.name, rubygem_path(version.rubygem.slug) %></div>
+            <div class="flex text-b1 text-neutral-800 dark:text-white"><%= link_to version.rubygem.name, rubygem_path(id: version.rubygem.slug) %></div>
             <%= version_number(version) %>
           <% end %>
         <% end %>
@@ -48,7 +48,7 @@
     <%= c.divided_list do %>
       <% @gems.each do |rubygem| %>
         <%= c.list_item_to(
-          rubygem_path(rubygem.slug),
+          rubygem_path(id: rubygem.slug),
           title: short_info(rubygem.most_recent_version),
         ) do %>
           <div class="flex flex-col w-full justify-between">
@@ -83,7 +83,7 @@
   <% else %>
     <%= c.divided_list do %>
       <% @memberships.each do |membership| %>
-        <%= c.list_item_to(profile_path(membership.user.handle)) do %>
+        <%= c.list_item_to(profile_path(id: membership.user.handle)) do %>
           <div class="flex justify-between">
             <p class="text-neutral-800 dark:text-white"><%= membership.user.name %></p>
             <% if @organization.user_is_member?(current_user) %>
@@ -100,7 +100,7 @@
 
     <% if policy(@organization).invite_member? %>
       <div class="pt-6 flex flex-row justify-end">
-        <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(@organization), type: :link %>
+        <%= render ButtonComponent.new t(".invite"), new_organization_membership_path(organization_id: @organization), type: :link %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -29,7 +29,7 @@
   <% @ownerships.each do |ownership| %>
     <tr class="owners__row">
       <td class="owners__cell" data-title="Name">
-        <%= link_to(ownership.owner_name, profile_path(ownership.user.display_id), class: "owner__profile") %>
+        <%= link_to(ownership.owner_name, profile_path(id: ownership.user.display_id), class: "owner__profile") %>
       </td>
       <td class="owners__cell" data-title="Confirmed">
         <span class="owners__icon">
@@ -55,7 +55,7 @@
       <td class="owners__cell" data-title="Action">
         <% if can_remove_owners?(@rubygem) %>
         <%= button_to t("remove"),
-          rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
+          rubygem_owner_path(rubygem_id: @rubygem.slug, handle: ownership.user.display_id),
           method: "delete",
           data: { confirm: t("owners.index.confirm_remove") },
           class: "form__submit form__submit--small" %>
@@ -63,7 +63,7 @@
         <% if can_modify_owners?(@rubygem) %>
         <br>
         <%= button_to t("edit"),
-          edit_rubygem_owner_path(@rubygem.name, ownership.user.display_id),
+          edit_rubygem_owner_path(rubygem_id: @rubygem.name, handle: ownership.user.display_id),
           disabled: ownership.user == current_user,
           method: "get",
           class: "form__submit form__submit--small" %>

--- a/app/views/owners/edit.html.erb
+++ b/app/views/owners/edit.html.erb
@@ -1,7 +1,7 @@
 <% @title = t('.title') %>
 <% @roles = Ownership.roles.map { |k,_| [Ownership.human_attribute_name("role.#{k}"), k] } %>
 
-<%= form_tag rubygem_owner_path(rubygem_id: @rubygem.slug, owner_id: @ownership.user.display_id), method: :patch do |form| %>
+<%= form_tag rubygem_owner_path(rubygem_id: @rubygem.slug, handle: @ownership.user.display_id), method: :patch do |form| %>
   <%= error_messages_for(@ownership) %>
 
   <div class="text_field">

--- a/app/views/owners_mailer/owner_added.html.erb
+++ b/app/views/owners_mailer/owner_added.html.erb
@@ -20,7 +20,7 @@
         </p>
 
         <%= render "mailer/compromised_instructions" do %>
-          <li>Remove <%= @owner.display_handle %> as an owner from <%= @rubygem.name %> gem using <code>gem owner -r <%= @owner.display_handle %></code> or <%= link_to "ownership page", rubygem_owners_url(@rubygem.slug) %></li>
+          <li>Remove <%= @owner.display_handle %> as an owner from <%= @rubygem.name %> gem using <code>gem owner -r <%= @owner.display_handle %></code> or <%= link_to "ownership page", rubygem_owners_url(rubygem_id: @rubygem.slug) %></li>
           <li>Look out for unexpected changes to your gems on RubyGems.org</li>
         <% end %>
 

--- a/app/views/owners_mailer/owner_updated.text.erb
+++ b/app/views/owners_mailer/owner_updated.text.erb
@@ -2,4 +2,4 @@
 
 <%= t("mailer.owner_updated.body_text", gem: @rubygem.name, host: Gemcutter::HOST_DISPLAY, role: Ownership.human_attribute_name("role.#{@ownership.role}")) %>
 
-<%= rubygem_owners_url(@rubygem.slug) %>
+<%= rubygem_owners_url(rubygem_id: @rubygem.slug) %>

--- a/app/views/owners_mailer/ownership_confirmation.html.erb
+++ b/app/views/owners_mailer/ownership_confirmation.html.erb
@@ -29,7 +29,7 @@
                       </td>
                       <td bgcolor="#e9573f">
                         <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href="<%= confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
+                          <a href="<%= confirm_rubygem_owners_url(rubygem_id: @rubygem.slug, token: @ownership.token) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
                         </div>
                       </td>
                       <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>

--- a/app/views/owners_mailer/ownership_confirmation.text.erb
+++ b/app/views/owners_mailer/ownership_confirmation.text.erb
@@ -1,4 +1,4 @@
 <%= t("mailer.ownership_confirmation.subtitle", handle: @user.handle) %>
 
 <%= t("mailer.ownership_confirmation.body_text", gem: @rubygem.name, authorizer: @ownership.authorizer.display_handle) %>
-<%= confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token.html_safe) %>
+<%= confirm_rubygem_owners_url(rubygem_id: @rubygem.slug, token: @ownership.token.html_safe) %>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -14,7 +14,7 @@
 
   <ul>
     <% Gemcutter::POLICY_PAGES.each do |policy| %>
-      <li><%= link_to(t("policies.#{policy}.title"), policy_path(policy)) %></li>
+      <li><%= link_to(t("policies.#{policy}.title"), policy_path(policy: policy)) %></li>
     <% end %>
   </ul>
 

--- a/app/views/profiles/_rubygem.html.erb
+++ b/app/views/profiles/_rubygem.html.erb
@@ -1,7 +1,7 @@
 <li class="small">
   <div class="gems__gem">
     <span class="gems__gem__info">
-      <a href="<%= rubygem_path(rubygem.slug) %>" class="gems__gem__name">
+      <a href="<%= rubygem_path(id: rubygem.slug) %>" class="gems__gem__name">
         <%= rubygem.name %>
         <span class="gems__gem__version"><%= rubygem.latest_version %></span>
       </a>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -9,17 +9,17 @@
 
       <% if @user.full_name.present? %>
         <h1 id="profile-full-name" class="profile__header__name t-display-full-name">
-          <%= link_to(@user.full_name, profile_path(@user.display_id), class: "t-link--black") %>
+          <%= link_to(@user.full_name, profile_path(id: @user.display_id), class: "t-link--black") %>
         </h1>
 
         <h1 id="profile-name" class="profile__header__username t-display-username">
-          <%= link_to(@user.display_handle, profile_path(@user.display_id), class: "t-link--black") %>
+          <%= link_to(@user.display_handle, profile_path(id: @user.display_id), class: "t-link--black") %>
         </h1>
       <% else %>
         <h1 id="profile-name" class="profile__header__name t-display">
           <%=
             link_to(
-              @user.display_handle, profile_path(@user.display_id),
+              @user.display_handle, profile_path(id: @user.display_id),
               class: "t-link--black"
             )
           %>

--- a/app/views/reverse_dependencies/_search.html.erb
+++ b/app/views/reverse_dependencies/_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag rubygem_reverse_dependencies_path(rubygem.slug),
+<%= form_tag rubygem_reverse_dependencies_path(rubygem_id: rubygem.slug),
   id: "rdeps-search", class: "home__search-wrap", method: :get do %>
   <%= search_field_tag :rdeps_query, params[:rdeps_query], placeholder: t('.search_reverse_dependencies_html'), class: "home__search" %>
   <%= label_tag :rdeps_query do %>

--- a/app/views/rubygems/_dependencies.html.erb
+++ b/app/views/rubygems/_dependencies.html.erb
@@ -5,7 +5,7 @@
       <% dependencies.each do |dependency| %>
         <% dependency.rubygem.tap do |rubygem| %>
           <div class="<%= class_names("gem__requirement-wrap", "gem__unregistered": !rubygem) %>">
-            <%= link_to_if rubygem, tag.strong(rubygem&.name || dependency.name), rubygem_path(rubygem&.slug || "-"), class: "t-list__item" %>
+            <%= link_to_if rubygem, tag.strong(rubygem&.name || dependency.name), rubygem_path(id: rubygem&.slug || "-"), class: "t-list__item" %>
             <%= dependency.clean_requirements %>
           </div>
         <% end %>

--- a/app/views/rubygems/_release_info.html.erb
+++ b/app/views/rubygems/_release_info.html.erb
@@ -4,7 +4,7 @@
     <div class="gem__organization-header">
       <h3 class="t-list__heading"><%= t '.managed_by' %>:</h3>
       <div class="gem__organization-info">
-        <h4 class="gem__organization-header"><%= link_to rubygem.organization.name, organization_path(rubygem.organization), class: "gem__organization-name" %></h4>
+        <h4 class="gem__organization-header"><%= link_to rubygem.organization.name, organization_path(id: rubygem.organization), class: "gem__organization-name" %></h4>
       </div>
 
       <% if rubygem.owners.any? %>

--- a/app/views/rubygems/_rubygem.html.erb
+++ b/app/views/rubygems/_rubygem.html.erb
@@ -1,4 +1,4 @@
-<%= link_to rubygem_path(rubygem.name), :class => 'gems__gem' do %>
+<%= link_to rubygem_path(id: rubygem.name), :class => 'gems__gem' do %>
   <span class="gems__gem__info">
     <h2 class="gems__gem__name">
       <%= rubygem.name %>

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,9 +1,9 @@
 <div class="gem__navigation">
   <% if latest_version.previous.present? %>
-    <%= link_to t('.previous_version'), rubygem_version_path(rubygem.slug, latest_version.previous.number), class: "gem__previous__version"  %>
+    <%= link_to t('.previous_version'), rubygem_version_path(rubygem_id: rubygem.slug, id: latest_version.previous.number), class: "gem__previous__version"  %>
   <% end %>
 
   <% if latest_version.next.present? %>
-    <%= link_to t('.next_version'), rubygem_version_path(rubygem.slug, latest_version.next.number), class: "gem__next__version" %>
+    <%= link_to t('.next_version'), rubygem_version_path(rubygem_id: rubygem.slug, id: latest_version.next.number), class: "gem__next__version" %>
   <% end %>
 </div>

--- a/app/views/rubygems/reserved.html.erb
+++ b/app/views/rubygems/reserved.html.erb
@@ -1,4 +1,7 @@
 <% @title = @reserved_gem %>
+<% content_for :search_engine_tags do %>
+  <meta name="robots" content="noindex" />
+<% end %>
 <div class="t-body">
   <p><%= t '.reserved_namespace' %></p>
 </div>

--- a/app/views/rubygems/security_events_view.rb
+++ b/app/views/rubygems/security_events_view.rb
@@ -13,7 +13,7 @@ class Rubygems::SecurityEventsView < ApplicationView
 
     div(class: "tw-space-y-2 t-body") do
       p do
-        t(".description_html", gem: link_to(rubygem.name, rubygem_path(rubygem.slug)))
+        t(".description_html", gem: link_to(rubygem.name, rubygem_path(id: rubygem.slug)))
       end
 
       render Events::TableComponent.new(security_events: security_events)

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -1,12 +1,12 @@
 <% @title = @rubygem.name %>
-<% @title_url = rubygem_path(@rubygem.slug) %>
+<% @title_url = rubygem_path(id: @rubygem.slug) %>
 <% @subtitle = @latest_version&.slug %>
 
 <% content_for :head do %>
-  <%= auto_discovery_link_tag(:atom, rubygem_versions_path(@rubygem.slug, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
+  <%= auto_discovery_link_tag(:atom, rubygem_versions_path(rubygem_id: @rubygem.slug, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
   <% if @rubygem.versions.any? && @latest_version.indexed %>
     <!-- canonical url -->
-    <link rel="canonical" href="<%= rubygem_version_url(@rubygem.slug, @latest_version.slug) %>" />
+    <link rel="canonical" href="<%= rubygem_version_url(rubygem_id: @rubygem.slug, id: @latest_version.slug) %>" />
     <%# Locale alternate links temporarily disabled to improve cacheability and mitigate bot abuse %>
   <% else %>
     <meta name="robots" content="noindex" />
@@ -47,7 +47,7 @@
             <%= render @versions %>
           </ol>
           <% if show_all_versions_link?(@rubygem) %>
-            <%= link_to t('.show_all_versions', :count => @rubygem.versions.count), rubygem_versions_url(@rubygem.slug), :class => "gem__see-all-versions t-link--gray t-link--has-arrow" %>
+            <%= link_to t('.show_all_versions', :count => @rubygem.versions.count), rubygem_versions_url(rubygem_id: @rubygem.slug), :class => "gem__see-all-versions t-link--gray t-link--has-arrow" %>
           <% end %>
         </div>
       </div>
@@ -58,7 +58,7 @@
       <%= render :partial => "rubygems/dependencies", :locals => { :dependencies => @latest_version.dependencies.development } %>
       <% if @latest_version.dependencies.present? && @latest_version.indexed %>
         <div class="dependencies_list">
-          <%= link_to t(:dependency_list), rubygem_version_dependencies_path(@rubygem.slug, @latest_version.slug), class: "gem__see-all-versions t-link--gray t-link--has-arrow push--s" %>
+          <%= link_to t(:dependency_list), rubygem_version_dependencies_path(rubygem_id: @rubygem.slug, version_id: @latest_version.slug), class: "gem__see-all-versions t-link--gray t-link--has-arrow push--s" %>
         </div>
       <% end %>
     </div>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -2,15 +2,16 @@
 <% @title_url = rubygem_path(id: @rubygem.slug) %>
 <% @subtitle = @latest_version&.slug %>
 
-<% content_for :head do %>
-  <%= auto_discovery_link_tag(:atom, rubygem_versions_path(rubygem_id: @rubygem.slug, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
+<% content_for :search_engine_tags do %>
   <% if @rubygem.versions.any? && @latest_version.indexed %>
-    <!-- canonical url -->
-    <link rel="canonical" href="<%= rubygem_version_url(rubygem_id: @rubygem.slug, id: @latest_version.slug) %>" />
-    <%# Locale alternate links temporarily disabled to improve cacheability and mitigate bot abuse %>
+    <%= canonical_link_tags { |locale| rubygem_version_url(rubygem_id: @rubygem.slug, id: @latest_version.slug, locale: locale_param(locale)) } %>
   <% else %>
     <meta name="robots" content="noindex" />
   <% end %>
+<% end %>
+
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:atom, rubygem_versions_path(rubygem_id: @rubygem.slug, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
 <% end %>
 
 

--- a/app/views/rubygems/show_yanked.html.erb
+++ b/app/views/rubygems/show_yanked.html.erb
@@ -1,6 +1,6 @@
 <% @title = @rubygem.name %>
 
-<% content_for :head do %>
+<% content_for :search_engine_tags do %>
   <meta name="robots" content="noindex" />
 <% end %>
 

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -10,7 +10,7 @@
   <% @subtitle = t('.subtitle_html', :query => params[:query]) %>
 
   <% if @yanked_gem.present? %>
-    <%= link_to rubygem_path(@yanked_gem.slug), :class => 'gems__gem' do %>
+    <%= link_to rubygem_path(id: @yanked_gem.slug), :class => 'gems__gem' do %>
       <span class="gems__gem__info">
         <h2 class="gems__gem__name">
           <%= @yanked_gem.name %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -25,7 +25,7 @@
 
 <% @most_downloaded.each do |gem| %>
   <div class="stats__graph__gem">
-    <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(gem.slug) %></h3>
+    <h3 class="stats__graph__gem__name"><%= link_to gem.name, rubygem_path(id: gem.slug) %></h3>
     <div class="stats__graph__gem__meter-wrap">
       <div class="stats__graph__gem__meter t-item--hidden" data-controller="stats" data-stats-width-value="<%= stats_graph_meter(gem, @most_downloaded_count) %>">
         <span class="stats__graph__gem__count"><%= number_to_delimited gem.downloads %></span>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -14,19 +14,19 @@
 <%= render CardComponent.new do |c| %>
   <% if @subscribed_gems.empty? %>
     <%= prose do %>
-      <i><%= t("dashboards.show.no_subscriptions_html", :gem_link => link_to(t('dashboards.show.gem_link_text'), rubygem_path("rake"))) %></i>
+      <i><%= t("dashboards.show.no_subscriptions_html", :gem_link => link_to(t('dashboards.show.gem_link_text'), rubygem_path(id: "rake"))) %></i>
     <% end %>
   <% else %>
     <%= c.list do %>
       <% @subscribed_gems.each do |gem| %>
         <%= c.list_item do %>
           <div class="flex flex-row w-full items-center justify-between">
-            <%= link_to rubygem_path(gem.slug) do %>
+            <%= link_to rubygem_path(id: gem.slug) do %>
               <h3 class="text-b1"><%= gem.name %></h3>
               <p class="text-b3"><%= short_info(gem.most_recent_version) %></p>
             <% end %>
             <%= button_to(
-              rubygem_subscription_path(gem.slug),
+              rubygem_subscription_path(rubygem_id: gem.slug),
               method: :delete,
               title: t("rubygems.aside.links.unsubscribe"),
               class: "h-8 w-8 ml-6 items-center justify-center outline-none -mr-2",

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,7 @@
 <% if signup_enabled? %>
   <%= form_for @user do |form| %>
     <%= render :partial => '/users/form', :object => form %>
-    <p class="form__legend"><%= t('by_signing_up')%> <%= link_to t('sign_up_terms'), policy_path('terms-of-service') %></p>
+    <p class="form__legend"><%= t('by_signing_up')%> <%= link_to t('sign_up_terms'), policy_path(policy: 'terms-of-service') %></p>
     <%= form.submit t('sign_up'), :data => {:disable_with => t('form_disable_with')}, :class => 'form__submit' %>
   <% end %>
 <% end %>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -1,5 +1,5 @@
 <li class="gem__version-wrap">
-  <%= link_to version.number, rubygem_version_path(version.rubygem.slug, version.slug), :class => 't-list__item' %>
+  <%= link_to version.number, rubygem_version_path(rubygem_id: version.rubygem.slug, id: version.slug), :class => 't-list__item' %>
   <%= version_date_tag(version) %>
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>

--- a/app/views/versions/_versions_feed.atom.builder
+++ b/app/views/versions/_versions_feed.atom.builder
@@ -15,8 +15,8 @@ builder.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   versions.each do |version|
     builder.entry do
       builder.title     version.to_title
-      builder.link      "rel" => "alternate", "href" => rubygem_version_url(version.rubygem.slug, version.slug)
-      builder.id        rubygem_version_url(version.rubygem.slug, version.slug)
+      builder.link      "rel" => "alternate", "href" => rubygem_version_url(rubygem_id: version.rubygem.slug, id: version.slug)
+      builder.id        rubygem_version_url(rubygem_id: version.rubygem.slug, id: version.slug)
       builder.updated   version.created_at.iso8601
       builder.author    { |author| author.name h(version.authors) }
       builder.summary   version.summary if version.summary?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,6 @@
 
 Rails.application.routes.draw do
   ################################################################################
-  # Root
-
-  root to: 'home#index'
-
-  ################################################################################
   # API
 
   namespace :api do
@@ -156,160 +151,177 @@ Rails.application.routes.draw do
   end
 
   ################################################################################
-  # UI
-  scope constraints: { format: :html }, defaults: { format: 'html' } do
-    resource :search, only: :show do
-      get :advanced
-    end
-    resource :dashboard, only: :show, constraints: { format: /html|atom/ }
-    resources :subscriptions, only: :index
-    resources :profiles, only: :show
-    get "profile/me", to: "profiles#me", as: :my_profile
-    resource :multifactor_auth, only: %i[update] do
-      get 'recovery'
-      post 'otp_update', to: 'multifactor_auths#otp_update', as: :otp_update
-      post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
-    end
-    resource :totp, only: %i[new create destroy]
-    resource :settings, only: :edit
-    resource :profile, only: %i[edit update] do
-      get :security_events
-      member do
-        get :delete
-        delete :destroy, as: :destroy
-      end
+  # Localized UI
+  scope "(:locale)", locale: LocaleRouting::PATH_CONSTRAINT do
+    root to: 'home#index'
 
-      resources :api_keys do
-        delete :reset, on: :collection
+    scope constraints: { format: :html }, defaults: { format: 'html' } do
+      resource :search, only: :show do
+        get :advanced
       end
+      resource :dashboard, only: :show, constraints: { format: /html|atom/ }
+      resources :subscriptions, only: :index
+      resources :profiles, only: :show
+      get "profile/me", to: "profiles#me", as: :my_profile
+      resource :multifactor_auth, only: %i[update] do
+        get 'recovery'
+        post 'otp_update', to: 'multifactor_auths#otp_update', as: :otp_update
+        post 'webauthn_update', to: 'multifactor_auths#webauthn_update', as: :webauthn_update
+      end
+      resource :totp, only: %i[new create destroy]
+      resource :settings, only: :edit
+      resource :profile, only: %i[edit update] do
+        get :security_events
+        member do
+          get :delete
+          delete :destroy, as: :destroy
+        end
 
-      namespace :oidc do
-        resources :api_key_roles, param: :token do
-          member do
-            get 'github_actions_workflow'
+        resources :api_keys do
+          delete :reset, on: :collection
+        end
+
+        namespace :oidc do
+          resources :api_key_roles, param: :token do
+            member do
+              get 'github_actions_workflow'
+            end
+          end
+          resources :api_key_roles, param: :token, only: %i[show], constraints: { format: :json }
+          resources :id_tokens, only: %i[index show]
+          resources :providers, only: %i[index show]
+          resources :pending_trusted_publishers, except: %i[show edit update]
+        end
+      end
+      resources :stats, only: :index
+      get "/news" => 'news#show', as: 'legacy_news_path'
+      resource :news, path: 'releases', only: [:show] do
+        get :popular, on: :collection
+      end
+      resource :notifier, only: %i[update show]
+
+      resources :rubygems,
+        only: %i[index show],
+        path: 'gems',
+        constraints: { id: Patterns::ROUTE_PATTERN, format: /html|atom/ } do
+        get :security_events, on: :member
+
+        resource :subscription,
+          only: %i[create destroy],
+          constraints: { format: :js },
+          defaults: { format: :js }
+        resources :versions, only: %i[show index] do
+          get '/dependencies', to: 'dependencies#show', constraints: { format: /json|html/ }
+        end
+        resources :reverse_dependencies, only: %i[index]
+        resources :owners, only: %i[index destroy edit update create], param: :handle do
+          get 'confirm', to: 'owners#confirm', as: :confirm, on: :collection
+          get 'resend_confirmation', to: 'owners#resend_confirmation', as: :resend_confirmation, on: :collection
+        end
+        resources :trusted_publishers, controller: 'oidc/rubygem_trusted_publishers', only: %i[index create destroy new]
+
+        collection do
+          get "transfer", to: "rubygems/transfers#new"
+          delete "transfer", to: "rubygems/transfers#destroy"
+
+          namespace :transfer do
+            get "organization", to: "/rubygems/transfer/organizations#new"
+            post "organization", to: "/rubygems/transfer/organizations#create"
+
+            get "rubygems", to: "/rubygems/transfer/rubygems#edit"
+            patch "rubygems", to: "/rubygems/transfer/rubygems#update"
+
+            get "users", to: "/rubygems/transfer/users#edit"
+            patch "users", to: "/rubygems/transfer/users#update"
+
+            get "confirm", to: "/rubygems/transfer/confirmations#edit"
+            patch "confirm", to: "/rubygems/transfer/confirmations#update"
           end
         end
-        resources :api_key_roles, param: :token, only: %i[show], constraints: { format: :json }
-        resources :id_tokens, only: %i[index show]
-        resources :providers, only: %i[index show]
-        resources :pending_trusted_publishers, except: %i[show edit update]
       end
-    end
-    resources :stats, only: :index
-    get "/news" => 'news#show', as: 'legacy_news_path'
-    resource :news, path: 'releases', only: [:show] do
-      get :popular, on: :collection
-    end
-    resource :notifier, only: %i[update show]
 
-    resources :rubygems,
-      only: %i[index show],
-      path: 'gems',
-      constraints: { id: Patterns::ROUTE_PATTERN, format: /html|atom/ } do
-      get :security_events, on: :member
-
-      resource :subscription,
-        only: %i[create destroy],
-        constraints: { format: :js },
-        defaults: { format: :js }
-      resources :versions, only: %i[show index] do
-        get '/dependencies', to: 'dependencies#show', constraints: { format: /json|html/ }
+      resources :webauthn_credentials, only: :destroy
+      resource :webauthn_verification, only: [] do
+        get 'successful_verification'
+        get 'failed_verification'
+        get ':webauthn_token', to: 'webauthn_verifications#prompt', as: ''
       end
-      resources :reverse_dependencies, only: %i[index]
-      resources :owners, only: %i[index destroy edit update create], param: :handle do
-        get 'confirm', to: 'owners#confirm', as: :confirm, on: :collection
-        get 'resend_confirmation', to: 'owners#resend_confirmation', as: :resend_confirmation, on: :collection
+
+      ################################################################################
+      # Clearance Overrides and Additions
+
+      resource :email_confirmations, only: %i[new create] do
+        get 'confirm', to: 'email_confirmations#update', as: :update
+        post 'otp_update', to: 'email_confirmations#otp_update', as: :otp_update
+        post 'webauthn_update', to: 'email_confirmations#webauthn_update', as: :webauthn_update
+        patch 'unconfirmed'
       end
-      resources :trusted_publishers, controller: 'oidc/rubygem_trusted_publishers', only: %i[index create destroy new]
 
-      collection do
-        get "transfer", to: "rubygems/transfers#new"
-        delete "transfer", to: "rubygems/transfers#destroy"
+      resource :password, only: %i[new create edit update] do
+        post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
+        post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
+      end
 
-        namespace :transfer do
-          get "organization", to: "/rubygems/transfer/organizations#new"
-          post "organization", to: "/rubygems/transfer/organizations#create"
+      resource :compromised_password, only: %i[show]
 
-          get "rubygems", to: "/rubygems/transfer/rubygems#edit"
-          patch "rubygems", to: "/rubygems/transfer/rubygems#update"
+      resource :session, only: %i[create destroy] do
+        post 'otp_create', to: 'sessions#otp_create', as: :otp_create
+        post 'webauthn_create', to: 'sessions#webauthn_create', as: :webauthn_create
+        post 'webauthn_full_create', to: 'sessions#webauthn_full_create', as: :webauthn_full_create
+        get 'verify', to: 'sessions#verify', as: :verify
+        post 'authenticate', to: 'sessions#authenticate', as: :authenticate
+        post 'webauthn_authenticate', to: 'sessions#webauthn_authenticate', as: :webauthn_authenticate
 
-          get "users", to: "/rubygems/transfer/users#edit"
-          patch "users", to: "/rubygems/transfer/users#update"
+        get 'development_log_in_as/:user_id', to: 'sessions#development_log_in_as' if Gemcutter::ENABLE_DEVELOPMENT_LOG_IN
+      end
 
-          get "confirm", to: "/rubygems/transfer/confirmations#edit"
-          patch "confirm", to: "/rubygems/transfer/confirmations#update"
+      resources :users, only: %i[new create]
+
+      get '/sign_in' => 'sessions#new', as: 'sign_in'
+      delete '/sign_out' => 'sessions#destroy', as: 'sign_out'
+
+      get '/sign_up' => 'users#new', as: 'sign_up'
+
+      namespace :organizations, as: :organization do
+        get "onboarding", to: "onboarding#new"
+        delete "onboarding", to: "onboarding#destroy"
+
+        namespace :onboarding do
+          get "name", to: "name#new"
+          post "name", to: "name#create"
+
+          get "gems", to: "gems#edit"
+          patch "gems", to: "gems#update"
+
+          get "users", to: "users#edit"
+          patch "users", to: "users#update"
+
+          get "confirm", to: "confirm#edit"
+          patch "confirm", to: "confirm#update"
         end
       end
-    end
-
-    resources :webauthn_credentials, only: :destroy
-    resource :webauthn_verification, only: [] do
-      get 'successful_verification'
-      get 'failed_verification'
-      get ':webauthn_token', to: 'webauthn_verifications#prompt', as: ''
+      resources :organizations, only: %i[index show edit update], constraints: { id: Patterns::ROUTE_PATTERN } do
+        resources :memberships, controller: 'organizations/members', except: :show do
+          member do
+            patch :resend_invitation
+          end
+        end
+        resource :invitation, only: %i[show update], constraints: { id: Patterns::ROUTE_PATTERN }, controller: "organizations/invitations"
+        resources :gems, only: :index, controller: 'organizations/gems'
+      end
     end
 
     ################################################################################
-    # Clearance Overrides and Additions
+    # static pages routes
 
-    resource :email_confirmations, only: %i[new create] do
-      get 'confirm', to: 'email_confirmations#update', as: :update
-      post 'otp_update', to: 'email_confirmations#otp_update', as: :otp_update
-      post 'webauthn_update', to: 'email_confirmations#webauthn_update', as: :webauthn_update
-      patch 'unconfirmed'
-    end
+    get 'pages/sponsors', to: "pages#sponsors", constraints: { format: :html }
+    get 'pages/*id' => 'pages#show', constraints: { format: :html, id: Regexp.union(Gemcutter::PAGES) }, as: :page
 
-    resource :password, only: %i[new create edit update] do
-      post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
-      post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
-    end
-
-    resource :compromised_password, only: %i[show]
-
-    resource :session, only: %i[create destroy] do
-      post 'otp_create', to: 'sessions#otp_create', as: :otp_create
-      post 'webauthn_create', to: 'sessions#webauthn_create', as: :webauthn_create
-      post 'webauthn_full_create', to: 'sessions#webauthn_full_create', as: :webauthn_full_create
-      get 'verify', to: 'sessions#verify', as: :verify
-      post 'authenticate', to: 'sessions#authenticate', as: :authenticate
-      post 'webauthn_authenticate', to: 'sessions#webauthn_authenticate', as: :webauthn_authenticate
-
-      get 'development_log_in_as/:user_id', to: 'sessions#development_log_in_as' if Gemcutter::ENABLE_DEVELOPMENT_LOG_IN
-    end
-
-    resources :users, only: %i[new create]
-
-    get '/sign_in' => 'sessions#new', as: 'sign_in'
-    delete '/sign_out' => 'sessions#destroy', as: 'sign_out'
-
-    get '/sign_up' => 'users#new', as: 'sign_up'
-
-    namespace :organizations, as: :organization do
-      get "onboarding", to: "onboarding#new"
-      delete "onboarding", to: "onboarding#destroy"
-
-      namespace :onboarding do
-        get "name", to: "name#new"
-        post "name", to: "name#create"
-
-        get "gems", to: "gems#edit"
-        patch "gems", to: "gems#update"
-
-        get "users", to: "users#edit"
-        patch "users", to: "users#update"
-
-        get "confirm", to: "confirm#edit"
-        patch "confirm", to: "confirm#update"
+    resources :policies, only: %i[index show], constraints: { format: :html, policy: Regexp.union(Gemcutter::POLICY_PAGES) },
+      param: :policy do
+      collection do
+        patch :acknowledge
       end
-    end
-    resources :organizations, only: %i[index show edit update], constraints: { id: Patterns::ROUTE_PATTERN } do
-      resources :memberships, controller: 'organizations/members', except: :show do
-        member do
-          patch :resend_invitation
-        end
-      end
-      resource :invitation, only: %i[show update], constraints: { id: Patterns::ROUTE_PATTERN }, controller: "organizations/invitations"
-      resources :gems, only: :index, controller: 'organizations/gems'
     end
   end
 
@@ -336,18 +348,6 @@ Rails.application.routes.draw do
       get 'avatar', on: :member, to: 'avatars#show', format: true
     end
   end
-
-  ################################################################################
-  # static pages routes
-  get 'pages/sponsors', to: "pages#sponsors", constraints: { format: :html }
-  get 'pages/*id' => 'pages#show', constraints: { format: :html, id: Regexp.union(Gemcutter::PAGES) }, as: :page
-
-  resources :policies, only: %i[index show], constraints: { format: :html, policy: Regexp.union(Gemcutter::POLICY_PAGES) },
-    param: :policy do
-      collection do
-        patch :acknowledge
-      end
-    end
 
   ################################################################################
   # Internal Routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,7 +223,7 @@ Rails.application.routes.draw do
       resources :trusted_publishers, controller: 'oidc/rubygem_trusted_publishers', only: %i[index create destroy new]
 
       collection do
-        get "transfer", to: redirect("/gems/transfer/organization")
+        get "transfer", to: "rubygems/transfers#new"
         delete "transfer", to: "rubygems/transfers#destroy"
 
         namespace :transfer do
@@ -285,7 +285,7 @@ Rails.application.routes.draw do
     get '/sign_up' => 'users#new', as: 'sign_up'
 
     namespace :organizations, as: :organization do
-      get "onboarding", to: redirect("/organizations/onboarding/name")
+      get "onboarding", to: "onboarding#new"
       delete "onboarding", to: "onboarding#destroy"
 
       namespace :onboarding do
@@ -339,7 +339,7 @@ Rails.application.routes.draw do
 
   ################################################################################
   # static pages routes
-  get 'pages/sponsors' => redirect('/pages/supporters'), constraints: { format: :html }
+  get 'pages/sponsors', to: "pages#sponsors", constraints: { format: :html }
   get 'pages/*id' => 'pages#show', constraints: { format: :html, id: Regexp.union(Gemcutter::PAGES) }, as: :page
 
   resources :policies, only: %i[index show], constraints: { format: :html, policy: Regexp.union(Gemcutter::POLICY_PAGES) },

--- a/lib/locale_routing.rb
+++ b/lib/locale_routing.rb
@@ -3,8 +3,7 @@
 module LocaleRouting
   DEFAULT_LOCALE = I18n.default_locale.to_s.freeze
   SUPPORTED_LOCALES = I18n.available_locales.map(&:to_s).freeze
-  NON_DEFAULT_LOCALES = (SUPPORTED_LOCALES - [DEFAULT_LOCALE]).freeze
-  PATH_CONSTRAINT = /#{NON_DEFAULT_LOCALES.map { |locale| Regexp.escape(locale) }.join('|')}/
+  PATH_CONSTRAINT = Regexp.union(SUPPORTED_LOCALES)
 
   def self.default_locale?(locale)
     locale.to_s == DEFAULT_LOCALE

--- a/lib/locale_routing.rb
+++ b/lib/locale_routing.rb
@@ -8,4 +8,8 @@ module LocaleRouting
   def self.default_locale?(locale)
     locale.to_s == DEFAULT_LOCALE
   end
+
+  def self.locale_param(locale)
+    default_locale?(locale) ? nil : locale
+  end
 end

--- a/lib/locale_routing.rb
+++ b/lib/locale_routing.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module LocaleRouting
+  DEFAULT_LOCALE = I18n.default_locale.to_s.freeze
+  SUPPORTED_LOCALES = I18n.available_locales.map(&:to_s).freeze
+  NON_DEFAULT_LOCALES = (SUPPORTED_LOCALES - [DEFAULT_LOCALE]).freeze
+  PATH_CONSTRAINT = /#{NON_DEFAULT_LOCALES.map { |locale| Regexp.escape(locale) }.join('|')}/
+
+  def self.default_locale?(locale)
+    locale.to_s == DEFAULT_LOCALE
+  end
+end

--- a/test/functional/dashboards_controller_test.rb
+++ b/test/functional/dashboards_controller_test.rb
@@ -55,7 +55,7 @@ class DashboardsControllerTest < ActionController::TestCase
       should "render links" do
         @gems.each do |g|
           assert page.has_content?(g.name)
-          selector = "a[href='#{rubygem_path(g.slug)}'][title='#{g.most_recent_version.info}']"
+          selector = "a[href='#{rubygem_path(id: g.slug)}'][title='#{g.most_recent_version.info}']"
 
           page.assert_selector(selector)
         end
@@ -99,8 +99,8 @@ class DashboardsControllerTest < ActionController::TestCase
       should "render posts with platform-specific titles and links of all subscribed versions" do
         @subscribed_versions.each do |v|
           assert_select "entry > title", count: 1, text: v.to_title
-          assert_select "entry > link[href='#{rubygem_version_url(v.rubygem.slug, v.slug)}']", count: 1
-          assert_select "entry > id", count: 1, text: rubygem_version_url(v.rubygem.slug, v.slug)
+          assert_select "entry > link[href='#{rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)}']", count: 1
+          assert_select "entry > id", count: 1, text: rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)
         end
       end
 

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -30,12 +30,6 @@ class HomeControllerTest < ActionController::TestCase
     assert_equal I18n.default_locale, I18n.locale
   end
 
-  should "ignore locale param and use default locale" do
-    get :index, params: { locale: "de" }
-
-    assert_equal I18n.default_locale, I18n.locale
-  end
-
   should "ignore Accept-Language header and use default locale" do
     @request.env["HTTP_ACCEPT_LANGUAGE"] = "de-DE,de;q=0.9,en;q=0.8"
     get :index

--- a/test/functional/organizations/invitations_controller_test.rb
+++ b/test/functional/organizations/invitations_controller_test.rb
@@ -10,7 +10,7 @@ class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "GET /organizations/:organization_handle/invitation" do
-    get organization_invitation_path(@organization, as: @user)
+    get organization_invitation_path(organization_id: @organization, as: @user)
 
     assert_response :success
   end
@@ -18,15 +18,15 @@ class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
   test "GET /organizations/:organization_handle/invitation with already confirmed membership" do
     @membership.update!(confirmed_at: Time.current)
 
-    get organization_invitation_path(@organization, as: @user)
+    get organization_invitation_path(organization_id: @organization, as: @user)
 
     assert_response :not_found
   end
 
   test "PATCH /organizations/:organization_handle/invitation" do
-    patch organization_invitation_path(@organization, as: @user)
+    patch organization_invitation_path(organization_id: @organization, as: @user)
 
-    assert_redirected_to organization_path(@organization)
+    assert_redirected_to organization_path(id: @organization)
 
     @membership.reload
 

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -12,7 +12,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "GET /organizations/:organization_handle/members" do
-    get organization_memberships_path(@organization)
+    get organization_memberships_path(organization_id: @organization)
 
     assert_response :success
     assert_select "h1", text: "Members"
@@ -22,20 +22,20 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     guest = create(:user)
     post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    get organization_memberships_path(@organization)
+    get organization_memberships_path(organization_id: @organization)
 
     assert_response :success
   end
 
   test "GET /organizations/:organization_handle/members as maintainer" do
     @membership.update(role: "maintainer")
-    get organization_memberships_path(@organization)
+    get organization_memberships_path(organization_id: @organization)
 
     assert_response :success
   end
 
   test "GET /organizations/:organization_handle/members/new" do
-    get new_organization_membership_path(@organization)
+    get new_organization_membership_path(organization_id: @organization)
 
     assert_response :success
     assert_select "h3", text: "Invite Member"
@@ -45,27 +45,27 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     guest = create(:user)
     post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    get new_organization_membership_path(@organization)
+    get new_organization_membership_path(organization_id: @organization)
 
     assert_response :not_found
   end
 
   test "GET /organizations/:organization_handle/members/new as a maintainer" do
     @membership.update(role: "maintainer")
-    get new_organization_membership_path(@organization)
+    get new_organization_membership_path(organization_id: @organization)
 
     assert_response :not_found
   end
 
   test "GET /organizations/:organization_handle/members/:id/edit" do
-    get edit_organization_membership_path(@organization, @membership)
+    get edit_organization_membership_path(organization_id: @organization, id: @membership)
 
     assert_response :success
   end
 
   test "GET /organizations/:organization_handle/members/:id/edit as a maintainer" do
     @membership.update(role: "maintainer")
-    get edit_organization_membership_path(@organization, @membership)
+    get edit_organization_membership_path(organization_id: @organization, id: @membership)
 
     assert_response :not_found
   end
@@ -74,7 +74,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     guest = create(:user)
     post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    get edit_organization_membership_path(@organization, @membership)
+    get edit_organization_membership_path(organization_id: @organization, id: @membership)
 
     assert_response :not_found
   end
@@ -82,9 +82,9 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   test "POST /organizations/:organization_handle/members" do
     new_user = create(:user)
 
-    post organization_memberships_path(@organization), params: { membership: { user: new_user.handle, role: :admin } }
+    post organization_memberships_path(organization_id: @organization), params: { membership: { user: new_user.handle, role: :admin } }
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "Member invited.", flash[:notice]
   end
 
@@ -100,7 +100,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "POST /organizations/:organization_handle/members with invalid values" do
-    post organization_memberships_path(@organization), params: { membership: { user: "invalid role", role: :invalid_role } }
+    post organization_memberships_path(organization_id: @organization), params: { membership: { user: "invalid role", role: :invalid_role } }
 
     assert_response :unprocessable_content
   end
@@ -109,7 +109,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     @membership.update(role: "maintainer")
     new_user = create(:user)
 
-    post organization_memberships_path(@organization), params: { membership: { user: new_user.handle, role: :admin } }
+    post organization_memberships_path(organization_id: @organization), params: { membership: { user: new_user.handle, role: :admin } }
 
     assert_response :not_found
   end
@@ -120,15 +120,15 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
 
     new_user = create(:user)
 
-    post organization_memberships_path(@organization), params: { membership: { user: new_user.handle, role: :admin } }
+    post organization_memberships_path(organization_id: @organization), params: { membership: { user: new_user.handle, role: :admin } }
 
     assert_response :not_found
   end
 
   test "PATCH /organizations/:organization_handle/members/:id" do
-    patch organization_membership_path(@organization, @membership), params: { membership: { role: "admin" } }
+    patch organization_membership_path(organization_id: @organization, id: @membership), params: { membership: { role: "admin" } }
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "Member updated successfully.", flash[:notice]
   end
 
@@ -167,7 +167,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "PATCH /organizations/:organization_handle/members/:id with invalid values" do
-    patch organization_membership_path(@organization, @membership), params: { membership: { role: "invalid_role" } }
+    patch organization_membership_path(organization_id: @organization, id: @membership), params: { membership: { role: "invalid_role" } }
 
     assert_response :unprocessable_content
   end
@@ -176,14 +176,14 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     guest = create(:user)
     post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    patch organization_membership_path(@organization, @membership), params: { membership: { role: "admin" } }
+    patch organization_membership_path(organization_id: @organization, id: @membership), params: { membership: { role: "admin" } }
 
     assert_response :not_found
   end
 
   test "PATCH /organizations/:organization_handle/members/:id as a maintainer" do
     @membership.update(role: "maintainer")
-    patch organization_membership_path(@organization, @membership), params: { membership: { role: "admin" } }
+    patch organization_membership_path(organization_id: @organization, id: @membership), params: { membership: { role: "admin" } }
 
     assert_response :not_found
   end
@@ -192,9 +192,9 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     new_user = create(:user)
     membership = create(:membership, organization: @organization, user: new_user)
 
-    delete organization_membership_path(@organization, membership)
+    delete organization_membership_path(organization_id: @organization, id: membership)
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "Member removed successfully.", flash[:notice]
   end
 
@@ -202,22 +202,22 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     guest = create(:user)
     post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    delete organization_membership_path(@organization, @membership)
+    delete organization_membership_path(organization_id: @organization, id: @membership)
 
     assert_response :not_found
   end
 
   test "DELETE /organizations/:organization_handle/members/:id as a maintainer" do
     @membership.update(role: "maintainer")
-    delete organization_membership_path(@organization, @membership)
+    delete organization_membership_path(organization_id: @organization, id: @membership)
 
     assert_response :not_found
   end
 
   test "DELETE /organizations/:organization_handle/members/:id with current user's membership" do
-    delete organization_membership_path(@organization, @membership)
+    delete organization_membership_path(organization_id: @organization, id: @membership)
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "You cannot remove yourself from the organization.", flash[:alert]
   end
 
@@ -226,17 +226,17 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     pending_membership = create(:membership, :pending, organization: @organization, user: pending_user)
 
     assert_enqueued_with job: ActionMailer::MailDeliveryJob do
-      patch resend_invitation_organization_membership_path(@organization, pending_membership)
+      patch resend_invitation_organization_membership_path(organization_id: @organization, id: pending_membership)
     end
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "Invitation resent successfully.", flash[:notice]
   end
 
   test "PATCH /organizations/:organization_handle/members/:id/resend_invitation with confirmed membership" do
-    patch resend_invitation_organization_membership_path(@organization, @membership)
+    patch resend_invitation_organization_membership_path(organization_id: @organization, id: @membership)
 
-    assert_redirected_to organization_memberships_path(@organization)
+    assert_redirected_to organization_memberships_path(organization_id: @organization)
     assert_equal "Member is already confirmed.", flash[:alert]
   end
 
@@ -245,7 +245,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     pending_user = create(:user)
     pending_membership = create(:membership, :pending, organization: @organization, user: pending_user)
 
-    patch resend_invitation_organization_membership_path(@organization, pending_membership)
+    patch resend_invitation_organization_membership_path(organization_id: @organization, id: pending_membership)
 
     assert_response :not_found
   end
@@ -257,7 +257,7 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     pending_user = create(:user)
     pending_membership = create(:membership, :pending, organization: @organization, user: pending_user)
 
-    patch resend_invitation_organization_membership_path(@organization, pending_membership)
+    patch resend_invitation_organization_membership_path(organization_id: @organization, id: pending_membership)
 
     assert_response :not_found
   end

--- a/test/functional/organizations/onboarding/confirm_controller_test.rb
+++ b/test/functional/organizations/onboarding/confirm_controller_test.rb
@@ -45,7 +45,7 @@ class Organizations::Onboarding::ConfirmControllerTest < ActionDispatch::Integra
     should "onboard the organization and render a success message" do
       patch "/organizations/onboarding/confirm"
 
-      assert_redirected_to organization_path(@organization_onboarding.reload.organization)
+      assert_redirected_to organization_path(id: @organization_onboarding.reload.organization)
 
       follow_redirect!
 

--- a/test/functional/owners_controller_test.rb
+++ b/test/functional/owners_controller_test.rb
@@ -57,7 +57,7 @@ class OwnersControllerTest < ActionController::TestCase
           get :index, params: { rubygem_id: @rubygem.name }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
         should set_flash[:alert].to "Forbidden"
       end
     end
@@ -72,7 +72,7 @@ class OwnersControllerTest < ActionController::TestCase
           post :create, params: { handle: @new_owner.display_id, rubygem_id: @rubygem.name, role: :owner }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
         should set_flash[:alert].to "Forbidden"
 
         should "not add other user as owner" do
@@ -107,7 +107,7 @@ class OwnersControllerTest < ActionController::TestCase
             post :create, params: { handle: @new_owner.display_id, rubygem_id: @rubygem.name, role: :owner }
           end
 
-          should redirect_to("ownerships index") { rubygem_owners_path(@rubygem.slug) }
+          should redirect_to("ownerships index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
           should "add unconfirmed ownership record" do
             assert_includes @rubygem.owners_including_unconfirmed, @new_owner
             assert_nil @rubygem.ownerships_including_unconfirmed.find_by(user: @new_owner).confirmed_at
@@ -167,7 +167,7 @@ class OwnersControllerTest < ActionController::TestCase
               post :create, params: { handle: @new_owner.display_id, rubygem_id: @rubygem.name, role: :owner }
             end
 
-            should redirect_to("ownerships index") { rubygem_owners_path(@rubygem.slug) }
+            should redirect_to("ownerships index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
             should "set success notice flash" do
               expected_notice = "#{@new_owner.handle} was added as an unconfirmed owner. " \
@@ -199,7 +199,7 @@ class OwnersControllerTest < ActionController::TestCase
           post :create, params: { handle: @other_user.display_id, rubygem_id: @rubygem.name }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
         should set_flash[:alert].to "Forbidden"
 
         should "not add other user as owner" do
@@ -219,7 +219,7 @@ class OwnersControllerTest < ActionController::TestCase
           delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
 
         should "not remove user as owner" do
           assert_includes @rubygem.owners, @second_user
@@ -243,7 +243,7 @@ class OwnersControllerTest < ActionController::TestCase
             end
           end
 
-          should redirect_to("ownership index") { rubygem_owners_path(@rubygem.slug) }
+          should redirect_to("ownership index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
           should "remove the ownership record" do
             refute_includes @rubygem.owners_including_unconfirmed, @second_user
@@ -263,7 +263,7 @@ class OwnersControllerTest < ActionController::TestCase
               delete :destroy, params: { rubygem_id: @rubygem.name, handle: @second_user.display_id }
             end
           end
-          should redirect_to("ownership index") { rubygem_owners_path(@rubygem.slug) }
+          should redirect_to("ownership index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
           should "remove the ownership record" do
             refute_includes @rubygem.owners_including_unconfirmed, @second_user
@@ -319,7 +319,7 @@ class OwnersControllerTest < ActionController::TestCase
               delete :destroy, params: { handle: @second_user.display_id, rubygem_id: @rubygem.name }
             end
 
-            should redirect_to("ownerships index") { rubygem_owners_path(@rubygem.slug) }
+            should redirect_to("ownerships index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
             should "set success notice flash" do
               expected_notice = "#{@second_user.handle} was removed from the owners successfully"
@@ -339,7 +339,7 @@ class OwnersControllerTest < ActionController::TestCase
           delete :destroy, params: { rubygem_id: @rubygem.name, handle: @last_owner.display_id }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
 
         should "not remove user as owner" do
           assert_includes @rubygem.owners, @last_owner
@@ -361,7 +361,7 @@ class OwnersControllerTest < ActionController::TestCase
           end
         end
 
-        should redirect_to("rubygem show") { rubygem_path(@rubygem.slug) }
+        should redirect_to("rubygem show") { rubygem_path(id: @rubygem.slug) }
         should "set success notice flash" do
           success_flash = "A confirmation mail has been re-sent to your email"
 
@@ -427,7 +427,7 @@ class OwnersControllerTest < ActionController::TestCase
           get :edit, params: { rubygem_id: @rubygem.name, handle: @owner.display_id }
         end
 
-        should redirect_to("gem info page") { rubygem_path(@rubygem.slug) }
+        should redirect_to("gem info page") { rubygem_path(id: @rubygem.slug) }
         should set_flash[:alert].to "Can't update your own Role"
       end
     end
@@ -442,7 +442,7 @@ class OwnersControllerTest < ActionController::TestCase
         patch :update, params: { rubygem_id: @rubygem.name, handle: @maintainer.display_id, role: :maintainer }
       end
 
-      should redirect_to("rubygem show") { rubygem_owners_path(@rubygem.slug) }
+      should redirect_to("rubygem show") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
       should "set success notice flash" do
         assert_equal "#{@maintainer.name} was successfully updated.", flash[:notice]
@@ -466,7 +466,7 @@ class OwnersControllerTest < ActionController::TestCase
         patch :update, params: { rubygem_id: @rubygem.name, handle: @maintainer.display_id }
       end
 
-      should redirect_to("ownerships index") { rubygem_owners_path(@rubygem.slug) }
+      should redirect_to("ownerships index") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
 
       should "not update the role" do
         ownership = Ownership.find_by(rubygem: @rubygem, user: @maintainer)
@@ -602,7 +602,7 @@ class OwnersControllerTest < ActionController::TestCase
 
         should "confirm ownership" do
           assert_predicate @ownership, :confirmed?
-          assert redirect_to("rubygem show") { rubygem_path(@rubygem.slug) }
+          assert redirect_to("rubygem show") { rubygem_path(id: @rubygem.slug) }
           assert_equal "You were added as an owner to the #{@rubygem.name} gem", flash[:notice]
         end
 

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -110,7 +110,7 @@ class ProfilesControllerTest < ActionController::TestCase
       end
 
       should respond_with :redirect
-      should redirect_to("the user's profile page") { profile_path(@user.handle) }
+      should redirect_to("the user's profile page") { profile_path(id: @user.handle) }
     end
 
     context "on GET to delete" do

--- a/test/functional/reverse_dependencies_controller_test.rb
+++ b/test/functional/reverse_dependencies_controller_test.rb
@@ -44,7 +44,7 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
       assert page.has_content?(@rubygem_two.name)
       refute page.has_content?(@rubygem_three.name)
 
-      form_path = rubygem_reverse_dependencies_path(@rubygem_one.slug)
+      form_path = rubygem_reverse_dependencies_path(rubygem_id: @rubygem_one.slug)
 
       assert page.has_selector?("form#rdeps-search[action='#{form_path}']")
     end
@@ -56,7 +56,7 @@ class ReverseDependenciesControllerTest < ActionController::TestCase
       assert page.has_content?(@rubygem_two.name, count: 1)
       refute page.has_content?(@rubygem_three.name)
 
-      form_path = rubygem_reverse_dependencies_path(@rubygem_one.slug)
+      form_path = rubygem_reverse_dependencies_path(rubygem_id: @rubygem_one.slug)
 
       assert page.has_selector?("form#rdeps-search[action='#{form_path}']")
     end

--- a/test/functional/rubygems/transfer/confirmations_controller_test.rb
+++ b/test/functional/rubygems/transfer/confirmations_controller_test.rb
@@ -16,7 +16,7 @@ class Rubygems::Transfer::ConfirmationsControllerTest < ActionDispatch::Integrat
     patch confirm_transfer_rubygems_path(as: @owner)
 
     assert_response :redirect
-    assert_redirected_to organization_path(@organization.handle)
+    assert_redirected_to organization_path(id: @organization.handle)
     assert_equal flash[:notice], "Successfully transferred 1 gem to #{@organization.name}."
   end
 

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -19,7 +19,7 @@ class RubygemsControllerTest < ActionController::TestCase
       should respond_with :success
       should "renders owner gems overview links" do
         @owners.each do |owner|
-          assert page.has_selector?("a[href='#{profile_path(owner.display_id)}']")
+          assert page.has_selector?("a[href='#{profile_path(id: owner.display_id)}']")
         end
       end
     end
@@ -110,7 +110,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render links" do
       @gems.each do |g|
         assert page.has_content?(g.name)
-        page.assert_selector("a[href='#{rubygem_path(g.slug)}']")
+        page.assert_selector("a[href='#{rubygem_path(id: g.slug)}']")
       end
     end
   end
@@ -128,8 +128,8 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render posts with platform-specific titles and links of all subscribed versions" do
       @versions.each do |v|
         assert_select "entry > title", count: 1, text: v.to_title
-        assert_select "entry > link[href='#{rubygem_version_url(v.rubygem.slug, v.slug)}']", count: 1
-        assert_select "entry > id", count: 1, text: rubygem_version_url(v.rubygem.slug, v.slug)
+        assert_select "entry > link[href='#{rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)}']", count: 1
+        assert_select "entry > id", count: 1, text: rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)
       end
     end
 
@@ -157,7 +157,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should respond_with :success
     should "render links" do
       assert page.has_content?(@zgem.name)
-      assert page.has_selector?("a[href='#{rubygem_path(@zgem.slug)}']")
+      assert page.has_selector?("a[href='#{rubygem_path(id: @zgem.slug)}']")
     end
   end
 
@@ -176,7 +176,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "render links" do
       @gems.each do |g|
         assert page.has_content?(g.name)
-        assert page.has_selector?("a[href='#{rubygem_path(g.slug)}']")
+        assert page.has_selector?("a[href='#{rubygem_path(id: g.slug)}']")
       end
     end
   end
@@ -299,7 +299,7 @@ class RubygemsControllerTest < ActionController::TestCase
         assert page.has_no_content?("Versions")
       end
       should "renders owner gems overview link" do
-        assert page.has_selector?("a[href='#{profile_path(@owner.display_id)}']")
+        assert page.has_selector?("a[href='#{profile_path(id: @owner.display_id)}']")
       end
     end
   end
@@ -456,7 +456,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "link the organization profile page" do
       get :show, params: { id: @rubygem.slug }
 
-      assert page.has_link?(@organization.name, href: organization_path(@organization))
+      assert page.has_link?(@organization.name, href: organization_path(id: @organization))
     end
   end
 
@@ -473,7 +473,7 @@ class RubygemsControllerTest < ActionController::TestCase
     should "display outside contributors" do
       get :show, params: { id: @rubygem.slug }
 
-      assert page.has_selector?("a[href='#{profile_path(@outside_contributor.display_id)}']")
+      assert page.has_selector?("a[href='#{profile_path(id: @outside_contributor.display_id)}']")
     end
   end
 end

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -45,11 +45,11 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
     should "see sinatra on the page in the results" do
       assert page.has_content?(@sinatra.name)
-      assert page.has_selector?("a[href='#{rubygem_path(@sinatra.slug)}']")
+      assert page.has_selector?("a[href='#{rubygem_path(id: @sinatra.slug)}']")
     end
     should "not see brando on the page in the results" do
       refute page.has_content?(@brando.name)
-      refute page.has_selector?("a[href='#{rubygem_path(@brando.slug)}']")
+      refute page.has_selector?("a[href='#{rubygem_path(id: @brando.slug)}']")
     end
     should "display 'gems' in pagination summary" do
       assert page.has_content?("all 2 gems")
@@ -70,11 +70,11 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
     should "see sinatra on the page in the results" do
       assert_text @sinatra.name
-      assert_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
+      assert_selector "a[href='#{rubygem_path(id: @sinatra.slug)}']"
     end
     should "not see brando on the page in the results" do
       refute_text @brando.name
-      refute_selector "a[href='#{rubygem_path(@brando.slug)}']"
+      refute_selector "a[href='#{rubygem_path(id: @brando.slug)}']"
     end
     should "display pagination summary" do
       assert page.has_text?("all 2 gems")
@@ -115,11 +115,11 @@ class SearchesControllerTest < ActionController::TestCase
       assert_selector "a[href='#{search_path(query: @sinatra.name)}']"
     end
     should "not see sinatra on the page in the results" do
-      refute_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
+      refute_selector "a[href='#{rubygem_path(id: @sinatra.slug)}']"
     end
     should "not see brando on the page in the results" do
       refute_text @brando.name
-      refute_selector "a[href='#{rubygem_path(@brando.slug)}']"
+      refute_selector "a[href='#{rubygem_path(id: @brando.slug)}']"
     end
     should "not see filters" do
       refute_text "Filter"
@@ -138,10 +138,10 @@ class SearchesControllerTest < ActionController::TestCase
     should respond_with :success
 
     should "see sinatra_redux on the page in the results" do
-      assert_selector "a[href='#{rubygem_path(@sinatra_redux.slug)}']"
+      assert_selector "a[href='#{rubygem_path(id: @sinatra_redux.slug)}']"
     end
     should "not see sinatra on the page in the results" do
-      refute_selector "a[href='#{rubygem_path(@sinatra.slug)}']"
+      refute_selector "a[href='#{rubygem_path(id: @sinatra.slug)}']"
     end
   end
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -518,7 +518,7 @@ class SessionsControllerTest < ActionController::TestCase
   context "on GET to verify" do
     setup do
       rubygem = create(:rubygem)
-      session[:redirect_uri] = rubygem_owners_url(rubygem.slug)
+      session[:redirect_uri] = rubygem_owners_url(rubygem_id: rubygem.slug)
     end
 
     context "when signed in" do
@@ -547,7 +547,7 @@ class SessionsControllerTest < ActionController::TestCase
   context "on POST to authenticate" do
     setup do
       rubygem = create(:rubygem)
-      session[:redirect_uri] = rubygem_owners_url(rubygem.slug)
+      session[:redirect_uri] = rubygem_owners_url(rubygem_id: rubygem.slug)
     end
 
     context "when signed in" do
@@ -555,14 +555,14 @@ class SessionsControllerTest < ActionController::TestCase
         @user = create(:user)
         @rubygem = create(:rubygem)
         sign_in_as(@user)
-        session[:redirect_uri] = rubygem_owners_url(@rubygem.slug)
+        session[:redirect_uri] = rubygem_owners_url(rubygem_id: @rubygem.slug)
       end
 
       context "on correct password" do
         setup do
           post :authenticate, params: { user_id: @user.id, verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         end
-        should redirect_to("redirect uri") { rubygem_owners_path(@rubygem.slug) }
+        should redirect_to("redirect uri") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
       end
 
       context "on incorrect password" do
@@ -745,7 +745,7 @@ class SessionsControllerTest < ActionController::TestCase
       @user = create(:user)
       sign_in_as(@user)
       @rubygem = create(:rubygem)
-      session[:redirect_uri] = rubygem_owners_url(@rubygem.slug)
+      session[:redirect_uri] = rubygem_owners_url(rubygem_id: @rubygem.slug)
       create(:ownership, rubygem: @rubygem, user: @user)
       GemDownload.increment(
         Rubygem::MFA_REQUIRED_THRESHOLD + 1,
@@ -819,7 +819,7 @@ class SessionsControllerTest < ActionController::TestCase
       context "on POST to authenticate" do
         setup { post :authenticate, params: { user_id: @user.id, verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD } } }
 
-        should redirect_to("redirect uri") { rubygem_owners_path(@rubygem.slug) }
+        should redirect_to("redirect uri") { rubygem_owners_path(rubygem_id: @rubygem.slug) }
       end
     end
   end

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -39,7 +39,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
       post :create, params: { rubygem_id: @rubygem.slug }
     end
 
-    should redirect_to("rubygems show") { rubygem_path(@rubygem.slug) }
+    should redirect_to("rubygems show") { rubygem_path(id: @rubygem.slug) }
 
     should "not set flash error" do
       assert_nil flash[:error]
@@ -52,7 +52,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
       post :create, params: { rubygem_id: @rubygem.slug }
     end
 
-    should redirect_to("rubygems show") { rubygem_path(@rubygem.slug) }
+    should redirect_to("rubygems show") { rubygem_path(id: @rubygem.slug) }
 
     should "set flash error" do
       assert_equal "Something went wrong. Please try again.", flash[:error]
@@ -64,7 +64,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
       delete :destroy, params: { rubygem_id: @rubygem.slug }
     end
 
-    should redirect_to("rubygems show") { rubygem_path(@rubygem.slug) }
+    should redirect_to("rubygems show") { rubygem_path(id: @rubygem.slug) }
 
     should "set flash error" do
       assert_equal "Something went wrong. Please try again.", flash[:error]
@@ -77,7 +77,7 @@ class SubscriptionsControllerTest < ActionController::TestCase
       delete :destroy, params: { rubygem_id: @rubygem.slug }
     end
 
-    should redirect_to("rubygems show") { rubygem_path(@rubygem.slug) }
+    should redirect_to("rubygems show") { rubygem_path(id: @rubygem.slug) }
 
     should "not set flash error" do
       assert_nil flash[:error]

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -43,8 +43,8 @@ class VersionsControllerTest < ActionController::TestCase
     should "render information about versions" do
       @versions.each do |v|
         assert_select "entry > title", count: 1, text: v.to_title
-        assert_select "entry > link[href='#{rubygem_version_url(v.rubygem.slug, v.slug)}']", count: 1
-        assert_select "entry > id", count: 1, text: rubygem_version_url(v.rubygem.slug, v.slug)
+        assert_select "entry > link[href='#{rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)}']", count: 1
+        assert_select "entry > id", count: 1, text: rubygem_version_url(rubygem_id: v.rubygem.slug, id: v.slug)
         # assert_select "entry > updated", :count => @versions.count, :text => v.created_at.iso8601
       end
     end
@@ -200,7 +200,7 @@ class VersionsControllerTest < ActionController::TestCase
       assert page.has_css?(css)
     end
     should "renders owner gems overview link" do
-      assert page.has_selector?("a[href='#{profile_path('johndoe')}']")
+      assert page.has_selector?("a[href='#{profile_path(id: 'johndoe')}']")
     end
   end
 end

--- a/test/integration/api/v1/owner_test.rb
+++ b/test/integration/api/v1/owner_test.rb
@@ -27,9 +27,9 @@ class Api::V1::OwnerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     @ownership = @rubygem.ownerships_including_unconfirmed.find_by(user: @other_user)
-    get confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token)
+    get confirm_rubygem_owners_url(rubygem_id: @rubygem.slug, token: @ownership.token)
 
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     assert page.has_selector?("a[alt='#{@user.handle}']")
     assert page.has_selector?("a[alt='#{@other_user.handle}']")
@@ -41,7 +41,7 @@ class Api::V1::OwnerTest < ActionDispatch::IntegrationTest
       params: { email: @other_user.email },
       headers: { "HTTP_AUTHORIZATION" => @user_api_key }
 
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     assert page.has_selector?("a[alt='#{@user.handle}']")
     refute page.has_selector?("a[alt='#{@other_user.handle}']")
@@ -54,7 +54,7 @@ class Api::V1::OwnerTest < ActionDispatch::IntegrationTest
       params: { email: @user.email },
       headers: { "HTTP_AUTHORIZATION" => @user_api_key }
 
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     refute page.has_selector?("a[alt='#{@user.handle}']")
     assert page.has_selector?("a[alt='#{@other_user.handle}']")

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -31,8 +31,6 @@ class GemsTest < ActionDispatch::IntegrationTest
   end
 
   test "canonical/alternate urls for gem points to most recent version" do
-    skip "locale alternate links temporarily disabled"
-
     base_url = "http://localhost/gems/sandworm/versions/1.1.1"
     create(:version, rubygem: @rubygem, number: "1.1.1")
     get rubygem_path(id: @rubygem.slug)

--- a/test/integration/gems_test.rb
+++ b/test/integration/gems_test.rb
@@ -9,7 +9,7 @@ class GemsTest < ActionDispatch::IntegrationTest
   end
 
   test "gem page with a non valid HTTP_ACCEPT header" do
-    get rubygem_path(@rubygem.slug), headers: { "HTTP_ACCEPT" => "application/mercurial-0.1" }
+    get rubygem_path(id: @rubygem.slug), headers: { "HTTP_ACCEPT" => "application/mercurial-0.1" }
 
     assert page.has_content? "1.0.0"
   end
@@ -24,18 +24,18 @@ class GemsTest < ActionDispatch::IntegrationTest
 
   test "versions with atom format" do
     create(:version, rubygem: @rubygem)
-    get rubygem_versions_path(@rubygem.slug, format: :atom)
+    get rubygem_versions_path(rubygem_id: @rubygem.slug, format: :atom)
 
     assert_equal "application/atom+xml", response.media_type
     assert page.has_content? "sandworm"
   end
 
   test "canonical/alternate urls for gem points to most recent version" do
-    skip "locales temporarily disabled"
+    skip "locale alternate links temporarily disabled"
 
     base_url = "http://localhost/gems/sandworm/versions/1.1.1"
     create(:version, rubygem: @rubygem, number: "1.1.1")
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
     css = %(link[rel="canonical"][href="#{base_url}"])
 
     assert page.has_css?(css, visible: false)
@@ -43,23 +43,25 @@ class GemsTest < ActionDispatch::IntegrationTest
     alternates = page.all(:css, css, visible: false)
     # I18n.available_locales.length + 1 (x-default)
     assert_equal (I18n.available_locales.length + 1), alternates.length
-    exp = I18n.available_locales.map { "#{base_url}?locale=#{it}" } << base_url
+    exp = I18n.available_locales.map do |locale|
+      LocaleRouting.default_locale?(locale) ? base_url : "http://localhost/#{locale}/gems/sandworm/versions/1.1.1"
+    end << base_url
     act = alternates.pluck(:href)
 
     assert_same_elements exp, act
   end
 
-  test "canonical locale urls for gem points to most recent version without locale" do
+  test "canonical locale urls for gem points to most recent version with locale path" do
     create(:version, rubygem: @rubygem, number: "1.1.1")
-    get rubygem_path(@rubygem.slug, locale: "en")
-    css = %(link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.1.1"])
+    get "/nl/gems/#{@rubygem.slug}"
+    css = %(link[rel="canonical"][href="http://localhost/nl/gems/sandworm/versions/1.1.1"])
 
     assert page.has_css?(css, visible: false)
   end
 
   test "canonical url for an old version" do
     create(:version, rubygem: @rubygem, number: "1.1.1")
-    get rubygem_version_path(@rubygem.slug, "1.0.0")
+    get rubygem_version_path(rubygem_id: @rubygem.slug, id: "1.0.0")
     css = %(link[rel="canonical"][href="http://localhost/gems/sandworm/versions/1.0.0"])
 
     assert page.has_css?(css, visible: false)
@@ -82,14 +84,14 @@ class GemsTest < ActionDispatch::IntegrationTest
   end
 
   test "anonymous gem show request does not set a session cookie" do
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     assert_response :success
     assert_nil response.headers["Set-Cookie"]
   end
 
   test "anonymous gem show request sets public cache headers" do
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     assert_response :success
     assert_includes response.headers["Cache-Control"], "public"
@@ -100,7 +102,7 @@ class GemsTest < ActionDispatch::IntegrationTest
   test "authenticated gem show request does not set public cache headers" do
     post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    get rubygem_path(@rubygem.slug)
+    get rubygem_path(id: @rubygem.slug)
 
     assert_response :success
     assert_includes response.headers["Set-Cookie"].to_s, "_rubygems_session"

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -36,6 +36,27 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "default locale path redirects to unprefixed path" do
+    get "/en/pages/about"
+
+    assert_response :redirect
+    assert_redirected_to "/pages/about"
+  end
+
+  test "default locale redirect preserves query string" do
+    get "/en/search?query=rails"
+
+    assert_response :redirect
+    assert_redirected_to "/search?query=rails"
+  end
+
+  test "default locale root redirects to unprefixed root" do
+    get "/en?query=rails"
+
+    assert_response :redirect
+    assert_redirected_to "/?query=rails"
+  end
+
   test "the localized sponsors alias redirects with the locale preserved" do
     get "/de/pages/sponsors"
 
@@ -56,6 +77,25 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert page.has_css?("a.header__nav-link.is-active", text: "Gems")
+  end
+
+  test "the default locale strip can never produce an external redirect" do
+    redirected_externally =
+      begin
+        get "/en/%2F%2Fevil.com"
+        response.redirect? && response.headers["Location"].to_s.match?(%r{\A(https?:)?//})
+      rescue ActionController::RoutingError
+        false
+      end
+
+    refute redirected_externally, "leaked an external/protocol-relative redirect"
+  end
+
+  test "a region locale (zh-CN) is taken from the URL path" do
+    get "/zh-CN"
+
+    assert_response :success
+    assert_includes response.body, %(<html lang="zh-CN")
   end
 
   test "keyword route helper arguments target non-locale segments" do

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -122,6 +122,40 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
     refute page.has_css?(%(link[rel="alternate"][hreflang]), visible: false)
   end
 
+  test "the footer language switcher is rendered" do
+    get "/"
+
+    assert_response :success
+    assert page.has_link?(I18n.t(:locale_name, locale: :de), href: "/de")
+  end
+
+  test "the language switcher keeps the current path when changing locale" do
+    create(:rubygem, name: "sandworm", number: "1.0.0")
+
+    get "/gems/sandworm"
+
+    assert_response :success
+    assert page.has_link?(I18n.t(:locale_name, locale: :de), href: "/de/gems/sandworm")
+  end
+
+  test "the language switcher preserves query parameters (minus a stale locale)" do
+    get "/search?query=rails&locale=fr"
+
+    assert_response :success
+    assert page.has_link?(I18n.t(:locale_name, locale: :de), href: "/de/search?query=rails")
+  end
+
+  test "the language switcher targets a GET page after a failed form submission" do
+    post users_path, params: { user: { handle: "", email: "", password: "" } }
+
+    assert_response :success
+    de_href = page.find_link(I18n.t(:locale_name, locale: :de))[:href]
+
+    get de_href
+
+    assert_response :success
+  end
+
   test "a region locale (zh-CN) is taken from the URL path" do
     get "/zh-CN"
 

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -91,6 +91,37 @@ class LocaleRoutingTest < ActionDispatch::IntegrationTest
     refute redirected_externally, "leaked an external/protocol-relative redirect"
   end
 
+  test "a localized gem page never emits ?locale= query params" do
+    create(:rubygem, name: "sandworm", number: "1.0.0")
+
+    get "/de/gems/sandworm"
+
+    assert_response :success
+    refute_includes response.body, "?locale=", "locale leaked as a query param, fragmenting the CDN cache"
+  end
+
+  test "localized pages emit a self-referential canonical plus hreflang alternates" do
+    get "/de"
+
+    assert_response :success
+    assert page.has_css?(%(link[rel="canonical"][href="http://localhost/de"]), visible: false)
+    alternates = page.all(:css, %(link[rel="alternate"][hreflang]), visible: false)
+
+    assert_equal I18n.available_locales.length + 1, alternates.length
+    assert page.has_css?(%(link[rel="alternate"][hreflang="x-default"][href="http://localhost/"]), visible: false)
+  end
+
+  test "search engine tags are omitted for signed-in requests" do
+    user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    get "/de"
+
+    assert_response :success
+    refute page.has_css?(%(link[rel="canonical"]), visible: false)
+    refute page.has_css?(%(link[rel="alternate"][hreflang]), visible: false)
+  end
+
   test "a region locale (zh-CN) is taken from the URL path" do
     get "/zh-CN"
 

--- a/test/integration/locale_routing_test.rb
+++ b/test/integration/locale_routing_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocaleRoutingTest < ActionDispatch::IntegrationTest
+  test "non-default locale is extracted from path" do
+    get "/de"
+
+    assert_response :success
+    assert_includes response.body, "RubyGems.org ist der Gem-Hosting-Dienst"
+  end
+
+  test "paths without locale use default locale" do
+    get "/"
+
+    assert_response :success
+    assert_includes response.body, "RubyGems.org is the Ruby community"
+  end
+
+  test "query string locale is ignored" do
+    get "/?locale=de"
+
+    assert_response :success
+    assert_includes response.body, "RubyGems.org is the Ruby community"
+  end
+
+  test "invalid locale path does not match localized routes" do
+    assert_raises(ActionController::RoutingError) do
+      get "/xx/gems/rails"
+    end
+  end
+
+  test "API routes are not affected by locale scope" do
+    assert_raises(ActionController::RoutingError) do
+      get "/de/api/v1/gems/rails.json"
+    end
+  end
+
+  test "the localized sponsors alias redirects with the locale preserved" do
+    get "/de/pages/sponsors"
+
+    assert_redirected_to "/de/pages/supporters"
+  end
+
+  test "localized page path works" do
+    get "/de/pages/about"
+
+    assert_response :success
+    assert page.has_link?(I18n.t("layouts.application.footer.security", locale: :de), href: "/de/pages/security")
+  end
+
+  test "the active nav link is locale-aware" do
+    create(:rubygem, name: "sandworm", number: "1.0.0")
+
+    get "/de/gems"
+
+    assert_response :success
+    assert page.has_css?("a.header__nav-link.is-active", text: "Gems")
+  end
+
+  test "keyword route helper arguments target non-locale segments" do
+    rubygem = create(:rubygem, name: "rails")
+
+    assert_equal "/gems/rails", rubygem_path(id: rubygem.slug)
+    assert_equal "/gems/rails/versions/7.0.0", rubygem_version_path(rubygem_id: rubygem.slug, id: "7.0.0")
+  end
+
+  test "admin routes are not affected by locale scope" do
+    assert_raises(ActionController::RoutingError) do
+      get "/de/admin"
+    end
+  end
+end

--- a/test/integration/oidc/api_key_roles_controller_test.rb
+++ b/test/integration/oidc/api_key_roles_controller_test.rb
@@ -17,13 +17,13 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
     end
 
     should "get show" do
-      get profile_oidc_api_key_role_url(@api_key_role.token)
+      get profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
     end
 
     should "get show format json" do
-      get profile_oidc_api_key_role_url(@api_key_role.token, format: :json)
+      get profile_oidc_api_key_role_url(token: @api_key_role.token, format: :json)
 
       assert_response :success
     end
@@ -62,7 +62,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
     end
 
     should "get github_actions_workflow" do
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role.token)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
     end
@@ -70,7 +70,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
     should "get github_actions_workflow with a github actions role" do
       provider = create(:oidc_provider, issuer: "https://token.actions.githubusercontent.com")
       @api_key_role = create(:oidc_api_key_role, provider:, user: @user).token
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role)
 
       assert_response :success
     end
@@ -84,7 +84,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
         user: @user,
         provider:,
         api_key_permissions: { scopes: ["push_rubygem"], gems: [rubygem.name] })
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role.token)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
     end
@@ -96,7 +96,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
         user: @user,
         provider:,
         access_policy: { statements: [effect: "allow", conditions: [claim: "aud", operator: "string_equals", value: "example.com"]] })
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role.token)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
       page.assert_text "audience: example.com"
@@ -109,14 +109,14 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
         user: @user,
         provider:,
         access_policy: { statements: [effect: "allow", conditions: [claim: "aud", operator: "string_equals", value: "rubygems.org"]] })
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role.token)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
       page.assert_no_text "audience:"
     end
 
     should "delete" do
-      delete profile_oidc_api_key_role_url(@api_key_role.token)
+      delete profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :redirect
       assert_redirected_to profile_oidc_api_key_roles_path
@@ -125,12 +125,12 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
 
       page.assert_no_text @api_key_role.token
 
-      get profile_oidc_api_key_role_url(@api_key_role.token)
+      get profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :success
       page.assert_selector "h2", text: /This role was deleted .+ ago and can no longer be used/
 
-      delete profile_oidc_api_key_role_url(@api_key_role.token)
+      delete profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :redirect
       assert_redirected_to profile_oidc_api_key_roles_path
@@ -139,7 +139,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
 
       page.assert_selector ".flash #flash_error", text: "The role has been deleted."
 
-      get edit_profile_oidc_api_key_role_url(@api_key_role.token)
+      get edit_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :redirect
       assert_redirected_to profile_oidc_api_key_roles_path
@@ -152,7 +152,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
 
   context "without a verified session" do
     should "redirect show to verify" do
-      get profile_oidc_api_key_role_url(@api_key_role.token)
+      get profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :redirect
       assert_redirected_to verify_session_path
@@ -166,7 +166,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
     end
 
     should "redirect github_actions_workflow to verify" do
-      get github_actions_workflow_profile_oidc_api_key_role_url(@api_key_role.token)
+      get github_actions_workflow_profile_oidc_api_key_role_url(token: @api_key_role.token)
 
       assert_response :redirect
       assert_redirected_to verify_session_path

--- a/test/integration/oidc/id_tokens_controller_test.rb
+++ b/test/integration/oidc/id_tokens_controller_test.rb
@@ -16,7 +16,7 @@ class OIDC::IdTokensControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "get show" do
-      get profile_oidc_id_token_url(@id_token)
+      get profile_oidc_id_token_url(id: @id_token)
 
       assert_response :success
     end
@@ -30,7 +30,7 @@ class OIDC::IdTokensControllerTest < ActionDispatch::IntegrationTest
 
   context "without a verified session" do
     should "redirect show to verify" do
-      get profile_oidc_id_token_url(@id_token)
+      get profile_oidc_id_token_url(id: @id_token)
 
       assert_response :redirect
       assert_redirected_to verify_session_path

--- a/test/integration/oidc/pending_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/pending_trusted_publishers_controller_test.rb
@@ -106,7 +106,7 @@ class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::Integration
 
     should "destroy trusted publisher" do
       assert_difference("OIDC::PendingTrustedPublisher.count", -1) do
-        delete profile_oidc_pending_trusted_publisher_url(@trusted_publisher)
+        delete profile_oidc_pending_trusted_publisher_url(id: @trusted_publisher)
       end
 
       assert_redirected_to profile_oidc_pending_trusted_publishers_url
@@ -119,7 +119,7 @@ class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::Integration
     should "return not found on destroy for other users trusted publisher" do
       trusted_publisher = create(:oidc_pending_trusted_publisher)
       assert_no_difference("OIDC::PendingTrustedPublisher.count") do
-        delete profile_oidc_pending_trusted_publisher_url(trusted_publisher)
+        delete profile_oidc_pending_trusted_publisher_url(id: trusted_publisher)
 
         assert_response :not_found
       end

--- a/test/integration/oidc/providers_controller_test.rb
+++ b/test/integration/oidc/providers_controller_test.rb
@@ -17,7 +17,7 @@ class OIDC::ProvidersControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "get show" do
-      get profile_oidc_provider_url(@provider)
+      get profile_oidc_provider_url(id: @provider)
 
       assert_response :success
     end
@@ -31,7 +31,7 @@ class OIDC::ProvidersControllerTest < ActionDispatch::IntegrationTest
 
   context "without a verified session" do
     should "redirect show to verify" do
-      get profile_oidc_provider_url(@provider)
+      get profile_oidc_provider_url(id: @provider)
 
       assert_response :redirect
       assert_redirected_to verify_session_path

--- a/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/rubygem_trusted_publishers_controller_test.rb
@@ -20,7 +20,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
     should "respond forbidden for non-owner" do
       @rubygem.disown
 
-      get rubygem_trusted_publishers_url(@rubygem.slug)
+      get rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
       assert_response :forbidden
     end
@@ -28,13 +28,13 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
     should "get index" do
       create(:oidc_rubygem_trusted_publisher, rubygem: @rubygem,
              trusted_publisher: create(:oidc_trusted_publisher_github_action, environment: "production"))
-      get rubygem_trusted_publishers_url(@rubygem.slug)
+      get rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
       assert_response :success
     end
 
     should "get new" do
-      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+      get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
       assert_response :success
     end
@@ -50,7 +50,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
 
       create(:version, rubygem: @rubygem, metadata: { "source_code_uri" => "https://github.com/example/rubygem1" })
 
-      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+      get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
       assert_response :success
 
@@ -65,7 +65,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
 
       create(:version, rubygem: @rubygem, metadata: { "source_code_uri" => "https://github.com/example/rubygem1" })
 
-      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+      get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
       assert_response :success
 
@@ -77,7 +77,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
       assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
         create(:version, rubygem: @rubygem, metadata: { "source_code_uri" => "https://github.com/CaioGarcia1" })
 
-        get new_rubygem_trusted_publisher_url(@rubygem.slug)
+        get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
         assert_response :success
       end
@@ -89,7 +89,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
 
       assert_difference("OIDC::RubygemTrustedPublisher.count") do
         trusted_publisher = build(:oidc_rubygem_trusted_publisher, rubygem: @rubygem)
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: {
             trusted_publisher_type: trusted_publisher.trusted_publisher_type,
             trusted_publisher_attributes: trusted_publisher.trusted_publisher.as_json
@@ -97,7 +97,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
         }
       end
 
-      assert_redirected_to rubygem_trusted_publishers_url(@rubygem.slug)
+      assert_redirected_to rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
     end
 
     should "create rubygem trusted publisher when trusted publisher already exists" do
@@ -107,7 +107,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
       github_action_trusted_publisher = create(:oidc_trusted_publisher_github_action)
 
       assert_difference("OIDC::RubygemTrustedPublisher.count") do
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: {
             trusted_publisher_type: github_action_trusted_publisher.class.polymorphic_name,
             trusted_publisher_attributes: github_action_trusted_publisher.as_json
@@ -116,12 +116,12 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
         }
       end
 
-      assert_redirected_to rubygem_trusted_publishers_url(@rubygem.slug)
+      assert_redirected_to rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
     end
 
     should "error creating trusted publisher with type" do
       assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: {
             trusted_publisher_type: "Hash",
             trusted_publisher_attributes: { repository_owner: "example" }
@@ -138,7 +138,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
         .to_return(status: 404, body: { message: "Not Found" }.to_json, headers: { "Content-Type" => "application/json" })
 
       assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: {
             trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
             trusted_publisher_attributes: { repository_owner: "example" }
@@ -159,7 +159,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
         .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
 
       assert_no_difference("OIDC::RubygemTrustedPublisher.count") do
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: {
             trusted_publisher_type: OIDC::TrustedPublisher::GitHubAction.polymorphic_name,
             trusted_publisher_attributes: { repository_name: "rubygem1", repository_owner: "example", workflow_filename: "ci.NO" }
@@ -173,10 +173,10 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
 
     should "destroy trusted publisher" do
       assert_difference("OIDC::RubygemTrustedPublisher.count", -1) do
-        delete rubygem_trusted_publisher_url(@rubygem.slug, @trusted_publisher)
+        delete rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug, id: @trusted_publisher)
       end
 
-      assert_redirected_to rubygem_trusted_publishers_url(@rubygem.slug)
+      assert_redirected_to rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
       assert_raises ActiveRecord::RecordNotFound do
         @trusted_publisher.reload
@@ -186,28 +186,28 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
 
   context "without a verified session" do
     should "redirect index to verify" do
-      get rubygem_trusted_publishers_url(@rubygem.slug)
+      get rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
       assert_response :redirect
       assert_redirected_to verify_session_path
     end
 
     should "redirect new to verify" do
-      get new_rubygem_trusted_publisher_url(@rubygem.slug)
+      get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
       assert_response :redirect
       assert_redirected_to verify_session_path
     end
 
     should "redirect create to verify" do
-      post rubygem_trusted_publishers_url(@rubygem.slug)
+      post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
       assert_response :redirect
       assert_redirected_to verify_session_path
     end
 
     should "redirect destroy to verify" do
-      delete new_rubygem_trusted_publisher_url(@rubygem.slug)
+      delete new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
       assert_response :redirect
       assert_redirected_to verify_session_path
@@ -223,19 +223,19 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
       end
 
       should "render forbidden on show" do
-        get rubygem_trusted_publishers_url(@rubygem.slug)
+        get rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug)
 
         assert_response :forbidden
       end
 
       should "render forbidden on new" do
-        get new_rubygem_trusted_publisher_url(@rubygem.slug)
+        get new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
         assert_response :forbidden
       end
 
       should "render forbidden on create" do
-        post rubygem_trusted_publishers_url(@rubygem.slug), params: {
+        post rubygem_trusted_publishers_url(rubygem_id: @rubygem.slug), params: {
           oidc_rubygem_trusted_publisher: { # avoid params permit error before authorization check
             trusted_publisher_type: "OIDC::TrustedPublisher::GitHubAction",
             trusted_publisher_attributes: {}
@@ -246,7 +246,7 @@ class OIDC::RubygemTrustedPublishersControllerTest < ActionDispatch::Integration
       end
 
       should "render forbidden on destroy" do
-        delete new_rubygem_trusted_publisher_url(@rubygem.slug)
+        delete new_rubygem_trusted_publisher_url(rubygem_id: @rubygem.slug)
 
         assert_response :forbidden
       end

--- a/test/integration/organizations/members_test.rb
+++ b/test/integration/organizations/members_test.rb
@@ -13,24 +13,28 @@ class Organizations::MembersTest < ActionDispatch::IntegrationTest
   end
 
   should "get index as a guest user" do
-    get organization_memberships_path(@organization)
+    get organization_memberships_path(organization_id: @organization)
 
     assert_response :success
     assert_select "h1", text: "Members"
     assert_select "a", text: "Invite", count: 0
-    assert_select "li a[href=?]", profile_path(@owner), text: @owner.handle
-    assert_select "li a[href=?]", profile_path(@maintainer), text: @maintainer.handle
+    assert_select "li a[href=?]", profile_path(id: @owner), text: @owner.handle
+    assert_select "li a[href=?]", profile_path(id: @maintainer), text: @maintainer.handle
   end
 
   should "get index as an owner" do
     post session_path(session: { who: @owner.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
 
-    get organization_memberships_path(@organization)
+    get organization_memberships_path(organization_id: @organization)
 
     assert_response :success
     assert_select "h1", text: "Members"
     assert_select "a", text: "Invite", count: 1
-    assert_select "li a[href=?]", edit_organization_membership_path(@organization, @owner_membership), text: "#{@owner.handle} owner"
-    assert_select "li a[href=?]", edit_organization_membership_path(@organization, @maintainer_membership), text: "#{@maintainer.handle} maintainer"
+    assert_select "li a[href=?]",
+      edit_organization_membership_path(organization_id: @organization, id: @owner_membership),
+      text: "#{@owner.handle} owner"
+    assert_select "li a[href=?]",
+      edit_organization_membership_path(organization_id: @organization, id: @maintainer_membership),
+      text: "#{@maintainer.handle} maintainer"
   end
 end

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -12,14 +12,14 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
     organization = create(:organization, owners: [@user], handle: "arrakis", name: "Arrakis")
     organization.rubygems << create(:rubygem, name: "arrakis", number: "1.0.0")
 
-    get organization_path(organization)
+    get organization_path(id: organization)
 
     assert_response :success
     assert page.has_content? "arrakis"
   end
 
   test "should render not found when an organization doesn't exist" do
-    get organization_path("nonexistent")
+    get organization_path(id: "nonexistent")
 
     assert_response :not_found
   end
@@ -43,21 +43,21 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
   test "should render organization edit form" do
     organization = create(:organization, owners: [@user])
 
-    get edit_organization_path(organization)
+    get edit_organization_path(id: organization)
 
     assert_response :success
-    assert_select "form[action=?]", organization_path(organization)
+    assert_select "form[action=?]", organization_path(id: organization)
     assert_select "input[name=?]", "organization[name]"
   end
 
   test "should update an organization display name" do
     organization = create(:organization, owners: [@user])
 
-    patch organization_path(organization), params: {
+    patch organization_path(id: organization), params: {
       organization: { name: "New Name" }
     }
 
-    assert_redirected_to organization_path(organization)
+    assert_redirected_to organization_path(id: organization)
     follow_redirect!
 
     assert page.has_content? "New Name"
@@ -66,7 +66,7 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
   test "should render user roles for users in the organization" do
     organization = create(:organization, owners: [@user])
 
-    get organization_path(organization)
+    get organization_path(id: organization)
 
     assert page.has_content? "#{@user.handle} owner", normalize_ws: true
   end
@@ -75,7 +75,7 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
     owner = create(:user)
     organization = create(:organization, owners: [owner])
 
-    get organization_path(organization)
+    get organization_path(id: organization)
 
     refute page.has_content? "#{owner.handle} owner", normalize_ws: true
   end
@@ -83,15 +83,15 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
   test "should render an invite button for admins+" do
     organization = create(:organization, owners: [@user])
 
-    get organization_path(organization)
+    get organization_path(id: organization)
 
-    assert_select "a[href=?]", new_organization_membership_path(organization), text: "Invite"
+    assert_select "a[href=?]", new_organization_membership_path(organization_id: organization), text: "Invite"
   end
 
   test "should not render the invite button for users with less access than admins" do
     organization = create(:organization, maintainers: [@user])
 
-    get organization_path(organization)
+    get organization_path(id: organization)
 
     refute page.has_content? "Invite"
   end

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -80,7 +80,7 @@ class PushTest < ActionDispatch::IntegrationTest
     assert_response :success
     perform_enqueued_jobs
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     assert page.has_content?("sandworm")
@@ -134,7 +134,7 @@ class PushTest < ActionDispatch::IntegrationTest
     assert_equal({ checksum_sha256: spec_checksum, key: "quick/Marshal.4.8/sandworm-2.0.0.gemspec.rz" },
                  RubygemFs.instance.head("quick/Marshal.4.8/sandworm-2.0.0.gemspec.rz"))
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     assert page.has_content?("sandworm")
@@ -171,7 +171,7 @@ class PushTest < ActionDispatch::IntegrationTest
       message_id: email.message_id, mailer: "mailer", action: "gem_pushed"
     }, @user.events.where(tag: Events::UserEvent::EMAIL_SENT).sole
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     page.assert_text("Pushed by")
@@ -188,7 +188,7 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     page.assert_text("Pushed by")
@@ -210,7 +210,7 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     page.assert_text("Pushed by")
@@ -231,7 +231,7 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     assert page.has_content?("crysknife")
@@ -245,7 +245,7 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get rubygem_path("sandworm")
+    get rubygem_path(id: "sandworm")
 
     assert_response :success
     assert page.has_content?("mauddib")
@@ -292,7 +292,7 @@ class PushTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get rubygem_path("valid_signature")
+    get rubygem_path(id: "valid_signature")
 
     assert_response :success
 
@@ -302,7 +302,7 @@ class PushTest < ActionDispatch::IntegrationTest
     refute page.has_content?("(expired)")
 
     travel_to Time.zone.local(2121, 8, 8)
-    get rubygem_path("valid_signature")
+    get rubygem_path(id: "valid_signature")
 
     assert page.has_content?("(expired)")
   end

--- a/test/integration/routing_test.rb
+++ b/test/integration/routing_test.rb
@@ -22,26 +22,23 @@ class RoutingTest < ActionDispatch::IntegrationTest
 
   test "non html format route don't exist for UI" do
     @ui_paths_verb.each do |path, verb|
-      next if path == "/" # adding random format after root (/) gives 404
+      concrete_path = concrete_ui_path(path)
+      next if root_route_path?(concrete_path) # adding random format after root (/) gives 404
+      next if path.end_with?("/:id(.:format)")
 
       assert_raises(ActionController::RoutingError, "#{verb} #{path} should raise") do
         # ex: get(/password/new.json)
-        send(verb.downcase, path.gsub("(.:format)", ".something"))
+        send(verb.downcase, concrete_path.gsub("(.:format)", ".something"))
       end
     end
   end
 
   test "adding format param to UI routes doesn't break the app" do
     @ui_paths_verb.each do |path, verb|
-      next if path == "/"
+      format_path = concrete_ui_path(path)
+      next if root_route_path?(format_path)
 
-      format_path = path.gsub("(.:format)", "?format=something")
-      format_path.gsub!(":rubygem_id", "someid")
-      format_path.gsub!(":id", "someid")
-      format_path.gsub!("*id", "about") # used in high voltage route
-      format_path.gsub!(":version_id", "someid")
-      format_path.gsub!(":organization_id", "someid")
-      format_path.gsub!(":policy", "privacy")
+      format_path.gsub!("(.:format)", "?format=something")
 
       assert_nothing_raised do
         # ex: get(/password/new?format=json)
@@ -73,6 +70,23 @@ class RoutingTest < ActionDispatch::IntegrationTest
     assert_nothing_raised do
       get "/releases?page=2&params=thing"
     end
+  end
+
+  def concrete_ui_path(path)
+    path = path.dup
+    path.gsub!("/(:locale)", "")
+    path.gsub!("(/:locale)", "")
+    path.gsub!(":rubygem_id", "someid")
+    path.gsub!(":id", "someid")
+    path.gsub!("*id", "about") # used in high voltage route
+    path.gsub!(":version_id", "someid")
+    path.gsub!(":organization_id", "someid")
+    path.gsub!(":policy", "privacy")
+    path
+  end
+
+  def root_route_path?(path)
+    ["/", "(.:format)", "/(.:format)"].include?(path)
   end
 
   teardown do

--- a/test/integration/rubygems/dependencies_test.rb
+++ b/test/integration/rubygems/dependencies_test.rb
@@ -9,7 +9,7 @@ class Rubygems::DependenciesTest < ActionDispatch::IntegrationTest
   end
 
   test "anonymous dependencies page sets public cache headers" do
-    get rubygem_version_dependencies_path(@rubygem.slug, @version.slug)
+    get rubygem_version_dependencies_path(rubygem_id: @rubygem.slug, version_id: @version.slug)
 
     assert_response :success
     assert_nil response.headers["Set-Cookie"]

--- a/test/integration/rubygems/reverse_dependencies_test.rb
+++ b/test/integration/rubygems/reverse_dependencies_test.rb
@@ -8,7 +8,7 @@ class Rubygems::ReverseDependenciesTest < ActionDispatch::IntegrationTest
   end
 
   test "anonymous reverse dependencies page sets public cache headers" do
-    get rubygem_reverse_dependencies_path(@rubygem.slug)
+    get rubygem_reverse_dependencies_path(rubygem_id: @rubygem.slug)
 
     assert_response :success
     assert_nil response.headers["Set-Cookie"]

--- a/test/integration/rubygems/versions_test.rb
+++ b/test/integration/rubygems/versions_test.rb
@@ -9,7 +9,7 @@ class Rubygems::VersionsTest < ActionDispatch::IntegrationTest
   end
 
   test "anonymous versions index sets public cache headers" do
-    get rubygem_versions_path(@rubygem.slug)
+    get rubygem_versions_path(rubygem_id: @rubygem.slug)
 
     assert_response :success
     assert_nil response.headers["Set-Cookie"]
@@ -19,7 +19,7 @@ class Rubygems::VersionsTest < ActionDispatch::IntegrationTest
   end
 
   test "anonymous version show sets public cache headers" do
-    get rubygem_version_path(@rubygem.slug, @version.slug)
+    get rubygem_version_path(rubygem_id: @rubygem.slug, id: @version.slug)
 
     assert_response :success
     assert_nil response.headers["Set-Cookie"]

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -376,7 +376,7 @@ class ApiKeysTest < ApplicationSystemTestCase
   end
 
   def visit_edit_profile_api_key_path(api_key)
-    visit edit_profile_api_key_path(api_key)
+    visit edit_profile_api_key_path(id: api_key)
     verify_password
   end
 

--- a/test/system/gems_test.rb
+++ b/test/system/gems_test.rb
@@ -10,17 +10,17 @@ class GemsSystemTest < ApplicationSystemTestCase
   end
 
   test "version navigation" do
-    visit rubygem_version_path(@rubygem.slug, "1.0.0")
+    visit rubygem_version_path(rubygem_id: @rubygem.slug, id: "1.0.0")
     click_link "Next version →"
 
-    assert_current_path rubygem_version_path(@rubygem.slug, "1.1.1")
+    assert_current_path rubygem_version_path(rubygem_id: @rubygem.slug, id: "1.1.1")
     click_link "← Previous version"
 
-    assert_current_path rubygem_version_path(@rubygem.slug, "1.0.0")
+    assert_current_path rubygem_version_path(rubygem_id: @rubygem.slug, id: "1.0.0")
   end
 
   test "subscribe to a gem" do
-    visit rubygem_path(@rubygem.slug, as: @user.id)
+    visit rubygem_path(id: @rubygem.slug, as: @user.id)
 
     assert page.has_css?("a#subscribe")
 
@@ -33,7 +33,7 @@ class GemsSystemTest < ApplicationSystemTestCase
   test "unsubscribe to a gem" do
     create(:subscription, rubygem: @rubygem, user: @user)
 
-    visit rubygem_path(@rubygem.slug, as: @user.id)
+    visit rubygem_path(id: @rubygem.slug, as: @user.id)
 
     assert page.has_css?("a#unsubscribe")
 
@@ -46,7 +46,7 @@ class GemsSystemTest < ApplicationSystemTestCase
   test "shows enable MFA instructions when logged in as owner with MFA disabled" do
     create(:ownership, rubygem: @rubygem, user: @user)
 
-    visit rubygem_path(@rubygem.slug, as: @user.id)
+    visit rubygem_path(id: @rubygem.slug, as: @user.id)
 
     assert_text "Please consider enabling multi-factor"
     find(".gem__users__mfa-text.mfa-warn").click
@@ -61,7 +61,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_without_mfa)
 
-    visit rubygem_path(@rubygem.slug, as: @user.id)
+    visit rubygem_path(id: @rubygem.slug, as: @user.id)
 
     assert page.has_selector?(".gem__users__mfa-text.mfa-warn")
     find(".gem__users__mfa-text.mfa-warn").click
@@ -77,7 +77,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_with_mfa)
 
-    visit rubygem_path(@rubygem.slug, as: @user.id)
+    visit rubygem_path(id: @rubygem.slug, as: @user.id)
 
     assert page.has_no_selector?(".gem__users__mfa-text.mfa-warn")
     assert page.has_selector?(".gem__users__mfa-text.mfa-info")
@@ -90,7 +90,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     create(:ownership, rubygem: @rubygem, user: @user)
     create(:ownership, rubygem: @rubygem, user: user_without_mfa)
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert page.has_no_selector?(".gem__users__mfa-disabled .gem__users a")
     assert page.has_no_selector?(".gem__users__mfa-text.mfa-warn")
@@ -101,7 +101,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     github_link = "http://github.com/user/project"
     create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "source_code_uri" => github_link })
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert page.has_selector?(".github-btn")
   end
@@ -110,7 +110,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     github_link = "http://github.com/user/project"
     create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "homepage_uri" => github_link })
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert page.has_selector?(".github-btn")
   end
@@ -119,7 +119,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     notgithub_link = "http://notgithub.com/user/project"
     create(:version, number: "3.0.1", rubygem: @rubygem, metadata: { "homepage_uri" => notgithub_link })
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert page.has_no_selector?(".github-btn")
   end
@@ -128,7 +128,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
     create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_version_path(@rubygem.slug, "0.1.1")
+    visit rubygem_version_path(rubygem_id: @rubygem.slug, id: "0.1.1")
 
     assert_text "NEW VERSIONS REQUIRE MFA"
     assert_text "VERSION PUBLISHED WITH MFA"
@@ -138,7 +138,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
     create(:version, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_version_path(@rubygem.slug, "0.1.1")
+    visit rubygem_version_path(rubygem_id: @rubygem.slug, id: "0.1.1")
 
     assert_text "NEW VERSIONS REQUIRE MFA"
     assert_no_text "VERSION PUBLISHED WITH MFA"
@@ -148,7 +148,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
     create(:version, :mfa_required, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_version_path(@rubygem.slug, "0.1.1")
+    visit rubygem_version_path(rubygem_id: @rubygem.slug, id: "0.1.1")
 
     assert_no_text "NEW VERSIONS REQUIRE MFA"
     assert_text "VERSION PUBLISHED WITH MFA"
@@ -158,7 +158,7 @@ class GemsSystemTest < ApplicationSystemTestCase
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
     create(:version, rubygem: @rubygem, number: "0.1.1")
 
-    visit rubygem_version_path(@rubygem.slug, "0.1.1")
+    visit rubygem_version_path(rubygem_id: @rubygem.slug, id: "0.1.1")
 
     assert_no_text "NEW VERSIONS REQUIRE MFA"
     assert_no_text "VERSION PUBLISHED WITH MFA"
@@ -167,7 +167,7 @@ class GemsSystemTest < ApplicationSystemTestCase
   test "shows both mfa headers if MFA enabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "true" }
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert_text "NEW VERSIONS REQUIRE MFA"
     assert_text "VERSION PUBLISHED WITH MFA"
@@ -176,7 +176,7 @@ class GemsSystemTest < ApplicationSystemTestCase
   test "shows neither mfa header if MFA disabled for latest version and viewing latest version" do
     @version.update_attribute :metadata, { "rubygems_mfa_required" => "false" }
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert_no_text "NEW VERSIONS REQUIRE MFA"
     assert_no_text "VERSION PUBLISHED WITH MFA"

--- a/test/system/invitation_test.rb
+++ b/test/system/invitation_test.rb
@@ -16,7 +16,7 @@ class InvitationTest < ApplicationSystemTestCase
   test "inviting a user to an organization" do
     sign_in
 
-    visit organization_path(@organization)
+    visit organization_path(id: @organization)
     click_on "Invite"
 
     fill_in "Handle", with: @outside_user.handle
@@ -33,7 +33,7 @@ class InvitationTest < ApplicationSystemTestCase
 
     sign_in maintainer
 
-    visit organization_path(@organization)
+    visit organization_path(id: @organization)
 
     assert_no_text "Invite"
   end
@@ -65,7 +65,7 @@ class InvitationTest < ApplicationSystemTestCase
 
     sign_in
 
-    visit edit_organization_membership_path(@organization, pending_membership)
+    visit edit_organization_membership_path(organization_id: @organization, id: pending_membership)
 
     assert_text @outside_user.handle
     assert_text "Resend Invitation"
@@ -80,7 +80,7 @@ class InvitationTest < ApplicationSystemTestCase
 
     sign_in
 
-    visit edit_organization_membership_path(@organization, confirmed_membership)
+    visit edit_organization_membership_path(organization_id: @organization, id: confirmed_membership)
 
     assert_text @outside_user.handle
     assert_text "Joined:"
@@ -94,7 +94,7 @@ class InvitationTest < ApplicationSystemTestCase
 
     sign_in maintainer
 
-    visit edit_organization_membership_path(@organization, pending_membership)
+    visit edit_organization_membership_path(organization_id: @organization, id: pending_membership)
 
     # Maintainers cannot access the edit page at all
     assert_text "Page not found"

--- a/test/system/locale_test.rb
+++ b/test/system/locale_test.rb
@@ -12,8 +12,6 @@ class LocaleTest < ApplicationSystemTestCase
   end
 
   test "locale is switched via locale menu" do
-    skip "locale switcher temporarily disabled"
-
     visit root_path
 
     assert_equal I18n.default_locale.to_s, page.find("html")[:lang]

--- a/test/system/locale_test.rb
+++ b/test/system/locale_test.rb
@@ -4,16 +4,15 @@ require "application_system_test_case"
 
 class LocaleTest < ApplicationSystemTestCase
   test "html lang attribute is set from locale" do
-    skip "locales temporarily disabled"
     I18n.available_locales.each do |locale|
-      visit root_path(locale: locale)
+      visit "/#{locale}"
 
       assert_equal locale.to_s, page.find("html")[:lang]
     end
   end
 
   test "locale is switched via locale menu" do
-    skip "locales temporarily disabled"
+    skip "locale switcher temporarily disabled"
 
     visit root_path
 
@@ -22,5 +21,18 @@ class LocaleTest < ApplicationSystemTestCase
     click_link "Deutsch"
 
     assert_equal "de", page.find("html")[:lang]
+  end
+
+  test "localized root keeps the home page layout" do
+    visit "/de"
+
+    assert_selector "body.body--index"
+    assert_no_selector "header.header--interior"
+    assert_no_selector "main.main--interior"
+  end
+
+  test "keyword route helper arguments target non-locale segments" do
+    assert_equal "/gems/rails", rubygem_path(id: "rails")
+    assert_equal "/gems/rails/versions/7.0.0", rubygem_version_path(rubygem_id: "rails", id: "7.0.0")
   end
 end

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -30,7 +30,7 @@ class OIDCTest < ApplicationSystemTestCase
     page.assert_text "https://token.actions.githubusercontent.com/.well-known/jwks"
     page.assert_text(/Displaying 1 api key role/i)
 
-    assert_link @id_token.api_key_role.name, href: profile_oidc_api_key_role_path(@id_token.api_key_role.token)
+    assert_link @id_token.api_key_role.name, href: profile_oidc_api_key_role_path(token: @id_token.api_key_role.token)
   end
 
   test "viewing api key roles" do
@@ -52,8 +52,8 @@ class OIDCTest < ApplicationSystemTestCase
     page.assert_text "Conditions\nsub string_equals repo:segiddins/oidc-test:ref:refs/heads/main"
     page.assert_text(/Displaying 1 id token/i)
 
-    assert_link "View provider https://token.actions.githubusercontent.com", href: profile_oidc_provider_path(@provider)
-    assert_link @id_token.jti, href: profile_oidc_id_token_path(@id_token)
+    assert_link "View provider https://token.actions.githubusercontent.com", href: profile_oidc_provider_path(id: @provider)
+    assert_link @id_token.jti, href: profile_oidc_id_token_path(id: @id_token)
   end
 
   test "viewing id tokens" do
@@ -70,8 +70,8 @@ class OIDCTest < ApplicationSystemTestCase
     page.assert_text "EXPIRES AT\n#{@id_token.api_key.expires_at.to_fs(:long)}"
     page.assert_text "JWT ID\n#{@id_token.jti}"
 
-    assert_link @api_key_role.name, href: profile_oidc_api_key_role_path(@api_key_role.token)
-    assert_link "https://token.actions.githubusercontent.com", href: profile_oidc_provider_path(@provider)
+    assert_link @api_key_role.name, href: profile_oidc_api_key_role_path(token: @api_key_role.token)
+    assert_link "https://token.actions.githubusercontent.com", href: profile_oidc_provider_path(id: @provider)
     page.assert_text "jti\n#{@id_token.jti}"
     page.assert_text "claim1\nvalue1"
     page.assert_text "claim2\nvalue2"
@@ -83,7 +83,7 @@ class OIDCTest < ApplicationSystemTestCase
     create(:version, rubygem: rubygem, metadata: { "source_code_uri" => "https://github.com/example/repo" })
 
     sign_in
-    visit rubygem_path(rubygem.slug)
+    visit rubygem_path(id: rubygem.slug)
     click_link "OIDC: Create"
     verify_session
 
@@ -229,7 +229,7 @@ class OIDCTest < ApplicationSystemTestCase
 
     sign_in
 
-    visit rubygem_path(rubygem.slug)
+    visit rubygem_path(id: rubygem.slug)
     click_link "OIDC: Create"
     verify_session
 
@@ -324,19 +324,19 @@ class OIDCTest < ApplicationSystemTestCase
     rubygem = create(:rubygem, name: "rubygem0")
     create(:version, rubygem: rubygem, metadata: { "source_code_uri" => "https://github.com/example/rubygem0" })
 
-    visit new_rubygem_trusted_publisher_path(rubygem.slug)
+    visit new_rubygem_trusted_publisher_path(rubygem_id: rubygem.slug)
 
     assert_text "Please sign in to continue."
 
     sign_in
-    visit new_rubygem_trusted_publisher_path(rubygem.slug)
+    visit new_rubygem_trusted_publisher_path(rubygem_id: rubygem.slug)
     verify_session
 
     assert_text "Forbidden"
 
     create(:ownership, rubygem: rubygem, user: @user)
 
-    visit rubygem_trusted_publishers_path(rubygem.slug)
+    visit rubygem_trusted_publishers_path(rubygem_id: rubygem.slug)
 
     page.assert_selector "h1", text: "Trusted Publishers"
     page.assert_text("Trusted publishers for rubygem0")
@@ -412,7 +412,7 @@ class OIDCTest < ApplicationSystemTestCase
     create(:version, rubygem:)
 
     sign_in
-    visit rubygem_trusted_publishers_path(rubygem.slug)
+    visit rubygem_trusted_publishers_path(rubygem_id: rubygem.slug)
     verify_session
 
     click_button "Delete"

--- a/test/system/onboarding_test.rb
+++ b/test/system/onboarding_test.rb
@@ -147,7 +147,7 @@ class OnboardingTest < ApplicationSystemTestCase
 
     click_button "Create Org"
 
-    visit rubygem_owners_path(@rubygem.slug)
+    visit rubygem_owners_path(rubygem_id: @rubygem.slug)
 
     assert_text "Please confirm your password to continue"
 

--- a/test/system/organization_invite_test.rb
+++ b/test/system/organization_invite_test.rb
@@ -12,7 +12,7 @@ class OrganizationInviteSystemTest < ApplicationSystemTestCase
   test "invite user to organization" do
     sign_in(@owner)
 
-    visit organization_path(@organization)
+    visit organization_path(id: @organization)
 
     click_on "Members"
     click_on "Invite"

--- a/test/system/owner_test.rb
+++ b/test/system/owner_test.rb
@@ -28,7 +28,7 @@ class OwnerTest < ApplicationSystemTestCase
     owners_table = page.find(:css, ".owners__table")
 
     within_element owners_table do
-      assert_selector(:css, "a[href='#{profile_path(@other_user.display_id)}']")
+      assert_selector(:css, "a[href='#{profile_path(id: @other_user.display_id)}']")
     end
 
     assert_cell(@other_user, "Confirmed", "Pending")
@@ -95,7 +95,7 @@ class OwnerTest < ApplicationSystemTestCase
       end
     end
 
-    refute page.has_selector? ".owners__table a[href='#{profile_path(@other_user)}']"
+    refute page.has_selector? ".owners__table a[href='#{profile_path(id: @other_user)}']"
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
@@ -113,7 +113,7 @@ class OwnerTest < ApplicationSystemTestCase
       end
     end
 
-    assert page.has_selector?("a[href='#{profile_path(@user.display_id)}']")
+    assert page.has_selector?("a[href='#{profile_path(id: @user.display_id)}']")
     assert page.has_selector? "#flash_alert", text: "Can't remove the only owner of the gem"
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
@@ -128,7 +128,7 @@ class OwnerTest < ApplicationSystemTestCase
     click_button "Authenticate with security device"
     find(:css, ".header__popup-link")
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
 
     assert page.has_css? "#verify_password_password"
@@ -145,7 +145,7 @@ class OwnerTest < ApplicationSystemTestCase
     click_button "Authenticate with security device"
     find(:css, ".header__popup-link")
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
 
     assert page.has_css? "#verify_password_password"
@@ -160,7 +160,7 @@ class OwnerTest < ApplicationSystemTestCase
   end
 
   test "incorrect password on verify shows error" do
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
 
     assert page.has_css? "#verify_password_password"
@@ -175,7 +175,7 @@ class OwnerTest < ApplicationSystemTestCase
 
     travel 15.minutes
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
 
     assert page.has_field? "Password"
@@ -184,7 +184,7 @@ class OwnerTest < ApplicationSystemTestCase
   end
 
   test "incorrect password error does not persist after correct password" do
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
 
     assert page.has_css? "#verify_password_password"
@@ -201,13 +201,13 @@ class OwnerTest < ApplicationSystemTestCase
 
   test "clicking on confirmation link confirms the account" do
     @unconfirmed_ownership = create(:ownership, :unconfirmed, rubygem: @rubygem)
-    confirmation_link = confirm_rubygem_owners_url(@rubygem.slug, token: @unconfirmed_ownership.token)
+    confirmation_link = confirm_rubygem_owners_url(rubygem_id: @rubygem.slug, token: @unconfirmed_ownership.token)
 
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
       visit confirmation_link
     end
 
-    assert_current_path rubygem_path(@rubygem.slug)
+    assert_current_path rubygem_path(id: @rubygem.slug)
     assert page.has_selector? "#flash_notice", text: "You were added as an owner to the #{@rubygem.name} gem"
 
     assert_emails 2
@@ -219,7 +219,7 @@ class OwnerTest < ApplicationSystemTestCase
   end
 
   test "clicking on incorrect link shows error" do
-    confirmation_link = confirm_rubygem_owners_url(@rubygem.slug, token: SecureRandom.hex(20).encode("UTF-8"))
+    confirmation_link = confirm_rubygem_owners_url(rubygem_id: @rubygem.slug, token: SecureRandom.hex(20).encode("UTF-8"))
     visit confirmation_link
 
     assert_text "Page not found."
@@ -240,8 +240,8 @@ class OwnerTest < ApplicationSystemTestCase
 
     owners_table = page.find(:css, ".owners__table")
     within_element owners_table do
-      assert_selector(:css, "a[href='#{profile_path(@user.display_id)}']")
-      assert_selector(:css, "a[href='#{profile_path(maintainer.display_id)}']")
+      assert_selector(:css, "a[href='#{profile_path(id: @user.display_id)}']")
+      assert_selector(:css, "a[href='#{profile_path(id: maintainer.display_id)}']")
     end
 
     assert_no_text "ADD OWNER"
@@ -256,40 +256,40 @@ class OwnerTest < ApplicationSystemTestCase
     sign_out
     sign_in(maintainer)
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    assert page.has_selector?("a[href='#{rubygem_owners_path(@rubygem.slug)}']")
+    assert page.has_selector?("a[href='#{rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
   end
 
   test "shows ownership link when is owner" do
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    assert page.has_selector?("a[href='#{rubygem_owners_path(@rubygem.slug)}']")
+    assert page.has_selector?("a[href='#{rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
   end
 
   test "hides ownership link when not owner" do
     sign_out
     sign_in(@other_user)
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem.slug)}']")
+    refute page.has_selector?("a[href='#{rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
   end
 
   test "hides ownership link when not signed in" do
     sign_out
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem.slug)}']")
+    refute page.has_selector?("a[href='#{rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
   end
 
   test "shows resend confirmation link when unconfirmed" do
     sign_out
     create(:ownership, :unconfirmed, user: @other_user, rubygem: @rubygem)
     sign_in(@other_user)
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    refute page.has_selector?("a[href='#{rubygem_owners_path(@rubygem.slug)}']")
-    assert page.has_selector?("a[href='#{resend_confirmation_rubygem_owners_path(@rubygem.slug)}']")
+    refute page.has_selector?("a[href='#{rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
+    assert page.has_selector?("a[href='#{resend_confirmation_rubygem_owners_path(rubygem_id: @rubygem.slug)}']")
   end
 
   test "deleting unconfirmed owner user" do
@@ -357,7 +357,7 @@ class OwnerTest < ApplicationSystemTestCase
   end
 
   def visit_ownerships_page
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
     click_link "Ownership"
     return unless page.has_css? "#verify_password_password"
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -4,10 +4,8 @@ require "application_system_test_case"
 
 class PagesTest < ApplicationSystemTestCase
   test "renders /pages/about for all supported languages" do
-    skip "locales temporarily disabled"
-
     I18n.available_locales.each do |locale|
-      visit "/pages/about?locale=#{locale}"
+      visit "/#{locale}/pages/about"
 
       assert_text I18n.t("pages.about.title", locale: locale)
     end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -12,7 +12,7 @@ class ProfileTest < ApplicationSystemTestCase
   test "changing handle" do
     sign_in
 
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     assert_text "nick1"
 
@@ -28,7 +28,7 @@ class ProfileTest < ApplicationSystemTestCase
     create(:user, email: "nick2@rubygems-test.org", handle: "nick2")
 
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
     click_link "Edit Profile"
 
     fill_in "user_handle", with: "nick2"
@@ -40,7 +40,7 @@ class ProfileTest < ApplicationSystemTestCase
 
   test "changing to invalid handle does not affect rendering" do
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
     click_link "Edit Profile"
 
     fill_in "user_handle", with: "nick1" * 10
@@ -53,7 +53,7 @@ class ProfileTest < ApplicationSystemTestCase
 
   test "changing email does not change email and asks to confirm email" do
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
     click_link "Edit Profile"
 
     fill_in "Email address", with: "nick2@rubygems-test.org"
@@ -90,12 +90,12 @@ class ProfileTest < ApplicationSystemTestCase
 
   test "enabling email on profile" do
     # email is hidden at public profile by default
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     assert_no_text("Email Me")
 
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
     click_link "Edit Profile"
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -105,14 +105,14 @@ class ProfileTest < ApplicationSystemTestCase
     assert_text "Your profile was updated."
     sign_out
 
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     assert_text("Email Me")
   end
 
   test "adding X(formerly Twitter) username" do
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     click_link "Edit Profile"
     fill_in "user_twitter_username", with: "nick1"
@@ -122,7 +122,7 @@ class ProfileTest < ApplicationSystemTestCase
     assert_text "Your profile was updated."
 
     sign_out
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     assert page.has_link?("@nick1", href: "https://twitter.com/nick1")
   end
@@ -131,7 +131,7 @@ class ProfileTest < ApplicationSystemTestCase
     twitter_username = "nick1twitter"
 
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     click_link "Edit Profile"
     fill_in "user_twitter_username", with: twitter_username
@@ -152,7 +152,7 @@ class ProfileTest < ApplicationSystemTestCase
 
   test "deleting profile" do
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
     click_link "Edit Profile"
 
     click_button "Delete"
@@ -195,7 +195,7 @@ class ProfileTest < ApplicationSystemTestCase
     create(:rubygem, owners: [@user], number: "1.0.0", downloads: 7)
 
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     downloads = page.all(".gems__gem__downloads__count")
 
@@ -209,7 +209,7 @@ class ProfileTest < ApplicationSystemTestCase
     create(:version, rubygem: Rubygem.first, number: "0.0.2")
 
     sign_in
-    visit profile_path("nick1")
+    visit profile_path(id: "nick1")
 
     version = page.find(".gems__gem__version").text
 

--- a/test/system/rubygem_transfer_test.rb
+++ b/test/system/rubygem_transfer_test.rb
@@ -16,7 +16,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     sign_in maintainer
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
 
     assert_no_link "Transfer"
   end
@@ -24,7 +24,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
   test "transfer a rubygem to an organization" do
     sign_in @owner
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
     click_on "Transfer"
 
     assert_current_path organization_transfer_rubygems_path
@@ -52,7 +52,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     sign_in @owner
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
     click_on "Transfer"
 
     assert_current_path organization_transfer_rubygems_path
@@ -74,7 +74,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     assert_text "Successfully transferred 1 gem to #{@organization.name}."
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
     click_on "Members"
 
     assert_text "#{maintainer.handle} Pending", normalize_ws: true
@@ -86,9 +86,9 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     sign_in @owner
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
     click_on "Transfer"
 
     assert_current_path organization_transfer_rubygems_path
@@ -108,7 +108,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
 
     click_on "Transfer Gem"
 
-    visit rubygem_path(@rubygem.name)
+    visit rubygem_path(id: @rubygem.name)
 
     assert_text "MANAGED BY: #{@organization.name}", normalize_ws: true
 
@@ -127,7 +127,7 @@ class RubygemTransferSystemTest < ApplicationSystemTestCase
   test "cancelling a rubygem transfer" do
     sign_in @owner
 
-    visit organization_path(@organization.handle)
+    visit organization_path(id: @organization.handle)
     click_on "Transfer"
 
     assert_current_path organization_transfer_rubygems_path

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -34,7 +34,7 @@ class SearchTest < ApplicationSystemTestCase
     click_link "Yanked (1)"
 
     assert_text "LDAP"
-    assert page.has_selector? "a[href='#{rubygem_path('LDAP')}']"
+    assert page.has_selector? "a[href='#{rubygem_path(id: 'LDAP')}']"
   end
 
   test "searching for a gem with yanked versions" do

--- a/test/system/subscriptions_test.rb
+++ b/test/system/subscriptions_test.rb
@@ -14,7 +14,7 @@ class SubscriptionsTest < ApplicationSystemTestCase
 
     assert_text "You're not subscribed to any gems yet."
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     click_link "Subscribe"
 

--- a/test/system/transitive_dependencies_test.rb
+++ b/test/system/transitive_dependencies_test.rb
@@ -44,7 +44,7 @@ class TransitiveDependenciesTest < ApplicationSystemTestCase
     dep_dep_version = create(:version, platform: "jruby")
     create(:dependency, requirements: ">=0", scope: :runtime, rubygem: dep_dep_version.rubygem, version: dep_version)
 
-    visit rubygem_path(version.rubygem.slug)
+    visit rubygem_path(id: version.rubygem.slug)
     click_on "Show all transitive dependencies"
 
     assert_text(dep_version.rubygem.name)

--- a/test/system/yank_test.rb
+++ b/test/system/yank_test.rb
@@ -62,14 +62,14 @@ class YankTest < ApplicationSystemTestCase
   test "yanked gem entirely then someone else pushes a new version" do
     create(:version, rubygem: @rubygem, number: "0.0.0")
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert_text "sandworm"
     assert_text "0.0.0"
 
     yank_gem_via_api(@user_api_key, @rubygem.name, "0.0.0")
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert_text "sandworm"
     assert_text "This gem is not currently hosted on RubyGems.org"
@@ -80,7 +80,7 @@ class YankTest < ApplicationSystemTestCase
     gem_io = build_gem(new_gemspec("sandworm", "1.0.0", "Gemcutter", "ruby"))
     push_gem_via_api(other_user_key, gem_io)
 
-    visit rubygem_path(@rubygem.slug)
+    visit rubygem_path(id: @rubygem.slug)
 
     assert_text "sandworm"
     assert_text "1.0.0"

--- a/test/unit/helpers/locale_switch_helper_test.rb
+++ b/test/unit/helpers/locale_switch_helper_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocaleSwitchHelperTest < ActionView::TestCase
+  include Rails.application.routes.url_helpers
+
+  should "fall back to the localized home for a non-GET action with no GET form" do
+    request.stubs(:get?).returns(false)
+    request.stubs(:head?).returns(false)
+    request.stubs(:path_parameters).returns(controller: "rubygems", action: "destroy")
+    request.stubs(:query_parameters).returns({})
+
+    assert_equal root_path(locale: :de), locale_switch_path(:de)
+  end
+end

--- a/test/unit/helpers/rubygems_helper_test.rb
+++ b/test/unit/helpers/rubygems_helper_test.rb
@@ -117,7 +117,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
       expected_links = users.sort_by(&:id).map do |u|
         link_to avatar(48, "gravatar-#{u.id}", u),
-          profile_path(u.display_id),
+          profile_path(id: u.display_id),
           alt: u.display_handle,
           title: u.display_handle
       end.join
@@ -134,7 +134,7 @@ class RubygemsHelperTest < ActionView::TestCase
 
       expected_links = without_mfa.sort_by(&:id).map do |u|
         link_to avatar(48, "gravatar-#{u.id}", u),
-          profile_path(u.display_id),
+          profile_path(id: u.display_id),
           alt: u.display_handle,
           title: u.display_handle
       end.join
@@ -228,7 +228,7 @@ class RubygemsHelperTest < ActionView::TestCase
       role = create(:oidc_api_key_role, name: "Push my_gem", api_key_permissions: { gems: ["my_gem"], scopes: ["push_rubygem"] }, user: user)
       stubs(:current_user).returns(user)
 
-      role_link = link_to "OIDC: #{role.name}", profile_oidc_api_key_role_path(role.token), class: "gem__link t-list__item"
+      role_link = link_to "OIDC: #{role.name}", profile_oidc_api_key_role_path(token: role.token), class: "gem__link t-list__item"
       create_link = link_to "OIDC: Create", new_profile_oidc_api_key_role_path(rubygem: rubygem.name, scopes: ["push_rubygem"]),
         class: "gem__link t-list__item"
 

--- a/test/views/events/rubygem_event/version/unyanked_component_test.rb
+++ b/test/views/events/rubygem_event/version/unyanked_component_test.rb
@@ -9,7 +9,8 @@ class Events::RubygemEvent::Version::UnyankedComponentTest < ComponentTest
 
     assert_text "Version:"
     assert_text "#{version.rubygem.name} (#{version.number})"
-    assert_link "#{version.rubygem.name} (#{version.number})", href: view_context.rubygem_version_path(version.rubygem.slug, version.slug)
+    assert_link "#{version.rubygem.name} (#{version.number})",
+      href: view_context.rubygem_version_path(rubygem_id: version.rubygem.slug, id: version.slug)
 
     preview rubygem: version.rubygem, number: version.number, platform: version.platform, version_gid: nil
 

--- a/test/views/events/rubygem_event/version/yanked_component_test.rb
+++ b/test/views/events/rubygem_event/version/yanked_component_test.rb
@@ -11,7 +11,7 @@ class Events::RubygemEvent::Version::YankedComponentTest < ComponentTest
     preview rubygem: version.rubygem, number: version.number, platform: version.platform
 
     assert_text "Version: RubyGem1 (0.0.1)\nYanked by: Yanker", exact: true
-    assert_link "RubyGem1 (0.0.1)", href: view_context.rubygem_version_path(version.rubygem.slug, version.slug)
-    assert_link "Yanker", href: view_context.profile_path(version.yanker.display_id)
+    assert_link "RubyGem1 (0.0.1)", href: view_context.rubygem_version_path(rubygem_id: version.rubygem.slug, id: version.slug)
+    assert_link "Yanker", href: view_context.profile_path(id: version.yanker.display_id)
   end
 end


### PR DESCRIPTION
## Summary

Re-enables the site's multi-language support (disabled in #6399 after a bot-abuse
incident) by moving the locale into the **URL path** (`/de/gems/rails`) instead of a
query param or session. This makes every URL a stable, language-specific,
independently-cacheable resource — closing the cache-fragmentation vector that caused
the original incident — and restores the footer language switcher.

Builds on Harriet's original work in #6461.

## Background

Locale used to come from `params[:locale]` / `session[:locale]` / `Accept-Language`,
so the same URL (`/gems/rails`) could return different content per user. That made CDN
caching impossible and let bots append `?locale=…` endlessly to bypass Fastly and hammer
the origin. #6399 disabled locale switching as a stopgap.

This PR makes locale a **path segment**, constrained to the supported locales:

- `?locale=…` is ignored — it can no longer vary cached content.
- Path locales are bounded to a known set (`en`, `nl`, `zh-CN`, `zh-TW`, `pt-BR`, `fr`,
  `es`, `de`, `ja`); anything else 404s.
- The default locale stays **unprefixed** (`/gems/rails`), and `/en/...` 301s to the
  canonical unprefixed URL.
- The locale never leaks as `?locale=` onto non-localized links (API/asset URLs), so
  those stay cacheable.

## What changed

The work is split into reviewable commits:

1. **Redirect convenience aliases via controller actions** — `/gems/transfer`,
   `/organizations/onboarding`, `/pages/sponsors` redirect through controller actions
   (using `redirect_to <path_helper>`) so the active locale is preserved through
   `default_url_options`.
2. **Add locale-scoped routing and locale-aware `default_url_options`** — wraps the
   HTML/UI routes in an optional `(:locale)` scope and resolves the locale from the path
   via an `around_action`. Named route helpers don't carry the request's `:locale`
   forward, so without `default_url_options` a link on a `/de/...` page would generate
   `/gems/rails` and silently drop the user back to the default locale;
   `default_url_options` injects the active locale into every generated URL so the user
   stays in their language as they navigate. It uses the **`path_params`** form
   (`{ path_params: { locale: ... } }`) rather than plain `{ locale: ... }` so the locale
   only fills a `:locale` path segment when a route has one and is **never** appended as
   `?locale=` to routes without one (API/asset/download links stay single, cacheable
   URLs); for the default locale it resolves to `nil`, keeping those URLs unprefixed.
   Adds `home_page?` since the root can now be `/de`.
3. **Use keyword arguments for URL helpers in app code** — under the optional `(:locale)`
   segment, positional args would bind to `:locale`, so helpers must name their segments
   (`rubygem_path(id:)`, `rubygem_version_path(rubygem_id:, id:)`).
4. **Use keyword arguments for URL helpers in tests** — same conversion across the suite,
   plus the core locale routing tests.
5. **Redirect explicit default-locale URLs to canonical via `before_action`** —
   `/en/... → /...`, built with `url_for` from matched route params (no open-redirect
   risk), GET/HEAD only.
6. **Add single hreflang helper** (`search_engine_tags`) — one place that emits
   a self-referential `<link rel="canonical">` + per-locale `hreflang` alternates +
   `x-default`. Pages opt out via `content_for :search_engine_tags` (gem show → latest
   version; yanked/reserved → `noindex`).
7. **Add footer language switcher** + locale routing integration tests.

## SEO

Each localized page emits a self-referential canonical plus an `hreflang` cluster (one
alternate per locale + `x-default` → the default locale), the Google-recommended pattern
for translated page sets. Query/paginated URLs get no canonical (so `/gems?page=2` isn't
collapsed onto `/gems`).