### PR TITLE
Redesign OIDC api keys + roles pages /views

### DIFF
--- a/app/controllers/oidc/api_key_roles_controller.rb
+++ b/app/controllers/oidc/api_key_roles_controller.rb
@@ -13,6 +13,8 @@ class OIDC::ApiKeyRolesController < ApplicationController
   before_action :redirect_for_deleted, only: %i[edit update destroy]
   before_action :set_page, only: :index
 
+  layout "subject"
+
   def index
     @api_key_roles = current_user.oidc_api_key_roles.active.includes(:provider)
       .page(@page)

--- a/app/controllers/oidc/api_key_roles_controller.rb
+++ b/app/controllers/oidc/api_key_roles_controller.rb
@@ -34,6 +34,10 @@ class OIDC::ApiKeyRolesController < ApplicationController
   end
 
   def github_actions_workflow
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t("oidc.api_key_roles.index.api_key_roles"), profile_oidc_api_key_roles_path)
+    add_breadcrumb(t("oidc.api_key_roles.git_hub_actions_workflow.title"))
+
     render OIDC::ApiKeyRoles::GitHubActionsWorkflowView.new(api_key_role: @api_key_role)
   end
 

--- a/app/controllers/oidc/id_tokens_controller.rb
+++ b/app/controllers/oidc/id_tokens_controller.rb
@@ -10,7 +10,12 @@ class OIDC::IdTokensController < ApplicationController
   before_action :find_id_token, except: %i[index]
   before_action :set_page, only: :index
 
+  layout "subject"
+
   def index
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t(".title"))
+
     id_tokens = current_user.oidc_id_tokens.includes(:api_key, :api_key_role, :provider)
       .page(@page)
       .strict_loading
@@ -18,6 +23,10 @@ class OIDC::IdTokensController < ApplicationController
   end
 
   def show
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t("oidc.id_tokens.index.title"), profile_oidc_id_tokens_path)
+    add_breadcrumb(@id_token.jti)
+
     render OIDC::IdTokens::ShowView.new(id_token: @id_token)
   end
 

--- a/app/controllers/oidc/providers_controller.rb
+++ b/app/controllers/oidc/providers_controller.rb
@@ -8,12 +8,21 @@ class OIDC::ProvidersController < ApplicationController
   before_action :find_provider, except: %i[index]
   before_action :set_page, only: :index
 
+  layout "subject"
+
   def index
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t(".title"))
+
     providers = OIDC::Provider.strict_loading.page(@page)
     render OIDC::Providers::IndexView.new(providers:)
   end
 
   def show
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(t("oidc.providers.index.title"), profile_oidc_providers_path)
+    add_breadcrumb(@provider.issuer)
+
     render OIDC::Providers::ShowView.new(provider: @provider)
   end
 

--- a/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/rubygem_trusted_publishers_controller.rb
@@ -2,11 +2,18 @@
 
 class OIDC::RubygemTrustedPublishersController < ApplicationController
   include OIDC::Concerns::TrustedPublisherCreation
+  include LatestVersion
 
   before_action :find_rubygem
   before_action :find_rubygem_trusted_publisher, except: %i[index new create]
+  before_action :latest_version, only: %i[index new create]
+  before_action :find_versioned_links, only: %i[index new create]
+
+  layout "subject"
 
   def index
+    add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
+    add_breadcrumb t(".title")
     render OIDC::RubygemTrustedPublishers::IndexView.new(
       rubygem: @rubygem,
       trusted_publishers: @rubygem.oidc_rubygem_trusted_publishers.includes(:trusted_publisher).page(@page).strict_loading
@@ -14,6 +21,8 @@ class OIDC::RubygemTrustedPublishersController < ApplicationController
   end
 
   def new
+    add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
+    add_breadcrumb t(".title")
     render OIDC::RubygemTrustedPublishers::NewView.new(
       rubygem_trusted_publisher: @rubygem.oidc_rubygem_trusted_publishers.new(trusted_publisher: gh_actions_trusted_publisher)
     )

--- a/app/views/components/oidc/api_key_role/table_component.rb
+++ b/app/views/components/oidc/api_key_role/table_component.rb
@@ -6,21 +6,21 @@ class OIDC::ApiKeyRole::TableComponent < ApplicationComponent
   prop :api_key_roles, reader: :public
 
   def view_template
-    table(class: "t-body") do
+    table(class: "w-full text-left border-separate") do
       thead do
-        tr(class: "owners__row owners__header") do
+        tr do
           header { OIDC::ApiKeyRole.human_attribute_name(:name) }
           header { OIDC::ApiKeyRole.human_attribute_name(:token) }
           header { OIDC::ApiKeyRole.human_attribute_name(:issuer) }
         end
       end
 
-      tbody(class: "t-body") do
+      tbody do
         api_key_roles.each do |api_key_role|
-          tr(class: "owners__row") do
-            cell(title: "Name") { link_to api_key_role.name, profile_oidc_api_key_role_path(api_key_role.token) }
+          tr(class: "text-sm") do
+            cell(title: "Name") { link_to api_key_role.name, profile_oidc_api_key_role_path(api_key_role.token), class: "hover:underline" }
             cell(title: "Role Token") { code { api_key_role.token } }
-            cell(title: "Provider") { link_to api_key_role.provider.issuer, api_key_role.provider.issuer }
+            cell(title: "Provider") { link_to api_key_role.provider.issuer, api_key_role.provider.issuer, class: LINK_CLASSES }
           end
         end
       end
@@ -29,11 +29,13 @@ class OIDC::ApiKeyRole::TableComponent < ApplicationComponent
 
   private
 
+  LINK_CLASSES = "text-orange-500 hover:underline dark:text-orange-400"
+
   def header(&)
-    th(class: "owners_cell", &)
+    th(&)
   end
 
   def cell(title:, &)
-    td(class: "owners__cell", data: { title: }, &)
+    td(data: { title: }, &)
   end
 end

--- a/app/views/components/oidc/id_token/key_value_pairs_component.rb
+++ b/app/views/components/oidc/id_token/key_value_pairs_component.rb
@@ -4,10 +4,10 @@ class OIDC::IdToken::KeyValuePairsComponent < ApplicationComponent
   prop :pairs, reader: :public
 
   def view_template
-    dl(class: "t-body provider_attributes full-width overflow-wrap") do
+    dl(class: "grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm overflow-x-auto") do
       pairs.each do |key, val|
-        dt(class: "description__heading text-right") { code { key } }
-        dd { code { val } }
+        dt(class: "text-right font-semibold text-neutral-600 dark:text-neutral-400") { code { key } }
+        dd(class: "break-all") { code { val } }
       end
     end
   end

--- a/app/views/components/oidc/id_token/table_component.rb
+++ b/app/views/components/oidc/id_token/table_component.rb
@@ -7,17 +7,17 @@ class OIDC::IdToken::TableComponent < ApplicationComponent
   include Phlex::Rails::Helpers::LinkToUnlessCurrent
 
   def view_template
-    table(class: "owners__table") do
+    table(class: "w-full text-left border-separate") do
       thead do
-        tr(class: "owners__row owners__header") do
-          th(class: "owners__cell") { OIDC::IdToken.human_attribute_name(:created_at) }
-          th(class: "owners__cell") { OIDC::IdToken.human_attribute_name(:expires_at) }
-          th(class: "owners__cell") { OIDC::IdToken.human_attribute_name(:api_key_role) }
-          th(class: "owners__cell") { OIDC::IdToken.human_attribute_name(:jti) }
+        tr do
+          th { OIDC::IdToken.human_attribute_name(:created_at) }
+          th { OIDC::IdToken.human_attribute_name(:expires_at) }
+          th { OIDC::IdToken.human_attribute_name(:api_key_role) }
+          th { OIDC::IdToken.human_attribute_name(:jti) }
         end
       end
 
-      tbody(class: "t-body") do
+      tbody do
         id_tokens.each do |token|
           row(token)
         end
@@ -27,14 +27,16 @@ class OIDC::IdToken::TableComponent < ApplicationComponent
 
   private
 
+  LINK_CLASSES = "text-orange-500 hover:underline dark:text-orange-400"
+
   def row(token)
-    row_classes = ["owners__row"]
-    row_classes << "owners__row__invalid" if token.api_key.expired?
+    row_classes = ["text-sm"]
+    row_classes << "text-neutral-500 dark:text-neutral-500" if token.api_key.expired?
     tr(class: row_classes.join(" ")) do
-      td(class: "owners__cell") { time_tag token.created_at }
-      td(class: "owners__cell") { time_tag token.api_key.expires_at }
-      td(class: "owners__cell") { link_to_unless_current token.api_key_role.name, profile_oidc_api_key_role_path(token.api_key_role.token) }
-      td(class: "owners__cell") { link_to_unless_current token.jti, profile_oidc_id_token_path(token), class: "recovery-code-list__item" }
+      td { time_tag token.created_at }
+      td { time_tag token.api_key.expires_at }
+      td { link_to_unless_current token.api_key_role.name, profile_oidc_api_key_role_path(token.api_key_role.token), class: LINK_CLASSES }
+      td { link_to_unless_current token.jti, profile_oidc_id_token_path(token), class: LINK_CLASSES }
     end
   end
 end

--- a/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
+++ b/app/views/components/oidc/trusted_publisher/github_action/table_component.rb
@@ -4,21 +4,21 @@ class OIDC::TrustedPublisher::GitHubAction::TableComponent < ApplicationComponen
   prop :github_action, reader: :public
 
   def view_template
-    dl(class: "tw-flex tw-flex-col sm:tw-grid sm:tw-grid-cols-2 tw-items-baseline tw-gap-4 full-width overflow-wrap") do
-      dt(class: "description__heading ") { "GitHub Repository" }
-      dd { code { github_action.repository } }
+    dl(class: "mt-4 grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2") do
+      detail_row("GitHub Repository", github_action.repository)
+      detail_row("Workflow Filename", github_action.workflow_filename)
+      detail_row("Workflow Repository", github_action.workflow_repository) if github_action.workflow_repository_owner.present?
+      detail_row("Environment", github_action.environment) if github_action.environment?
+    end
+  end
 
-      dt(class: "description__heading ") { "Workflow Filename" }
-      dd { code { github_action.workflow_filename } }
+  private
 
-      if github_action.workflow_repository_owner.present?
-        dt(class: "description__heading") { "Workflow Repository" }
-        dd { code { github_action.workflow_repository } }
-      end
-
-      if github_action.environment?
-        dt(class: "description__heading") { "Environment" }
-        dd { code { github_action.environment } }
+  def detail_row(label, value)
+    div do
+      dt(class: "text-b4 font-semibold text-neutral-800 dark:text-neutral-200") { label }
+      dd(class: "mt-0.5 break-all") do
+        code(class: "font-mono text-c4 text-neutral-900 dark:text-white") { value }
       end
     end
   end

--- a/app/views/oidc/access_policies/_access_policy.html.erb
+++ b/app/views/oidc/access_policies/_access_policy.html.erb
@@ -1,8 +1,9 @@
-<div class="access-policy">
-  <dl class="oidc_access_policy">
-    <dt><%= access_policy.class.human_attribute_name :statements %></dt>
-    <dd>
-      <%= render access_policy.statements %>
-    </dd>
-  </dl>
+<div>
+  <ul class="-mx-4 divide-y divide-neutral-200 dark:divide-neutral-800 border-y border-neutral-200 dark:border-neutral-800">
+    <% access_policy.statements.each do |statement| %>
+      <li class="px-4 py-3">
+        <%= render statement %>
+      </li>
+    <% end %>
+  </ul>
 </div>

--- a/app/views/oidc/access_policy/statement/conditions/_fields.html.erb
+++ b/app/views/oidc/access_policy/statement/conditions/_fields.html.erb
@@ -1,24 +1,26 @@
-<div class="form__nested_fields"  id="<%= f.field_id :wrapper %>">
-  <div class="form__flex_group">
-    <div class="form_group">
-      <%= f.label :claim, class: "form__label" %>
-      <%= f.text_field :claim, list: f.field_id(:claims_supported), class: "form__input", autocomplete: :off %>
+<%
+  label_class = "block text-b2 font-semibold mb-2"
+  input_class = "w-full text-b2 rounded-lg dark:bg-neutral-950 focus:ring-inset focus:ring-1 focus:ring-orange-500"
+%>
+<div class="form__nested_fields rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 mt-4" id="<%= f.field_id :wrapper %>">
+  <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+    <div class="flex-1">
+      <%= f.label :claim, class: label_class %>
+      <%= f.text_field :claim, list: f.field_id(:claims_supported), class: input_class, autocomplete: :off %>
       <%= content_tag(:datalist, id: f.field_id(:claims_supported)) do %>
         <% if claims_supported = @api_key_role&.provider&.configuration&.claims_supported.presence %>
           <%= options_from_collection_for_select(claims_supported, :to_s, :to_s) %>
         <% end %>
       <% end %>
     </div>
-    <div class="form_group">
-      <%= f.label :operator, class: "form__label" %>
-      <p/>
-      <%= f.collection_select :operator, f.object.class::OPERATORS, :to_s, :titleize, class: "form__input form__select" %>
+    <div class="flex-1">
+      <%= f.label :operator, class: label_class %>
+      <%= f.collection_select :operator, f.object.class::OPERATORS, :to_s, :titleize, {}, class: input_class %>
     </div>
-    <div class="form_group">
-      <%= f.label :value, class: "form__label" %>
-      <p/>
-      <%= f.text_field :value, class: "form__input", autocomplete: :off %>
+    <div class="flex-1">
+      <%= f.label :value, class: label_class %>
+      <%= f.text_field :value, class: input_class, autocomplete: :off %>
     </div>
-    <%= f.button t("oidc.api_key_roles.form.remove_condition"), class: "form__submit form__remove_nested_button" %>
+    <%= render ButtonComponent.new(t("oidc.api_key_roles.form.remove_condition"), type: :button, size: :small, color: :red, style: :outline, class: "form__remove_nested_button") %>
   </div>
 </div>

--- a/app/views/oidc/access_policy/statements/_fields.html.erb
+++ b/app/views/oidc/access_policy/statements/_fields.html.erb
@@ -1,24 +1,27 @@
-<div class="form__nested_fields" id="<%= f.field_id :wrapper %>">
-  <div class="form__group">
-    <%= f.label :effect, class: "form__label" %>
-    <p/>
-    <%= f.collection_select :effect, f.object.class::EFFECTS, :to_s, :to_s, selected: :effect, class: "form__input form__select" %>
+<%
+  label_class = "block text-b2 font-semibold mb-2"
+  input_class = "w-full text-b2 rounded-lg dark:bg-neutral-950 focus:ring-inset focus:ring-1 focus:ring-orange-500"
+%>
+<div class="form__nested_fields rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 mt-4" id="<%= f.field_id :wrapper %>">
+  <div class="mb-6">
+    <%= f.label :effect, class: label_class %>
+    <%= f.collection_select :effect, f.object.class::EFFECTS, :to_s, :to_s, { selected: f.object.effect }, class: input_class %>
   </div>
-  <div class="form__group t-item--hidden">
-    <%= f.label :principal, class: "form__label" %>
+  <div class="mb-6 t-item--hidden">
+    <%= f.label :principal, class: label_class %>
     <%= f.fields_for :principal, f.object.principal do |f| %>
-      <div class="form__nested_fields" id="<%= f.field_id :wrapper %>">
-        <%= f.label :oidc, class: "form__label" %>
-        <%= f.text_field :oidc, class: "form__input", autocomplete: :off, list: f.field_id(:issuers) %>
+      <div id="<%= f.field_id :wrapper %>">
+        <%= f.label :oidc, class: label_class %>
+        <%= f.text_field :oidc, class: input_class, autocomplete: :off, list: f.field_id(:issuers) %>
         <%= content_tag(:datalist, id: f.field_id(:issuers)) do %>
           <%= options_from_collection_for_select(OIDC::Provider.limit(50).pluck(:issuer), :to_s, :to_s) %>
         <% end %>
       </div>
     <% end %>
   </div>
-  <div class="form__group">
-    <%= f.label :conditions, class: "form__label" %>
-    <%= f.button t("oidc.api_key_roles.form.add_condition"), class: "form__submit form__add_nested_button" %>
+  <div>
+    <%= f.label :conditions, class: label_class %>
+    <%= render ButtonComponent.new(t("oidc.api_key_roles.form.add_condition"), type: :button, size: :small, style: :outline, class: "form__add_nested_button mt-2 mb-2") %>
     <%= f.fields_for :conditions, [OIDC::AccessPolicy::Statement::Condition.new], child_index: 'NEW_OBJECT' do |f| %>
       <template class="form__nested_fields">
         <%= render(partial: "oidc/access_policy/statement/conditions/fields", locals: { f: }) %>
@@ -26,7 +29,7 @@
     <% end %>
     <%= f.fields_for :conditions do |f| %>
       <%= render(partial: "oidc/access_policy/statement/conditions/fields", locals: { f: }) %>
-    <%end%>
+    <% end %>
   </div>
-  <%= f.button t("oidc.api_key_roles.form.remove_statement"), class: "form__submit form__remove_nested_button" %>
+  <%= render ButtonComponent.new(t("oidc.api_key_roles.form.remove_statement"), type: :button, size: :small, color: :red, style: :outline, class: "form__remove_nested_button mt-4") %>
 </div>

--- a/app/views/oidc/access_policy/statements/_statement.html.erb
+++ b/app/views/oidc/access_policy/statements/_statement.html.erb
@@ -1,10 +1,26 @@
-<div>
-  <dl class="oidc_access_policy">
-    <dt><%= statement.class.human_attribute_name(:effect) %></dt>
-    <dd><code><%= statement.effect %></code></dd>
-    <dt><%= statement.class.human_attribute_name(:principal) %></dt>
-    <dd><%= link_to statement.principal.oidc, statement.principal.oidc %></dd>
-    <dt><%= statement.class.human_attribute_name(:conditions) %></dt>
-    <dd><%= render statement.conditions %></dd>
-  </dl>
-</div>
+<% heading = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide" %>
+<dl class="space-y-4">
+  <div>
+    <dt class="<%= heading %>"><%= statement.class.human_attribute_name(:effect) %></dt>
+    <dd class="mt-1"><code><%= statement.effect %></code></dd>
+  </div>
+  <div>
+    <dt class="<%= heading %>"><%= statement.class.human_attribute_name(:principal) %></dt>
+    <dd class="mt-1">
+      <%= link_to statement.principal.oidc, statement.principal.oidc,
+        class: "text-orange-500 hover:underline dark:text-orange-400" %>
+    </dd>
+  </div>
+  <div>
+    <dt class="<%= heading %>"><%= statement.class.human_attribute_name(:conditions) %></dt>
+    <dd class="mt-1">
+      <ul class="-mx-4 divide-y divide-neutral-200 dark:divide-neutral-800 border-y border-neutral-200 dark:border-neutral-800">
+        <% statement.conditions.each do |condition| %>
+          <li class="px-4 py-3">
+            <%= render condition %>
+          </li>
+        <% end %>
+      </ul>
+    </dd>
+  </div>
+</dl>

--- a/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
+++ b/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
@@ -1,10 +1,21 @@
-<div class="">
-  <dl class="api_key_permissions">
-    <dt><%= api_key_permissions.class.human_attribute_name :scopes %></dt>
-    <dd><%= to_sentence api_key_permissions.scopes %></dd>
-    <dt><%= api_key_permissions.class.human_attribute_name :valid_for %></dt>
-    <dd><%= duration_string api_key_permissions.valid_for %></dd>
-    <dt><%= api_key_permissions.class.human_attribute_name :gems %></dt>
-    <dd><%= to_sentence(api_key_permissions.gems.presence&.map { |gem| link_to(gem, rubygem_path(gem)) } || [t("api_keys.all_gems")])  %></dd>
-  </dl>
-</div>
+<% heading = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide" %>
+<dl class="space-y-4">
+  <div>
+    <dt class="<%= heading %>"><%= api_key_permissions.class.human_attribute_name :scopes %></dt>
+    <dd class="mt-1"><%= to_sentence api_key_permissions.scopes %></dd>
+  </div>
+  <div>
+    <dt class="<%= heading %>"><%= api_key_permissions.class.human_attribute_name :valid_for %></dt>
+    <dd class="mt-1"><%= duration_string api_key_permissions.valid_for %></dd>
+  </div>
+  <div>
+    <dt class="<%= heading %>"><%= api_key_permissions.class.human_attribute_name :gems %></dt>
+    <dd class="mt-1">
+      <%= to_sentence(
+        api_key_permissions.gems.presence&.map { |gem|
+          link_to(gem, rubygem_path(gem), class: "text-orange-500 hover:underline dark:text-orange-400")
+        } || [t("api_keys.all_gems")]
+      ) %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -1,53 +1,61 @@
-<% url_attrs = @api_key_role.persisted? ? {url: profile_oidc_api_key_role_path(@api_key_role.token)} : {} %>
-<%= form_for [:profile, @api_key_role], **url_attrs do |f|%>
+<%
+  url_attrs = @api_key_role.persisted? ? { url: profile_oidc_api_key_role_path(@api_key_role.token) } : {}
+  label_class = "block text-b2 font-semibold mb-2"
+  section_class = "block text-b1 font-semibold mb-4"
+  input_class = "w-full text-b2 rounded-lg dark:bg-neutral-950 focus:ring-inset focus:ring-1 focus:ring-orange-500"
+  nested_box = "form__nested_fields rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 md:p-6"
+  submit_label = @api_key_role.persisted? ? t("oidc.api_key_roles.edit.edit_role") : t("oidc.api_key_roles.index.new_role")
+%>
+<%= form_for [:profile, @api_key_role], **url_attrs do |f| %>
   <%= error_messages_for @api_key_role %>
-  <%= f.label :name, class: "form__label" %>
-  <%= f.text_field :name, class: "form__input", autocomplete: :off %>
-  <div class="form__group">
-    <%= f.label :oidc_provider_id, class: "form__label" %>
-    <p/>
-    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, class: "form__input form__select" %>
+
+  <div class="mb-8">
+    <%= f.label :name, class: label_class %>
+    <%= f.text_field :name, class: input_class, autocomplete: :off %>
   </div>
-  <div class="form__group">
-    <%= f.label :api_key_permissions, class: "form__label" %>
-    <%= f.fields_for :api_key_permissions, f.object.api_key_permissions do |f|%>
-      <div class="form__nested_fields"  id="<%= f.field_id :wrapper %>">
-        <div class="form__group">
-          <%= f.label :scopes, t("api_keys.index.scopes"), class: "form__label" %>
-          <div class="form__scope_checkbox_grid_group">
+
+  <div class="mb-8">
+    <%= f.label :oidc_provider_id, class: label_class %>
+    <%= f.collection_select :oidc_provider_id, OIDC::Provider.all, :id, :issuer, {}, class: input_class %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.label :api_key_permissions, class: section_class %>
+    <%= f.fields_for :api_key_permissions, f.object.api_key_permissions do |f| %>
+      <div class="<%= nested_box %>" id="<%= f.field_id :wrapper %>">
+        <div class="mb-6">
+          <%= f.label :scopes, t("api_keys.index.scopes"), class: label_class %>
+          <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <%= f.collection_check_boxes :scopes, ApiKey::API_SCOPES, :to_s, :to_s, include_hidden: false do |b| %>
-              <div class = "form__checkbox__item">
-                <%=
-                    b.check_box(class: "form__checkbox__input") +
-                    b.label(class: "form__checkbox__label") do
-                      t("api_keys.index.#{b.value}")
-                    end
-                %>
+              <div class="flex items-center gap-2">
+                <%= b.check_box(class: "rounded border-neutral-300 dark:border-neutral-700 text-orange-500 focus:ring-orange-500") %>
+                <%= b.label(class: "text-b3") { t("api_keys.index.#{b.value}") } %>
               </div>
             <% end %>
           </div>
         </div>
-        <div class="form__group">
-          <%= f.label :valid_for, class: "form__label" %>
-          <%= f.text_field :valid_for, value: f.object.valid_for.iso8601, class: "form__input", list: f.field_id(:valid_for_suggestions), autocomplete: :off %>
+        <div class="mb-6">
+          <%= f.label :valid_for, class: label_class %>
+          <%= f.text_field :valid_for, value: f.object.valid_for.iso8601, class: input_class, list: f.field_id(:valid_for_suggestions), autocomplete: :off %>
           <%= content_tag(:datalist, id: f.field_id(:valid_for_suggestions)) do %>
             <%= options_from_collection_for_select([5.minutes, 15.minutes, 30.minutes, 1.hour, 6.hours, 1.day], :iso8601, :inspect) %>
           <% end %>
         </div>
-        <div class="form__group">
-          <%= f.label :gems, t("api_keys.form.rubygem_scope"), class: "form__label" %>
-          <p><%= t("api_keys.form.rubygem_scope_info") %></p>
-          <%= f.collection_select :gems, current_user.rubygems.by_name, :name, :name, { include_blank: t("api_keys.all_gems"), include_hidden: false }, selected: :name, class: "form__input form__select",  multiple: true %>
+        <div>
+          <%= f.label :gems, t("api_keys.form.rubygem_scope"), class: label_class %>
+          <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.rubygem_scope_info") %></p>
+          <%= f.collection_select :gems, current_user.rubygems.by_name, :name, :name, { include_blank: t("api_keys.all_gems"), include_hidden: false }, selected: :name, class: input_class, multiple: true %>
         </div>
       </div>
-    <% end%>
+    <% end %>
   </div>
-  <div class="form__group">
-    <%= f.label :access_policy, class: "form__label" %>
-    <%= f.fields_for :access_policy, f.object.access_policy do |f|%>
-      <div class="form__nested_fields"  id="<%= f.field_id :wrapper %>">
-        <%= f.label :statements, class: "form__label" %>
-        <%= f.button t("oidc.api_key_roles.form.add_statement"), class: "form__submit form__add_nested_button" %>
+
+  <div class="mb-8">
+    <%= f.label :access_policy, class: section_class %>
+    <%= f.fields_for :access_policy, f.object.access_policy do |f| %>
+      <div class="<%= nested_box %>" id="<%= f.field_id :wrapper %>">
+        <%= f.label :statements, class: label_class %>
+        <%= render ButtonComponent.new(t("oidc.api_key_roles.form.add_statement"), type: :button, size: :small, style: :outline, class: "form__add_nested_button mt-2 mb-2") %>
         <%= f.fields_for :statements, [OIDC::AccessPolicy::Statement.new(conditions: [OIDC::AccessPolicy::Statement::Condition.new])], child_index: 'NEW_OBJECT' do |f| %>
           <template class="form__nested_fields">
             <%= render(partial: "oidc/access_policy/statements/fields", locals: { f: }) %>
@@ -59,5 +67,8 @@
       </div>
     <% end %>
   </div>
-  <%= f.submit class: "form__submit" %>
+
+  <div class="flex">
+    <%= render ButtonComponent.new(submit_label, type: :submit, style: :outline) %>
+  </div>
 <% end %>

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -7,7 +7,11 @@
   submit_label = @api_key_role.persisted? ? t("oidc.api_key_roles.edit.edit_role") : t("oidc.api_key_roles.index.new_role")
 %>
 <%= form_for [:profile, @api_key_role], **url_attrs do |f| %>
-  <%= error_messages_for @api_key_role %>
+  <% if error_messages_for(@api_key_role).present? %>
+    <div class="border rounded border-red-500 bg-red-200 text-neutral-800 dark:bg-red-900 dark:text-white p-4 my-4">
+      <%= error_messages_for @api_key_role %>
+    </div>
+  <% end %>
 
   <div class="mb-8">
     <%= f.label :name, class: label_class %>

--- a/app/views/oidc/api_key_roles/edit.html.erb
+++ b/app/views/oidc/api_key_roles/edit.html.erb
@@ -1,4 +1,15 @@
 <% @title = t(".edit_role") %>
-<div class="t-body">
+<% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
+<% add_breadcrumb(t(".api_key_roles"), profile_oidc_api_key_roles_path) %>
+<% add_breadcrumb(@title) %>
+
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :profile %>
+<% end %>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title t(".edit_role"), icon: "settings" %>
+  <% end %>
   <%= render "form" %>
-</div>
+<% end %>

--- a/app/views/oidc/api_key_roles/edit.html.erb
+++ b/app/views/oidc/api_key_roles/edit.html.erb
@@ -1,6 +1,6 @@
 <% @title = t(".edit_role") %>
 <% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
-<% add_breadcrumb(t(".api_key_roles"), profile_oidc_api_key_roles_path) %>
+<% add_breadcrumb(t("oidc.api_key_roles.index.api_key_roles"), profile_oidc_api_key_roles_path) %>
 <% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>

--- a/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
+++ b/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
@@ -2,6 +2,7 @@
 
 class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ContentFor
 
   attr_reader :api_key_role
 
@@ -13,41 +14,79 @@ class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
   def view_template
     self.title = t(".title")
 
-    return if not_configured
+    subject_sidebar
 
-    div(class: "t-body", data: { controller: "clipboard", clipboard_success_content_value: "✔" }) do
-      p do
-        t(".configured_for_html", link_html:
-          single_gem_role? ? link_to(gem_name, rubygem_path(gem_name)) : t(".a_gem"))
-      end
+    return render_not_configured unless configured?
 
-      p do
-        t(".to_automate_html", link_html:
-         single_gem_role? ? link_to(gem_name, rubygem_path(gem_name)) : t(".a_gem"))
-      end
+    render CardComponent.new do |c|
+      c.head { c.title(t(".title"), icon: "settings") }
 
-      p { t(".instructions_html") }
+      div(data: { controller: "clipboard", clipboard_success_content_value: "✔" }) do
+        div(class: "text-lg mb-4") { gem_link }
+        p(class: "text-b2 mb-4") { t(".configured_for_html", link_html: gem_name) }
+        p(class: "text-b2 mb-4") { t(".to_automate_html", link_html: gem_name) }
+        p(class: "text-b2 mb-8") { t(".instructions_html") }
 
-      header(class: "gem__code__header") do
-        h3(class: "t-list__heading l-mb-0") { code { ".github/workflows/push_gem.yml" } }
-        button(
-          class: "gem__code__icon",
-          title: t("copy_to_clipboard"),
-          data: { action: "click->clipboard#copy", clipboard_target: "button" }
-        ) { "=" }
-      end
-      pre(class: "gem__code multiline") do
-        code(class: "multiline", id: "workflow_yaml", data: { clipboard_target: "source" }) do
-          plain workflow_yaml
-        end
+        code_block
       end
     end
   end
 
   private
 
+  COPY_BUTTON = "shrink-0 p-1 rounded text-b4 cursor-pointer " \
+                "text-neutral-700 dark:text-neutral-400 " \
+                "hover:bg-neutral-100 hover:text-neutral-800 active:bg-neutral-200 " \
+                "dark:hover:bg-neutral-800 dark:hover:text-white dark:active:bg-neutral-700 " \
+                "transition duration-200 ease-in-out"
+
+  def subject_sidebar
+    content_for :subject do
+      raw view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
+    end
+  end
+
+  def code_block
+    div(class: "rounded-lg border border-neutral-200 dark:border-neutral-800 overflow-hidden") do
+      div(class: "flex items-center justify-between gap-2 px-4 py-2 " \
+                 "border-b border-neutral-200 dark:border-neutral-800 " \
+                 "bg-neutral-050 dark:bg-neutral-950") do
+        code(class: "text-c4 font-mono text-neutral-800 dark:text-neutral-200") { ".github/workflows/push_gem.yml" }
+        button(
+          type: :button,
+          class: COPY_BUTTON,
+          title: t("copy_to_clipboard"),
+          aria: { label: t("copy_to_clipboard") },
+          data: { action: "click->clipboard#copy", clipboard_target: "button" }
+        ) { icon_tag("content-copy", size: 5, class: "pointer-events-none") }
+      end
+      pre(class: "overflow-x-auto p-4 text-c4 bg-white dark:bg-black") do
+        code(class: "font-mono", id: "workflow_yaml", data: { clipboard_target: "source" }) do
+          plain workflow_yaml
+        end
+      end
+    end
+  end
+
+  def render_not_configured
+    render CardComponent.new do |c|
+      c.head { c.title(t(".title"), icon: "settings") }
+
+      p(class: "text-b2") { t(".not_github") } unless github?
+      p(class: "text-b2") { t(".not_push") } unless push?
+    end
+  end
+
+  def gem_link
+    render link_to("#{gem_name} →", rubygem_path(gem_name), class: "text-orange-500 hover:underline")
+  end
+
   def gem_name
-    single_gem_role? ? api_key_role.api_key_permissions.gems.first : "YOUR_GEM_NAME"
+    if single_gem_role?
+      api_key_role.api_key_permissions.gems.first
+    else
+      "YOUR_GEM_NAME"
+    end
   end
 
   def workflow_yaml
@@ -96,15 +135,16 @@ class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
     BASH
   end
 
-  def not_configured
-    is_github = api_key_role.provider.github_actions?
-    is_push = api_key_role.api_key_permissions.scopes.include?("push_rubygem")
-    return if is_github && is_push
-    div(class: "t-body") do
-      p { t(".not_github") } unless is_github
-      p { t(".not_push") } unless is_push
-    end
-    true
+  def configured?
+    github? && push?
+  end
+
+  def github?
+    api_key_role.provider.github_actions?
+  end
+
+  def push?
+    api_key_role.api_key_permissions.scopes.include?("push_rubygem")
   end
 
   def configured_audience

--- a/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
+++ b/app/views/oidc/api_key_roles/github_actions_workflow_view.rb
@@ -42,7 +42,7 @@ class OIDC::ApiKeyRoles::GitHubActionsWorkflowView < ApplicationView
 
   def subject_sidebar
     content_for :subject do
-      raw view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
+      view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
     end
   end
 

--- a/app/views/oidc/api_key_roles/index.html.erb
+++ b/app/views/oidc/api_key_roles/index.html.erb
@@ -6,7 +6,10 @@
   <%= render "dashboards/subject", user: current_user, current: :profile %>
 <% end %>
 
-<%= render CardComponent.new do %>
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title @title, icon: "settings" %>
+  <% end %>
   <div class="py-4">
     <%= render ButtonComponent.new(t(".new_role"), new_profile_oidc_api_key_role_path, method: "get") %>
   </div>

--- a/app/views/oidc/api_key_roles/index.html.erb
+++ b/app/views/oidc/api_key_roles/index.html.erb
@@ -1,5 +1,5 @@
 <% @title = t(".api_key_roles") %>
-<% add_breadcrumb(t("breadcrumb.settings"), edit_settings_path) %>
+<% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
 <% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>
@@ -19,13 +19,13 @@
   <table class="w-full text-left border-separate">
     <thead>
       <tr>
-        <th class="">
+        <th>
           <%= OIDC::ApiKeyRole.human_attribute_name(:name) %>
         </th>
-        <th class="">
+        <th>
           <%= OIDC::ApiKeyRole.human_attribute_name(:token) %>
         </th>
-        <th class="">
+        <th>
           <%= OIDC::Provider.human_attribute_name(:issuer) %>
         </th>
       </tr>

--- a/app/views/oidc/api_key_roles/index.html.erb
+++ b/app/views/oidc/api_key_roles/index.html.erb
@@ -1,40 +1,54 @@
 <% @title = t(".api_key_roles") %>
-<div class="t-body">
-  <p>
-    <%= button_to(t(".new_role"), new_profile_oidc_api_key_role_path, method: "get", class: "form__submit") %>
-  </p>
-  <header class="gems__header push--s">
-    <p class="gems__meter l-mb-0"><%= page_entries_info(@api_key_roles) %></p>
+<% add_breadcrumb(t("breadcrumb.settings"), edit_settings_path) %>
+<% add_breadcrumb(@title) %>
+
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :profile %>
+<% end %>
+
+<%= render CardComponent.new do %>
+  <div class="py-4">
+    <%= render ButtonComponent.new(t(".new_role"), new_profile_oidc_api_key_role_path, method: "get") %>
+  </div>
+
+  <header class="flex items-center py-4">
+    <p class="text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
+    <%= page_entries_info(@api_key_roles) %>
+    </p>
   </header>
-  <table class="owners__table">
+  <table class="w-full text-left border-separate">
     <thead>
-      <tr class="owners__row owners__header">
-        <th class="owners__cell">
+      <tr>
+        <th class="">
           <%= OIDC::ApiKeyRole.human_attribute_name(:name) %>
         </th>
-        <th class="owners__cell">
+        <th class="">
           <%= OIDC::ApiKeyRole.human_attribute_name(:token) %>
         </th>
-        <th class="owners__cell">
+        <th class="">
           <%= OIDC::Provider.human_attribute_name(:issuer) %>
         </th>
       </tr>
     </thead>
-    <tbody class="t-body">
+    <tbody>
       <% @api_key_roles.each do |api_key_role| %>
-        <tr class="owners__row">
-          <td class="owners__cell" data-title="Name">
-            <%= link_to api_key_role.name, profile_oidc_api_key_role_path(api_key_role.token) %>
+        <tr class="text-sm">
+          <td data-title="Name">
+            <%= link_to api_key_role.name,
+              profile_oidc_api_key_role_path(api_key_role.token),
+              class: "hover:underline" %>
           </td>
-          <td class="owners__cell " data-title="Role Token">
+          <td data-title="Role Token">
             <code><%= api_key_role.token %></code>
           </td>
-          <td class="owners__cell" data-title="Provider">
-            <%= link_to api_key_role.provider.issuer, profile_oidc_provider_path(api_key_role.provider) %>
+          <td data-title="Provider">
+            <%= link_to api_key_role.provider.issuer,
+              profile_oidc_provider_path(api_key_role.provider),
+              class: "text-b3 text-orange-500 hover:underline dark:text-orange-400" %>
           </td>
         </tr>
       <% end %>
     </tbody>
   </table>
   <%= paginate @api_key_roles %>
-</div>
+<% end %>

--- a/app/views/oidc/api_key_roles/new.html.erb
+++ b/app/views/oidc/api_key_roles/new.html.erb
@@ -1,5 +1,6 @@
 <% @title = t(".title") %>
 <% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
+<% add_breadcrumb(t("oidc.api_key_roles.index.api_key_roles"), profile_oidc_api_key_roles_path) %>
 <% add_breadcrumb(@title) %>
 
 <% content_for :subject do %>

--- a/app/views/oidc/api_key_roles/new.html.erb
+++ b/app/views/oidc/api_key_roles/new.html.erb
@@ -1,4 +1,14 @@
 <% @title = t(".title") %>
-<div class="t-body">
+<% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
+<% add_breadcrumb(@title) %>
+
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :profile %>
+<% end %>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title @title, icon: "settings" %>
+  <% end %>
   <%= render "form" %>
-</div>
+<% end %>

--- a/app/views/oidc/api_key_roles/show.html.erb
+++ b/app/views/oidc/api_key_roles/show.html.erb
@@ -1,41 +1,79 @@
 <% @title = t(".api_key_role_name", name: @api_key_role.name) %>
-<div class="t-body">
+<% add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path) %>
+<% add_breadcrumb(t("oidc.api_key_roles.index.api_key_roles"), profile_oidc_api_key_roles_path) %>
+<% add_breadcrumb(@title) %>
+
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :profile %>
+<% end %>
+
+<% heading = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide" %>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title @title, icon: "settings" %>
+  <% end %>
   <% if @api_key_role.github_actions_push? && !@api_key_role.deleted_at? %>
-    <h2 class="t-display"><%= link_to t(".automate_gh_actions_publishing"), github_actions_workflow_profile_oidc_api_key_role_path(@api_key_role.token), class: "t-link t-underline" %> →</h2>
+    <div class="py-4">
+      <%= render ButtonComponent.new(
+        "#{t(".automate_gh_actions_publishing")} →",
+        github_actions_workflow_profile_oidc_api_key_role_path(@api_key_role.token),
+        method: "get") %>
+    </div>
   <% end %>
   <% if @api_key_role.deleted_at? %>
-    <h2 class="t-display">
-      <%= t(".deleted_at_html", time_html:  time_tag(@api_key_role.deleted_at, time_ago_in_words(@api_key_role.deleted_at))) %>
+    <h2 class="text-lg font-semibold mb-8">
+      <%= t(".deleted_at_html", time_html: time_tag(@api_key_role.deleted_at, time_ago_in_words(@api_key_role.deleted_at))) %>
     </h2>
   <% end %>
-  <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:token) %></h3>
-  <div class="push--s">
+
+  <h3 class="<%= heading %>"><%= OIDC::ApiKeyRole.human_attribute_name(:token) %></h3>
+  <div class="mt-1 mb-6">
     <code><%= @api_key_role.token %></code>
   </div>
-  <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:provider) %></h3>
-  <div class="push--s">
-    <%= link_to t(".view_provider", issuer: @api_key_role.provider.issuer), profile_oidc_provider_path(@api_key_role.provider) %> →
+
+  <h3 class="<%= heading %>"><%= OIDC::ApiKeyRole.human_attribute_name(:provider) %></h3>
+  <div class="mt-1 mb-6">
+    <%= render ButtonComponent.new(
+      "#{t(".view_provider", issuer: @api_key_role.provider.issuer)} →",
+      profile_oidc_provider_path(@api_key_role.provider)) %>
   </div>
-  <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:api_key_permissions) %></h3>
-  <div class="push--s">
+
+  <h3 class="<%= heading %>"><%= OIDC::ApiKeyRole.human_attribute_name(:api_key_permissions) %></h3>
+  <div class="mt-1 mb-6">
     <%= render partial: "oidc/api_key_permissions/api_key_permissions", object: @api_key_role.api_key_permissions %>
   </div>
-  <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:access_policy) %></h3>
-  <div class="push--s">
+
+  <h3 class="<%= heading %>"><%= OIDC::ApiKeyRole.human_attribute_name(:access_policy) %></h3>
+  <div class="mt-1 mb-6">
     <%= render partial: "oidc/access_policies/access_policy", object: @api_key_role.access_policy %>
   </div>
 
   <% unless @api_key_role.deleted_at? %>
-    <%= button_to t(".edit_role"), edit_profile_oidc_api_key_role_path(@api_key_role.token), method: "get", class: "form__submit" %>
-    <%= button_to t(".delete_role"), profile_oidc_api_key_role_path(@api_key_role.token), method: "delete", class: "form__submit", data: { confirm: t(".confirm_delete") } %>
+    <div class="flex flex-wrap gap-4 mb-6">
+      <%= render ButtonComponent.new(
+        t(".edit_role"),
+        edit_profile_oidc_api_key_role_path(@api_key_role.token),
+        method: "get",
+        color: :secondary) %>
+      <%= render ButtonComponent.new(
+        t(".delete_role"),
+        profile_oidc_api_key_role_path(@api_key_role.token),
+        method: :delete,
+        color: :red,
+        data: { confirm: t(".confirm_delete") }) %>
+    </div>
   <% end %>
-  <h3 class="t-list__heading"><%= OIDC::ApiKeyRole.human_attribute_name(:id_tokens) %></h3>
-  <div class="push--s">
-    <header class="gems__header push--s">
-      <p class="gems__meter l-mb-0"><%= page_entries_info(@id_tokens) %></p>
+
+  <h3 class="<%= heading %>"><%= OIDC::ApiKeyRole.human_attribute_name(:id_tokens) %></h3>
+  <div class="mt-1">
+    <header class="flex items-center py-4">
+      <p class="text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
+      <%= page_entries_info(@id_tokens) %>
+      </p>
     </header>
     <% if @id_tokens.present? %>
       <%= render OIDC::IdToken::TableComponent.new(id_tokens: @id_tokens) %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/oidc/id_tokens/index_view.rb
+++ b/app/views/oidc/id_tokens/index_view.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class OIDC::IdTokens::IndexView < ApplicationView
+  include Phlex::Rails::Helpers::ContentFor
+
   attr_reader :id_tokens
 
   def initialize(id_tokens:)
@@ -11,14 +13,29 @@ class OIDC::IdTokens::IndexView < ApplicationView
   def view_template
     self.title = t(".title")
 
-    div(class: "t-body") do
-      header(class: "gems__header push--s") do
-        p(class: "gems__meter l-mb-0") { plain page_entries_info(id_tokens) }
+    subject_sidebar
+
+    render CardComponent.new do |c|
+      c.head { c.title(t(".title"), icon: "settings") }
+
+      header(class: "flex items-center py-4") do
+        p(class: HEADING) { plain page_entries_info(id_tokens) }
       end
+
       if id_tokens.present?
         render OIDC::IdToken::TableComponent.new(id_tokens:)
         plain paginate(id_tokens)
       end
+    end
+  end
+
+  private
+
+  HEADING = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide"
+
+  def subject_sidebar
+    content_for :subject do
+      view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
     end
   end
 end

--- a/app/views/oidc/id_tokens/show_view.rb
+++ b/app/views/oidc/id_tokens/show_view.rb
@@ -3,18 +3,23 @@
 class OIDC::IdTokens::ShowView < ApplicationView
   include Phlex::Rails::Helpers::TimeTag
   include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ContentFor
 
   prop :id_token, reader: :public
 
   def view_template # rubocop:disable Metrics/AbcSize
     self.title = t(".title")
 
-    div(class: "t-body") do
+    subject_sidebar
+
+    render CardComponent.new do |c|
+      c.head { c.title(t(".title"), icon: "settings") }
+
       section(:created_at) { time_tag id_token.created_at }
       section(:expires_at) { time_tag id_token.api_key.expires_at }
       section(:jti) { code { id_token.jti } }
-      section(:api_key_role) { link_to id_token.api_key_role.name, profile_oidc_api_key_role_path(id_token.api_key_role.token) }
-      section(:provider) { link_to id_token.provider.issuer, profile_oidc_provider_path(id_token.provider) }
+      section(:api_key_role) { link_to id_token.api_key_role.name, profile_oidc_api_key_role_path(id_token.api_key_role.token), class: LINK_CLASSES }
+      section(:provider) { link_to id_token.provider.issuer, profile_oidc_provider_path(id_token.provider), class: LINK_CLASSES }
       section(:claims) { render OIDC::IdToken::KeyValuePairsComponent.new(pairs: id_token.claims) }
       section(:header) { render OIDC::IdToken::KeyValuePairsComponent.new(pairs: id_token.header) }
     end
@@ -22,8 +27,17 @@ class OIDC::IdTokens::ShowView < ApplicationView
 
   private
 
+  HEADING = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide"
+  LINK_CLASSES = "text-orange-500 hover:underline dark:text-orange-400"
+
+  def subject_sidebar
+    content_for :subject do
+      view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
+    end
+  end
+
   def section(header, &)
-    h3(class: "t-list__heading") { id_token.class.human_attribute_name(header) }
-    div(class: "push--s", &)
+    h3(class: HEADING) { id_token.class.human_attribute_name(header) }
+    div(class: "mt-1 mb-6", &)
   end
 end

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -62,28 +62,7 @@ class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
             view_context.distance_of_time_in_words_to_now(pending_trusted_publisher.expires_at)))
       end
 
-      publisher_details(pending_trusted_publisher.trusted_publisher)
-    end
-  end
-
-  # Rendered inline (rather than the shared tw-prefixed TableComponent) so the
-  # details are styled under the new hammy layout. GitHub Actions is currently
-  # the only trusted publisher type.
-  def publisher_details(github_action)
-    dl(class: "mt-4 grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2") do
-      detail_row("GitHub Repository", github_action.repository)
-      detail_row("Workflow Filename", github_action.workflow_filename)
-      detail_row("Workflow Repository", github_action.workflow_repository) if github_action.workflow_repository_owner.present?
-      detail_row("Environment", github_action.environment) if github_action.environment?
-    end
-  end
-
-  def detail_row(label, value)
-    div do
-      dt(class: "text-b4 font-semibold text-neutral-800 dark:text-neutral-200") { label }
-      dd(class: "mt-0.5 break-all") do
-        code(class: "font-mono text-c4 text-neutral-900 dark:text-white") { value }
-      end
+      render pending_trusted_publisher.trusted_publisher
     end
   end
 end

--- a/app/views/oidc/providers/index_view.rb
+++ b/app/views/oidc/providers/index_view.rb
@@ -2,6 +2,7 @@
 
 class OIDC::Providers::IndexView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ContentFor
 
   attr_reader :providers
 
@@ -13,20 +14,46 @@ class OIDC::Providers::IndexView < ApplicationView
   def view_template
     self.title = t(".title")
 
-    div(class: "t-body") do
-      p do
-        t(".description_html")
+    subject_sidebar
+
+    render CardComponent.new do |c|
+      c.head { c.title(t(".title"), icon: "settings") }
+
+      p(class: "text-b2 mb-6") { t(".description_html") }
+
+      header(class: "flex items-center py-4") do
+        p(class: HEADING) { plain page_entries_info(providers) }
       end
-      hr
-      header(class: "gems__header push--s") do
-        p(class: "gems__meter l-mb-0") { plain page_entries_info(providers) }
-      end
-      ul do
-        providers.each do |provider|
-          li { link_to provider.issuer, profile_oidc_provider_path(provider) }
+
+      table(class: "w-full text-left border-separate") do
+        thead do
+          tr do
+            th { OIDC::Provider.human_attribute_name(:issuer) }
+          end
+        end
+        tbody do
+          providers.each do |provider|
+            tr(class: "text-sm") do
+              td(data: { title: "Issuer" }) do
+                link_to provider.issuer, profile_oidc_provider_path(provider), class: LINK_CLASSES
+              end
+            end
+          end
         end
       end
+
       plain paginate(providers)
+    end
+  end
+
+  private
+
+  HEADING = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide"
+  LINK_CLASSES = "text-orange-500 hover:underline dark:text-orange-400"
+
+  def subject_sidebar
+    content_for :subject do
+      view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
     end
   end
 end

--- a/app/views/oidc/providers/show_view.rb
+++ b/app/views/oidc/providers/show_view.rb
@@ -2,6 +2,7 @@
 
 class OIDC::Providers::ShowView < ApplicationView
   include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ContentFor
 
   attr_reader :provider
 
@@ -13,30 +14,42 @@ class OIDC::Providers::ShowView < ApplicationView
   def view_template
     self.title = t(".title")
 
-    div(class: "") do
-      dl(class: "t-body provider_attributes") do
+    subject_sidebar
+
+    render CardComponent.new do |c|
+      c.head { c.title(provider.issuer, icon: "settings") }
+
+      dl do
         supported_attrs.each do |attr|
           val = provider.configuration.send(attr)
           next if val.blank?
-          dt { provider.configuration.class.human_attribute_name(attr) }
-          dd do
+          dt(class: "#{HEADING} mt-4") { provider.configuration.class.human_attribute_name(attr) }
+          dd(class: "mt-1 mb-6") do
             attr.end_with?("s_supported") ? tags_attr(attr, val) : text_attr(attr, val)
           end
         end
       end
 
-      div(class: "t-body") do
-        hr
-        h3(class: "t-list__heading") { "Roles" }
-
-        div(class: "") do
-          api_key_roles = current_user.oidc_api_key_roles.where(provider:).page(0).per(10)
-          header(class: "gems__header push--s") do
-            p(class: "gems__meter l-mb-0") { plain page_entries_info(api_key_roles) }
-          end
-          render OIDC::ApiKeyRole::TableComponent.new(api_key_roles:) if api_key_roles.present?
+      h3(class: HEADING) { "Roles" }
+      div(class: "mt-1") do
+        api_key_roles = current_user.oidc_api_key_roles.where(provider:).page(0).per(10)
+        header(class: "flex items-center py-4") do
+          p(class: HEADING) { plain page_entries_info(api_key_roles) }
         end
+        render OIDC::ApiKeyRole::TableComponent.new(api_key_roles:) if api_key_roles.present?
       end
+    end
+  end
+
+  private
+
+  HEADING = "text-sm text-neutral-600 dark:text-neutral-400 uppercase tracking-wide"
+  LINK_CLASSES = "text-orange-500 hover:underline dark:text-orange-400"
+  TAG_CLASSES = "rounded bg-neutral-100 dark:bg-neutral-900 px-2 py-1 text-c4"
+
+  def subject_sidebar
+    content_for :subject do
+      view_context.render(partial: "dashboards/subject", locals: { user: current_user, current: :profile })
     end
   end
 
@@ -45,9 +58,9 @@ class OIDC::Providers::ShowView < ApplicationView
   end
 
   def tags_attr(_attr, val)
-    ul(class: "tag-list") do
+    ul(class: "flex flex-wrap gap-2") do
       val.each do |t|
-        li { code { t } }
+        li { code(class: TAG_CLASSES) { t } }
       end
     end
   end
@@ -56,7 +69,7 @@ class OIDC::Providers::ShowView < ApplicationView
     code do
       case attr
       when "issuer", /_(uri|endpoint)$/
-        link_to(val, val)
+        link_to(val, val, class: LINK_CLASSES)
       else
         val
       end

--- a/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/concerns/title.rb
@@ -4,17 +4,38 @@ module OIDC::RubygemTrustedPublishers::Concerns::Title
   extend ActiveSupport::Concern
 
   included do
-    def title_content
-      self.title_for_header_only = t(".title")
-      content_for :title do
-        h1(class: "t-display page__heading page__heading-small") do
-          plain t(".title")
+    include Phlex::Rails::Helpers::ContentFor
+  end
 
-          i(class: "page__subheading page__subheading--block") do
-            raw t(".subtitle_owner_html", gem_html: view_context.link_to(rubygem.name, rubygem_path(rubygem.slug), class: "t-link t-underline"))
-          end
+  private
+
+  # Wraps the page body in the per-gem "subject" layout (matching the gem's
+  # other sub-pages, e.g. security events): the gem sidebar on the left and a
+  # heading that links back to the gem above the yielded content.
+  def gem_subject_page(&)
+    self.title = t(".title")
+
+    if gem_versions?
+      content_for(:subject) { raw(view_context.render("rubygems/aside")) } # rubocop:disable Rails/OutputSafety -- trusted Rails partial
+      content_for(:subject_secondary) { raw(view_context.render("rubygems/aside_secondary")) } # rubocop:disable Rails/OutputSafety -- trusted Rails partial
+    end
+
+    div(class: "flex flex-col gap-8 pb-16 lg:pt-10 text-neutral-800 dark:text-neutral-200") do
+      div do
+        h1(class: "text-h4 font-semibold text-neutral-900 dark:text-white") { t(".title") }
+        p(class: "text-b2 mt-2") do
+          raw t(".subtitle_owner_html",
+            gem_html: view_context.link_to(rubygem.name, rubygem_path(rubygem.slug), class: "text-orange-500 hover:text-orange-600"))
         end
       end
+
+      yield
     end
+  end
+
+  # The gem sidebar partials require a latest version; gems without one render
+  # without the sidebar, mirroring the gem's other subject pages.
+  def gem_versions?
+    view_context.instance_variable_get(:@latest_version).present?
   end
 end

--- a/app/views/oidc/rubygem_trusted_publishers/index_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/index_view.rb
@@ -3,42 +3,53 @@
 class OIDC::RubygemTrustedPublishers::IndexView < ApplicationView
   include Phlex::Rails::Helpers::ButtonTo
   include Phlex::Rails::Helpers::LinkTo
-  include Phlex::Rails::Helpers::ContentFor
   include OIDC::RubygemTrustedPublishers::Concerns::Title
 
   prop :rubygem, reader: :public
   prop :trusted_publishers, reader: :public
 
   def view_template
-    title_content
-
-    div(class: "tw-space-y-2 t-body") do
-      p do
-        t(".description_html")
+    gem_subject_page do
+      p(class: "max-w-2xl text-b3 text-neutral-700 dark:text-neutral-300 " \
+               "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400") do
+        raw t(".description_html")
       end
 
-      p do
-        button_to t(".create"), new_rubygem_trusted_publisher_path(rubygem.slug), class: "form__submit", method: :get
+      div do
+        render ButtonComponent.new(t(".create"), new_rubygem_trusted_publisher_path(rubygem.slug), method: "get")
       end
 
-      header(class: "gems__header push--s") do
-        p(class: "gems__meter l-mb-0") { plain page_entries_info(trusted_publishers) }
-      end
-
-      div(class: "tw-divide-y") do
-        trusted_publishers.each do |rubygem_trusted_publisher|
-          div(class: "tw-border-solid tw-my-4 tw-space-y-4 tw-flex tw-flex-col") do
-            div(class: "sm:tw-flex sm:tw-items-baseline tw-mt-4 tw-gap-2") do
-              h4 { rubygem_trusted_publisher.trusted_publisher.class.publisher_name }
-              button_to(t(".delete"), rubygem_trusted_publisher_path(rubygem.slug, rubygem_trusted_publisher),
-                        method: :delete, class: "form__submit form__submit--small")
-            end
-            render rubygem_trusted_publisher.trusted_publisher
-          end
+      render CardComponent.new do
+        p(class: "mb-2 text-b4 text-neutral-600 dark:text-neutral-400 uppercase tracking-wide") do
+          page_entries_info(trusted_publishers)
         end
+
+        div(class: "divide-y divide-neutral-200 dark:divide-neutral-800") do
+          trusted_publishers.each { |rubygem_trusted_publisher| publisher_section(rubygem_trusted_publisher) }
+        end
+
+        div(class: "mt-4") { paginate(trusted_publishers) }
+      end
+    end
+  end
+
+  private
+
+  DANGER_BTN = "inline-flex items-center justify-center rounded border-2 border-red-500 text-red-500 " \
+               "px-4 h-9 min-h-9 text-b3 hover:bg-red-500/5 active:bg-red-500/10 " \
+               "dark:hover:bg-red-500/15 dark:active:bg-red-500/25 transition focus:outline-none"
+
+  def publisher_section(rubygem_trusted_publisher)
+    div(class: "py-6 first:pt-0 last:pb-0 space-y-4") do
+      div(class: "flex flex-wrap items-center justify-between gap-3") do
+        h2(class: "text-b1 font-semibold text-neutral-900 dark:text-white") do
+          plain rubygem_trusted_publisher.trusted_publisher.class.publisher_name
+        end
+        button_to(t(".delete"), rubygem_trusted_publisher_path(rubygem.slug, rubygem_trusted_publisher),
+          method: :delete, class: DANGER_BTN)
       end
 
-      plain paginate(trusted_publishers)
+      render rubygem_trusted_publisher.trusted_publisher
     end
   end
 end

--- a/app/views/oidc/rubygem_trusted_publishers/new_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/new_view.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
-  include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::FormWith
   include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::OptionsForSelect
@@ -10,26 +9,37 @@ class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
 
   prop :rubygem_trusted_publisher, reader: :public
 
+  delegate :rubygem, to: :rubygem_trusted_publisher
+
   def view_template
-    title_content
+    gem_subject_page do
+      render CardComponent.new do
+        form_with(
+          model: rubygem_trusted_publisher,
+          url: rubygem_trusted_publishers_path(rubygem.slug)
+        ) do |f|
+          div class: "py-4" do
+            f.label :trusted_publisher_type, class: label_class
+            f.select :trusted_publisher_type,
+              OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
+              {}
+          end
 
-    div(class: "t-body") do
-      form_with(
-        model: rubygem_trusted_publisher,
-        url: rubygem_trusted_publishers_path(rubygem_trusted_publisher.rubygem.slug)
-      ) do |f|
-        f.label :trusted_publisher_type, class: "form__label"
-        f.select :trusted_publisher_type, OIDC::TrustedPublisher.all.map { |type|
-                                            [type.publisher_name, type.polymorphic_name]
-                                          }, {}, class: "form__input form__select"
+          render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
+            github_action_form: f
+          )
 
-        render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
-          github_action_form: f
-        )
-        f.submit class: "form__submit"
+          render ButtonComponent.new do
+            f.submit
+          end
+        end
       end
     end
   end
 
-  delegate :rubygem, to: :rubygem_trusted_publisher
+  private
+
+  def label_class
+    "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -985,8 +985,8 @@ en:
         edit_role: "Edit API Key Role"
       git_hub_actions_workflow:
         title: "OIDC Gem Push GitHub Actions Workflow"
-        configured_for_html: "This OIDC API Key Role is configured to allow pushing %{link_html} from GitHub Actions."
-        to_automate_html: "To automate releasing %{link_html} when a new tag is pushed, add the following workflow to your repository."
+        configured_for_html: "This OIDC API Key Role is configured to allow pushing <span class='underline'>%{link_html}</span> from GitHub Actions."
+        to_automate_html: "To automate releasing <span class='underline'> %{link_html}</span> when a new tag is pushed, add the following workflow to your repository."
         not_github: "This OIDC API Key Role is not configured for GitHub Actions."
         not_push: "This OIDC API Key Role is not configured to allow pushing gems."
         a_gem: a gem

--- a/test/integration/oidc/api_key_roles_controller_test.rb
+++ b/test/integration/oidc/api_key_roles_controller_test.rb
@@ -137,7 +137,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
 
       follow_redirect!
 
-      page.assert_selector ".flash #flash_error", text: "The role has been deleted."
+      page.assert_selector "#flash_error", text: "The role has been deleted."
 
       get edit_profile_oidc_api_key_role_url(@api_key_role.token)
 
@@ -146,7 +146,7 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
 
       follow_redirect!
 
-      page.assert_selector ".flash #flash_error", text: "The role has been deleted."
+      page.assert_selector "#flash_error", text: "The role has been deleted."
     end
   end
 

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -21,11 +21,11 @@ class OIDCTest < ApplicationSystemTestCase
     visit profile_oidc_providers_path
     verify_session
 
-    page.assert_selector "h1", text: "OIDC Providers"
+    page.assert_selector "h3", text: "OIDC Providers"
     page.assert_text(/displaying 1 provider/i)
     page.click_link "https://token.actions.githubusercontent.com"
 
-    page.assert_selector "h1", text: "OIDC Provider"
+    page.assert_selector "h3", text: "https://token.actions.githubusercontent.com"
     page.assert_text "https://token.actions.githubusercontent.com"
     page.assert_text "https://token.actions.githubusercontent.com/.well-known/jwks"
     page.assert_text(/Displaying 1 api key role/i)
@@ -38,21 +38,22 @@ class OIDCTest < ApplicationSystemTestCase
     visit profile_oidc_api_key_roles_path
     verify_session
 
-    page.assert_selector "h1", text: "OIDC API Key Roles"
+    page.assert_selector "h3", text: "OIDC API Key Roles"
     page.assert_text(/displaying 1 api key role/i)
     page.click_link @id_token.api_key_role.name
 
-    page.assert_selector "h1", text: "API Key Role #{@id_token.api_key_role.name}"
+    page.assert_selector "h3", text: "API Key Role #{@id_token.api_key_role.name}"
     page.assert_text @id_token.api_key_role.token
-    page.assert_text "Scopes\npush_rubygem"
-    page.assert_text "Gems\nAll Gems"
-    page.assert_text "Valid for\n30 minutes"
-    page.assert_text "Effect\nallow"
-    page.assert_text "Principal\nhttps://token.actions.githubusercontent.com"
-    page.assert_text "Conditions\nsub string_equals repo:segiddins/oidc-test:ref:refs/heads/main"
+    page.assert_text "SCOPES\npush_rubygem"
+    page.assert_text "GEMS\nAll Gems"
+    page.assert_text "VALID FOR\n30 minutes"
+    page.assert_text "EFFECT\nallow"
+    page.assert_text "PRINCIPAL\nhttps://token.actions.githubusercontent.com"
+    page.assert_text "CONDITIONS\nsub string_equals repo:segiddins/oidc-test:ref:refs/heads/main"
     page.assert_text(/Displaying 1 id token/i)
 
-    assert_link "View provider https://token.actions.githubusercontent.com", href: profile_oidc_provider_path(@provider)
+    assert_selector "form[action='#{profile_oidc_provider_path(@provider)}'] button",
+      text: "View provider https://token.actions.githubusercontent.com"
     assert_link @id_token.jti, href: profile_oidc_id_token_path(@id_token)
   end
 
@@ -61,11 +62,11 @@ class OIDCTest < ApplicationSystemTestCase
     visit profile_oidc_id_tokens_path
     verify_session
 
-    page.assert_selector "h1", text: "OIDC ID Tokens"
+    page.assert_selector "h3", text: "OIDC ID Tokens"
     page.assert_text(/displaying 1 id token/i)
     page.click_link @id_token.jti
 
-    page.assert_selector "h1", text: "OIDC ID Token"
+    page.assert_selector "h3", text: "OIDC ID Token"
     page.assert_text "CREATED AT\n#{@id_token.created_at.to_fs(:long)}"
     page.assert_text "EXPIRES AT\n#{@id_token.api_key.expires_at.to_fs(:long)}"
     page.assert_text "JWT ID\n#{@id_token.jti}"
@@ -87,7 +88,7 @@ class OIDCTest < ApplicationSystemTestCase
     click_link "OIDC: Create"
     verify_session
 
-    page.assert_selector "h1", text: "New OIDC API Key Role"
+    page.assert_selector "h3", text: "New OIDC API Key Role"
 
     assert_field "Name", with: "Push #{rubygem.name}"
     assert_select "OIDC provider", options: ["https://token.actions.githubusercontent.com"], selected: "https://token.actions.githubusercontent.com"
@@ -112,9 +113,9 @@ class OIDCTest < ApplicationSystemTestCase
 
     page.scroll_to page.find(id: "oidc_api_key_role_access_policy_statements_attributes_0_conditions_attributes_1_claim")
 
-    click_button "Create Api key role"
+    click_button "Create API Key Role"
 
-    page.assert_selector "h1", text: "API Key Role Push #{rubygem.name}"
+    page.assert_selector "h3", text: "API Key Role Push #{rubygem.name}"
 
     role = OIDC::ApiKeyRole.where(name: "Push #{rubygem.name}", user: @user, provider: @provider).sole
 
@@ -145,9 +146,9 @@ class OIDCTest < ApplicationSystemTestCase
 
     click_button "Edit API Key Role"
     page.scroll_to :bottom
-    click_button "Update Api key role"
+    click_button "Edit API Key Role"
 
-    page.assert_selector "h1", text: "API Key Role Push #{rubygem.name}"
+    page.assert_selector "h3", text: "API Key Role Push #{rubygem.name}"
 
     assert_equal_hash(expected, role.reload.as_json.slice(*expected.keys))
 
@@ -174,7 +175,7 @@ class OIDCTest < ApplicationSystemTestCase
 
     page.assert_selector("button.form__remove_nested_button", text: "Remove condition", count: 3)
 
-    click_button "Update Api key role"
+    click_button "Edit API Key Role"
 
     page.assert_text "Access policy statements[1] conditions[1] claim unknown for the provider"
 
@@ -187,9 +188,9 @@ class OIDCTest < ApplicationSystemTestCase
     page.unselect rubygem.name, from: "Gem Scope"
     page.check "Yank rubygem"
 
-    click_button "Update Api key role"
+    click_button "Edit API Key Role"
 
-    page.assert_selector "h1", text: "API Key Role Push gems"
+    page.assert_selector "h3", text: "API Key Role Push gems"
 
     expected.merge!(
       "name" => "Push gems",
@@ -206,7 +207,7 @@ class OIDCTest < ApplicationSystemTestCase
             ]
           },
           {
-            "effect" => "allow",
+            "effect" => "deny",
             "principal" => { "oidc" => "https://token.actions.githubusercontent.com" },
             "conditions" => [
               { "operator" => "string_matches", "claim" => "sub", "value" => "repo:example/repo:ref:refs/tags/.*" },
@@ -233,7 +234,7 @@ class OIDCTest < ApplicationSystemTestCase
     click_link "OIDC: Create"
     verify_session
 
-    page.assert_selector "h1", text: "New OIDC API Key Role"
+    page.assert_selector "h3", text: "New OIDC API Key Role"
 
     # The page loads defaulting to Github Actions shaped config
     assert_field "Name", with: "Push #{rubygem.name}"
@@ -275,9 +276,9 @@ class OIDCTest < ApplicationSystemTestCase
     new_condition.fill_in "Claim", with: "pipeline_slug"
     new_condition.fill_in "Value", with: "example-pipeline"
 
-    click_button "Create Api key role"
+    click_button "Create API Key Role"
 
-    page.assert_selector "h1", text: "API Key Role Push #{rubygem.name}"
+    page.assert_selector "h3", text: "API Key Role Push #{rubygem.name}"
 
     role = OIDC::ApiKeyRole.where(name: "Push #{rubygem.name}", user: @user, provider: provider_two).sole
 
@@ -309,15 +310,15 @@ class OIDCTest < ApplicationSystemTestCase
 
     click_button "Edit API Key Role"
 
-    page.assert_selector "h1", text: "Edit API Key Role"
+    page.assert_selector "h3", text: "Edit API Key Role"
 
     assert_select "OIDC provider", options: ["https://token.actions.githubusercontent.com", "https://agent.buildkite.com"], selected: "https://agent.buildkite.com"
 
     page.fill_in "Name", with: "Another Name"
 
-    click_button "Update Api key role"
+    click_button "Edit API Key Role"
 
-    page.assert_selector "h1", text: "API Key Role Another Name"
+    page.assert_selector "h3", text: "API Key Role Another Name"
   end
 
   test "creating rubygem trusted publishers" do

--- a/test/views/oidc/trusted_publisher/github_action/table_component_test.rb
+++ b/test/views/oidc/trusted_publisher/github_action/table_component_test.rb
@@ -41,6 +41,7 @@ class OIDC::TrustedPublisher::GitHubAction::TableComponentTest < ComponentTest
   end
 
   def assert_dl(*rows, node: page)
+    # rubocop:disable Rails/FindEach
     node.all("dl > div").each do |row_node|
       dt = row_node.find("dt")
       dd = row_node.find("dd")
@@ -50,6 +51,7 @@ class OIDC::TrustedPublisher::GitHubAction::TableComponentTest < ComponentTest
       flunk "Unexpected row: #{dt.text} => #{dd.text}" unless row
       row[dt, dd]
     end
+    # rubocop:enable Rails/FindEach
 
     assert_empty rows
   end

--- a/test/views/oidc/trusted_publisher/github_action/table_component_test.rb
+++ b/test/views/oidc/trusted_publisher/github_action/table_component_test.rb
@@ -41,9 +41,9 @@ class OIDC::TrustedPublisher::GitHubAction::TableComponentTest < ComponentTest
   end
 
   def assert_dl(*rows, node: page)
-    node.all("dl > *").each_slice(2) do |dt, dd|
-      assert_equal "dt", dt.tag_name
-      assert_equal "dd", dd.tag_name
+    node.all("dl > div").each do |row_node|
+      dt = row_node.find("dt")
+      dd = row_node.find("dd")
 
       row = rows.shift
 


### PR DESCRIPTION
/profile/oidc/api_key_roles
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/12a7e45a-fd30-4300-814b-0ed4bbb36de0" />

/profile/oidc/api_key_roles/new?
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/3a77e486-1a68-4c90-84d7-e56a5bfb6007" />

/profile/oidc/api_key_roles/rg_oidc_akr_h9m37vvw6p3obf1go1cn
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/721df69a-1341-4fa4-8893-0fc0c349c53f" />

/profile/oidc/api_key_roles/rg_oidc_akr_h9m37vvw6p3obf1go1cn/github_actions_workflow?
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/877b6722-6f3c-4df0-b24d-1ed593f992a0" />

profile/oidc/providers/1?
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/c0ec7cfe-24a0-4737-ab52-4f80215481f6" />

/profile/oidc/api_key_roles/rg_oidc_akr_h9m37vvw6p3obf1go1cn/edit?
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/b1726848-dd69-4187-ace2-4014429c7f3d" />

/profile/oidc/id_tokens/1
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/c47b195a-9922-4a1e-a250-995c13b69391" />

/profile/oidc/id_tokens
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/8454c544-0965-464b-a1f7-7b04481238ec" />

/profile/api_keys
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/4585ce08-86be-491e-a9ad-75cb8b379590" />

/profile/api_keys/1/edit?
<img width="1311" height="1168" alt="image" src="https://github.com/user-attachments/assets/879dc173-c9fe-4998-9ff5-1b12c20207d7" />

SO MANY OIDC VIEWS AND FORMS 
