### PR TITLE
Upgrade `rubocop-rails` and `rubocop-capybara` and remove defunct cop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -164,9 +164,6 @@ Style/ClassAndModuleChildren:
     - lib/gemcutter/middleware/hostess.rb
     - lib/gemcutter/middleware/redirector.rb
 
-Capybara/ClickLinkOrButtonStyle:
-  Enabled: false
-
 Rails/ThreeStateBooleanColumn:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :development, :test do
   gem "rubocop-rails", "~> 2.35", require: false
   gem "rubocop-performance", "~> 1.26", require: false
   gem "rubocop-minitest", "~> 0.39", require: false
-  gem "rubocop-capybara", "~> 2.23", require: false
+  gem "rubocop-capybara", "~> 3.0", require: false
   gem "rubocop-factory_bot", "~> 2.28", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -758,7 +758,7 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.23.0)
+    rubocop-capybara (3.0.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     rubocop-factory_bot (2.28.0)
@@ -772,7 +772,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -1009,7 +1009,7 @@ DEPENDENCIES
   rotp (~> 6.2)
   rqrcode (~> 3.2)
   rubocop (~> 1.88)
-  rubocop-capybara (~> 2.23)
+  rubocop-capybara (~> 3.0)
   rubocop-factory_bot (~> 2.28)
   rubocop-minitest (~> 0.39)
   rubocop-performance (~> 1.26)
@@ -1316,11 +1316,11 @@ CHECKSUMS
   rqrcode_core (2.1.0) sha256=f303b85df89c1b8fc5ee8dc19808c9dc4330e6329b660d99d4a8cbb36ca13051
   rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
-  rubocop-capybara (2.23.0) sha256=f9ea1ba3a7561ee8e88cf76fc378ce517ce5327155f305ee7b5c2500e5aee357
+  rubocop-capybara (3.0.0) sha256=7a64655238acda7f8f3c87e37ac825a64c615a79c17c253f1a28270dc3768c4b
   rubocop-factory_bot (2.28.0) sha256=4b17fc02124444173317e131759d195b0d762844a71a29fe8139c1105d92f0cb
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.35.4) sha256=3aeaa325439c89950e8327565682ea794065d08e2ecbbfe95032bfa295a35df5
+  rubocop-rails (2.35.5) sha256=f00b3c936002ba8e9ac62e8607c54bb24cda44b36e41b9c7e4f3872e1b0f3fe3
   ruby-magic (0.6.0) sha256=7b2138877b7d23aff812c95564eba6473b74b815ef85beb0eb792e729a2b6101
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-statistics (4.1.1) sha256=a9923db9bc4b1bda685fac2c47a9fadcc9a93cfd36465f5782a68dfbdf43c171


### PR DESCRIPTION
Qick PR to bring us up to date on `rubocop-rails` and `rubocop-capybara`. For the latter we need to remove a no-longer-existent cop `Capybara/ClickLinkOrButtonStyle` from our `.rubocop.yml` as it was removed in v3.0.0. ([source](https://github.com/rubocop/rubocop-capybara/blob/fcf260cb536547ce14257d44598c13f8202180f6/CHANGELOG.md#300-2026-06-22))

<img width="1440" height="360" alt="Screenshot From 2026-06-26 20-52-10" src="https://github.com/user-attachments/assets/9b3fa419-6577-4e1d-9f3d-486c700c6259" />

Supersedes https://github.com/rubygems/rubygems.org/pull/6644