### PR TITLE
Redesign the notifiers show 

### DIFF
--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -5,6 +5,8 @@ class NotifiersController < ApplicationController
   before_action :redirect_to_new_mfa, if: :mfa_required_not_yet_enabled?
   before_action :redirect_to_settings_strong_mfa_required, if: :mfa_required_weak_level_enabled?
 
+  layout "subject"
+
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name.includes(:rubygem)
   end

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -9,6 +9,9 @@ class NotifiersController < ApplicationController
 
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name.includes(:rubygem)
+    @title = t(".title")
+    add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
+    add_breadcrumb(@title)
   end
 
   def update

--- a/app/views/components/card_component.rb
+++ b/app/views/components/card_component.rb
@@ -67,6 +67,10 @@ class CardComponent < ApplicationComponent
     end
   end
 
+  def sub_heading_classes
+    "text-b2 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"
+  end
+
   private
 
   TITLE_CLASSES = "flex items-center text-lg space-x-2"

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -5,10 +5,8 @@
   <%= render "dashboards/subject", user: current_user, current: :settings %>
 <% end %>
 
-<%
-    radio_label = "flex items-center gap-3 text-b2 text-neutral-900 dark:text-white cursor-pointer"
-    radio_input = "h-5 w-5 accent-orange focus:ring-0"
-%>
+<% radio_label = "flex items-center gap-3 text-b2 text-neutral-900 dark:text-white cursor-pointer"
+   radio_input = "h-5 w-5 accent-orange focus:ring-0" %>
 
 <%= render CardComponent.new do |c| %>
   <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -1,6 +1,3 @@
-<% @title = t('.title') %>
-<% add_breadcrumb(@title) %>
-
 <% content_for :subject do %>
   <%= render "dashboards/subject", user: current_user, current: :settings %>
 <% end %>

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -1,39 +1,67 @@
 <% @title = t('.title') %>
+<% add_breadcrumb(@title) %>
 
-<% if @ownerships.any? %>
-  <div class="t-body">
-    <%= form_tag notifier_path, method: :put do %>
-      <p><%= t('.info') %></p>
+<% content_for :subject do %>
+  <%= render "dashboards/subject", user: current_user, current: :settings %>
+<% end %>
 
-      <% @ownerships.each do |ownership| %>
-        <h2><%= ownership.rubygem.name %></h2>
-        <h4 class="t-list__heading"><%= t('.push_heading') %></h4>
-        <div class="push--s">
-          <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier? %>
-            <%= t('.on') %> <em>(<%= t('.recommended') %>)</em>
-          <% end %>
-          <br>
-          <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier? %>
-            <%= t('.off') %>
-          <% end %>
-        </div>
+<%
+    radio_label = "flex items-center gap-3 text-b2 text-neutral-900 dark:text-white cursor-pointer"
+    radio_input = "h-5 w-5 accent-orange focus:ring-0"
+%>
 
-        <h4 class="t-list__heading"><%= t('.owner_heading') %></h4>
-        <div class="push--s">
-          <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier? %>
-            <%= t('.on') %> <em>(<%= t('.recommended') %>)</em>
-          <% end %>
-          <br>
-          <%= label_tag do %>
-            <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier? %>
-            <%= t('.off') %>
-          <% end %>
-        </div>
-      <% end %>
-      <%= submit_tag t('.update'), class: 'form__submit' %>
-    <% end %>
+<%= render CardComponent.new do |c| %>
+  <%= c.head(class: "border-b border-neutral-200 dark:border-neutral-800") do %>
+    <%= c.section_title t('.title'), icon: "notifications" %>
+  <% end %>
+
+  <div class="my-8">
+    <p class="text-b2 text-neutral-700 dark:text-neutral-300"><%= t('.info') %></p>
   </div>
+
+  <% if @ownerships.any? %>
+    <%= form_tag notifier_path, method: :put do %>
+      <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
+        <% @ownerships.each do |ownership| %>
+          <section class="py-4 first:pt-0 last:pb-0">
+            <h2 class="text-h4 mb-4"><%= ownership.rubygem.name %></h2>
+
+            <div class="flex flex-col gap-8 sm:flex-row">
+              <fieldset class="flex-1">
+                <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.push_heading') %></legend>
+                <div class="space-y-2">
+                  <%= label_tag(nil, nil, class: radio_label) do %>
+                    <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier?, class: radio_input %>
+                    <span><%= t('.on') %> <span class="text-b3 text-neutral-500 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                  <% end %>
+                  <%= label_tag(nil, nil, class: radio_label) do %>
+                    <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier?, class: radio_input %>
+                    <span><%= t('.off') %></span>
+                  <% end %>
+                </div>
+              </fieldset>
+
+              <fieldset class="flex-1">
+                <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.owner_heading') %></legend>
+                <div class="space-y-3">
+                  <%= label_tag(nil, nil, class: radio_label) do %>
+                    <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier?, class: radio_input %>
+                    <span><%= t('.on') %> <span class="text-b3 text-neutral-500 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                  <% end %>
+                  <%= label_tag(nil, nil, class: radio_label) do %>
+                    <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier?, class: radio_input %>
+                    <span><%= t('.off') %></span>
+                  <% end %>
+                </div>
+              </fieldset>
+            </div>
+          </section>
+        <% end %>
+      </div>
+
+      <div class="flex justify-end my-4">
+        <%= render ButtonComponent.new(t('.update'), type: :submit) %>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -27,7 +27,7 @@
                 <div class="space-y-2">
                   <%= label_tag(nil, nil, class: radio_label) do %>
                     <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier?, class: radio_input %>
-                    <span><%= t('.on') %> <span class="text-b3 text-neutral-500 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                    <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
                   <% end %>
                   <%= label_tag(nil, nil, class: radio_label) do %>
                     <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier?, class: radio_input %>
@@ -41,7 +41,7 @@
                 <div class="space-y-3">
                   <%= label_tag(nil, nil, class: radio_label) do %>
                     <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier?, class: radio_input %>
-                    <span><%= t('.on') %> <span class="text-b3 text-neutral-500 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                    <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
                   <% end %>
                   <%= label_tag(nil, nil, class: radio_label) do %>
                     <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier?, class: radio_input %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -6,7 +6,6 @@
 <% end %>
 
 <%
-  sub_heading = "text-b2 font-bold uppercase tracking-wide text-neutral-800 dark:text-neutral-200"
   note_class  = "mt-2 text-b3 text-neutral-700 dark:text-neutral-300 " \
                 "[&_a]:text-orange-700 [&_a]:underline dark:[&_a]:text-orange-400"
   label_class = "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
@@ -25,7 +24,7 @@
   <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
     <% if @user.mfa_enabled? %>
       <section class="py-4">
-        <h3 class="<%= sub_heading %> pt-8"><%= t(".mfa.level.title") %></h3>
+        <h3 class="<%= c.sub_heading_classes %> pt-8"><%= t(".mfa.level.title") %></h3>
         <p class="<%= note_class %>"><%= t(".mfa.level_html") %></p>
 
         <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit",
@@ -41,7 +40,7 @@
 
     <section class="py-4">
       <div class="flex items-center gap-3">
-        <h3 class="<%= sub_heading %>"><%= t(".webauthn_credentials") %></h3>
+        <h3 class="<%= c.sub_heading_classes %>"><%= t(".webauthn_credentials") %></h3>
         <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.webauthn_enabled?) %>
       </div>
       <p class="<%= note_class %>"><%= t(".webauthn_credential_note") %></p>
@@ -61,7 +60,7 @@
 
     <section class="py-8 first:pt-0 last:pb-0">
       <div class="flex items-center gap-3">
-        <h3 class="<%= sub_heading %>"><%= t(".mfa.otp") %></h3>
+        <h3 class="<%= c.sub_heading_classes %>"><%= t(".mfa.otp") %></h3>
         <%= render Settings::MfaStatusBadgeComponent.new(enabled: @user.totp_enabled?) %>
       </div>
 


### PR DESCRIPTION
Why this change is being made:
- This is a quick one! The whole page is one big form with a bunch of radio buttons
- also abstract a sub_heading_classes method to the card_component


<img width="1251" height="1168" alt="image" src="https://github.com/user-attachments/assets/2c32d0a2-862e-4cbe-8df6-b5e74eda0eeb" />
<img width="1240" height="1174" alt="image" src="https://github.com/user-attachments/assets/252f5f23-d7c0-4fd6-8280-36c2620649ef" />



<img width="391" height="840" alt="image" src="https://github.com/user-attachments/assets/885817ca-cd08-49a3-ba87-901ac5fa50bc" />

<img width="391" height="840" alt="image" src="https://github.com/user-attachments/assets/d1988c36-254d-484c-b755-416f5fe731f1" />
