### PR TITLE
Harden markdown page rendering

### DIFF
--- a/lib/gemcutter/markdown.rb
+++ b/lib/gemcutter/markdown.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "action_controller"
+require "kramdown"
+require "rails-html-sanitizer"
+
+module Gemcutter::Markdown
+  ALLOWED_TAGS = (Rails::HTML5::SafeListSanitizer.allowed_tags + %w[
+    caption table tbody td tfoot th thead tr
+  ]).freeze
+  ALLOWED_ATTRIBUTES = (Rails::HTML5::SafeListSanitizer.allowed_attributes + %w[id]).freeze
+
+  def self.render(source)
+    html = Kramdown::Document.new(source).to_html
+
+    ActionController::Base.helpers.sanitize(
+      html,
+      tags: ALLOWED_TAGS,
+      attributes: ALLOWED_ATTRIBUTES
+    )
+  end
+end

--- a/lib/gemcutter/markdown_handler.rb
+++ b/lib/gemcutter/markdown_handler.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require "gemcutter/markdown"
+
 module Gemcutter::MarkdownHandler
   def self.call(_template, source)
-    "@title = t('.title'); prose { Kramdown::Document.new(#{source.dump}).to_html.html_safe }"
+    "@title = t('.title'); prose { Gemcutter::Markdown.render(#{source.dump}) }"
   end
 end

--- a/test/integration/static_pages_manifest_test.rb
+++ b/test/integration/static_pages_manifest_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StaticPagesManifestTest < ActionDispatch::IntegrationTest
+  test "configured static pages have templates and titles" do
+    Gemcutter::PAGES.each do |page|
+      assert_template_exists "pages", page
+      assert I18n.exists?("pages.#{page}.title"), "missing title for pages.#{page}"
+    end
+  end
+
+  test "configured policy pages have templates and titles" do
+    Gemcutter::POLICY_PAGES.each do |policy|
+      assert_template_exists "policies", policy
+      assert I18n.exists?("policies.#{policy}.title"), "missing title for policies.#{policy}"
+    end
+  end
+
+  test "configured policy markdown pages render" do
+    Gemcutter::POLICY_PAGES.each do |policy|
+      get policy_path(policy)
+
+      assert_response :success
+      assert_select "main"
+    end
+  end
+
+  private
+
+  def assert_template_exists(directory, page)
+    pattern = Rails.root.join("app/views/#{directory}/#{page}.*")
+
+    assert_predicate Dir.glob(pattern.to_s), :any?, "missing template for #{directory}/#{page}"
+  end
+end

--- a/test/lib/markdown_test.rb
+++ b/test/lib/markdown_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MarkdownTest < ActiveSupport::TestCase
+  test "renders markdown as html" do
+    html = Gemcutter::Markdown.render("# Publishing Gems\n\nUse `gem push`.")
+
+    assert_includes html, "<h1 id=\"publishing-gems\">Publishing Gems</h1>"
+    assert_includes html, "<code>gem push</code>"
+    assert_predicate html, :html_safe?
+  end
+
+  test "allows markdown tables" do
+    html = Gemcutter::Markdown.render(<<~MARKDOWN)
+      | Name | Value |
+      | ---- | ----- |
+      | MFA  | true  |
+    MARKDOWN
+
+    assert_includes html, "<table>"
+    assert_includes html, "<td>MFA</td>"
+  end
+
+  test "removes unsafe html from markdown" do
+    html = Gemcutter::Markdown.render(<<~MARKDOWN)
+      # Safe
+
+      <script>alert("pwnd")</script>
+      <a href="javascript:alert(1)" onclick="alert(2)">bad link</a>
+    MARKDOWN
+
+    refute_includes html, "<script"
+    refute_includes html, "javascript:"
+    refute_includes html, "onclick"
+    assert_includes html, ">bad link</a>"
+  end
+end


### PR DESCRIPTION
Markdown pages are repo-backed, but we currently mark the rendered HTML as trusted output. That means any raw HTML in those files would be sent straight to users.

This adds a Markdown renderer that sanitizes the generated HTML before Rails treats it as safe. The allowlist keeps the formatting we need for docs and policies, including headings, links, code blocks, tables, and captions, while stripping unsafe tags and attributes.

I also added tests for unsafe HTML, supported Markdown output, and drift between the static page manifests and their templates/titles.