### PR TITLE
[Content Addressable] Part 3: Include Ruby ABI in uniqueness checks and duplicate detection

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,13 +129,16 @@ class Pusher
         pusher_api_key: api_key
       )
 
+    version.required_ruby_version = spec.required_ruby_version.to_s
+    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version)
+
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
 
       # If the gem is yanked, we can't repush it
       # Additionally, we don't allow overwriting existing versions
-      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform))
+      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_abi: version.ruby_abi))
         return republish_notification(existing)
       end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,7 @@ require "digest/sha2"
 
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
+  DEFAULT_CONTENT_ADDRESS_LENGTH = 8
 
   self.ignored_columns += %w[info_checksum yanked_info_checksum]
 
@@ -66,6 +67,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validate :metadata_links_format, if: -> { validation_context == :create || metadata_changed? }
   validate :metadata_attribute_length
   validate :no_dashes_in_version_number, on: :create
+  validate :sha256_presence_for_content_addressable_version
 
   class AuthorType < ActiveModel::Type::String
     def cast_value(value)
@@ -459,6 +461,16 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   private
 
+  def content_addressable?
+    platformed? && ruby_abi.present? && sha256.present?
+  end
+
+  def sha256_presence_for_content_addressable_version
+    return unless platformed? && ruby_abi.present?
+
+    errors.add(:sha256, "can't be blank") if sha256.blank?
+  end
+
   def set_ruby_abi
     self.ruby_abi = derive_ruby_abi
   end
@@ -517,15 +529,34 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def full_nameify!
     return if rubygem.nil?
-    self.full_name = "#{rubygem.name}-#{number}"
-    full_name << "-#{platform}" if platformed?
+    self.full_name = platform_identity(platform)
   end
 
   def gem_full_nameify!
     return if gem_platform.blank?
     return if rubygem.nil?
-    self.gem_full_name = "#{rubygem.name}-#{number}"
-    gem_full_name << "-#{gem_platform}" unless gem_platform == "ruby"
+
+    self.gem_full_name = platform_identity(gem_platform)
+  end
+
+  def content_address
+    digest = sha256_hex
+    raise ArgumentError, "Could not generate unique content-address" if digest.blank?
+
+    (DEFAULT_CONTENT_ADDRESS_LENGTH..digest.length).each do |length|
+      identity = "#{rubygem.name}-#{number}-#{digest.first(length)}"
+      return identity unless Version.where(full_name: identity).where.not(id: id).exists?
+    end
+
+    raise ArgumentError, "Could not generate unique content-address"
+  end
+
+  def platform_identity(platform_value)
+    return content_address if content_addressable?
+
+    identity = "#{rubygem.name}-#{number}"
+    identity << "-#{platform_value}" unless platform_value == "ruby"
+    identity
   end
 
   def set_canonical_number

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -459,23 +459,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{full_name}.gem"
   end
 
-  private
-
-  def content_addressable?
-    platformed? && ruby_abi.present? && sha256.present?
-  end
-
-  def sha256_presence_for_content_addressable_version
-    return unless platformed? && ruby_abi.present?
-
-    errors.add(:sha256, "can't be blank") if sha256.blank?
-  end
-
-  def set_ruby_abi
-    self.ruby_abi = derive_ruby_abi
-  end
-
-  def derive_ruby_abi
+  def self.ruby_abi_for(required_ruby_version)
     return if required_ruby_version.blank?
 
     requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
@@ -498,19 +482,48 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
+  private
+
+  def content_addressable?
+    platformed? && ruby_abi.present? && sha256.present?
+  end
+
+  def sha256_presence_for_content_addressable_version
+    return unless platformed? && ruby_abi.present?
+
+    errors.add(:sha256, "can't be blank") if sha256.blank?
+  end
+
+  def set_ruby_abi
+    self.ruby_abi = Version.ruby_abi_for(required_ruby_version)
+  end
+
   def update_prerelease
     self[:prerelease] = prerelease
   end
 
   def platform_and_number_are_unique
-    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)
-    errors.add(:base, "A version already exists with this number or platform.")
+    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_abi: ruby_abi)
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, platform and Ruby ABI"
+              else
+                "A version already exists with this number or platform"
+              end
+
+    errors.add(:base, message)
   end
 
   def gem_platform_and_number_are_unique
-    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform).pluck(:platform)
+    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_abi: ruby_abi).pluck(:platform)
     return if platforms.empty?
-    errors.add(:base, "A version already exists with this number and resolved platform #{platforms}")
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, resolved platform, and Ruby ABI #{platforms}"
+              else
+                "A version already exists with this number or resolved platform #{platforms}"
+              end
+    errors.add(:base, message)
   end
 
   def original_platform_resolves_to_gem_platform
@@ -591,7 +604,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def unique_canonical_number
-    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_abi: ruby_abi)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -20,9 +20,9 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
-  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_save :create_link_verifications, if: :metadata_changed?
   before_save :update_prerelease, if: :number_changed?
   # TODO: Remove this once we move to GemDownload only

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -22,6 +22,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   before_validation :set_canonical_number, if: :number_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
+  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_save :create_link_verifications, if: :metadata_changed?
   before_save :update_prerelease, if: :number_changed?
   # TODO: Remove this once we move to GemDownload only
@@ -457,6 +458,33 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def set_ruby_abi
+    self.ruby_abi = derive_ruby_abi
+  end
+
+  def derive_ruby_abi
+    return if required_ruby_version.blank?
+
+    requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
+    requirements = requirement.requirements
+
+    return unless requirements.one?
+
+    operator, version = requirements.first
+    return unless operator == "~>"
+
+    segments = version.segments
+    return unless segments.length == 3
+
+    patch = segments[2]
+    return unless patch.is_a?(Integer)
+    return unless patch.zero?
+
+    "#{segments[0]}.#{segments[1]}"
+  rescue Gem::Requirement::BadRequirementError
+    nil
+  end
 
   def update_prerelease
     self[:prerelease] = prerelease

--- a/db/migrate/20260629112747_add_ruby_abi_to_versions.rb
+++ b/db/migrate/20260629112747_add_ruby_abi_to_versions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToVersions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :versions, :ruby_abi, :string
+  end
+end

--- a/db/migrate/20260701131420_add_ruby_abi_to_version_unique_indexes.rb
+++ b/db/migrate/20260701131420_add_ruby_abi_to_version_unique_indexes.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToVersionUniqueIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      where: "ruby_abi IS NULL",
+      name: "index_versions_on_canonical_number_rubygem_id_platform_no_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[canonical_number rubygem_id platform ruby_abi],
+      unique: true,
+      where: "ruby_abi IS NOT NULL",
+      name: "index_versions_on_canonical_number_rubygem_id_platform_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      where: "ruby_abi IS NULL",
+      name: "index_versions_on_rubygem_id_number_platform_no_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform ruby_abi],
+      unique: true,
+      where: "ruby_abi IS NOT NULL",
+      name: "index_versions_on_rubygem_id_number_platform_abi",
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_rubygem_id_platform_no_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_rubygem_id_platform_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_number_platform_no_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_number_platform_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_131420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -727,7 +727,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
-    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
+    t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_on_canonical_number_rubygem_id_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
+    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_rubygem_id_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -736,7 +737,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
-    t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
+    t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_on_rubygem_id_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
+    t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -714,6 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.string "required_ruby_version"
     t.string "required_rubygems_version", limit: 255
     t.text "requirements"
+    t.string "ruby_abi"
     t.integer "rubygem_id"
     t.string "sha256"
     t.integer "size"

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -314,6 +314,44 @@ class PusherIntegrationTest < ActiveSupport::TestCase
     [root_cert, cert]
   end
 
+  context "finding an existing gem version" do
+    should "initialize a new version when the existing version has a different Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      spec = new_gemspec("sandworm", "1.0.0", "Gemcutter", "ruby", { ruby_version: "~> 3.4.0" }) do |gem_spec|
+        gem_spec.platform = "arm64-darwin-25"
+      end
+
+      gem = build_gem(spec)
+      pusher = Pusher.new(@api_key, gem)
+
+      assert pusher.pull_spec
+      assert pusher.find
+
+      assert_equal("~> 3.4.0", pusher.version.required_ruby_version)
+      assert_equal("3.4", pusher.version.ruby_abi)
+    end
+
+    should "reject a new version when the existing version has the same Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.4.0")
+
+      spec = new_gemspec("sandworm", "1.0.0", "Gemcutter", "ruby", { ruby_version: "~> 3.4.0" }) do |gem_spec|
+        gem_spec.platform = "arm64-darwin-25"
+      end
+
+      gem = build_gem(spec)
+      pusher = Pusher.new(@api_key, gem)
+
+      assert pusher.pull_spec
+      refute pusher.find
+
+      assert_equal(409, pusher.code)
+      assert_match(/Repushing of gem versions is not allowed/, pusher.message)
+    end
+  end
+
   context "successfully saving a gemcutter" do
     setup do
       @rubygem = create(:rubygem, name: "gemsgemsgems")

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -485,6 +485,77 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
     end
 
+    context "deriving ruby ABI" do
+      should "set ruby_abi when required_ruby_version targets a single Ruby minor version" do
+        version = create(:version, required_ruby_version: "~> 3.2.0")
+
+        assert_equal("3.2", version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is broad" do
+        version = create(:version, required_ruby_version: ">= 3.2")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "only set ruby_abi for clean three-segment requirements" do
+        version = create(:version, required_ruby_version: "~> 3.2.0.0")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version has multiple requirements" do
+        version = create(:version, required_ruby_version: ">= 3.2, < 3.4")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is malformed" do
+        version = build(:version, required_ruby_version: "not a requirement")
+
+        assert_nothing_raised { version.valid? }
+        assert_nil(version.ruby_abi)
+        assert_includes(version.errors[:required_ruby_version], "must be list of valid requirements")
+      end
+
+      should "not set ruby_abi when required_ruby_version indicates multiple Ruby ABIs" do
+        version = create(:version, required_ruby_version: "~> 3.2")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is blank" do
+        version = create(:version, required_ruby_version: "")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi for patch-specific pessimistic requirements" do
+        version = create(:version, required_ruby_version: "~> 3.2.1")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "recalculate ruby_abi when required_ruby_version is updated" do
+        version = create(:version, required_ruby_version: ">= 3.2.0")
+
+        assert_nil(version.ruby_abi)
+
+        version.update!(required_ruby_version: "~> 3.2.0")
+
+        assert_equal("3.2", version.reload.ruby_abi)
+      end
+
+      should "not recalculate ruby_abi when required_ruby_version is unchanged" do
+        version = create(:version, required_ruby_version: "~> 3.2.0")
+        version.update_column(:ruby_abi, "manually-set")
+
+        version.update!(summary: "Updated summary")
+
+        assert_equal("manually-set", version.reload.ruby_abi)
+      end
+    end
+
     should "raise an ActiveRecord::RecordNotFound if an invalid slug is given" do
       assert_raise ActiveRecord::RecordNotFound do
         @version.rubygem.find_version!(number: "some stupid version 399", platform: @version.platform)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -570,6 +570,92 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
+    context "with content-addressable naming" do
+      setup do
+        @rubygem = create(:rubygem, name: "nokogiri")
+      end
+
+      should "use platform identity for fat binaries" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: ">= 3.2"
+        )
+
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.full_name)
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "use sha256 identity for skinny binaries" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: Digest::SHA2.base64digest("skinny gem")
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(8)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "extend sha256 identity when another version already uses the first eight characters" do
+        shared_hex_prefix = "abc12345"
+        existing_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("0" * 56))
+        colliding_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("1" * 56))
+
+        existing_version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.3.0",
+          sha256: existing_sha256
+        )
+
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: colliding_sha256
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(9)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_not_equal(existing_version.full_name, version.full_name)
+      end
+
+      should "be invalid when content-addressable version has no sha256" do
+        version = build(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: nil
+        )
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:sha256], "can't be blank"
+      end
+    end
+
     %w[x86_64-linux java mswin x86-mswin32-60].each do |platform|
       should "be able to find with platform of #{platform}" do
         version = create(:version, platform: platform)
@@ -1187,5 +1273,11 @@ class VersionTest < ActiveSupport::TestCase
         end
       end
     end
+  end
+
+  private
+
+  def encoded_sha256_with_hex_prefix(hex_sha256)
+    [[hex_sha256].pack("H*")].pack("m0")
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,42 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "allow duplicate versions with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow duplicate versions with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+    end
+
+    should "allow canonical number duplicates with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow canonical number duplicates with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+    end
+
     should "be able to find dependencies" do
       @dependency = create(:rubygem)
       @version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "ruby")


### PR DESCRIPTION
### Changes:
- Updates Version uniqueness checks to include ruby_abi when comparing duplicate versions.
- Updates the push-path duplicate lookup so skinny binaries with different Ruby ABIs can coexist, while same-ABI
  duplicates are still rejected.
- Replaces the existing Version unique indexes with partial unique indexes that preserve old fat/source gem uniqueness
  when ruby_abi is NULL, and include ruby_abi for skinny gems.
- Updates schema for the new indexes.

  ### Testing:
- Tests added to version_test for duplicate version and canonical version behavior with same/different Ruby ABIs.
- Tests added to pusher_test for push duplicate detection with same/different Ruby ABIs.

To tophat:

Pull branch down, ensure migrations have been run.

```
rubygem = Rubygem.find_or_create_by!(name: "skinny-tophat-different-abi")

v1 = rubygem.versions.create!(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.3.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.3")
)

v2 = rubygem.versions.create!(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.4.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.4")
)

[v1.ruby_abi, v2.ruby_abi]
# => ["3.3", "3.4"]

# Duplicate same-ABI skinny version should be invalid:

dup_skinny = rubygem.versions.build(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.4.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.4-dup")
)

dup_skinny.valid?
# => false

# Fat binaries without Ruby ABIs still follow the old uniqueness behaviour.
```