### PR TITLE
Redesign: Update email_confirmation new

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -16,6 +16,8 @@ class EmailConfirmationsController < ApplicationController
   before_action :validate_webauthn, only: :webauthn_update
   after_action :delete_mfa_expiry_session, only: %i[otp_update webauthn_update]
 
+  layout "hammy"
+
   def new
   end
 

--- a/app/views/components/button_component.rb
+++ b/app/views/components/button_component.rb
@@ -30,6 +30,9 @@ class ButtonComponent < ApplicationComponent
       link_to(*args, class: css, **options, &block)
     elsif (args.size == 1 && block_given?) || args.size == 2
       button_to(*args, class: css, method: :get, **options, &block)
+    elsif type == :submit
+      block ||= proc { args.first }
+      button(class: css, type:, **submit_button_options(options), &block)
     else
       block ||= proc { args.first }
       button(class: css, type:, **options, &block)
@@ -37,6 +40,16 @@ class ButtonComponent < ApplicationComponent
   end
 
   private
+
+  def submit_button_options(options)
+    if options.dig(:data, :disable_with).present?
+      options
+    else
+      data = options.delete(:data) || {}
+      data.merge!(disable_with: t("form_disable_with"))
+      options.merge(data:)
+    end
+  end
 
   def button_color(color, style)
     color = color.to_sym

--- a/app/views/email_confirmations/new.html.erb
+++ b/app/views/email_confirmations/new.html.erb
@@ -14,8 +14,10 @@
       <div class="mb-6">
         <%= form.label :email, t('activerecord.attributes.user.email'),
           class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-        <%= form.email_field :email, size: '25',
-          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+        <%= form.email_field :email,
+          size: '25',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+          required: true %>
       </div>
       <div class="submit_field">
         <%= render ButtonComponent.new(t(".submit"), type: :submit, color: :primary) %>

--- a/app/views/email_confirmations/new.html.erb
+++ b/app/views/email_confirmations/new.html.erb
@@ -1,15 +1,25 @@
 <% @title = t('.title') %>
+<% add_breadcrumb @title %>
 
-<div class="t-body">
-  <p><%= t '.will_email_notice' %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6">
+      <%= t('.title') %>
+    </h1>
+    <div class="mb-4">
+      <p><%= t '.will_email_notice' %></p>
+    </div>
+
+  <%= form_for :email_confirmation, url: email_confirmations_path do |form| %>
+      <div class="mb-6">
+        <%= form.label :email, t('activerecord.attributes.user.email'),
+          class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+        <%= form.email_field :email, size: '25',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+      </div>
+      <div class="submit_field">
+        <%= render ButtonComponent.new(t(".submit"), type: :submit, color: :primary) %>
+      </div>
+    <% end %>
+  </div>
 </div>
-
-<%= form_for :email_confirmation, url: email_confirmations_path do |form| %>
-  <div class="text_field">
-    <%= form.label :email, t('activerecord.attributes.user.email'), class: 'form__label' %>
-    <%= form.email_field :email, size: '25', class: 'form__input' %>
-  </div>
-  <div class="submit_field">
-    <%= form.submit t('.submit'), data: {disable_with: t('form_disable_with')}, class: 'form__submit' %>
-  </div>
-<% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -14,8 +14,11 @@
       <div class="mb-6">
         <%= form.label :email, t('activerecord.attributes.user.email'),
           class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-        <%= form.email_field :email, :size => '25',
-          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+        <%= form.email_field :email,
+          size: '25',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+          required: true
+        %>
       </div>
       <div class="submit_field">
         <%= render ButtonComponent.new(t(".submit"), type: :submit, color: :primary) %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,41 +6,39 @@
     <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t(".title") %></h1>
     <% if Gemcutter::ENABLE_DEVELOPMENT_LOG_IN %>
       <div class="mb-8">
-      <ul>
-        <% User.all.order(id: :asc).each do |user| %>
-          <li>
-            <span class="text-b3 text-orange-500 underline dark:text-orange-400">
-              <%= link_to "login as #{user.handle}", controller: :sessions, action: "development_log_in_as", user_id: user.id %>
-            </span>
-          </li>
-        <% end %>
-      </ul>
+        <ul>
+          <% User.all.order(id: :asc).each do |user| %>
+            <li>
+              <span class="text-b3 text-orange-500 underline dark:text-orange-400">
+                <%= link_to "login as #{user.handle}", controller: :sessions, action: "development_log_in_as", user_id: user.id %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
       </div>
     <% end %>
 
     <div class="mb-8">
       <div>
-        <%= link_to t('.forgot_password'), new_password_path, class: "text-b3 text-orange-500 underline dark:text-orange-400"%>
+        <%= link_to t('.forgot_password'), new_password_path, class: "text-b3 text-orange-500 underline dark:text-orange-400" %>
       </div>
       <div>
-        <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: "text-b3 text-orange-500 underline dark:text-orange-400"%>
+        <%= link_to t('.resend_confirmation'), new_email_confirmations_path, class: "text-b3 text-orange-500 underline dark:text-orange-400" %>
       </div>
     </div>
 
     <%= form_for :session, url: session_path do |form| %>
-    <div class="mb-8">
-      <%= form.label :who, t('activerecord.attributes.session.who'),
-        class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-      <%= form.text_field :who, autofocus: true,
-          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition mb-2" %>
-      <%= form.label :password, t('activerecord.attributes.session.password'),
-        class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-      <%= form.password_field :password, autocomplete: 'current-password',
-        class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
-
-    </div>
-
-    <%= render ButtonComponent.new(t("sign_in"), type: :submit, color: :primary) %>
+      <div class="mb-8">
+        <%= form.label :who, t('activerecord.attributes.session.who'),
+          class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+        <%= form.text_field :who, autofocus: true,
+            class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition mb-2" %>
+        <%= form.label :password, t('activerecord.attributes.session.password'),
+          class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+        <%= form.password_field :password, autocomplete: 'current-password',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+      </div>
+      <%= render ButtonComponent.new(t("sign_in"), type: :submit, color: :primary) %>
     <% end %>
 
     <%= render "multifactor_auths/webauthn_prompt" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -31,12 +31,16 @@
       <div class="mb-8">
         <%= form.label :who, t('activerecord.attributes.session.who'),
           class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-        <%= form.text_field :who, autofocus: true,
-            class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition mb-2" %>
+        <%= form.text_field :who,
+            autofocus: true,
+            class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition mb-2",
+            required: true %>
         <%= form.label :password, t('activerecord.attributes.session.password'),
           class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-        <%= form.password_field :password, autocomplete: 'current-password',
-          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+        <%= form.password_field :password,
+          autocomplete: 'current-password',
+          class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+          required: true %>
       </div>
       <%= render ButtonComponent.new(t("sign_in"), type: :submit, color: :primary) %>
     <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -10,17 +10,24 @@
 
   <div>
     <%= form.label :email, class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-    <%= form.email_field :email, class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+    <%= form.email_field :email,
+      class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+      required: true %>
   </div>
 
   <div>
     <%= form.label :handle, class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-    <%= form.text_field :handle, class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+    <%= form.text_field :handle,
+      class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+      required: true %>
   </div>
 
   <div>
-    <%= form.label :password, t('activerecord.attributes.user.password'), class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
-    <%= form.password_field :password, autocomplete: "new-password", class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition" %>
+    <%= form.label :password, t('activerecord.attributes.user.password'),
+      class: "block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2" %>
+    <%= form.password_field :password, autocomplete: "new-password",
+      class: "w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+      required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -31,16 +31,6 @@ class SignUpTest < ApplicationSystemTestCase
     assert_equal "Email@person.com", User.last.email
   end
 
-  test "sign up with no handle" do
-    visit sign_up_path
-
-    fill_in "Email", with: "email@person.com"
-    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
-    click_button "Sign up"
-
-    assert_text "errors prohibited"
-  end
-
   test "sign up with bad handle" do
     visit sign_up_path
 


### PR DESCRIPTION
Why this change is being made:
- Missed this one the first time around!
- Use the hammy/tailwind styling for the email_confirmation

What were the changes made to support this:
- Match this to the reset password pages

<img width="1486" height="1172" alt="image" src="https://github.com/user-attachments/assets/b3b188ba-5857-44a1-88a1-58d15b032f7d" />

<img width="548" height="816" alt="image" src="https://github.com/user-attachments/assets/a5578ee5-de53-4204-a1e2-e468c594abaf" />

