### PR TITLE
Redesign: Don't use bg-black on desktop size

### DIFF
--- a/app/views/layouts/subject.html.erb
+++ b/app/views/layouts/subject.html.erb
@@ -25,7 +25,7 @@
           main content (subject top -> main -> subject secondary, matching DOM order);
           at desktop width both subject blocks share the left column while main spans the right. %>
       <div class="lg:max-w-screen-xl lg:w-full lg:mx-auto grid grid-cols-1 lg:grid-cols-[18rem_1fr] lg:grid-rows-[auto_1fr] lg:gap-x-20">
-        <aside aria-label="<%= t("layouts.subject.subject_label") %>" class="w-full px-8 lg:px-0 pb-6 lg:pb-0 lg:col-start-1 lg:row-start-1 bg-white dark:bg-black lg:bg-transparent border-b border-neutral-400 dark:border-neutral-800 lg:border-none">
+        <aside aria-label="<%= t("layouts.subject.subject_label") %>" class="w-full px-8 lg:px-0 pb-6 lg:pb-0 lg:col-start-1 lg:row-start-1 lg:bg-transparent border-b border-neutral-400 dark:border-neutral-800 lg:border-none">
           <div class="flex flex-col w-full">
             <%= yield :subject %>
           </div>
@@ -37,7 +37,7 @@
           </div>
         </main>
 
-        <aside aria-label="<%= t("layouts.subject.subject_secondary_label") %>" class="w-full px-8 lg:px-0 pb-6 lg:pb-32 lg:col-start-1 lg:row-start-2 bg-white dark:bg-black lg:bg-transparent border-t border-neutral-400 dark:border-neutral-800 lg:border-none">
+        <aside aria-label="<%= t("layouts.subject.subject_secondary_label") %>" class="w-full px-8 lg:px-0 pb-6 lg:pb-32 lg:col-start-1 lg:row-start-2 lg:bg-transparent border-t border-neutral-400 dark:border-neutral-800 lg:border-none">
           <div class="flex flex-col w-full">
             <%= yield :subject_secondary %>
           </div>


### PR DESCRIPTION
Why this change is being made:
- This is rendering weirdly for me. On Chrome, dark mode seems to be working as expected for me.
  - On firefox and safari it's visible having a hard black background on the gem info subject side bar.
- Remove the black background and use same background as the primary section BUT continue to keep the black background for the aside and secondary aside on mobile (for visual distinction between the main and navigation content)

What were the changes made to support this:
- drop the bg-black from the subject layout

Desktop darkmode 
<img width="1435" height="1167" alt="image" src="https://github.com/user-attachments/assets/a75f50e1-fd77-4dcf-9b17-1b4bebe92cda" />


Mobile keeps the black background on the top and bottom for darkmode 
<img width="397" height="848" alt="image" src="https://github.com/user-attachments/assets/e022ccfa-96b7-42f1-9cbe-f12a2a42e131" />
<img width="397" height="848" alt="image" src="https://github.com/user-attachments/assets/23ad37c7-f082-4f5e-939a-8b5ef3ecbc1f" />
