### PR TITLE
Require username confirmation when removing yourself as gem owner

### DIFF
--- a/app/javascript/controllers/confirm_remove_self_controller.js
+++ b/app/javascript/controllers/confirm_remove_self_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["dialog", "usernameInput", "submitButton"];
+  static values = { username: String };
+
+  open() {
+    this.usernameInputTarget.value = "";
+    this.submitButtonTarget.disabled = true;
+    this.dialogTarget.show();
+  }
+
+  close() {
+    this.dialogTarget.close();
+  }
+
+  validate() {
+    this.submitButtonTarget.disabled =
+      this.usernameInputTarget.value.trim() !== this.usernameValue;
+  }
+}

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -26,6 +26,9 @@
         <tr class="block md:table-row border-b border-neutral-200 py-4 dark:border-neutral-800 md:border-0 md:py-0">
           <td data-title="Name" class="<%= cell_class %> font-medium">
             <%= link_to(ownership.owner_name, profile_path(ownership.user.display_id), class: "text-orange-500 hover:underline dark:text-orange-400") %>
+            <% if ownership.user == current_user %>
+              <span class="text-b4 text-neutral-500">(<%= t("owners.index.current_user_badge") %>)</span>
+            <% end %>
           </td>
           <td data-title="Confirmed" class="<%= cell_class %>">
             <span class="inline-flex items-center gap-1"><%= confirmation_status(ownership) %></span>
@@ -56,12 +59,60 @@
                     disabled: ownership.user == current_user) %>
                 <% end %>
                 <% if can_remove_owners?(@rubygem) %>
-                  <%= render ButtonComponent.new(
-                    t("remove"),
-                    rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
-                    method: "delete",
-                    data: { confirm: t("owners.index.confirm_remove") },
-                    color: :red) %>
+                  <% if ownership.user == current_user %>
+                    <div data-controller="confirm-remove-self"
+                         data-confirm-remove-self-username-value="<%= current_user.display_id %>">
+                      <%= render ButtonComponent.new(
+                        t("remove"),
+                        color: :red,
+                        size: :small,
+                        data: { action: "confirm-remove-self#open" }) %>
+                      <dialog data-confirm-remove-self-target="dialog"
+                              class="fixed inset-0 m-0 w-full h-full max-w-none max-h-none border-0 p-0 z-50 open:flex open:items-center open:justify-center open:bg-black/50">
+                        <div class="bg-white dark:bg-neutral-900 rounded p-6 w-[calc(100%-2rem)] max-w-[440px] shadow-xl">
+                          <p class="text-lg font-bold mb-3 text-neutral-900 dark:text-white">
+                            <%= t("owners.index.remove_self_dialog.title") %>
+                          </p>
+                          <p class="text-b3 font-light leading-relaxed mb-5 text-neutral-500 dark:text-neutral-400">
+                            <%= t("owners.index.remove_self_dialog.warning") %>
+                          </p>
+                          <label class="block text-b3 mb-2 text-neutral-900 dark:text-white"
+                                 for="username_confirm_<%= ownership.id %>">
+                            <%= t("owners.index.remove_self_dialog.confirm_label", username: current_user.display_id) %>
+                          </label>
+                          <input id="username_confirm_<%= ownership.id %>"
+                                 type="text"
+                                 autocomplete="off"
+                                 spellcheck="false"
+                                 data-confirm-remove-self-target="usernameInput"
+                                 data-action="input->confirm-remove-self#validate"
+                                 class="form__input">
+                          <div class="flex gap-3 justify-end items-center mt-5">
+                            <%= render ButtonComponent.new(
+                              t("owners.index.remove_self_dialog.cancel"),
+                              color: :secondary,
+                              size: :small,
+                              data: { action: "confirm-remove-self#close" }) %>
+                            <%= render ButtonComponent.new(
+                              t("owners.index.remove_self_dialog.submit"),
+                              rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
+                              method: "delete",
+                              disabled: true,
+                              data: { "confirm-remove-self-target": "submitButton" },
+                              color: :red,
+                              size: :small) %>
+                          </div>
+                        </div>
+                      </dialog>
+                    </div>
+                  <% else %>
+                    <%= render ButtonComponent.new(
+                      t("remove"),
+                      rubygem_owner_path(@rubygem.slug, ownership.user.display_id),
+                      method: "delete",
+                      data: { confirm: t("owners.index.confirm_remove") },
+                      color: :red) %>
+                  <% end %>
                 <% end %>
               </div>
             </td>

--- a/app/views/owners/_owners_table.html.erb
+++ b/app/views/owners/_owners_table.html.erb
@@ -65,7 +65,6 @@
                       <%= render ButtonComponent.new(
                         t("remove"),
                         color: :red,
-                        size: :small,
                         data: { action: "confirm-remove-self#open" }) %>
                       <dialog data-confirm-remove-self-target="dialog"
                               class="fixed inset-0 m-0 w-full h-full max-w-none max-h-none border-0 p-0 z-50 open:flex open:items-center open:justify-center open:bg-black/50">
@@ -86,7 +85,7 @@
                                  spellcheck="false"
                                  data-confirm-remove-self-target="usernameInput"
                                  data-action="input->confirm-remove-self#validate"
-                                 class="form__input">
+                                 class="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition">
                           <div class="flex gap-3 justify-end items-center mt-5">
                             <%= render ButtonComponent.new(
                               t("owners.index.remove_self_dialog.cancel"),

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -781,7 +781,14 @@ de:
       info:
       confirmed:
       pending:
+      current_user_badge:
       confirm_remove:
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice:
     create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -700,7 +700,14 @@ en:
       info: add or remove owners
       confirmed: Confirmed
       pending: Pending
+      current_user_badge: you
       confirm_remove: Are you sure you want to remove this user from the owners?
+      remove_self_dialog:
+        title: Remove yourself as owner?
+        warning: "You will lose access to this gem. You will need to ask another owner to re-add you to regain ownership. This cannot be undone."
+        confirm_label: "Type your username (%{username}) to confirm:"
+        submit: Remove my access
+        cancel: Cancel
     resend_confirmation:
       resent_notice: A confirmation mail has been re-sent to your email
     create:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -769,7 +769,14 @@ es:
       info: añadir o eliminar propietarios
       confirmed: Confirmado
       pending: Pendiente
+      current_user_badge:
       confirm_remove: "¿Seguro que quieres eliminar a este usuario de los propietarios?"
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice: Se ha reenviado un mensaje de confirmación a tu correo electrónico
     create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -710,7 +710,14 @@ fr:
       info:
       confirmed:
       pending:
+      current_user_badge:
       confirm_remove:
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice:
     create:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -706,7 +706,14 @@ ja:
       info: 所有者を追加または削除する
       confirmed: 確定
       pending: 保留
+      current_user_badge:
       confirm_remove: このユーザーを所有者から削除されたいとのことでよろしいですか。
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice: 確定メールがEメールに再送されました。
     create:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -693,7 +693,14 @@ nl:
       info:
       confirmed:
       pending:
+      current_user_badge:
       confirm_remove:
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice:
     create:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -704,7 +704,14 @@ pt-BR:
       info:
       confirmed:
       pending:
+      current_user_badge:
       confirm_remove:
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice:
     create:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -698,7 +698,14 @@ zh-CN:
       info: 添加或移除所有者
       confirmed: 已批准
       pending: 待定
+      current_user_badge:
       confirm_remove: 您确定您想要从所有者中移除该用户吗？
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice: 一封确认邮件已被重新发送到您的邮箱中
     create:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -692,7 +692,14 @@ zh-TW:
       info: 新增或移除擁有者
       confirmed: 已確認
       pending: 待確認
+      current_user_badge:
       confirm_remove: 您確定要將此使用者從擁有者名單中移除嗎？
+      remove_self_dialog:
+        title:
+        warning:
+        confirm_label:
+        submit:
+        cancel:
     resend_confirmation:
       resent_notice:
     create:

--- a/test/system/owner_test.rb
+++ b/test/system/owner_test.rb
@@ -108,9 +108,9 @@ class OwnerTest < ApplicationSystemTestCase
     visit_ownerships_page
 
     within_element owner_row(@user) do
-      accept_confirm do
-        click_button "Remove"
-      end
+      click_button "Remove"
+      fill_in "username_confirm_#{@ownership.id}", with: @user.handle
+      click_button "Remove my access"
     end
 
     assert page.has_selector?("a[href='#{profile_path(@user.display_id)}']")
@@ -119,6 +119,65 @@ class OwnerTest < ApplicationSystemTestCase
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
 
     assert_no_emails
+  end
+
+  test "removing self as owner shows username confirmation dialog" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+
+    visit_ownerships_page
+
+    within_element owner_row(@user) do
+      click_button "Remove"
+
+      assert_selector "dialog[open]"
+      assert_selector "[data-confirm-remove-self-target='submitButton'][disabled]"
+    end
+  end
+
+  test "removing self as owner requires correct username before submitting" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+
+    visit_ownerships_page
+
+    within_element owner_row(@user) do
+      click_button "Remove"
+      fill_in "username_confirm_#{@ownership.id}", with: "wrong-handle"
+
+      assert_selector "[data-confirm-remove-self-target='submitButton'][disabled]"
+    end
+  end
+
+  test "removing self as owner succeeds after typing correct username" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+
+    visit_ownerships_page
+
+    within_element owner_row(@user) do
+      perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+        click_button "Remove"
+        fill_in "username_confirm_#{@ownership.id}", with: @user.handle
+        click_button "Remove my access"
+      end
+    end
+
+    refute page.has_selector? "[data-testid='owners_table'] a[href='#{profile_path(@user.display_id)}']"
+  end
+
+  test "cancelling self-removal dialog keeps owner in place" do
+    create(:ownership, user: @other_user, rubygem: @rubygem)
+
+    visit_ownerships_page
+
+    within_element owner_row(@user) do
+      click_button "Remove"
+
+      assert_selector "dialog[open]"
+      click_button "Cancel"
+
+      refute_selector "dialog[open]"
+    end
+
+    assert page.has_selector? "[data-testid='owners_table'] a[href='#{profile_path(@user.display_id)}']"
   end
 
   test "verify using webauthn" do
@@ -346,8 +405,8 @@ class OwnerTest < ApplicationSystemTestCase
 
   def owner_row(owner)
     page.find('[data-testid="owners_table"]')
-      .find(:css, "td[data-title='Name']", text: /^#{owner.handle}$/)
-      .find(:xpath, "./parent::tr")
+      .find(:css, "td[data-title='Name'] a", text: /^#{owner.handle}$/)
+      .find(:xpath, "./parent::td/parent::tr")
   end
 
   def assert_cell(user, column, expected)


### PR DESCRIPTION
Closes #5058

When an owner clicks "Remove" on their own row in the owners table, a custom `<dialog>` opens and requires them to type their username before the submit button enables. Other owners still get the browser `confirm()` since removing someone else is lower risk.

> **Before**: a generic browser confirm
> **After**: a typed-username confirmation modal

### Behavior

- Remove on own row: opens a `<dialog>` with a typed username confirmation
- Submit stays disabled until the typed value matches the username exactly
- Cancel closes without action
- Remove on other owners: unchanged (browser `confirm()`)
- Sole owner removing themselves: same server-side flash error as before
  (see also #5709, which hides the button in that case)

### Design note

The owners page still uses the older BEM-based CSS system (`form__submit`, `owners__cell`, etc.) while the rest of the site has moved to Tailwind. The modal matches that older system on purpose, using the same class conventions and color palette, to keep the page consistent until it gets migrated.

### Changes

- `confirm_remove_self_controller.js`: new Stimulus controller with
  `open`, `close`, and `validate` actions; uses `dialog.show()` per the
  existing project pattern
- `_owners_table.html.erb`: dialog markup for the current user's row,
  plus a "(you)" badge and row highlight
- `owners.css`: dialog overlay styles
- `config/locales/en.yml` + other locales (via `bin/fill-locales`)
- `test/system/owner_test.rb`: 4 new system tests, existing tests updated

### Screenshot

<img width="985" height="835" alt="image" src="https://github.com/user-attachments/assets/9da60d70-5499-4f0f-91c7-152a392a5c40" />

### Test plan

- [x] Remove on own row → modal opens, submit disabled
- [x] Type wrong username → submit stays disabled
- [x] Type correct username → submit enables, deletion proceeds
- [x] Cancel → modal closes, owner stays
- [x] Remove on another owner → browser confirm, unchanged
- [x] Sole owner removes themselves → flash error, unchanged