### PR TITLE
Apply field_class to trusted_publisher_type select

### DIFF
--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -30,7 +30,8 @@ class OIDC::PendingTrustedPublishers::NewView < ApplicationView
           f.label :trusted_publisher_type, class: label_class
           f.select :trusted_publisher_type,
             OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
-            {}
+            {},
+            class: field_class
         end
 
         render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(

--- a/app/views/oidc/rubygem_trusted_publishers/new_view.rb
+++ b/app/views/oidc/rubygem_trusted_publishers/new_view.rb
@@ -22,7 +22,8 @@ class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
             f.label :trusted_publisher_type, class: label_class
             f.select :trusted_publisher_type,
               OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
-              {}
+              {},
+              class: field_class
           end
 
           render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
@@ -41,5 +42,11 @@ class OIDC::RubygemTrustedPublishers::NewView < ApplicationView
 
   def label_class
     "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"
+  end
+
+  def field_class
+    "block w-full rounded border border-neutral-300 dark:border-neutral-700 " \
+      "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 h-12 " \
+      "outline-none focus:border-neutral-500 focus:ring-0"
   end
 end


### PR DESCRIPTION
The select input on the new (pending) trusted publisher pages had no styling, so in dark mode the browser default rendered a white background with white option text and became unreadable.

Reuse the existing `field_class` so the select matches the surrounding text inputs in both light and dark modes.

| mode | before | after |
| - | - | - |
| light | <img width="199" height="106" alt="スクリーンショット 2026-07-06 18 12 20" src="https://github.com/user-attachments/assets/8e5607a7-4acd-454f-9bc9-8cf462ea2d34" /> | <img width="726" height="118" alt="スクリーンショット 2026-07-06 18 12 31" src="https://github.com/user-attachments/assets/207e564f-017e-4570-8f51-ba643811c544" /> |
| dark | <img width="206" height="106" alt="スクリーンショット 2026-07-06 18 10 46" src="https://github.com/user-attachments/assets/ee9267cd-91f4-4ef0-87eb-55190c7e46ef" /> | <img width="877" height="116" alt="スクリーンショット 2026-07-06 17 42 45" src="https://github.com/user-attachments/assets/2fd44dfd-57a5-4e11-b7e5-a0a5a2752495" /> |