### PR TITLE
Workaround: Temporarily patch OAuth2 secure_compare

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -40,7 +40,7 @@ OmniAuth.config.on_failure = FailureEndpoint
 # https://github.com/omniauth/omniauth-oauth2/issues/189#issuecomment-4624416883
 # https://github.com/omniauth/omniauth-oauth2/pull/186
 OmniAuth::Strategies::OAuth2.prepend(Module.new do
-  def secure_compare(a, b)
-    super(a.to_s, b.to_s)
+  def secure_compare(string_a, string_b)
+    super(string_a.to_s, string_b.to_s)
   end
 end)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -30,3 +30,17 @@ class FailureEndpoint < OmniAuth::FailureEndpoint
 end
 
 OmniAuth.config.on_failure = FailureEndpoint
+
+# TODO: Delete this when pull#186 is merged for omniauth-oauth2
+# TLDR: There's a bug in the comparison for the `state` value if the state from the omniauth callback
+#   is not yet set in the session. Deleting the params from the session causes a nil-byte error that bubbles
+#   up to OmniAuth's catch for StandardErrors and will redirect to our FailureEndpoint
+#   - We can avoid this by calling .to_s on nil and returning "" in the secure_compare
+# https://github.com/omniauth/omniauth-oauth2/issues/189
+# https://github.com/omniauth/omniauth-oauth2/issues/189#issuecomment-4624416883
+# https://github.com/omniauth/omniauth-oauth2/pull/186
+OmniAuth::Strategies::OAuth2.prepend(Module.new do
+  def secure_compare(a, b)
+    super(a.to_s, b.to_s)
+  end
+end)


### PR DESCRIPTION
Why this change is being made:
- When we redirect back to our OAuth2 callback flow we get to a point where the OAuth2 library is doing a secure_compare on our session["omniauth.state"] before our session has an "omniauth.state" set. We still get a valid state from Github but it is not set in the session at the time of comparison.
  - This causes a nil error which bubbles up and is caught by OmniAuth which kicks us over to our FailureEndpoint with the failure message from the error

What were the changes made to support this:
- Temporarily overwrite secure_compare for omniauth so that we are always comparing strings and never nil.

See:
https://github.com/omniauth/omniauth-oauth2/issues/189 
https://github.com/omniauth/omniauth-oauth2/issues/189#issuecomment-4624416883 https://github.com/omniauth/omniauth-oauth2/pull/186