### PR TITLE
Render gem summaries without double-escaping them

### DIFF
--- a/app/views/components/rubygem_component.rb
+++ b/app/views/components/rubygem_component.rb
@@ -6,7 +6,7 @@ class RubygemComponent < ApplicationComponent
   extend Phlex::Rails::HelperMacros
 
   register_output_helper :download_count_component
-  register_value_helper :short_info
+  register_output_helper :short_info
   register_value_helper :latest_version_number
 
   prop :rubygem
@@ -26,7 +26,7 @@ class RubygemComponent < ApplicationComponent
 
       div(class: "flex flex-row w-full items-center justify-between mt-1") do
         p(class: "text-b3 text-neutral-600 dark:text-neutral-400 truncate flex-1 mr-4") do
-          plain short_info(@rubygem)
+          short_info(@rubygem)
         end
         download_count_component(@rubygem)
       end

--- a/test/views/rubygem_component_test.rb
+++ b/test/views/rubygem_component_test.rb
@@ -39,6 +39,21 @@ class RubygemComponentTest < ComponentTest
     assert_text view_context.short_info(@rubygem)
   end
 
+  should "display quotes in the gem description without escaping them" do
+    @rubygem.latest_version.update!(description: "Generate 'Add To Calendar' URLs")
+    render RubygemComponent.new(rubygem: @rubygem.reload)
+
+    assert_text "Generate 'Add To Calendar' URLs"
+  end
+
+  should "sanitize html in the gem description" do
+    @rubygem.latest_version.update!(description: "<script>alert('foo');</script>Rails authentication & authorization")
+    render RubygemComponent.new(rubygem: @rubygem.reload)
+
+    refute_selector "script", visible: :all
+    assert_text "alert('foo');Rails authentication & authorization"
+  end
+
   should "not display a version badge when the version number is absent" do
     @rubygem.latest_version.stubs(:number).returns(nil)
     render RubygemComponent.new(rubygem: @rubygem)


### PR DESCRIPTION
Before, RubygemComponent registered `short_info` as a Phlex value helper and emitted it with `plain`. The helper already returns a sanitized, html_safe string via `escape_once(sanitize(info))`.

Passing that safe string through `plain` escapes it a second time, so a gem whose summary contains a quote or ampersand renders as `Generate &#39;Add To Calendar&#39; URLs` on the page.

Now it is registered as an output helper and written straight to the buffer, which emits the already-sanitized markup as-is. Sanitization is unaffected: script elements are still stripped before the string is marked safe, and a test covers that.

<img width="2682" height="1160" alt="screenshot-2026-07-10-at-11 49 32@2x" src="https://github.com/user-attachments/assets/483cfc24-c4f1-4f64-87c3-58d53b6643aa" />