### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/actions/setup-rubygems.org/action.yml
+++ b/.github/actions/setup-rubygems.org/action.yml
@@ -25,8 +25,8 @@ runs:
     - name: Configure bundler environment
       shell: bash
       if: inputs.install-avo-pro == 'true'
-      run: |
-        printf "BUNDLE_WITH=avo\nRAILS_GROUPS=avo\n" >> $GITHUB_ENV
+      run: | # zizmor: ignore[github-env] Only literal, trusted values are written.
+        printf "BUNDLE_WITH=avo\nRAILS_GROUPS=avo\n" >> "$GITHUB_ENV"
     - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
   versioning-strategy: increase
   groups:
     avo:
@@ -22,6 +24,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
   groups:
     github-actions-patch-minor:
       patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,17 +20,20 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
-permissions: # added using https://github.com/step-security/secure-workflows
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
-      actions: read
       contents: read
-      security-events: write
+      security-events: write # Needed to upload CodeQL results to code scanning
 
     strategy:
       fail-fast: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,12 +29,16 @@ on:
       - docker-compose.yml
       - config/database.yml.sample
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,26 +5,33 @@ on:
     branches:
       - master
       - oidc-api-tokens
-permissions:
-  contents: read
+
+concurrency:
+  # PR runs supersede each other; push runs publish unique SHA tags and must finish.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   build:
     name: Docker build (and optional push)
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       RUBYGEMS_VERSION: "4.0.12"
       RUBY_VERSION: .ruby-version
       RUBYGEMS_ORG_SECRETS_AVAILABLE: ${{ github.repository == 'rubygems/rubygems.org' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'rubygems/rubygems.org') }}
     permissions:
-      id-token: write
+      contents: read
+      id-token: write # Needed to authenticate to AWS through OIDC
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # master
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Cache Docker layers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,20 @@ on:
   push:
     branches:
       - master
-permissions:
-  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -23,6 +30,9 @@ jobs:
   herb:
     name: Herb 🌿
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -35,6 +45,9 @@ jobs:
   brakeman:
     name: Brakeman
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -47,6 +60,9 @@ jobs:
   importmap:
     name: Importmap Verify
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -59,6 +75,9 @@ jobs:
   prettier:
     name: Prettier
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -71,6 +90,9 @@ jobs:
   kubeconform:
     name: Kubeconform
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       matrix:
         kubernetes_version: ["1.29.1"]
@@ -79,7 +101,9 @@ jobs:
           - production
     steps:
       - name: login to Github Packages
-        run: echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        run: printf '%s\n' "$GHCR_TOKEN" | docker login https://ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+        env:
+          GHCR_TOKEN: ${{ github.token }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -88,7 +112,7 @@ jobs:
           bundler-cache: true
       - name: krane render
         run: |
-          gem exec --silent krane render -f config/deploy/$ENVIRONMENT --bindings=environment=$ENVIRONMENT --current-sha=$REVISION > config/deploy/$ENVIRONMENT.rendered.yaml
+          gem exec --silent krane render -f "config/deploy/$ENVIRONMENT" --bindings="environment=$ENVIRONMENT" --current-sha="$REVISION" > "config/deploy/$ENVIRONMENT.rendered.yaml"
         env:
           ENVIRONMENT: "${{ matrix.environment }}"
           REVISION: "${{ github.sha }}"
@@ -104,6 +128,9 @@ jobs:
   frizbee:
     name: Frizbee
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -118,31 +145,19 @@ jobs:
           fail_on_unpinned: true
           open_pr: false
           repo_root: "."
+
   zizmor:
     name: zizmor
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
-      security-events: write
-      # required for workflows in private repositories
+      security-events: write # Needed to upload zizmor results to code scanning
       contents: read
-      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
-
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,22 +14,25 @@ on:
   # push:
   #   branches: [ "master" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Deny permissions by default; the analysis job grants only what it needs.
+permissions: {}
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
+      contents: read
+      security-events: write # Needed to upload results to the code-scanning dashboard
+      id-token: write # Needed to publish results and generate the Scorecard badge
+      # Uncomment the permission below if installing in a private repository.
       # actions: read
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - master
-permissions:
-  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   rails:
@@ -24,6 +28,9 @@ jobs:
             command: "test test/*/avo"
     name: Rails tests ${{ matrix.tests.name }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
     env:
       RUBYGEMS_VERSION: "4.0.12"
       # Fail hard when Toxiproxy is not running to ensure all tests (even Toxiproxy optional ones) are passing
@@ -56,7 +63,12 @@ jobs:
 
       - name: Tests ${{ matrix.tests.name }}
         id: test-all
-        run: bin/rails ${{ matrix.tests.command }}
+        run: |
+          # Intentional splitting and glob expansion for the static matrix command.
+          # shellcheck disable=SC2086
+          bin/rails $TEST_COMMAND
+        env:
+          TEST_COMMAND: ${{ matrix.tests.command }}
 
       - name: Save capybara screenshots
         if: ${{ failure() && steps.test-all.outcome == 'failure' }}


### PR DESCRIPTION
Workflow-config hardening from a zizmor audit: deny-by-default permissions with least-privilege per-job grants, concurrency groups, job timeouts, 7-day Dependabot cooldowns, and the SHA-pinned zizmor-action in place of the hand-rolled uvx/SARIF job. No application code; secret scoping is unchanged and deferred to a follow-up. `actionlint` and `zizmor .` clean locally.
