### PR TITLE
Adjust Ordering to Prevent Over-Eager Matches

### DIFF
--- a/config/deploy/nginx-configmap.yaml.erb
+++ b/config/deploy/nginx-configmap.yaml.erb
@@ -45,10 +45,10 @@ data:
         ~^/api/v\d+/dependencies$                     /api/vN/dependencies;
         ~^/api/v\d+/dependencies\.json$               /api/vN/dependencies.json;
         ~^/api/v\d+/timeframe_versions\.json$         /api/vN/timeframe_versions.json;
-        ~^/gems/[^/]+(/.*)?$                          /gems/GEM_NAME$1;
-        ~^/api/v\d+/gems/[^/]+(/.*)?$                 /api/vN/gems/GEM_NAME$1;
         ~^/api/v\d+/gems/[^/]+/versions/[^/]+(/.*)?$  /api/vN/gems/GEM_NAME/versions/VERSION$1;
+        ~^/api/v\d+/gems/[^/]+(/.*)?$                 /api/vN/gems/GEM_NAME$1;
         ~^/gems/[^/]+/versions/[^/]+(/.*)?$           /gems/GEM_NAME/versions/VERSION$1;
+        ~^/gems/[^/]+(/.*)?$                          /gems/GEM_NAME$1;
         ~^/search\?.*$                                /search?QUERY;
         ~^/versions/[^/]+(/.*)?$                      /versions/VERSION$1;
         ~^/api/v\d+/search\?.*$                       /api/vN/search?QUERY;


### PR DESCRIPTION
I had made changes in a previous commit to get cardinality under control when reporting metrics. However, the ordering used would cause some paths to be merged unintentionally.

This is meant to fix an issue shipped in https://github.com/rubygems/rubygems.org/pull/5974