### PR TITLE
🎳 Group Remaining Minor and Match Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       patterns: ["aws-*"]
     flipper:
       patterns: ["flipper*"]
+    minor-and-patch:
+      patterns: ["*"]
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Any non-major updates outside the the `avo`, `rubocop`, `rails`, `aws` and `flipper` groups should be grouped in the new `minor-and-patch` group.

Closes: https://github.com/rubygems/rubygems.org/issues/6538