### PR TITLE
Isolate the names cache to fix a flaky compact index test

### DIFF
--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 class Api::CompactIndexTest < ActionDispatch::IntegrationTest
   setup do
+    Rails.cache.delete("names")
+
     @rubygem2 = create(:rubygem, name: "gemB")
     @version = create(:version, rubygem: @rubygem2, number: "1.0.0", **checksum_attribute("v2qw2dwe"))
 
@@ -33,6 +35,10 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     create(:dependency, rubygem: dep2, version: @gem_a_v21)
   end
 
+  teardown do
+    Rails.cache.delete("names")
+  end
+
   test "/names output" do
     get names_path
 
@@ -54,6 +60,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
   test "/names partial response" do
     get names_path
     full_body = @response.body
+
+    assert_operator full_body.bytesize, :>, 15
 
     get names_path, env: { range: "bytes=15-" }
 


### PR DESCRIPTION
`Api::CompactIndexTest#test_/names_partial_response` fails intermittently in CI. The test environment shares one memcached, and `GemInfo.ordered_names` caches the gem list under a global `names` key that is never cleared between tests, so a prior test can leave a shorter list cached; the request then returns a body under 15 bytes and `full_body.byteslice(15..)` evaluates to `nil`, tripping the assertion.

This clears the `names` key in setup and teardown so each test derives the list from its own data, and adds a `bytesize > 15` guard so a stale or truncated response fails with a clear message instead of a confusing `nil` mismatch. The delete is scoped to the key (not `Rails.cache.clear`) and respects the per-worker cache namespace, so it stays safe under parallel tests.

Verified by running the integration suite under parallelization across several seeds; the compact index tests pass consistently.
