### PR TITLE
Redesign: Update MFA verification

### DIFF
--- a/app/controllers/multifactor_auths_controller.rb
+++ b/app/controllers/multifactor_auths_controller.rb
@@ -5,6 +5,8 @@ class MultifactorAuthsController < ApplicationController
   include RequireMfa
   include WebauthnVerifiable
 
+  layout "hammy"
+
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :require_mfa_enabled, only: %i[update otp_update]
   before_action :find_mfa_user, only: %i[update otp_update webauthn_update]

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -10,6 +10,8 @@ class WebauthnVerificationsController < ApplicationController
   before_action :set_verification, :set_user, except: %i[successful_verification failed_verification]
   before_action :check_show_verification_status, only: %i[successful_verification failed_verification]
 
+  layout "hammy"
+
   def prompt
     redirect_to root_path, alert: t(".no_port") unless (port = params[:port])
     redirect_to root_path, alert: t(".no_webauthn_devices") if @user.webauthn_credentials.blank?

--- a/app/views/multifactor_auths/recovery.html.erb
+++ b/app/views/multifactor_auths/recovery.html.erb
@@ -1,25 +1,42 @@
 <% @title = t(".title") %>
 
-<%= tag.div(
-  class: "t-body",
-  data: {
-    controller: "clipboard",
-    clipboard_success_content_value: t('copied')
-  }
-) do %>
-  <p><%= t ".note_html" %></p>
+<div class="flex items-center justify-center">
+  <div
+    class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10"
+    data-controller="clipboard"
+    data-clipboard-success-content-value="<%= t('copied') %>"
+  >
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t(".title") %></h1>
 
-  <%# This tag contains the recovery codes and should not be a part of the form %>
-  <%= text_area_tag "source", "#{@mfa_recovery_codes.join("\n")}\n", class: "recovery-code-list", rows: @mfa_recovery_codes.size + 1, cols: @mfa_recovery_codes.first.length + 1, readonly: true, data: { clipboard_target: "source" } %>
+    <p class="mb-6 text-b3 text-neutral-700 dark:text-neutral-300"><%= t ".note_html" %></p>
 
-  <%= form_tag(@continue_path, method: "get", class: "form", data: { controller: "recovery", recovery_confirm_value: t(".confirm_dialog"), action: "recovery#submit" }) do %>
-    <p><%= link_to t("copy_to_clipboard"), "#/", class: "t-link--bold recovery__copy__icon", data: { action: "clipboard#copy recovery#copy", clipboard_target: "button" } %></p>
+    <%# This tag contains the recovery codes and should not be a part of the form %>
+    <%= text_area_tag "source", "#{@mfa_recovery_codes.join("\n")}\n",
+      class: "recovery-code-list w-full px-4 py-3 mb-4 font-mono text-sm border border-neutral-300 dark:border-neutral-600 " \
+             "rounded-lg bg-neutral-050 dark:bg-neutral-900 text-neutral-900 dark:text-white resize-none " \
+             "focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none transition",
+      rows: @mfa_recovery_codes.size + 1,
+      readonly: true,
+      data: { clipboard_target: "source" } %>
 
-    <div class = "form__checkbox__item">
-      <%= check_box_tag "checked", "ack", false, required: true, class: "form__checkbox__input" %>
-      <%= label_tag "checked", t(".saved"), class: "form__checkbox__label" %>
-    </div>
+    <%= form_tag(@continue_path, method: "get", data: { controller: "recovery", recovery_confirm_value: t(".confirm_dialog"), action: "recovery#submit" }) do %>
+      <p class="mb-6">
+        <%= link_to t("copy_to_clipboard"), "#/",
+          class: "inline-flex items-center text-b3 font-semibold text-orange-500 hover:text-orange-600 dark:hover:text-orange-400 transition",
+          data: { action: "clipboard#copy recovery#copy", clipboard_target: "button" } %>
+      </p>
 
-    <%= button_tag t(".continue"), class: "form__submit form__submit--no-hover" %>
-  <% end %>
-<% end %>
+      <div class="flex items-center gap-3 mb-8">
+        <%= check_box_tag "checked", "ack", false, required: true, class: "h-4 w-4 rounded border-neutral-300 text-orange-500 focus:ring-orange-500" %>
+        <%= label_tag "checked", t(".saved"), class: "text-sm text-neutral-700 dark:text-neutral-300" %>
+      </div>
+
+      <%# ButtonComponent is intentionally not used here: it forces `disable_with`, which would leave the
+          button stuck-disabled when the user cancels the "leave without copying" confirm dialog. %>
+      <%= button_tag t(".continue"),
+        class: "inline-flex items-center justify-center text-nowrap no-underline hover:shadow-md transition duration-200 ease-in-out " \
+               "focus:outline-2 focus:outline-offset-2 focus:outline-orange-500 text-white bg-orange-500 hover:bg-orange-600 active:bg-orange-600 " \
+               "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 px-4 py-3 h-12 min-h-12 text-b2 rounded" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/webauthn_verifications/failed_verification.html.erb
+++ b/app/views/webauthn_verifications/failed_verification.html.erb
@@ -1,13 +1,12 @@
 <% @title = t(".title") %>
 
-<div>
-  <svg version="1.1" class="status-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-    <circle class="path circle" fill="none" stroke="#D06079" stroke-width="6" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
-    <line class="path line" fill="none" stroke="#D06079" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" x1="34.4" y1="37.9" x2="95.8" y2="92.3"/>
-    <line class="path line" fill="none" stroke="#D06079" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" x1="95.8" y1="38" x2="34.4" y2="92.2"/>
-  </svg>
-  <div class="status error">
-    <p><%= @message %></p>
-    <p><%= t(".close_browser") %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10 text-center">
+    <%= icon_tag "error", size: 16, class: "mx-auto mb-6 text-red-500" %>
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-3"><%= t(".title") %></h1>
+    <% if @message.present? %>
+      <p class="mb-2 text-b3 text-red-600 dark:text-red-400"><%= @message %></p>
+    <% end %>
+    <p class="text-b3 text-neutral-700 dark:text-neutral-300"><%= t(".close_browser") %></p>
   </div>
 </div>

--- a/app/views/webauthn_verifications/prompt.html.erb
+++ b/app/views/webauthn_verifications/prompt.html.erb
@@ -1,16 +1,24 @@
-<% @title = t(".title")%>
+<% @title = t(".title") %>
 
-<% if @user.webauthn_enabled? %>
-  <div class="t-body">
-    <h2><%= t(".authenticating_as") %> <%= @user.name %></h2>
-    <p><%= t("settings.edit.webauthn_credential_note") %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10">
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-6"><%= t(".title") %></h1>
+
+    <% if @user.webauthn_enabled? %>
+      <h2 class="font-bold text-b2 text-neutral-900 dark:text-white mb-4">
+        <%= t(".authenticating_as") %> <%= @user.name %>
+      </h2>
+      <p class="mb-6 text-b3 text-neutral-700 dark:text-neutral-300"><%= t("settings.edit.webauthn_credential_note") %></p>
+
+      <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session-cli--form", data: { options: @webauthn_options.to_json } do %>
+        <p hidden class="js-webauthn-session-cli--error mb-3 text-b3 text-red-600 dark:text-red-400"></p>
+
+        <%= submit_tag t(".authenticate"),
+          class: "js-webauthn-session-cli--submit inline-flex items-center justify-center w-full rounded text-white bg-orange-500 " \
+                 "px-4 min-h-12 text-b2 cursor-pointer hover:bg-orange-600 active:bg-orange-600 " \
+                 "dark:bg-orange-500 dark:hover:bg-orange-700 dark:active:bg-orange-700 transition " \
+                 "focus:outline-2 focus:outline-offset-2 focus:outline-orange-500" %>
+      <% end %>
+    <% end %>
   </div>
-
-  <%= form_tag @webauthn_verification_url, method: :post, class: "js-webauthn-session-cli--form", data: { options: @webauthn_options.to_json } do %>
-    <div class="form_bottom">
-      <p hidden class="l-text-red-600 js-webauthn-session-cli--error"></p>
-
-      <%= submit_tag t(".authenticate"), class: 'js-webauthn-session-cli--submit form__submit form__submit--no-hover' %>
-    </div>
-  <% end %>
-<% end %>
+</div>

--- a/app/views/webauthn_verifications/successful_verification.html.erb
+++ b/app/views/webauthn_verifications/successful_verification.html.erb
@@ -1,9 +1,9 @@
 <% @title = t(".title") %>
 
-<div>
-  <svg version="1.1" class="status-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-    <circle class="path circle" fill="none" stroke="#73AF55" stroke-width="6" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
-    <polyline class="path check" fill="none" stroke="#73AF55" stroke-width="6" stroke-linecap="round" stroke-miterlimit="10" points="100.2,40.2 51.5,88.8 29.8,67.5 "/>
-  </svg>
-  <p class="status success"><%= t(".close_browser") %></p>
+<div class="flex items-center justify-center">
+  <div class="max-w-lg w-full bg-white dark:bg-black border border-neutral-200 dark:border-neutral-800 rounded-xl shadow-md p-10 text-center">
+    <%= icon_tag "check-circle", size: 16, class: "mx-auto mb-6 text-green-500" %>
+    <h1 class="text-xl font-semibold text-neutral-900 dark:text-white mb-3"><%= t(".title") %></h1>
+    <p class="text-b3 text-neutral-700 dark:text-neutral-300"><%= t(".close_browser") %></p>
+  </div>
 </div>

--- a/test/system/webauthn_verification_test.rb
+++ b/test/system/webauthn_verification_test.rb
@@ -15,7 +15,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     assert_text "Authenticate with Security Device"
-    assert_text "Authenticating as #{@user.handle}".upcase
+    assert_text "Authenticating as #{@user.handle}"
 
     click_on "Authenticate"
 
@@ -31,7 +31,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     assert_text "Authenticate with Security Device"
-    assert_text "Authenticating as #{@user.handle}".upcase
+    assert_text "Authenticating as #{@user.handle}"
 
     click_on "Authenticate"
 
@@ -49,7 +49,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     assert_text "Authenticate with Security Device"
-    assert_text "Authenticating as #{@user.handle}".upcase
+    assert_text "Authenticating as #{@user.handle}"
 
     @mock_client.kill_server
     click_on "Authenticate"
@@ -67,7 +67,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: wrong_port })
 
     assert_text "Authenticate with Security Device"
-    assert_text "Authenticating as #{@user.handle}".upcase
+    assert_text "Authenticating as #{@user.handle}"
 
     click_on "Authenticate"
 
@@ -84,7 +84,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
     visit webauthn_verification_path(webauthn_token: @verification.path_token, params: { port: @port })
 
     assert_text "Authenticate with Security Device"
-    assert_text "Authenticating as #{@user.handle}".upcase
+    assert_text "Authenticating as #{@user.handle}"
 
     click_on "Authenticate"
 
@@ -100,7 +100,7 @@ class WebAuthnVerificationTest < ApplicationSystemTestCase
 
     travel 3.minutes do
       assert_text "Authenticate with Security Device"
-      assert_text "Authenticating as #{@user.handle}".upcase
+      assert_text "Authenticating as #{@user.handle}"
 
       click_on "Authenticate"
 


### PR DESCRIPTION
Why this change is being made:
- These are the pages for the MFA challenge and to save the recovery code for setting up a new MFA.

What were the changes made to support this:
- Swap to using the Hammy style layout

<img width="1278" height="685" alt="image" src="https://github.com/user-attachments/assets/1b714c54-4f9f-4c0e-ace2-1b98fcebeda9" />
<img width="1278" height="685" alt="image" src="https://github.com/user-attachments/assets/4ac0b85d-d2c1-49b5-938a-fa8477453d9c" />

AND 

<img width="1300" height="787" alt="image" src="https://github.com/user-attachments/assets/17eb0697-e650-468d-8959-349c2cd6cf91" />
<img width="1137" height="1022" alt="image" src="https://github.com/user-attachments/assets/bb7e19bc-7ecb-45d2-b266-229ee213e006" />
