### PR TITLE
Add a previous API keys view to the profile page

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -12,9 +12,13 @@ class ApiKeysController < ApplicationController
   verify_session_before
 
   def index
-    @api_key  = session.delete(:api_key)
-    @api_keys = current_user.api_keys.unexpired.not_oidc.preload(ownership: :rubygem).page(@page)
-    redirect_to new_profile_api_key_path if @api_keys.empty?
+    @api_key = session.delete(:api_key)
+    @expired_view = params[:expired] == "true"
+    api_keys = current_user.api_keys.not_oidc
+    @has_expired_keys = api_keys.expired.exists?
+    scope = @expired_view ? api_keys.expired.order(expires_at: :desc, id: :desc) : api_keys.unexpired
+    @api_keys = scope.preload(ownership: :rubygem).page(@page)
+    redirect_to new_profile_api_key_path if !@expired_view && @api_keys.empty? && !@has_expired_keys
   end
 
   def new
@@ -23,9 +27,14 @@ class ApiKeysController < ApplicationController
 
   def edit
     @api_key = current_user.api_keys.find(params.expect(:id))
-    return unless @api_key.soft_deleted?
+    error = if @api_key.soft_deleted?
+              t(".invalid_key")
+            elsif @api_key.expired?
+              t(".expired_key")
+            end
+    return if error.blank?
 
-    flash[:error] = t(".invalid_key")
+    flash[:error] = error
     redirect_to profile_api_keys_path
   end
 
@@ -71,7 +80,9 @@ class ApiKeysController < ApplicationController
   def destroy
     api_key = current_user.api_keys.find(params.expect(:id))
 
-    if api_key.expire!
+    if api_key.expired?
+      flash[:error] = t(".already_expired")
+    elsif api_key.expire!
       flash[:notice] = t(".success", name: api_key.name)
     else
       flash[:error] = api_key.errors.full_messages.to_sentence

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -43,8 +43,8 @@ module ApiKeysHelper
     content_tag(
       :span,
       "#{name} [?]",
-      class: "tooltip__text",
-      data: { tooltip: t("api_keys.gem_ownership_removed", rubygem_name: name) }
+      class: "cursor-help",
+      title: t("api_keys.gem_ownership_removed", rubygem_name: name)
     )
   end
 end

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -35,10 +35,17 @@
   <div class="flex">
     <div class="grow mt-8 mb-4 pr-4">
       <p class="text-b4 text-neutral-600 dark:text-neutral-400"><%= page_entries_info @api_keys, entry_name: "API keys" %></p>
+      <% if @expired_view %>
+        <%= link_to t(".view_active"), profile_api_keys_path, class: "text-b3 text-orange-500 underline dark:text-orange-400" %>
+      <% elsif @has_expired_keys %>
+        <%= link_to t(".view_expired"), profile_api_keys_path(expired: "true"), class: "text-b3 text-orange-500 underline dark:text-orange-400" %>
+      <% end %>
     </div>
-    <div class="flex-initial mt-6 mb-4">
-      <%= button_to t(".reset"), reset_profile_api_keys_path, method: :delete, class: "#{danger_btn} right", data: { confirm: t(".confirm_all") } %>
-    </div>
+    <% unless @expired_view %>
+      <div class="flex-initial mt-6 mb-4">
+        <%= button_to t(".reset"), reset_profile_api_keys_path, method: :delete, class: "#{danger_btn} right", data: { confirm: t(".confirm_all") } %>
+      </div>
+    <% end %>
   </div>
 
   <div class="overflow-x-auto">
@@ -54,12 +61,14 @@
           <% end %>
           <th scope="col" class="<%= th_class %>"><%= t(".last_access") %></th>
           <th scope="col" class="<%= th_class %>"><%= t(".expiration") %></th>
-          <th scope="col" class="<%= th_class %>"><span class="sr-only"><%= t(".action") %></span></th>
+          <% unless @expired_view %>
+            <th scope="col" class="<%= th_class %>"><span class="sr-only"><%= t(".action") %></span></th>
+          <% end %>
         </tr>
       </thead>
       <tbody class="md:divide-y md:divide-neutral-200 md:dark:divide-neutral-800">
         <% @api_keys.each do |api_key| %>
-          <tr data-soft-deleted="<%= api_key.soft_deleted? %>" class="block md:table-row border-b border-neutral-200 py-4 dark:border-neutral-800 md:border-0 md:py-0 <%= "opacity-60" if api_key.soft_deleted? %>">
+          <tr data-soft-deleted="<%= api_key.soft_deleted? %>" class="block md:table-row border-b border-neutral-200 py-4 dark:border-neutral-800 md:border-0 md:py-0 <%= "opacity-60" if api_key.soft_deleted? && !@expired_view %>">
             <td data-title="<%= t('.name') %>" class="<%= cell_class %> font-medium text-neutral-900 dark:text-white"><%= api_key.name %></td>
             <td data-title="<%= t('.scopes') %>" class="<%= cell_class %>">
               <span class="flex flex-wrap gap-1">
@@ -77,14 +86,16 @@
             <% end %>
             <td data-title="<%= t('.last_access') %>" class="<%= cell_class %> text-nowrap text-neutral-700 dark:text-neutral-300"><%= api_key.last_accessed_at&.strftime("%Y-%m-%d %H:%M %Z") %></td>
             <td data-title="<%= t('.expiration') %>" class="<%= cell_class %> text-nowrap text-neutral-700 dark:text-neutral-300"><%= api_key.expires_at&.strftime("%Y-%m-%d %H:%M %Z") %></td>
-            <td class="block py-2 align-top md:table-cell md:py-3">
-              <div class="flex gap-2">
-                <% unless api_key.soft_deleted? %>
-                  <%= button_to t("edit"), edit_profile_api_key_path(id: api_key.id), method: :get, class: edit_btn %>
-                <% end %>
-                <%= button_to t(".delete"), profile_api_key_path(id: api_key.id), method: :delete, class: danger_btn, data: { confirm: t(".confirm") } %>
-              </div>
-            </td>
+            <% unless @expired_view %>
+              <td class="block py-2 align-top md:table-cell md:py-3">
+                <div class="flex gap-2">
+                  <% unless api_key.soft_deleted? %>
+                    <%= button_to t("edit"), edit_profile_api_key_path(id: api_key.id), method: :get, class: edit_btn %>
+                  <% end %>
+                  <%= button_to t(".delete"), profile_api_key_path(id: api_key.id), method: :delete, class: danger_btn, data: { confirm: t(".confirm") } %>
+                </div>
+              </td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -191,6 +191,7 @@ de:
       invalid_gem: Das ausgewählte Gem kann diesem Schlüssel nicht zugeordnet werden
     destroy:
       success: 'API-Schlüssel erfolgreich gelöscht: %{name}'
+      already_expired:
     index:
       api_keys: API-Schlüssel
       name: Name
@@ -217,6 +218,8 @@ de:
       mfa: MFA
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key: Neuer API-Schlüssel
     reset:
@@ -228,6 +231,7 @@ de:
       edit_api_key: API-Schlüssel bearbeiten
       invalid_key: Ein ungültiger API-Schlüssel kann nicht bearbeitet werden. Bitte
         löschen Sie ihn und erstellen Sie einen neuen.
+      expired_key:
     all_gems: Alle Gems
     gem_ownership_removed: Die Eigentümerschaft von %{rubygem_name} wurde nach der
       Zuordnung zu diesem Schlüssel entfernt.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,7 @@ en:
       invalid_gem: Selected gem cannot be scoped to this key
     destroy:
       success: "Successfully deleted API key: %{name}"
+      already_expired: The API key has already expired.
     index:
       api_keys: API keys
       name: Name
@@ -207,6 +208,8 @@ en:
       mfa: MFA
       expiration: Expiration
       update_owner: Update Owner
+      view_expired: View previous API keys
+      view_active: Back to active API keys
     new:
       new_api_key: New API key
     reset:
@@ -217,6 +220,7 @@ en:
     edit:
       edit_api_key: "Edit API key"
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
+      expired_key: An expired API key cannot be edited. Please create a new one.
     all_gems: All Gems
     gem_ownership_removed: Ownership of the %{rubygem_name} gem has been removed after being scoped to this key.
   dashboards:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -187,6 +187,7 @@ es:
       invalid_gem: La gema seleccionada no se puede incluir en esta clave
     destroy:
       success: 'Clave de API eliminada con éxito: %{name}'
+      already_expired:
     index:
       api_keys: Claves de API
       name: Nombre
@@ -213,6 +214,8 @@ es:
       mfa: AMF
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key: Nueva clave de API
     reset:
@@ -225,6 +228,7 @@ es:
       edit_api_key: Editar clave de API
       invalid_key: No se puede editar una clave de API inválida. Por favor bórrala
         y crea una nueva.
+      expired_key:
     all_gems: Todas las gemas
     gem_ownership_removed: Se ha eliminado la propiedad de %{rubygem_name} tras haber
       sido añadida a esta clave.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -182,6 +182,7 @@ fr:
       invalid_gem:
     destroy:
       success:
+      already_expired:
     index:
       api_keys:
       name:
@@ -207,6 +208,8 @@ fr:
       mfa:
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key:
     reset:
@@ -217,6 +220,7 @@ fr:
     edit:
       edit_api_key:
       invalid_key:
+      expired_key:
     all_gems:
     gem_ownership_removed:
   dashboards:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -178,6 +178,7 @@ ja:
       invalid_gem: 選択されたgemはこのキーのスコープにありません
     destroy:
       success: APIキーが正常に削除されました：%{name}
+      already_expired:
     index:
       api_keys: APIキー
       name: 名前
@@ -203,6 +204,8 @@ ja:
       mfa: MFA
       expiration: 期限
       update_owner: 所有者を更新
+      view_expired:
+      view_active:
     new:
       new_api_key: 新しいAPIキー
     reset:
@@ -213,6 +216,7 @@ ja:
     edit:
       edit_api_key: APIキーを編集する
       invalid_key: 正しくないAPIキーは編集できません。削除して新規作成してください。
+      expired_key:
     all_gems: 全てのgem
     gem_ownership_removed: このキーのスコープにあった%{rubygem_name}の所有権が削除されました。
   dashboards:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -177,6 +177,7 @@ nl:
       invalid_gem:
     destroy:
       success:
+      already_expired:
     index:
       api_keys:
       name:
@@ -202,6 +203,8 @@ nl:
       mfa:
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key:
     reset:
@@ -212,6 +215,7 @@ nl:
     edit:
       edit_api_key:
       invalid_key:
+      expired_key:
     all_gems:
     gem_ownership_removed:
   dashboards:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -183,6 +183,7 @@ pt-BR:
       invalid_gem:
     destroy:
       success:
+      already_expired:
     index:
       api_keys:
       name:
@@ -208,6 +209,8 @@ pt-BR:
       mfa:
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key:
     reset:
@@ -218,6 +221,7 @@ pt-BR:
     edit:
       edit_api_key:
       invalid_key:
+      expired_key:
     all_gems:
     gem_ownership_removed:
   dashboards:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -178,6 +178,7 @@ zh-CN:
       invalid_gem: 该 Gem 未被此 API 密钥所允许的作用范围包含
     destroy:
       success: 成功删除 API 密钥：%{name}
+      already_expired:
     index:
       api_keys: API 密钥
       name: 名称
@@ -203,6 +204,8 @@ zh-CN:
       mfa: 多因素验证（MFA）
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key: 生成新 API 密钥
     reset:
@@ -213,6 +216,7 @@ zh-CN:
     edit:
       edit_api_key: 编辑 API 密钥
       invalid_key: 已作废的 API 密钥不能被编辑，请删除它并创建一个新的 API 密钥。
+      expired_key:
     all_gems: 所有 Gem
     gem_ownership_removed: 对 %{rubygem_name} 的所有权已经被移除（在使用此 API 密钥决定作用范围后）
   dashboards:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -177,6 +177,7 @@ zh-TW:
       invalid_gem:
     destroy:
       success: 已刪除 API 金鑰：%{name}
+      already_expired:
     index:
       api_keys: API 金鑰
       name: 名稱
@@ -202,6 +203,8 @@ zh-TW:
       mfa: MFA
       expiration:
       update_owner:
+      view_expired:
+      view_active:
     new:
       new_api_key: 新 API 金鑰
     reset:
@@ -212,6 +215,7 @@ zh-TW:
     edit:
       edit_api_key: 編輯 API 金鑰
       invalid_key: 無法編輯無效的 API 金鑰。請刪除此金鑰並重新建立。
+      expired_key:
     all_gems: 所有 Gems
     gem_ownership_removed:
   dashboards:

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -71,6 +71,32 @@ class ApiKeysControllerTest < ActionController::TestCase
         should redirect_to("the new api key page") { new_profile_api_key_path }
       end
 
+      context "only expired keys exist" do
+        setup do
+          @expired_key = create(:api_key, owner: @user, name: "expired-key")
+          @expired_key.update_column(:expires_at, 1.week.ago)
+          get :index
+        end
+
+        should respond_with :success
+
+        should "not list the expired key in the active view" do
+          refute page.has_content? @expired_key.name
+        end
+
+        should "render a link to view previous keys" do
+          assert page.has_link? "View previous API keys", href: profile_api_keys_path(expired: "true")
+        end
+      end
+
+      context "no api key exists and the expired view is requested" do
+        setup do
+          get :index, params: { expired: "true" }
+        end
+
+        should respond_with :success
+      end
+
       context "api key exists" do
         setup do
           @api_key = create(:api_key, owner: @user)
@@ -86,6 +112,102 @@ class ApiKeysControllerTest < ActionController::TestCase
         should "render on the subject layout with settings active" do
           assert_select "h1", text: "API keys"
           assert_select "nav a[href=?].bg-orange-100", edit_settings_path
+        end
+      end
+
+      context "user has no expired keys" do
+        setup do
+          create(:api_key, owner: @user)
+          get :index
+        end
+
+        should "not render a link to view previous keys" do
+          refute page.has_link? "View previous API keys"
+        end
+      end
+
+      context "user has expired keys" do
+        setup do
+          @active_key = create(:api_key, owner: @user, name: "active-key")
+          @expired_key = create(:api_key, owner: @user, name: "expired-key")
+          @expired_key.update_column(:expires_at, 1.week.ago)
+        end
+
+        context "without the expired param" do
+          setup { get :index }
+
+          should respond_with :success
+
+          should "list only active keys" do
+            assert page.has_content? @active_key.name
+            refute page.has_content? @expired_key.name
+          end
+
+          should "render a link to view previous keys" do
+            assert page.has_link? "View previous API keys", href: profile_api_keys_path(expired: "true")
+          end
+
+          should "render the reset button" do
+            assert page.has_button? "Reset"
+          end
+        end
+
+        context "with the expired param" do
+          setup { get :index, params: { expired: "true" } }
+
+          should respond_with :success
+
+          should "list only expired keys" do
+            assert page.has_content? @expired_key.name
+            refute page.has_content? @active_key.name
+          end
+
+          should "not render edit or delete buttons" do
+            refute page.has_button? "Edit"
+            refute page.has_button? "Delete"
+          end
+
+          should "not render the reset button" do
+            refute page.has_button? "Reset"
+          end
+
+          should "render the new key button" do
+            assert page.has_button? "New API key"
+          end
+
+          should "render a link back to active keys" do
+            assert page.has_link? "Back to active API keys", href: profile_api_keys_path
+          end
+        end
+
+        should "order previous keys by expiration descending" do
+          ancient_key = create(:api_key, owner: @user, name: "ancient-key")
+          ancient_key.update_column(:expires_at, 2.weeks.ago)
+          get :index, params: { expired: "true" }
+
+          assert_operator response.body.index(@expired_key.name), :<, response.body.index(ancient_key.name)
+        end
+
+        should "not list expired OIDC keys" do
+          oidc_key = create(:api_key, owner: @user, name: "oidc-key", scopes: %i[push_rubygem])
+          create(:oidc_id_token, api_key: oidc_key)
+          oidc_key.update_column(:expires_at, 1.week.ago)
+          get :index, params: { expired: "true" }
+
+          refute page.has_content? oidc_key.name
+        end
+
+        should "render the gem name for an expired key whose gem ownership was removed" do
+          ownership = create(:ownership, user: @user, rubygem: create(:rubygem))
+          orphaned_key = create(:api_key, owner: @user, name: "orphaned-key", scopes: %i[push_rubygem], ownership: ownership)
+          ownership.destroy!
+          orphaned_key.update_column(:expires_at, 3.days.ago)
+          get :index, params: { expired: "true" }
+
+          tooltip = "Ownership of the #{ownership.rubygem.name} gem has been removed after being scoped to this key."
+
+          assert page.has_css? "span[title='#{tooltip}']", text: "#{ownership.rubygem.name} [?]"
+          refute page.has_css? "tr.opacity-60"
         end
       end
     end
@@ -206,6 +328,23 @@ class ApiKeysControllerTest < ActionController::TestCase
         assert_redirected_to profile_api_keys_path
         assert_equal "An invalid API key cannot be edited. Please delete it and create a new one.", flash[:error]
       end
+
+      should "redirect to index with expired key" do
+        @api_key.update_column(:expires_at, 1.hour.ago)
+        get :edit, params: { id: @api_key.id }
+
+        assert_redirected_to profile_api_keys_path
+        assert_equal "An expired API key cannot be edited. Please create a new one.", flash[:error]
+      end
+
+      should "prefer the soft deleted error for a key both soft deleted and expired" do
+        @api_key.soft_delete!
+        @api_key.update_column(:expires_at, 1.hour.ago)
+        get :edit, params: { id: @api_key.id }
+
+        assert_redirected_to profile_api_keys_path
+        assert_equal "An invalid API key cannot be edited. Please delete it and create a new one.", flash[:error]
+      end
     end
 
     context "on PATCH to update" do
@@ -274,6 +413,21 @@ class ApiKeysControllerTest < ActionController::TestCase
         end
       end
 
+      context "with an expired key" do
+        setup do
+          @api_key.update_column(:expires_at, 1.hour.ago)
+          patch :update, params: { api_key: { add_owner: true }, id: @api_key.id }
+        end
+
+        should "show error to user" do
+          assert_text "An expired API key cannot be used. Please create a new one."
+        end
+
+        should "not update scope of the key" do
+          refute_predicate @api_key.reload, :can_add_owner?
+        end
+      end
+
       context "with an expiration" do
         should "not allow chaging expiration" do
           @api_key.update_column(:expires_at, 1.month.from_now)
@@ -322,6 +476,28 @@ class ApiKeysControllerTest < ActionController::TestCase
 
           should "not expire api key of user" do
             refute_empty @user.api_keys.unexpired
+          end
+        end
+
+        context "with an already-expired key" do
+          setup do
+            @api_key.update_column(:expires_at, 1.hour.ago)
+            @original_expires_at = @api_key.reload.expires_at
+            delete :destroy, params: { id: @api_key.id }
+          end
+
+          should redirect_to("the index api key page") { profile_api_keys_path }
+
+          should "show an error to the user" do
+            assert_equal "The API key has already expired.", flash[:error]
+          end
+
+          should "not change the expiration timestamp" do
+            assert_equal @original_expires_at, @api_key.reload.expires_at
+          end
+
+          should "not record another deletion event" do
+            assert_empty @user.events.where(tag: Events::UserEvent::API_KEY_DELETED)
           end
         end
       end

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -330,7 +330,7 @@ class ApiKeysTest < ApplicationSystemTestCase
       click_button "Delete"
     end
 
-    assert_text "New API key"
+    assert_current_path profile_api_keys_path
     page.assert_text "Successfully deleted API key: #{api_key.name}"
 
     assert_event Events::UserEvent::API_KEY_DELETED, { name: api_key.name, api_key_gid: api_key.to_global_id.to_s },
@@ -345,8 +345,34 @@ class ApiKeysTest < ApplicationSystemTestCase
       click_button "Reset"
     end
 
-    assert_text "New API key"
+    assert_current_path profile_api_keys_path
     page.assert_no_text api_key.name
+  end
+
+  test "viewing previous api keys" do
+    create(:api_key, owner: @user, name: "old-key")
+
+    visit_profile_api_keys_path
+
+    assert_no_link "View previous API keys"
+
+    accept_alert do
+      click_button "Delete"
+    end
+
+    assert_text "Successfully deleted API key: old-key"
+    assert_current_path profile_api_keys_path
+
+    click_link "View previous API keys"
+
+    assert_text "old-key"
+    assert_no_button "Edit"
+    assert_no_button "Delete"
+    assert_no_button "Reset"
+
+    click_link "Back to active API keys"
+
+    assert_no_text "old-key"
   end
 
   test "gem ownership removed displays api key as invalid" do

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -23,8 +23,8 @@ class ApiKeysHelperTest < ActionView::TestCase
 
       expected_dom = <<~HTML.squish.gsub(/>\s+</, "><")
         <span
-          class="tooltip__text"
-          data-tooltip="Ownership of the #{rubygem_name} gem has been removed after being scoped to this key."\
+          class="cursor-help"
+          title="Ownership of the #{rubygem_name} gem has been removed after being scoped to this key."\
         >#{rubygem_name} [?]</span>
       HTML
 


### PR DESCRIPTION
This PR adds a new view under the API Key section to show an account's previously expired API key that we have on record.


<img width="1411" height="852" alt="Screenshot 2026-07-23 at 8 11 04 am" src="https://github.com/user-attachments/assets/1c0f6946-d55a-4c25-bbff-42025f106a79" />
