### PR TITLE
dependabot: cover ruby/setup-ruby in the composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,21 @@ updates:
         - minor
         - patch
 - package-ecosystem: github-actions
-  directory: "/"
+  directories:
+    - "/"
+    - "/.github/actions/setup-rubygems.org"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
   cooldown:
     default-days: 7
   groups:
+    setup-ruby:
+      patterns: ["ruby/setup-ruby"]
+      update-types:
+        - patch
+        - minor
+      group-by: dependency-name
     github-actions-patch-minor:
       patterns: ["*"]
       update-types:


### PR DESCRIPTION
Dependabot's default behavior only scans `.github/workflows`, so the ruby/setup-ruby pin in `.github/actions/setup-rubygems.org/action.yml` wasn't being updated with the rest of the workflows. This PR allows all instances of ruby/setup-ruby to be bumped together.