### PR TITLE
Add maintenance task to stagger queued cache-exposure mail jobs

### DIFF
--- a/app/tasks/maintenance/stagger_cache_exposure_mail_jobs_task.rb
+++ b/app/tasks/maintenance/stagger_cache_exposure_mail_jobs_task.rb
@@ -24,7 +24,7 @@ class Maintenance::StaggerCacheExposureMailJobsTask < MaintenanceTasks::Task
   private
 
   def queued_jobs
-    GoodJob::Job.where(job_class: JOB_CLASS, queue_name: QUEUE_NAME, finished_at: nil)
+    GoodJob::Job.where(job_class: JOB_CLASS, queue_name: QUEUE_NAME, finished_at: nil, performed_at: nil)
   end
 
   def next_wave_at

--- a/app/tasks/maintenance/stagger_cache_exposure_mail_jobs_task.rb
+++ b/app/tasks/maintenance/stagger_cache_exposure_mail_jobs_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Maintenance::StaggerCacheExposureMailJobsTask < MaintenanceTasks::Task
+  include SemanticLogger::Loggable
+
+  JOB_CLASS = "CacheExposureMailDeliveryJob"
+  QUEUE_NAME = "within_24_hours"
+
+  attribute :batch_size, :integer, default: 1000
+  attribute :wave_interval_minutes, :integer, default: 3
+  validates :batch_size, numericality: { only_integer: true, greater_than: 0 }
+  validates :wave_interval_minutes, numericality: { only_integer: true, greater_than: 0 }
+
+  def collection
+    queued_jobs.in_batches(of: batch_size)
+  end
+
+  def process(batch)
+    wave_at = next_wave_at
+    staggered = batch.update_all(scheduled_at: wave_at)
+    logger.info("Staggered cache-exposure mail wave", scheduled_at: wave_at, jobs: staggered)
+  end
+
+  private
+
+  def queued_jobs
+    GoodJob::Job.where(job_class: JOB_CLASS, queue_name: QUEUE_NAME, finished_at: nil)
+  end
+
+  def next_wave_at
+    latest = queued_jobs.maximum(:scheduled_at)
+    [latest, Time.current].compact.max + wave_interval_minutes.minutes
+  end
+end

--- a/test/tasks/maintenance/stagger_cache_exposure_mail_jobs_task_test.rb
+++ b/test/tasks/maintenance/stagger_cache_exposure_mail_jobs_task_test.rb
@@ -10,7 +10,7 @@ class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCas
   end
 
   def create_good_job(job_class: "CacheExposureMailDeliveryJob", queue_name: "within_24_hours",
-    scheduled_at: 1.hour.ago, finished_at: nil)
+    scheduled_at: 1.hour.ago, finished_at: nil, performed_at: nil)
     GoodJob::Job.create!(
       id: SecureRandom.uuid,
       active_job_id: SecureRandom.uuid,
@@ -18,6 +18,7 @@ class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCas
       queue_name: queue_name,
       scheduled_at: scheduled_at,
       finished_at: finished_at,
+      performed_at: performed_at,
       serialized_params: { "job_class" => job_class, "queue_name" => queue_name }
     )
   end
@@ -28,6 +29,7 @@ class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCas
       other_class = create_good_job(job_class: "ActionMailer::MailDeliveryJob")
       other_queue = create_good_job(queue_name: "mailers")
       finished = create_good_job(finished_at: Time.current)
+      running = create_good_job(performed_at: Time.current)
 
       covered = @task.collection.each_record.to_a
 
@@ -35,6 +37,7 @@ class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCas
       refute_includes covered, other_class
       refute_includes covered, other_queue
       refute_includes covered, finished
+      refute_includes covered, running
     end
   end
 
@@ -54,12 +57,14 @@ class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCas
     end
 
     should "not reschedule jobs outside the collection" do
-      untouched = create_good_job(job_class: "ActionMailer::MailDeliveryJob", scheduled_at: 2.hours.ago)
-      create_good_job
+      freeze_time do
+        untouched = create_good_job(job_class: "ActionMailer::MailDeliveryJob", scheduled_at: 2.hours.ago)
+        create_good_job
 
-      @task.collection.each { |batch| @task.process(batch) }
+        @task.collection.each { |batch| @task.process(batch) }
 
-      assert_equal 2.hours.ago.to_i, untouched.reload.scheduled_at.to_i
+        assert_equal 2.hours.ago, untouched.reload.scheduled_at
+      end
     end
 
     should "continue after the latest scheduled wave when resumed" do

--- a/test/tasks/maintenance/stagger_cache_exposure_mail_jobs_task_test.rb
+++ b/test/tasks/maintenance/stagger_cache_exposure_mail_jobs_task_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Maintenance::StaggerCacheExposureMailJobsTaskTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @task = Maintenance::StaggerCacheExposureMailJobsTask.new
+  end
+
+  def create_good_job(job_class: "CacheExposureMailDeliveryJob", queue_name: "within_24_hours",
+    scheduled_at: 1.hour.ago, finished_at: nil)
+    GoodJob::Job.create!(
+      id: SecureRandom.uuid,
+      active_job_id: SecureRandom.uuid,
+      job_class: job_class,
+      queue_name: queue_name,
+      scheduled_at: scheduled_at,
+      finished_at: finished_at,
+      serialized_params: { "job_class" => job_class, "queue_name" => queue_name }
+    )
+  end
+
+  context "#collection" do
+    should "cover only queued cache-exposure mail jobs" do
+      queued = create_good_job
+      other_class = create_good_job(job_class: "ActionMailer::MailDeliveryJob")
+      other_queue = create_good_job(queue_name: "mailers")
+      finished = create_good_job(finished_at: Time.current)
+
+      covered = @task.collection.each_record.to_a
+
+      assert_includes covered, queued
+      refute_includes covered, other_class
+      refute_includes covered, other_queue
+      refute_includes covered, finished
+    end
+  end
+
+  context "#process" do
+    should "schedule successive batches one wave interval apart, starting in the future" do
+      freeze_time do
+        jobs = Array.new(4) { create_good_job }
+        @task.batch_size = 2
+
+        @task.collection.each { |batch| @task.process(batch) }
+
+        waves = jobs.map { |job| job.reload.scheduled_at }.uniq.sort
+
+        assert_equal [3.minutes.from_now, 6.minutes.from_now], waves
+        waves.each { |wave| assert_operator wave, :>, Time.current }
+      end
+    end
+
+    should "not reschedule jobs outside the collection" do
+      untouched = create_good_job(job_class: "ActionMailer::MailDeliveryJob", scheduled_at: 2.hours.ago)
+      create_good_job
+
+      @task.collection.each { |batch| @task.process(batch) }
+
+      assert_equal 2.hours.ago.to_i, untouched.reload.scheduled_at.to_i
+    end
+
+    should "continue after the latest scheduled wave when resumed" do
+      freeze_time do
+        create_good_job(scheduled_at: 30.minutes.from_now)
+        resumed = create_good_job
+
+        # GoodJob::Job's primary key is active_job_id, so #id returns that UUID.
+        @task.process(GoodJob::Job.where(active_job_id: resumed.id))
+
+        assert_equal 33.minutes.from_now, resumed.reload.scheduled_at
+      end
+    end
+
+    should "respect a custom wave interval" do
+      freeze_time do
+        job = create_good_job
+        @task.wave_interval_minutes = 10
+
+        @task.collection.each { |batch| @task.process(batch) }
+
+        assert_equal 10.minutes.from_now, job.reload.scheduled_at
+      end
+    end
+  end
+
+  context "validations" do
+    should "reject non-positive batch size and wave interval" do
+      @task.batch_size = 0
+
+      refute_predicate @task, :valid?
+
+      @task.batch_size = 1000
+      @task.wave_interval_minutes = -1
+
+      refute_predicate @task, :valid?
+    end
+  end
+end


### PR DESCRIPTION
The queue is large and GoodJob is loading too much into temporary tables that's causing the queue to be processed at a snails pace. This task will amend the existing jobs with a `scheduled_at`, and allow GoodJob to have a much better time processing the backlog.