### PR TITLE
Fix Deprecation: Use skip instead of add_filter for simplecov

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@
 
 require "simplecov"
 SimpleCov.start "rails" do
-  add_filter "lib/tasks"
-  add_filter "lib/rails_development_log_formatter.rb"
+  skip "lib/tasks"
+  skip "lib/rails_development_log_formatter.rb"
 
   if ENV["CI"]
     require "simplecov-cobertura"


### PR DESCRIPTION
Why this change is being made:
- Updates the test_helper to remove the deprecation warning for add_filter in favor of calling skip