### PR TITLE
Remove lingering compact index v1 version object

### DIFF
--- a/app/models/concerns/compact_index_versions.rb
+++ b/app/models/concerns/compact_index_versions.rb
@@ -21,7 +21,7 @@ module CompactIndexVersions
                       v.yanked_at > ?)
                 ORDER BY date, number, platform, name", date, date]
 
-      map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] })
+      map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] }, version:)
     end
 
     def each_compact_index_public_version(updated_at, version: self::CURRENT_VERSION, &block)
@@ -43,7 +43,7 @@ module CompactIndexVersions
 
       execute_raw_sql(query)
         .chunk_while { |a, b| a["name"] == b["name"] }
-        .each { |rows| public_compact_index_gem(rows.first["name"], rows, &block) }
+        .each { |rows| public_compact_index_gem(rows.first["name"], rows, version:, &block) }
     end
 
     def compact_index_public_versions(updated_at, version: self::CURRENT_VERSION)
@@ -55,26 +55,31 @@ module CompactIndexVersions
       ActiveRecord::Base.connection.execute(sanitized_sql)
     end
 
-    def map_gem_versions(versions_by_gem)
-      versions_by_gem.map { |gem_name, versions| build_compact_index_gem(gem_name, versions) }
+    def map_gem_versions(versions_by_gem, version:)
+      versions_by_gem.map { |gem_name, versions| build_compact_index_gem(gem_name, versions, version:) }
     end
 
-    def public_compact_index_gem(gem_name, versions)
+    def public_compact_index_gem(gem_name, versions, version:)
       info_checksum = versions.last["info_checksum"]
       versions.select! { |v| v["indexed"] == true }
       return if versions.empty?
 
       # Set all versions' info_checksum to work around https://github.com/bundler/compact_index/pull/20
       versions.each { |v| v["info_checksum"] = info_checksum }
-      yield build_compact_index_gem(gem_name, versions)
+      yield build_compact_index_gem(gem_name, versions, version:)
     end
 
-    def build_compact_index_gem(gem_name, versions)
-      compact_index_versions = versions.map do |version|
-        CompactIndex::GemVersion.new(version["number"],
-          version["platform"],
-          version["sha256"],
-          version["info_checksum"])
+    def build_compact_index_gem(gem_name, versions, version:)
+      version_class = self::VERSIONS.fetch(version).fetch(:klass)
+      compact_index_versions = versions.map do |version_row|
+        args = {
+          number: version_row["number"],
+          platform: version_row["platform"],
+          checksum: version_row["sha256"],
+          info_checksum: version_row["info_checksum"]
+        }
+        args = args.slice(*version_class.members)
+        version_class.new(**args)
       end
       CompactIndex::Gem.new(gem_name, compact_index_versions)
     end

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -52,11 +52,6 @@ module CompactIndex
     end
   end
 
-  GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version) do
-    include GemVersionMethods
-  end
-
   GemVersionV2 = Struct.new(:number, :platform, :checksum, :info_checksum,
                             :dependencies, :ruby_version, :rubygems_version,
                             :created_at) do

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -1,22 +1,19 @@
 # frozen_string_literal: true
 
 module CompactIndexHelpers
-  def build_version(version: 1, **args)
+  def build_version(**args)
     name = args.fetch(:name, "test_gem")
     number = args.fetch(:number, "1.0")
-    common = [
+
+    CompactIndex::GemVersionV2.new(
       number,
       args[:platform],
       args.fetch(:checksum, "sum+#{name}+#{number}"),
       args.fetch(:info_checksum, "info+#{name}+#{number}"),
       args[:dependencies],
       args[:ruby_version],
-      args[:rubygems_version]
-    ]
-    if version == 2
-      CompactIndex::GemVersionV2.new(*common, args[:created_at])
-    else
-      CompactIndex::GemVersion.new(*common)
-    end
+      args[:rubygems_version],
+      args[:created_at]
+    )
   end
 end

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "compact_index"
 require "helpers/compact_index_helpers"
 
-class CompactIndex::GemVersionTest < ActiveSupport::TestCase
+class CompactIndex::GemVersionV2Test < ActiveSupport::TestCase
   include CompactIndexHelpers
 
   context "#<=>" do
@@ -32,20 +32,14 @@ class CompactIndex::GemVersionTest < ActiveSupport::TestCase
   end
 
   context "#to_line" do
-    should "not include created_at for v1" do
+    should "not include created_at when absent" do
       v = build_version(number: "1.0")
 
       assert_equal "1.0 |checksum:sum+test_gem+1.0", v.to_line
     end
 
-    should "not include created_at for v2 when absent" do
-      v = build_version(version: 2, number: "1.0")
-
-      assert_equal "1.0 |checksum:sum+test_gem+1.0", v.to_line
-    end
-
-    should "include created_at for v2 when present" do
-      v = build_version(version: 2, number: "1.0", created_at: "2026-05-12T10:00:00Z")
+    should "include created_at when present" do
+      v = build_version(number: "1.0", created_at: "2026-05-12T10:00:00Z")
 
       assert_equal "1.0 |checksum:sum+test_gem+1.0,created_at:2026-05-12T10:00:00Z", v.to_line
     end

--- a/test/models/concerns/compact_index_versions_test.rb
+++ b/test/models/concerns/compact_index_versions_test.rb
@@ -17,8 +17,8 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       versions = GemInfo.compact_index_versions(4.days.ago)
 
       expected_versions = [
-        CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("1.0.1", "ruby", nil, "v232ddwe")]),
-        CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("2.0.0", "ruby", nil, "v2qw2dwe")])
+        CompactIndex::Gem.new("foo", [CompactIndex::GemVersionV2.new("1.0.1", "ruby", nil, "v232ddwe")]),
+        CompactIndex::Gem.new("foo", [CompactIndex::GemVersionV2.new("2.0.0", "ruby", nil, "v2qw2dwe")])
       ]
 
       assert_equal expected_versions, versions
@@ -32,7 +32,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       versions = GemInfo.compact_index_versions(4.days.ago)
 
       assert_includes versions,
-        CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("-1.0.0", "ruby", nil, "v2yanked")])
+        CompactIndex::Gem.new("bar", [CompactIndex::GemVersionV2.new("-1.0.0", "ruby", nil, "v2yanked")])
     end
   end
 
@@ -45,7 +45,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
 
       expected_versions = [CompactIndex::Gem.new(
         version.rubygem.name,
-        [CompactIndex::GemVersion.new(version.number, version.platform, version.sha256, version.info_checksum_v2)]
+        [CompactIndex::GemVersionV2.new(version.number, version.platform, version.sha256, version.info_checksum_v2)]
       )]
 
       assert_equal expected_versions, versions
@@ -59,7 +59,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
 
       versions = GemInfo.compact_index_public_versions(@ts)
 
-      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
+      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersionV2.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
     end
 
     should "fall back to info_checksum_v2 for yanked rows missing yanked_info_checksum_v2" do
@@ -71,7 +71,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
 
       versions = GemInfo.compact_index_public_versions(@ts)
 
-      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2qw2dwe")])
+      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersionV2.new("1.0.0", "ruby", indexed_version.sha256, "v2qw2dwe")])
     end
 
     should "stream public versions one gem at a time" do
@@ -82,7 +82,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
 
       versions = GemInfo.each_compact_index_public_version(@ts).to_a
 
-      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersion.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
+      assert_includes versions, CompactIndex::Gem.new("bar", [CompactIndex::GemVersionV2.new("1.0.0", "ruby", indexed_version.sha256, "v2yanked")])
       assert_equal GemInfo.compact_index_public_versions(@ts), versions
     end
 


### PR DESCRIPTION
## What

Remove the lingering compact index v1 `CompactIndex::GemVersion` struct and update remaining builders/tests to use the current v2 version object.

## Why

The app now serves compact index v2, but `/versions` helper code could still construct the old v1 object. This keeps compact index version objects consistent with the v2-only compact index runtime.

## Tophat

- Ran lint on changed Ruby files
- Confirmed old v1 constant is gone and v2 remains in Rails console:

```ruby
defined?(CompactIndex::GemVersion)
# => nil

defined?(CompactIndex::GemVersionV2)
# => "constant"
```

- Running the affected compact index tests should suffice