### PR TITLE
Treat Organization Handles as their own type of handles

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,9 +6,10 @@ class Organization < ApplicationRecord
   validates :handle, presence: true,
     uniqueness: { case_sensitive: false },
     length: { within: 2..40 },
-    format: { with: Patterns::HANDLE_PATTERN }
+    format: { with: Patterns::ORGANIZATION_HANDLE_PATTERN }
   validates :name, presence: true, length: { within: 2..255 }
   validate :handle_not_reserved
+  validate :unique_with_user_handle, if: :handle_changed?
 
   has_many :memberships, -> { where.not(confirmed_at: nil) }, dependent: :destroy, inverse_of: :organization
   has_many :unconfirmed_memberships, -> { where(confirmed_at: nil) }, class_name: "Membership", dependent: :destroy, inverse_of: :organization
@@ -57,8 +58,16 @@ class Organization < ApplicationRecord
   def handle_not_reserved
     return if handle.blank?
 
-    return unless Handle.reserved?(handle)
+    return unless Organization::Handle.reserved?(handle)
 
     errors.add(:handle, "is reserved and cannot be used")
+  end
+
+  # Prevent creating a organization if there's a User with the same handle
+  # TODO BRIAN: Is this a worth-while requirement?
+  def unique_with_user_handle
+    return if handle.blank?
+
+    errors.add(:handle, "has already been taken") if User.where("lower(handle) = lower(?)", handle).any?
   end
 end

--- a/app/models/organization/handle.rb
+++ b/app/models/organization/handle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Organization::Handle # rubocop:disable Metrics/ClassLength
+class Organization::Handle
   # Handles are compared without separators
   # ex "rubygems" reserves "ruby-gems" and "ruby_gems"
   def self.normalize(handle)
@@ -332,79 +332,6 @@ class Organization::Handle # rubocop:disable Metrics/ClassLength
     void
   ].freeze
 
-  # Reserved names held until we can verify
-  HELD_FOR_CLAIM = %w[
-    amazon
-    anthropic
-    apple
-    auth0
-    azure
-    bitbucket
-    capybara
-    cloudflare
-    crates
-    cucumber
-    datadog
-    debian
-    devise
-    digitalocean
-    docker
-    dryrb
-    facebook
-    falcon
-    faraday
-    github
-    gitlab
-    google
-    grape
-    hanami
-    hashicorp
-    heroku
-    ibm
-    jekyll
-    jetbrains
-    kubernetes
-    maven
-    meta
-    microsoft
-    minitest
-    mongoid
-    netlify
-    nokogiri
-    npm
-    nuget
-    okta
-    openai
-    oracle
-    puma
-    pundit
-    pypi
-    rack
-    railsfoundation
-    redhat
-    redis
-    resque
-    rspec
-    rubocop
-    rubylsp
-    salesforce
-    sendgrid
-    sentry
-    sequel
-    sidekiq
-    sinatra
-    solargraph
-    sorbet
-    standardrb
-    stripe
-    thoughtbot
-    trailblazer
-    twilio
-    ubuntu
-    unicorn
-    vercel
-  ].freeze
-
   RESERVED = [
     *RESTFUL_ACTIONS,
     *ROUTES,
@@ -414,8 +341,7 @@ class Organization::Handle # rubocop:disable Metrics/ClassLength
     *RUBY_CORE,
     *TRUST_AND_SAFETY,
     *INFRASTRUCTURE,
-    *RESERVED_WORDS,
-    *HELD_FOR_CLAIM
+    *RESERVED_WORDS
   ].freeze
 
   # Indexed on the normalized form so lookups stay O(1) and every separator

--- a/app/models/organization/handle.rb
+++ b/app/models/organization/handle.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-class Organization::Handle
+class Organization::Handle # rubocop:disable Metrics/ClassLength
+  # Handles are compared without separators
+  # ex "rubygems" reserves "ruby-gems" and "ruby_gems"
+  def self.normalize(handle)
+    handle.to_s.downcase.delete("-_")
+  end
+
   RESTFUL_ACTIONS = %w[
     create
     destroy
@@ -11,29 +17,412 @@ class Organization::Handle
     update
   ].freeze
 
+  # Path segments matching current routes
+  # - not technically necessary but could be confusing in a world with top level orgs
+  #   ex a private hosted gem repository as "www.rubygems.org/<org_handle>/gems/"
   ROUTES = %w[
+    activity
     admin
     api
+    api_key
+    api_keys
+    attestations
+    compromised_password
     dashboard
+    dependencies
+    downloads
+    email_confirmations
     gems
+    info
+    internal
     invitation
     invitations
+    letter_opener
+    lookbook
     members
     memberships
+    multifactor_auth
+    names
+    news
+    notifier
+    oauth
     onboarding
+    organization
+    organizations
+    owners
+    pages
+    password
+    policies
     profile
+    profiles
+    releases
+    search
+    sendgrid_events
+    session
     settings
+    sign_in
+    sign_out
+    sign_up
     stats
+    subscriptions
     teams
+    totp
+    trusted_publishers
     users
+    versions
+    webauthn_credentials
+    webauthn_verification
+  ].freeze
+
+  # Served from public/ or by the asset pipeline, outside the Rails router.
+  STATIC_PATHS = %w[
+    assets
+    favicon
+    fonts
+    images
+    maintenance
+    opensearch
+    robots
+    sponsors
+    stylesheets
+  ].freeze
+
+  # Not routed yet. Cheap to hold now, expensive to reclaim from an org later.
+  FUTURE_ROUTES = %w[
+    about
+    atom
+    auth
+    billing
+    blog
+    callback
+    contact
+    doc
+    docs
+    documentation
+    explore
+    feed
+    graphql
+    help
+    invoices
+    latest
+    login
+    logout
+    notifications
+    oidc
+    plans
+    popular
+    pricing
+    register
+    rss
+    saml
+    sitemap
+    sso
+    status
+    trending
+    upload
+    uploads
+    webhook
+    webhooks
+  ].freeze
+
+  # RubyGems.org and related entities
+  REGISTRY_IDENTITY = %w[
+    bundler
+    gem
+    gemcutter
+    rubycentral
+    rubyfoundation
+    rubygem
+    rubygems
+    rubygemsadmin
+    rubygemshelp
+    rubygemsorg
+    rubygemssecurity
+    rubygemsstaff
+    rubygemssupport
+    rubygemsteam
+    rubytogether
+  ].freeze
+
+  # The language and its implementation
+  RUBY_CORE = %w[
+    artichoke
+    cruby
+    irb
+    jruby
+    mjit
+    mri
+    mruby
+    opal
+    prism
+    psych
+    racc
+    rake
+    rbs
+    rdoc
+    rubinius
+    ruby
+    rubycore
+    rubylang
+    stdlib
+    truffleruby
+    yjit
+    zjit
+  ].freeze
+
+  # Words that imply authority, endorsement, or a security role. Also covers
+  # the RFC 2142 mailbox names, which matter if handles ever become
+  # subdomains or email local-parts.
+  TRUST_AND_SAFETY = %w[
+    abuse
+    administrator
+    admins
+    advisories
+    advisory
+    audit
+    cert
+    compliance
+    copyright
+    csirt
+    cve
+    disclosure
+    dmca
+    email
+    gdpr
+    helpdesk
+    hostmaster
+    incident
+    legal
+    mail
+    mailer_daemon
+    mod
+    moderator
+    moderators
+    noreply
+    official
+    postmaster
+    privacy
+    root
+    security
+    smtp
+    soc
+    staff
+    superuser
+    support
+    sysadmin
+    terms
+    tos
+    trademark
+    trust
+    trusted
+    trustedpublishing
+    verification
+    verified
+    vulnerability
+    webmaster
+  ].freeze
+
+  # Hostnames and environment names, for the case where a handle is ever
+  # projected into DNS or used to address a deployment.
+  INFRASTRUCTURE = %w[
+    alpha
+    backup
+    beta
+    canary
+    cdn
+    chat
+    community
+    dev
+    development
+    devops
+    discord
+    dns
+    edge
+    forum
+    forums
+    ftp
+    gateway
+    git
+    health
+    healthcheck
+    infra
+    irc
+    local
+    localhost
+    matrix
+    metrics
+    mirror
+    mirrors
+    monitoring
+    mx
+    ns
+    ns1
+    ns2
+    ops
+    ping
+    preview
+    prod
+    production
+    proxy
+    public
+    qa
+    sandbox
+    slack
+    sre
+    stage
+    staging
+    static
+    svn
+    test
+    testing
+    uptime
+    vpn
+    wiki
+    www
+  ].freeze
+
+  # Placeholder words that tend to break stuff or become confusing
+  RESERVED_WORDS = %w[
+    account
+    accounts
+    all
+    anonymous
+    app
+    application
+    apps
+    bar
+    baz
+    bot
+    bots
+    config
+    configuration
+    current
+    default
+    everyone
+    example
+    examples
+    false
+    foo
+    group
+    groups
+    guest
+    licence
+    license
+    me
+    my
+    nan
+    nil
+    none
+    null
+    org
+    organisation
+    organisations
+    orgs
+    robot
+    sample
+    self
+    service
+    services
+    system
+    team
+    this
+    true
+    undefined
+    user
+    void
+  ].freeze
+
+  # Reserved names held until we can verify
+  HELD_FOR_CLAIM = %w[
+    amazon
+    anthropic
+    apple
+    auth0
+    azure
+    bitbucket
+    capybara
+    cloudflare
+    crates
+    cucumber
+    datadog
+    debian
+    devise
+    digitalocean
+    docker
+    dryrb
+    facebook
+    falcon
+    faraday
+    github
+    gitlab
+    google
+    grape
+    hanami
+    hashicorp
+    heroku
+    ibm
+    jekyll
+    jetbrains
+    kubernetes
+    maven
+    meta
+    microsoft
+    minitest
+    mongoid
+    netlify
+    nokogiri
+    npm
+    nuget
+    okta
+    openai
+    oracle
+    puma
+    pundit
+    pypi
+    rack
+    railsfoundation
+    redhat
+    redis
+    resque
+    rspec
+    rubocop
+    rubylsp
+    salesforce
+    sendgrid
+    sentry
+    sequel
+    sidekiq
+    sinatra
+    solargraph
+    sorbet
+    standardrb
+    stripe
+    thoughtbot
+    trailblazer
+    twilio
+    ubuntu
+    unicorn
+    vercel
   ].freeze
 
   RESERVED = [
     *RESTFUL_ACTIONS,
-    *ROUTES
+    *ROUTES,
+    *STATIC_PATHS,
+    *FUTURE_ROUTES,
+    *REGISTRY_IDENTITY,
+    *RUBY_CORE,
+    *TRUST_AND_SAFETY,
+    *INFRASTRUCTURE,
+    *RESERVED_WORDS,
+    *HELD_FOR_CLAIM
   ].freeze
 
+  # Indexed on the normalized form so lookups stay O(1) and every separator
+  # spelling of a reserved name resolves to the same entry.
+  NORMALIZED_RESERVED = RESERVED.to_set { |handle| normalize(handle) }.freeze
+
   def self.reserved?(handle)
-    RESERVED.include?(handle.to_s.downcase)
+    NORMALIZED_RESERVED.include?(normalize(handle))
   end
 end

--- a/app/models/organization_onboarding.rb
+++ b/app/models/organization_onboarding.rb
@@ -28,6 +28,7 @@ class OrganizationOnboarding < ApplicationRecord
   before_validation :remove_invalid_invites
 
   validate :organization_handle_reservable
+  validate :organization_handle_available
   validate :created_by_gem_ownerships
   validates :organization_name, :organization_handle, presence: true
 
@@ -142,6 +143,18 @@ class OrganizationOnboarding < ApplicationRecord
 
     return unless Organization::Handle.reserved?(organization_handle)
     errors.add(:organization_handle, "is reserved and cannot be used")
+  end
+
+  def organization_handle_available
+    return if organization_handle.blank?
+
+    # Exclude the organization this onboarding just created: #onboard! calls save and re-runs the validations
+    organizations = Organization.where("lower(handle) = lower(?)", organization_handle)
+    organizations = organizations.where.not(id: onboarded_organization_id) if onboarded_organization_id.present?
+
+    taken = organizations.any? || User.where("lower(handle) = lower(?)", organization_handle).any?
+
+    errors.add(:organization_handle, "has already been taken") if taken
   end
 
   def created_by_gem_ownerships

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,12 @@
 
 password = "super-secret-password"
 
+# "rubygems" is a reserved handle (see Organization::Handle), so the seed
+# organization uses the same gem-* naming as the seed users below.
 org = Organization.create_with(
-  name: "RubyGems",
-  handle: "rubygems"
-).find_or_create_by!(name: "RubyGems")
+  name: "Gem Org",
+  handle: "gem-org"
+).find_or_create_by!(name: "Gem Org")
 
 author = User.create_with(
   handle: "gem-author",

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -14,8 +14,9 @@ module Patterns
   REQUIREMENT_PATTERN   = Gem::Requirement::PATTERN
   BASE64_SHA256_PATTERN = %r{\A[0-9a-zA-Z_+/-]{43}={0,2}\z}
   HANDLE_PATTERN        = /\A[A-Za-z][A-Za-z_\-0-9]*\z/
-  SPECIAL_CHAR_PREFIX_REGEXP = /\A[#{Regexp.escape(SPECIAL_CHARACTERS)}]/o
-  SPECIAL_CHAR_SUFFIX_REGEXP = /[#{Regexp.escape(SPECIAL_CHARACTERS)}]\z/o
-  BANNED_EXTENSIONS          = %w[gem json html gemspec].freeze
-  BANNED_EXTENSION_REGEXP    = /\.(?:#{Regexp.union(BANNED_EXTENSIONS)})\z/i
+  ORGANIZATION_HANDLE_PATTERN = /\A[0-9A-Za-z][A-Za-z_\-0-9]*\z/
+  SPECIAL_CHAR_PREFIX_REGEXP  = /\A[#{Regexp.escape(SPECIAL_CHARACTERS)}]/o
+  SPECIAL_CHAR_SUFFIX_REGEXP  = /[#{Regexp.escape(SPECIAL_CHARACTERS)}]\z/o
+  BANNED_EXTENSIONS           = %w[gem json html gemspec].freeze
+  BANNED_EXTENSION_REGEXP     = /\.(?:#{Regexp.union(BANNED_EXTENSIONS)})\z/i
 end

--- a/test/models/organization/handle_test.rb
+++ b/test/models/organization/handle_test.rb
@@ -3,13 +3,20 @@
 require "test_helper"
 
 class Organization::ReservedHandlesTest < ActiveSupport::TestCase
-  context ".reserved?" do
-    should "return true for reserved handles" do
-      %w[onboarding api admin dashboard profile settings].each do |handle|
-        assert Organization::Handle.reserved?(handle), "Expected '#{handle}' to be reserved"
-      end
+  context ".normalize" do
+    should "downcase and strip separators" do
+      assert_equal "signin", Organization::Handle.normalize("Sign_In")
+      assert_equal "rubygems", Organization::Handle.normalize("Ruby-Gems")
+      assert_equal "rubygems", Organization::Handle.normalize("ruby_gems")
     end
 
+    should "handle nil and symbols" do
+      assert_equal "", Organization::Handle.normalize(nil)
+      assert_equal "api", Organization::Handle.normalize(:API)
+    end
+  end
+
+  context ".reserved?" do
     should "be case insensitive" do
       assert Organization::Handle.reserved?("onboarding")
       assert Organization::Handle.reserved?("ONBOARDING")
@@ -21,14 +28,24 @@ class Organization::ReservedHandlesTest < ActiveSupport::TestCase
       assert Organization::Handle.reserved?(:API)
     end
 
-    should "return false for non-reserved handles" do
-      %w[mycompany validname github microsoft].each do |handle|
-        refute Organization::Handle.reserved?(handle), "Expected '#{handle}' to not be reserved"
-      end
+    should "ignore separators, so one spelling covers all variations" do
+      assert Organization::Handle.reserved?("sign_in")
+      assert Organization::Handle.reserved?("sign-in")
+      assert Organization::Handle.reserved?("signin")
+
+      assert Organization::Handle.reserved?("rubygems")
+      assert Organization::Handle.reserved?("ruby-gems")
+      assert Organization::Handle.reserved?("RUBY_GEMS")
+    end
+
+    # TODO: BRIAN: I'm not sure on how to handle the prefix problem as of yet
+    should "not treat a reserved name as a prefix or substring match" do
+      refute Organization::Handle.reserved?("apiary")
+      refute Organization::Handle.reserved?("myapi")
+      refute Organization::Handle.reserved?("rubygemsfan")
     end
 
     should "include common route conflicts" do
-      # Test a subset of important reserved handles to ensure they're included
       expected_reserved = %w[
         new edit create update destroy index show
         onboarding members users invitation invitations
@@ -39,6 +56,49 @@ class Organization::ReservedHandlesTest < ActiveSupport::TestCase
       expected_reserved.each do |handle|
         assert_includes Organization::Handle::RESERVED, handle, "Expected '#{handle}' to be in RESERVED list"
       end
+    end
+
+    should "reserve every top-level path segment used in the app's routes" do
+      segments = Rails.application.routes.routes.filter_map do |route|
+        spec = route.path.spec.to_s
+        next if spec.start_with?("/:", "/*")
+
+        spec.split("/").compact_blank.first
+      end
+
+      segments.uniq.each do |segment|
+        # Skip segments that can't be typed as a handle
+        next unless segment.match?(Patterns::HANDLE_PATTERN)
+        next if segment.length < 2 || segment.length > 40
+        next if segment == "rails" # This is already taken as an Organization handle
+
+        assert Organization::Handle.reserved?(segment),
+          "Route segment '/#{segment}' is not a reserved Organization::Handle"
+      end
+    end
+  end
+
+  context "the reserved list" do
+    should "contain only handles that are otherwise valid" do
+      Organization::Handle::RESERVED.each do |handle|
+        assert_match Patterns::HANDLE_PATTERN, handle, "Reserved handle '#{handle}' is not a valid handle format"
+        assert_operator handle.length, :>=, 2, "Reserved handle '#{handle}' is shorter than the minimum handle length"
+        assert_operator handle.length, :<=, 40, "Reserved handle '#{handle}' is longer than the maximum handle length"
+      end
+    end
+
+    should "be lowercase" do
+      Organization::Handle::RESERVED.each do |handle|
+        assert_equal handle.downcase, handle, "Reserved handle '#{handle}' should be lowercase"
+      end
+    end
+
+    should "not contain entries that are redundant once normalized" do
+      duplicates = Organization::Handle::RESERVED
+        .group_by { Organization::Handle.normalize(it) }
+        .select { |_normalized, handles| handles.size > 1 }
+
+      assert_empty duplicates, "Redundant reserved entries (identical once normalized): #{duplicates.values.inspect}"
     end
   end
 end

--- a/test/models/organization_onboarding_test.rb
+++ b/test/models/organization_onboarding_test.rb
@@ -151,6 +151,35 @@ class OrganizationOnboardingTest < ActiveSupport::TestCase
         assert_includes @onboarding.errors[:organization_handle], "is reserved and cannot be used"
       end
     end
+
+    context "when the organization handle is reserved under another spelling" do
+      should "be invalid" do
+        @onboarding.organization_handle = "sign-in"
+
+        assert_predicate @onboarding, :invalid?
+        assert_includes @onboarding.errors[:organization_handle], "is reserved and cannot be used"
+      end
+    end
+
+    context "when an existing organization already owns the handle" do
+      should "be invalid" do
+        create(:organization, handle: "takenhandle")
+        @onboarding.organization_handle = "TakenHandle"
+
+        assert_predicate @onboarding, :invalid?
+        assert_includes @onboarding.errors[:organization_handle], "has already been taken"
+      end
+    end
+
+    context "when a user already owns the handle" do
+      should "be invalid" do
+        create(:user, handle: "takenhandle")
+        @onboarding.organization_handle = "TakenHandle"
+
+        assert_predicate @onboarding, :invalid?
+        assert_includes @onboarding.errors[:organization_handle], "has already been taken"
+      end
+    end
   end
 
   context "#save" do

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -17,8 +17,9 @@ class OrganizationTest < ActiveSupport::TestCase
   context "validations" do
     context "handle" do
       should allow_value("CapsLOCK").for(:handle)
+      should allow_value("1abcde").for(:handle)
+
       should_not allow_value(nil).for(:handle)
-      should_not allow_value("1abcde").for(:handle)
       should_not allow_value("abc^%def").for(:handle)
       should_not allow_value("abc\n<script>bad").for(:handle)
 
@@ -77,6 +78,40 @@ class OrganizationTest < ActiveSupport::TestCase
 
         refute_predicate organization, :valid?
         assert_contains organization.errors[:handle], "is reserved and cannot be used"
+      end
+
+      should "be invalid when handle is reserved under a different separator spelling" do
+        organization = build(:organization, handle: "ruby-gems")
+
+        refute_predicate organization, :valid?
+        assert_contains organization.errors[:handle], "is reserved and cannot be used"
+      end
+
+      should "be invalid when a user already owns the handle" do
+        create(:user, handle: "someuser")
+        organization = build(:organization, handle: "someuser")
+
+        refute_predicate organization, :valid?
+        assert_contains organization.errors[:handle], "has already been taken"
+      end
+
+      should "be invalid when a user already owns the handle in different case" do
+        create(:user, handle: "someuser")
+        organization = build(:organization, handle: "SomeUser")
+
+        refute_predicate organization, :valid?
+        assert_contains organization.errors[:handle], "has already been taken"
+      end
+
+      should "not check user handles when the handle is unchanged" do
+        organization = create(:organization, handle: "mycompany")
+        # Simulate a collision predating this validation: User's own guard
+        # would reject this handle now, so write it past validation.
+        create(:user).update_column(:handle, "mycompany")
+
+        organization.name = "A New Name"
+
+        assert_predicate organization, :valid?
       end
     end
   end


### PR DESCRIPTION
Why this change is being made:
- As we work towards a public rollout we want to reduce the surface area for problems in the Organization handle namespaces.

What were the changes made to support this:
- allow for a handle starting with a number (in this case 37signals)
- dont allow for organization handles which are taken by User handles (I'm not 100% on this one as of currently since I know the use of service user accounts is something that happens)
- Add a BUNCH of reserved words to the organization handle reserved list. This includes all our routes path segments, a bunch of words that look like they could belong to the app or rubygems namespaces, words that are tricky and annoying to sort out like "nil", and words that imply "trust" like "admin" or "safety"
- Update the seeds to use gem-org as the local test org
- Update the lib/patterns to include ORGANIZATION_HANDLE_PATTERN which is the same as the base handle pattern but allows for leading integers