### PR TITLE
Admin delete user

### DIFF
--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -13,10 +13,34 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
 
   self.confirm_button_label = "Delete User"
 
+  def self.blocked_reason
+    I18n.t("admin.delete_user.blocked_reason")
+  end
+
+  def enabled?
+    super && !blocked?
+  end
+
+  def action_name
+    return super unless blocked?
+
+    "#{super} — #{self.class.blocked_reason}"
+  end
+
   class ActionHandler < Avo::Actions::ActionHandler
     def handle_record(user)
+      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_old_gem_versions?
+
       DeleteUserJob.perform_later(user:)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
     end
+  end
+
+  private
+
+  def blocked?
+    return @blocked if defined?(@blocked)
+
+    @blocked = record.sole_owner_of_old_gem_versions?
   end
 end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -31,7 +31,7 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
     def handle_record(user)
       return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_old_gem_versions?
 
-      DeleteUserJob.perform_later(user:, send_emails: false)
+      DeleteUserJob.perform_later(user:, initiated_by: :admin)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
     end
   end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -31,7 +31,7 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
     def handle_record(user)
       return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_old_gem_versions?
 
-      DeleteUserJob.perform_later(user:)
+      DeleteUserJob.perform_later(user:, send_emails: false)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
     end
   end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -31,7 +31,7 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
     def handle_record(user)
       return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_old_gem_versions?
 
-      DeleteUserJob.perform_later(user:, initiated_by: :admin)
+      DeleteUserJob.perform_later(user:, actor: current_user)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
     end
   end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -7,7 +7,7 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
   }
 
   self.message = lambda {
-    "Are you sure you would like to delete user #{record.handle} with #{record.email}? " \
+    "Are you sure you would like to delete user #{record.display_handle} with #{record.email}? " \
       "This action can't be undone and will use the same account deletion process available from the user's profile."
   }
 

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -29,7 +29,7 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
 
   class ActionHandler < Avo::Actions::ActionHandler
     def handle_record(user)
-      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_old_gem_versions?
+      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_ineligible_gem_versions?
 
       DeleteUserJob.perform_later(user:, actor: current_user)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
@@ -41,6 +41,6 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
   def blocked?
     return @blocked if defined?(@blocked)
 
-    @blocked = record.sole_owner_of_old_gem_versions?
+    @blocked = record.sole_owner_of_ineligible_gem_versions?
   end
 end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
+  self.name = "Delete User"
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :show
+  }
+
+  self.message = lambda {
+    "Are you sure you would like to delete user #{record.handle} with #{record.email}? " \
+      "This action can't be undone and will use the same account deletion process available from the user's profile."
+  }
+
+  self.confirm_button_label = "Delete User"
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_record(user)
+      DeleteUserJob.perform_later(user:)
+      succeed("Account deletion for #{user.display_handle} has been scheduled")
+    end
+  end
+end

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -13,6 +13,7 @@ class Avo::Resources::User < Avo::BaseResource
     action Avo::Actions::BlockUser
     action Avo::Actions::CreateUser
     action Avo::Actions::ChangeUserEmail
+    action Avo::Actions::DeleteUser
     action Avo::Actions::ResetApiKey
     action Avo::Actions::ResetUser2fa
     action Avo::Actions::YankRubygemsForUser

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -49,7 +49,7 @@ class ProfilesController < ApplicationController
   end
 
   def destroy
-    DeleteUserJob.perform_later(user: current_user, initiated_by: :user)
+    DeleteUserJob.perform_later(user: current_user, actor: current_user)
     sign_out
     redirect_to root_path, notice: t(".request_queued")
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -49,7 +49,7 @@ class ProfilesController < ApplicationController
   end
 
   def destroy
-    DeleteUserJob.perform_later(user: current_user)
+    DeleteUserJob.perform_later(user: current_user, initiated_by: :user)
     sign_out
     redirect_to root_path, notice: t(".request_queued")
   end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -4,8 +4,8 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:profile_deletion)
 
-  def perform(user:, initiated_by:)
-    notify_user = notify_user?(initiated_by)
+  def perform(user:, actor:)
+    notify_user = actor == user
     email = user.email
     return if user.discarded?
     user.discard!
@@ -15,15 +15,5 @@ class DeleteUserJob < ApplicationJob
     # us no hint as to why the deletion failed.
     Rails.error.report(e, context: { user: user.as_json, email: }, handled: true)
     Mailer.deletion_failed(email).deliver_later if notify_user
-  end
-
-  private
-
-  def notify_user?(initiated_by)
-    case initiated_by.to_sym
-    when :user then true
-    when :admin then false
-    else raise ArgumentError, "Unknown deletion initiator: #{initiated_by.inspect}"
-    end
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -4,14 +4,15 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:profile_deletion)
 
-  def perform(user:)
+  def perform(user:, send_emails: true)
     email = user.email
     return if user.discarded?
+    user.skip_deletion_complete_email = !send_emails
     user.discard!
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     # Catch the exception so we can log it, otherwise using `destroy` would give
     # us no hint as to why the deletion failed.
     Rails.error.report(e, context: { user: user.as_json, email: }, handled: true)
-    Mailer.deletion_failed(email).deliver_later
+    Mailer.deletion_failed(email).deliver_later if send_emails
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -7,8 +7,7 @@ class DeleteUserJob < ApplicationJob
   def perform(user:, send_emails: true)
     email = user.email
     return if user.discarded?
-    user.skip_deletion_complete_email = !send_emails
-    user.discard!
+    send_emails ? user.discard! : user.discard_without_deletion_email!
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     # Catch the exception so we can log it, otherwise using `destroy` would give
     # us no hint as to why the deletion failed.

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -5,15 +5,20 @@ class DeleteUserJob < ApplicationJob
   queue_with_priority PRIORITIES.fetch(:profile_deletion)
 
   def perform(user:, actor:)
-    notify_user = actor == user
     email = user.email
     return if user.discarded?
     user.discard!
-    Mailer.deletion_complete(email).deliver_later if notify_user
+    Mailer.deletion_complete(email).deliver_later if self_service_deletion?(user, actor)
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     # Catch the exception so we can log it, otherwise using `destroy` would give
     # us no hint as to why the deletion failed.
     Rails.error.report(e, context: { user: user.as_json, email: }, handled: true)
-    Mailer.deletion_failed(email).deliver_later if notify_user
+    Mailer.deletion_failed(email).deliver_later if self_service_deletion?(user, actor)
+  end
+
+  private
+
+  def self_service_deletion?(user, actor)
+    user == actor
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -4,14 +4,26 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:profile_deletion)
 
-  def perform(user:, send_emails: true)
+  def perform(user:, initiated_by:)
+    notify_user = notify_user?(initiated_by)
     email = user.email
     return if user.discarded?
-    send_emails ? user.discard! : user.discard_without_deletion_email!
+    user.discard!
+    Mailer.deletion_complete(email).deliver_later if notify_user
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     # Catch the exception so we can log it, otherwise using `destroy` would give
     # us no hint as to why the deletion failed.
     Rails.error.report(e, context: { user: user.as_json, email: }, handled: true)
-    Mailer.deletion_failed(email).deliver_later if send_emails
+    Mailer.deletion_failed(email).deliver_later if notify_user
+  end
+
+  private
+
+  def notify_user?(initiated_by)
+    case initiated_by.to_sym
+    when :user then true
+    when :admin then false
+    else raise ArgumentError, "Unknown deletion initiator: #{initiated_by.inspect}"
+    end
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Deletion < ApplicationRecord
+  MAXIMUM_VERSION_AGE = 30.days
+
   # we nullify the user when they delete their account
   belongs_to :user, optional: true
 
@@ -37,7 +39,7 @@ class Deletion < ApplicationRecord
   end
 
   def ineligible_reason
-    if version.created_at&.before? 30.days.ago
+    if version.created_at&.before? MAXIMUM_VERSION_AGE.ago
       "Versions published more than 30 days ago cannot be deleted."
     elsif version.downloads_count > 100_000
       "Versions with more than 100,000 downloads cannot be deleted."

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -2,6 +2,7 @@
 
 class Deletion < ApplicationRecord
   MAXIMUM_VERSION_AGE = 30.days
+  MAXIMUM_DOWNLOADS = 100_000
 
   # we nullify the user when they delete their account
   belongs_to :user, optional: true
@@ -41,7 +42,7 @@ class Deletion < ApplicationRecord
   def ineligible_reason
     if version.created_at&.before? MAXIMUM_VERSION_AGE.ago
       "Versions published more than 30 days ago cannot be deleted."
-    elsif version.downloads_count > 100_000
+    elsif version.downloads_count > MAXIMUM_DOWNLOADS
       "Versions with more than 100,000 downloads cannot be deleted."
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   self.discard_column = :deleted_at
   self.ignored_columns += [:token]
 
+  attr_accessor :skip_deletion_complete_email
+
   default_scope { not_deleted }
 
   before_save :_generate_confirmation_token_no_reset_unconfirmed_email, if: :will_save_change_to_unconfirmed_email?
@@ -25,7 +27,7 @@ class User < ApplicationRecord
   before_discard :expire_all_api_keys
   before_discard :destroy_associations_for_discard
   before_discard :clear_personal_attributes
-  after_discard :send_deletion_complete_email
+  after_discard :send_deletion_complete_email, unless: :skip_deletion_complete_email
   before_destroy :yank_gems
 
   scope :not_deleted, -> { kept }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,6 +245,14 @@ class User < ApplicationRecord
       SELECT rubygem_id FROM ownerships GROUP BY rubygem_id HAVING count(rubygem_id) = 1)')
   end
 
+  def sole_owner_of_old_gem_versions?
+    only_owner_gems
+      .joins(:versions)
+      .where(versions: { indexed: true })
+      .where(Version.arel_table[:created_at].lt(Deletion::MAXIMUM_VERSION_AGE.ago))
+      .exists?
+  end
+
   def remember_me!
     self.remember_token = Clearance::Token.new
     self.remember_token_expires_at = Gemcutter::REMEMBER_FOR.from_now

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,6 @@ class User < ApplicationRecord
   self.discard_column = :deleted_at
   self.ignored_columns += [:token]
 
-  attr_accessor :skip_deletion_complete_email
-
   default_scope { not_deleted }
 
   before_save :_generate_confirmation_token_no_reset_unconfirmed_email, if: :will_save_change_to_unconfirmed_email?
@@ -27,7 +25,6 @@ class User < ApplicationRecord
   before_discard :expire_all_api_keys
   before_discard :destroy_associations_for_discard
   before_discard :clear_personal_attributes
-  after_discard :send_deletion_complete_email, unless: :skip_deletion_complete_email
   before_destroy :yank_gems
 
   scope :not_deleted, -> { kept }
@@ -171,13 +168,6 @@ class User < ApplicationRecord
 
   def display_id
     handle || id
-  end
-
-  def discard_without_deletion_email!
-    self.skip_deletion_complete_email = true
-    discard!
-  ensure
-    self.skip_deletion_complete_email = false
   end
 
   def flipper_id
@@ -366,7 +356,6 @@ class User < ApplicationRecord
   end
 
   def clear_personal_attributes
-    @email_before_discard = email
     update!(
       email: "deleted+#{id}@rubygems.org",
       handle: nil, email_confirmed: false,
@@ -377,10 +366,6 @@ class User < ApplicationRecord
       mfa_level: :disabled,
       password: SecureRandom.hex(20).encode("UTF-8")
     )
-  end
-
-  def send_deletion_complete_email
-    Mailer.deletion_complete(@email_before_discard).deliver_later
   end
 
   def record_create_event

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,6 +173,13 @@ class User < ApplicationRecord
     handle || id
   end
 
+  def discard_without_deletion_email!
+    self.skip_deletion_complete_email = true
+    discard!
+  ensure
+    self.skip_deletion_complete_email = false
+  end
+
   def flipper_id
     "user:#{handle}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,11 +244,14 @@ class User < ApplicationRecord
       SELECT rubygem_id FROM ownerships GROUP BY rubygem_id HAVING count(rubygem_id) = 1)')
   end
 
-  def sole_owner_of_old_gem_versions?
+  def sole_owner_of_ineligible_gem_versions?
     only_owner_gems
-      .joins(:versions)
+      .left_joins(versions: :gem_download)
       .where(versions: { indexed: true })
-      .where(Version.arel_table[:created_at].lt(Deletion::MAXIMUM_VERSION_AGE.ago))
+      .where(
+        Version.arel_table[:created_at].lt(Deletion::MAXIMUM_VERSION_AGE.ago)
+          .or(GemDownload.arel_table[:count].gt(Deletion::MAXIMUM_DOWNLOADS))
+      )
       .exists?
   end
 

--- a/app/tasks/maintenance/discard_spam_accounts_task.rb
+++ b/app/tasks/maintenance/discard_spam_accounts_task.rb
@@ -23,7 +23,7 @@ class Maintenance::DiscardSpamAccountsTask < MaintenanceTasks::Task
 
   def process(user)
     return if user.discarded?
-    user.discard_without_deletion_email!
+    user.discard!
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     Rails.error.report(e, context: { user_id: user.id }, handled: true)
   end

--- a/app/tasks/maintenance/discard_spam_accounts_task.rb
+++ b/app/tasks/maintenance/discard_spam_accounts_task.rb
@@ -23,17 +23,8 @@ class Maintenance::DiscardSpamAccountsTask < MaintenanceTasks::Task
 
   def process(user)
     return if user.discarded?
-    without_deletion_email { user.discard! }
+    user.discard_without_deletion_email!
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     Rails.error.report(e, context: { user_id: user.id }, handled: true)
-  end
-
-  private
-
-  def without_deletion_email
-    User.skip_callback(:discard, :after, :send_deletion_complete_email)
-    yield
-  ensure
-    User.set_callback(:discard, :after, :send_deletion_complete_email)
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,8 @@
 ---
 de:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required:
   copied: Kopiert!
   copy_to_clipboard: In die Zwischenablage kopieren

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  admin:
+    delete_user:
+      blocked_reason: Blocked because this user is the sole owner of gem versions published more than 30 days ago.
   credentials_required: Credentials required
   copied: Copied!
   copy_to_clipboard: Copy to clipboard

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   admin:
     delete_user:
-      blocked_reason: Blocked because this user is the sole owner of gem versions published more than 30 days ago.
+      blocked_reason: Blocked because this user is the sole owner of gem versions published more than 30 days ago or with more than 100,000 downloads.
   credentials_required: Credentials required
   copied: Copied!
   copy_to_clipboard: Copy to clipboard

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,8 @@
 ---
 es:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required: Credenciales requeridas
   copied: "¡Copiado!"
   copy_to_clipboard: Copiar al portapapeles

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,8 @@
 ---
 fr:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required:
   copied: Copié!
   copy_to_clipboard: Copier

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,8 @@
 ---
 ja:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required: 認証情報が必要です
   copied: コピー完了!
   copy_to_clipboard: クリップボードにコピー

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,8 @@
 ---
 nl:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required:
   copied: Gekopieerd
   copy_to_clipboard: Kopieer naar klembord

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,8 @@
 ---
 pt-BR:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required:
   copied: Copiado
   copy_to_clipboard: Copiar

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,5 +1,8 @@
 ---
 zh-CN:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required: 需要凭证
   copied: 已复制！
   copy_to_clipboard: 复制到剪贴板

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,5 +1,8 @@
 ---
 zh-TW:
+  admin:
+    delete_user:
+      blocked_reason:
   credentials_required: 需要認證
   copied: 已複製
   copy_to_clipboard: 複製

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -284,7 +284,7 @@ class ProfilesControllerTest < ActionController::TestCase
     context "on DELETE to destroy" do
       context "correct password" do
         should "enqueue deletion request" do
-          assert_enqueued_jobs 1, only: DeleteUserJob do
+          assert_enqueued_with(job: DeleteUserJob, args: [user: @user, initiated_by: :user]) do
             delete :destroy, params: { user: { password: @user.password } }
           end
         end

--- a/test/functional/profiles_controller_test.rb
+++ b/test/functional/profiles_controller_test.rb
@@ -284,7 +284,7 @@ class ProfilesControllerTest < ActionController::TestCase
     context "on DELETE to destroy" do
       context "correct password" do
         should "enqueue deletion request" do
-          assert_enqueued_with(job: DeleteUserJob, args: [user: @user, initiated_by: :user]) do
+          assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @user]) do
             delete :destroy, params: { user: { password: @user.password } }
           end
         end

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -35,6 +35,48 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     assert page.has_content? "Delete User"
   end
 
+  test "disabling the delete action when the user is the sole owner of an old gem version" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+    create(:version, rubygem:, created_at: 31.days.ago)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
+    assert page.has_content?(
+      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago."
+    )
+    assert_select "a[data-action-name^='Delete User'][data-disabled='true']", count: 1
+  end
+
+  test "enabling the delete action when an old gem version has another owner" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user, create(:user)])
+    create(:version, rubygem:, created_at: 31.days.ago)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
+    assert_select "a[data-action-name='Delete User'][data-disabled='false']", count: 1
+    refute page.has_content? Avo::Actions::DeleteUser.blocked_reason
+  end
+
+  test "enabling the delete action when the user's old gem version is already yanked" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user)
+    rubygem = create(:rubygem, owners: [user])
+    create(:version, rubygem:, created_at: 31.days.ago, indexed: false)
+    create(:version, rubygem:)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
+    assert_select "a[data-action-name='Delete User'][data-disabled='false']", count: 1
+    refute page.has_content? Avo::Actions::DeleteUser.blocked_reason
+  end
+
   test "not showing the delete action on the users index" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
 

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -23,5 +23,6 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert page.has_content? user.name
+    assert page.has_content? "Delete User"
   end
 end

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -23,6 +23,37 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert page.has_content? user.name
+  end
+
+  test "showing the delete action to rubygems.org operators on the user page" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
     assert page.has_content? "Delete User"
+  end
+
+  test "not showing the delete action on the users index" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_users_path
+
+    assert_response :success
+    refute page.has_content? "Delete User"
+  end
+
+  test "not showing the delete action to operators outside the rubygems.org team" do
+    admin = create(:admin_github_user, :is_admin)
+    info_data = admin.info_data.deep_dup
+    info_data[:viewer][:organization][:teams][:edges].reject! { |edge| edge.dig(:node, :slug) == "rubygems-org" }
+    admin.update!(info_data:)
+    admin_sign_in_as admin
+
+    get avo.resources_user_path(create(:user))
+
+    assert_response :success
+    refute page.has_content? "Delete User"
   end
 end

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -45,7 +45,25 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert page.has_content?(
-      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago."
+      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago " \
+      "or with more than 100,000 downloads."
+    )
+    assert_select "a[data-action-name^='Delete User'][data-disabled='true']", count: 1
+  end
+
+  test "disabling the delete action when the user is the sole owner of a gem version with too many downloads" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user)
+    rubygem = create(:rubygem, name: "admin-delete-blocked-popular-gem", owners: [user])
+    version = create(:version, rubygem:)
+    GemDownload.increment(100_001, rubygem_id: rubygem.id, version_id: version.id)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
+    assert page.has_content?(
+      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago " \
+      "or with more than 100,000 downloads."
     )
     assert_select "a[data-action-name^='Delete User'][data-disabled='true']", count: 1
   end
@@ -96,6 +114,6 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
     get avo.resources_user_path(create(:user))
 
-    assert_redirected_to avo_path
+    assert_redirected_to avo.root_path
   end
 end

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -38,7 +38,7 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
   test "disabling the delete action when the user is the sole owner of an old gem version" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)
-    rubygem = create(:rubygem, owners: [user])
+    rubygem = create(:rubygem, name: "admin-delete-blocked-old-gem", owners: [user])
     create(:version, rubygem:, created_at: 31.days.ago)
 
     get avo.resources_user_path(user)
@@ -53,7 +53,7 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
   test "enabling the delete action when an old gem version has another owner" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)
-    rubygem = create(:rubygem, owners: [user, create(:user)])
+    rubygem = create(:rubygem, name: "admin-delete-shared-old-gem", owners: [user, create(:user)])
     create(:version, rubygem:, created_at: 31.days.ago)
 
     get avo.resources_user_path(user)
@@ -66,7 +66,7 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
   test "enabling the delete action when the user's old gem version is already yanked" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)
-    rubygem = create(:rubygem, owners: [user])
+    rubygem = create(:rubygem, name: "admin-delete-yanked-old-gem", owners: [user])
     create(:version, rubygem:, created_at: 31.days.ago, indexed: false)
     create(:version, rubygem:)
 
@@ -86,7 +86,8 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     refute page.has_content? "Delete User"
   end
 
-  test "not showing the delete action to operators outside the rubygems.org team" do
+  test "redirecting operators outside the rubygems.org team" do
+    requires_avo_pro
     admin = create(:admin_github_user, :is_admin)
     info_data = admin.info_data.deep_dup
     info_data[:viewer][:organization][:teams][:edges].reject! { |edge| edge.dig(:node, :slug) == "rubygems-org" }
@@ -95,7 +96,6 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
     get avo.resources_user_path(create(:user))
 
-    assert_response :success
-    refute page.has_content? "Delete User"
+    assert_redirected_to avo_path
   end
 end

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class DeleteUserJobTest < ActiveJob::TestCase
   test "sends deletion complete on success" do
     user = create(:user)
-    rubygem = create(:ownership, user:).rubygem
+    rubygem = create(:rubygem, name: "self-service-deletion-email", owners: [user])
     version = create(:version, rubygem:)
 
     assert_delete user
@@ -21,34 +21,31 @@ class DeleteUserJobTest < ActiveJob::TestCase
 
     Mailer.expects(:deletion_failed).with(user.email).returns(mock(deliver_later: nil))
     User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
-    DeleteUserJob.new(user:).perform(user:)
+    DeleteUserJob.new(user:, initiated_by: :user).perform(user:, initiated_by: :user)
 
     refute_predicate user.reload, :destroyed?
     refute_predicate user, :deleted_at
   end
 
-  test "does not send email after spam account deletion when a successful deletion has emails disabled" do
-    spam_user = create(:user, email: "spam@spammy-test.org", email_confirmed: false)
-    Maintenance::DiscardSpamAccountsTask.process(spam_user)
-
+  test "does not send email when deletion is initiated by an admin" do
     user = create(:user)
     rubygem = create(:rubygem, name: "admin-email-suppression", owners: [user])
     create(:version, rubygem:)
 
     Mailer.expects(:deletion_complete).never
     assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-      DeleteUserJob.new(user:, send_emails: false).perform(user:, send_emails: false)
+      DeleteUserJob.new(user:, initiated_by: :admin).perform(user:, initiated_by: :admin)
     end
 
     assert_predicate user.reload, :discarded?
   end
 
-  test "does not send deletion failed when emails are disabled" do
+  test "does not send deletion failed when deletion is initiated by an admin" do
     user = create(:user)
 
     Mailer.expects(:deletion_failed).never
     User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
-    DeleteUserJob.new(user:, send_emails: false).perform(user:, send_emails: false)
+    DeleteUserJob.new(user:, initiated_by: :admin).perform(user:, initiated_by: :admin)
 
     refute_predicate user.reload, :discarded?
   end
@@ -155,7 +152,7 @@ class DeleteUserJobTest < ActiveJob::TestCase
   def assert_delete(user)
     Mailer.expects(:deletion_complete).with(user.email).returns(mock(deliver_later: nil))
     Mailer.expects(:deletion_failed).never
-    DeleteUserJob.new(user:).perform(user:)
+    DeleteUserJob.new(user:, initiated_by: :user).perform(user:, initiated_by: :user)
 
     refute_predicate user.reload, :destroyed?
     assert_predicate user.reload, :deleted_at

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -21,7 +21,7 @@ class DeleteUserJobTest < ActiveJob::TestCase
 
     Mailer.expects(:deletion_failed).with(user.email).returns(mock(deliver_later: nil))
     User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
-    DeleteUserJob.new(user:, initiated_by: :user).perform(user:, initiated_by: :user)
+    DeleteUserJob.new(user:, actor: user).perform(user:, actor: user)
 
     refute_predicate user.reload, :destroyed?
     refute_predicate user, :deleted_at
@@ -29,12 +29,13 @@ class DeleteUserJobTest < ActiveJob::TestCase
 
   test "does not send email when deletion is initiated by an admin" do
     user = create(:user)
+    actor = create(:admin_github_user, :is_admin)
     rubygem = create(:rubygem, name: "admin-email-suppression", owners: [user])
     create(:version, rubygem:)
 
     Mailer.expects(:deletion_complete).never
     assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
-      DeleteUserJob.new(user:, initiated_by: :admin).perform(user:, initiated_by: :admin)
+      DeleteUserJob.new(user:, actor:).perform(user:, actor:)
     end
 
     assert_predicate user.reload, :discarded?
@@ -42,10 +43,11 @@ class DeleteUserJobTest < ActiveJob::TestCase
 
   test "does not send deletion failed when deletion is initiated by an admin" do
     user = create(:user)
+    actor = create(:admin_github_user, :is_admin)
 
     Mailer.expects(:deletion_failed).never
     User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
-    DeleteUserJob.new(user:, initiated_by: :admin).perform(user:, initiated_by: :admin)
+    DeleteUserJob.new(user:, actor:).perform(user:, actor:)
 
     refute_predicate user.reload, :discarded?
   end
@@ -152,7 +154,7 @@ class DeleteUserJobTest < ActiveJob::TestCase
   def assert_delete(user)
     Mailer.expects(:deletion_complete).with(user.email).returns(mock(deliver_later: nil))
     Mailer.expects(:deletion_failed).never
-    DeleteUserJob.new(user:, initiated_by: :user).perform(user:, initiated_by: :user)
+    DeleteUserJob.new(user:, actor: user).perform(user:, actor: user)
 
     refute_predicate user.reload, :destroyed?
     assert_predicate user.reload, :deleted_at

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -27,6 +27,29 @@ class DeleteUserJobTest < ActiveJob::TestCase
     refute_predicate user, :deleted_at
   end
 
+  test "does not send email when a successful deletion has emails disabled" do
+    user = create(:user)
+    rubygem = create(:rubygem, name: "admin-email-suppression", owners: [user])
+    create(:version, rubygem:)
+
+    Mailer.expects(:deletion_complete).never
+    assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      DeleteUserJob.new(user:, send_emails: false).perform(user:, send_emails: false)
+    end
+
+    assert_predicate user.reload, :discarded?
+  end
+
+  test "does not send deletion failed when emails are disabled" do
+    user = create(:user)
+
+    Mailer.expects(:deletion_failed).never
+    User.any_instance.expects(:yank_gems).raises(ActiveRecord::RecordNotDestroyed)
+    DeleteUserJob.new(user:, send_emails: false).perform(user:, send_emails: false)
+
+    refute_predicate user.reload, :discarded?
+  end
+
   test "succeeds with api key" do
     user = create(:user)
     create(:api_key, owner: user)

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -27,7 +27,10 @@ class DeleteUserJobTest < ActiveJob::TestCase
     refute_predicate user, :deleted_at
   end
 
-  test "does not send email when a successful deletion has emails disabled" do
+  test "does not send email after spam account deletion when a successful deletion has emails disabled" do
+    spam_user = create(:user, email: "spam@spammy-test.org", email_confirmed: false)
+    Maintenance::DiscardSpamAccountsTask.process(spam_user)
+
     user = create(:user)
     rubygem = create(:rubygem, name: "admin-email-suppression", owners: [user])
     create(:version, rubygem:)

--- a/test/tasks/maintenance/discard_spam_accounts_task_test.rb
+++ b/test/tasks/maintenance/discard_spam_accounts_task_test.rb
@@ -39,14 +39,14 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
     end
   end
 
-  test "#process restores deletion email callback after processing" do
+  test "#process does not affect user-initiated deletion emails" do
     user = create(:user, email: "spam@spammy-test.org", created_at: 1.day.ago, email_confirmed: false)
     Maintenance::DiscardSpamAccountsTask.process(user)
 
     other_user = create(:user, email: "regular@spammy-test.org", created_at: 1.day.ago)
 
-    assert_enqueued_emails 1 do
-      other_user.discard!
+    assert_enqueued_email_with Mailer, :deletion_complete, args: [other_user.email] do
+      DeleteUserJob.new(user: other_user, initiated_by: :user).perform(user: other_user, initiated_by: :user)
     end
   end
 

--- a/test/tasks/maintenance/discard_spam_accounts_task_test.rb
+++ b/test/tasks/maintenance/discard_spam_accounts_task_test.rb
@@ -46,7 +46,7 @@ class Maintenance::DiscardSpamAccountsTaskTest < ActiveSupport::TestCase
     other_user = create(:user, email: "regular@spammy-test.org", created_at: 1.day.ago)
 
     assert_enqueued_email_with Mailer, :deletion_complete, args: [other_user.email] do
-      DeleteUserJob.new(user: other_user, initiated_by: :user).perform(user: other_user, initiated_by: :user)
+      DeleteUserJob.new(user: other_user, actor: other_user).perform(user: other_user, actor: other_user)
     end
   end
 

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -12,7 +12,7 @@ class DeleteUserTest < ActiveSupport::TestCase
     @action = Avo::Actions::DeleteUser.new(record: @user, resource: @resource, user: @current_user, view: :show)
   end
 
-  should "enqueue the same deletion job used by profile deletion" do
+  should "enqueue deletion without sending the user emails" do
     args = {
       current_user: @current_user,
       resource: @resource,
@@ -23,7 +23,7 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_enqueued_with(job: DeleteUserJob, args: [user: @user]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, send_emails: false]) do
       @action.handle(**args)
     end
   end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DeleteUserTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @user = create(:user)
+    @current_user = create(:admin_github_user, :is_admin)
+    @resource = Avo::Resources::User.new.hydrate(record: @user)
+    @action = Avo::Actions::DeleteUser.new(record: @user, resource: @resource, user: @current_user, view: :show)
+  end
+
+  should "enqueue the same deletion job used by profile deletion" do
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user],
+      fields: {
+        comment: "Deleting at the user's request"
+      },
+      query: nil
+    }
+
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user]) do
+      @action.handle(**args)
+    end
+  end
+
+  should "ask for confirmation naming the user" do
+    action_mock = Data.define(:record).new(record: @user)
+
+    message = action_mock.instance_exec(&Avo::Actions::DeleteUser.message)
+
+    assert_includes message, @user.handle
+    assert_includes message, @user.email
+  end
+
+  should "be visible to rubygems.org operators on the user page" do
+    action_mock = Data.define(:current_user, :view).new(current_user: @current_user, view: :show)
+
+    assert action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
+  end
+
+  should "not be visible outside the user page" do
+    action_mock = Data.define(:current_user, :view).new(current_user: @current_user, view: :index)
+
+    refute action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
+  end
+
+  should "not be visible to operators outside the rubygems.org team" do
+    current_user = create(:admin_github_user)
+    action_mock = Data.define(:current_user, :view).new(current_user:, view: :show)
+
+    refute action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
+  end
+end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -29,7 +29,7 @@ class DeleteUserTest < ActiveSupport::TestCase
   end
 
   should "not enqueue deletion when the user is the sole owner of an old gem version" do
-    rubygem = create(:rubygem, owners: [@user])
+    rubygem = create(:rubygem, name: "old-gem-owned-by-deleted-user", owners: [@user])
     create(:version, rubygem:, created_at: 31.days.ago)
     args = {
       current_user: @current_user,
@@ -52,5 +52,13 @@ class DeleteUserTest < ActiveSupport::TestCase
 
     assert_includes message, @user.handle
     assert_includes message, @user.email
+  end
+
+  should "ask for confirmation naming a user without a handle" do
+    @user.update!(handle: nil)
+
+    message = @action.get_message
+
+    assert_includes message, "delete user ##{@user.id} with #{@user.email}"
   end
 end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -29,30 +29,9 @@ class DeleteUserTest < ActiveSupport::TestCase
   end
 
   should "ask for confirmation naming the user" do
-    action_mock = Data.define(:record).new(record: @user)
-
-    message = action_mock.instance_exec(&Avo::Actions::DeleteUser.message)
+    message = @action.get_message
 
     assert_includes message, @user.handle
     assert_includes message, @user.email
-  end
-
-  should "be visible to rubygems.org operators on the user page" do
-    action_mock = Data.define(:current_user, :view).new(current_user: @current_user, view: :show)
-
-    assert action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
-  end
-
-  should "not be visible outside the user page" do
-    action_mock = Data.define(:current_user, :view).new(current_user: @current_user, view: :index)
-
-    refute action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
-  end
-
-  should "not be visible to operators outside the rubygems.org team" do
-    current_user = create(:admin_github_user)
-    action_mock = Data.define(:current_user, :view).new(current_user:, view: :show)
-
-    refute action_mock.instance_exec(&Avo::Actions::DeleteUser.visible)
   end
 end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -28,6 +28,25 @@ class DeleteUserTest < ActiveSupport::TestCase
     end
   end
 
+  should "not enqueue deletion when the user is the sole owner of an old gem version" do
+    rubygem = create(:rubygem, owners: [@user])
+    create(:version, rubygem:, created_at: 31.days.ago)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user],
+      fields: {
+        comment: "Deleting at the user's request"
+      },
+      query: nil
+    }
+
+    assert_no_enqueued_jobs only: DeleteUserJob do
+      @action.handle(**args)
+    end
+    assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
+  end
+
   should "ask for confirmation naming the user" do
     message = @action.get_message
 

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -47,6 +47,26 @@ class DeleteUserTest < ActiveSupport::TestCase
     assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
   end
 
+  should "not enqueue deletion when the user is the sole owner of a gem version with too many downloads" do
+    rubygem = create(:rubygem, name: "popular-gem-owned-by-deleted-user", owners: [@user])
+    version = create(:version, rubygem:)
+    GemDownload.increment(100_001, rubygem_id: rubygem.id, version_id: version.id)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user],
+      fields: {
+        comment: "Deleting at the user's request"
+      },
+      query: nil
+    }
+
+    assert_no_enqueued_jobs only: DeleteUserJob do
+      @action.handle(**args)
+    end
+    assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
+  end
+
   should "ask for confirmation naming the user" do
     message = @action.get_message
 

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -12,7 +12,7 @@ class DeleteUserTest < ActiveSupport::TestCase
     @action = Avo::Actions::DeleteUser.new(record: @user, resource: @resource, user: @current_user, view: :show)
   end
 
-  should "enqueue deletion without sending the user emails" do
+  should "enqueue an admin-initiated deletion" do
     args = {
       current_user: @current_user,
       resource: @resource,
@@ -23,7 +23,7 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, send_emails: false]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, initiated_by: :admin]) do
       @action.handle(**args)
     end
   end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -23,7 +23,7 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, initiated_by: :admin]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @current_user]) do
       @action.handle(**args)
     end
   end


### PR DESCRIPTION
We've received numerous support tickets in response to the legacy api key email, asking for their accounts to be deleted. Instead of directing users to log into their account, we should be able to this from the admin panel.

This PR largely is adding a new action for users that will follow the existing self-serve process of deleting a user.