### PR TITLE
Add push notifications for organization members

### DIFF
--- a/app/avo/resources/membership.rb
+++ b/app/avo/resources/membership.rb
@@ -14,5 +14,6 @@ class Avo::Resources::Membership < Avo::BaseResource
     field :user, as: :belongs_to
     field :organization, as: :belongs_to
     field :role, as: :select, enum: Membership.roles
+    field :push_notifier, as: :boolean
   end
 end

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -9,18 +9,21 @@ class NotifiersController < ApplicationController
 
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name.includes(:rubygem)
+    @memberships = current_user.memberships.confirmed.by_organization_handle.includes(:organization)
     @title = t(".title")
     add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
     add_breadcrumb(@title)
   end
 
   def update
-    to_enable_push, to_disable_push = notifier_options("push")
-    to_enable_owner, to_disable_owner = notifier_options("owner")
+    to_enable_ownership_push, to_disable_ownership_push = notifier_options(notifier_params, "push")
+    to_enable_ownership_owner, to_disable_ownership_owner = notifier_options(notifier_params, "owner")
+    to_enable_membership_push, to_disable_membership_push = notifier_options(membership_params, "push")
 
     current_user.transaction do
-      current_user.ownerships.update_push_notifier(to_enable_push, to_disable_push)
-      current_user.ownerships.update_owner_notifier(to_enable_owner, to_disable_owner)
+      current_user.ownerships.update_push_notifier(to_enable_ownership_push, to_disable_ownership_push)
+      current_user.ownerships.update_owner_notifier(to_enable_ownership_owner, to_disable_ownership_owner)
+      current_user.memberships.update_push_notifier(to_enable_membership_push, to_disable_membership_push)
       Mailer.notifiers_changed(current_user.id).deliver_later
     end
 
@@ -30,14 +33,22 @@ class NotifiersController < ApplicationController
   private
 
   def notifier_params
+    return {} unless params.key?(:ownerships)
+
     params.expect(ownerships: [%i[push owner]])
   end
 
-  def notifier_options(param)
+  def membership_params
+    return {} unless params.key?(:memberships)
+
+    params.expect(memberships: [%i[push]])
+  end
+
+  def notifier_options(records, param)
     to_enable  = []
     to_disable = []
-    notifier_params.each do |ownership_id, notifier|
-      (notifier[param] == "off" ? to_disable : to_enable) << ownership_id.to_i
+    records.each do |record_id, notifier|
+      (notifier[param] == "off" ? to_disable : to_enable) << record_id.to_i
     end
 
     [to_enable, to_disable]

--- a/app/jobs/after_version_write_job.rb
+++ b/app/jobs/after_version_write_job.rb
@@ -6,9 +6,8 @@ class AfterVersionWriteJob < ApplicationJob
   def perform(version:)
     version.transaction do
       rubygem = version.rubygem
-      version.rubygem.push_notifiable_owners.each do |notified_user|
-        Mailer.gem_pushed(owner, version.id, notified_user.id).deliver_later
-      end
+      notify_pushed(rubygem.push_notifiable_owners, version)
+      notify_pushed(rubygem.organization.push_notifiable_members, version) if rubygem.organization.present?
       Indexer.perform_later
       UploadVersionsFileJob.perform_later
       UploadInfoFileJob.perform_later(rubygem_name: rubygem.name)
@@ -27,5 +26,13 @@ class AfterVersionWriteJob < ApplicationJob
 
   def owner
     arguments.dig(0, :version).pusher_api_key&.owner
+  end
+
+  private
+
+  def notify_pushed(users, version)
+    users.each do |notified_user|
+      Mailer.gem_pushed(owner, version.id, notified_user.id).deliver_later
+    end
   end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -56,6 +56,7 @@ class Mailer < ApplicationMailer
   def notifiers_changed(user_id)
     @user = User.find(user_id)
     @ownerships = @user.ownerships.by_indexed_gem_name
+    @memberships = @user.memberships.confirmed.by_organization_handle.includes(:organization)
 
     mail to: @user.email,
          subject: I18n.t("mailer.notifiers_changed.subject", host: Gemcutter::HOST_DISPLAY,

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -148,7 +148,13 @@ class Deletion < ApplicationRecord
   end
 
   def send_gem_yanked_mail
-    version.rubygem.push_notifiable_owners.each do |notified_user|
+    rubygem = version.rubygem
+    notify_yanked(rubygem.push_notifiable_owners)
+    notify_yanked(rubygem.organization.push_notifiable_members) if rubygem.organization.present?
+  end
+
+  def notify_yanked(users)
+    users.each do |notified_user|
       Mailer.gem_yanked(user.id, version.id, notified_user.id).deliver_later
     end
   end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -145,7 +145,13 @@ class Deletion < ApplicationRecord
   end
 
   def send_gem_yanked_mail
-    version.rubygem.push_notifiable_owners.each do |notified_user|
+    rubygem = version.rubygem
+    notify_yanked(rubygem.push_notifiable_owners)
+    notify_yanked(rubygem.organization.push_notifiable_members) if rubygem.organization.present?
+  end
+
+  def notify_yanked(users)
+    users.each do |notified_user|
       Mailer.gem_yanked(user.id, version.id, notified_user.id).deliver_later
     end
   end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -13,7 +13,18 @@ class Membership < ApplicationRecord
 
   scope :with_minimum_role, ->(role) { where(role: Access.flag_for_role(role)...) }
 
+  scope :by_organization_handle, -> { joins(:organization).order("organizations.handle ASC") }
+
   validates :user, uniqueness: { scope: :organization }
+
+  def self.update_notifier(to_enable, to_disable, notifier_attr)
+    where(id: to_enable).update_all(notifier_attr => true) if to_enable.any?
+    where(id: to_disable).update_all(notifier_attr => false) if to_disable.any?
+  end
+
+  def self.update_push_notifier(to_enable_push, to_disable_push)
+    update_notifier(to_enable_push, to_disable_push, "push_notifier")
+  end
 
   before_create :set_invitation_expire_time
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -14,6 +14,7 @@ class Organization < ApplicationRecord
   has_many :unconfirmed_memberships, -> { where(confirmed_at: nil) }, class_name: "Membership", dependent: :destroy, inverse_of: :organization
   has_many :memberships_including_unconfirmed, class_name: "Membership", dependent: :destroy, inverse_of: :organization
   has_many :users, through: :memberships
+  has_many :push_notifiable_members, ->(org) { org.users.push_notifiable_members }, through: :memberships, source: :user
   has_many :rubygems, dependent: :nullify
   has_many :audits, as: :auditable, dependent: :nullify
   has_one :organization_onboarding, foreign_key: :onboarded_organization_id, inverse_of: :organization, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,10 @@ class User < ApplicationRecord
     where(ownerships: { push_notifier: true })
   end
 
+  def self.push_notifiable_members
+    where(memberships: { push_notifier: true })
+  end
+
   def self.ownership_notifiable_owners
     where(ownerships: { owner_notifier: true })
   end

--- a/app/views/mailer/notifiers_changed.html.erb
+++ b/app/views/mailer/notifiers_changed.html.erb
@@ -26,6 +26,21 @@
             </li>
           <% end %>
         </ul>
+        <% if @memberships.any? %>
+          <p>
+            Here are your email notification settings for each organization you belong to:
+          </p>
+          <ul>
+            <% @memberships.each do |membership| %>
+              <li>
+                <%= membership.organization.handle %> organization emails:
+                <ul>
+                  <li>Gem Push Notifications: <%= membership.push_notifier? ? t("mailer.notifiers_changed.on") : t("mailer.notifiers_changed.off_html") %></li>
+                </ul>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
         <p>If this change to your settings is expected, you do not need to take further action.</p>
         <p>
           <strong>Only if this change to your settings is unexpected</strong>

--- a/app/views/notifiers/show.html.erb
+++ b/app/views/notifiers/show.html.erb
@@ -14,45 +14,74 @@
     <p class="text-b2 text-neutral-700 dark:text-neutral-300"><%= t('.info') %></p>
   </div>
 
-  <% if @ownerships.any? %>
+  <% if @ownerships.any? || @memberships.any? %>
     <%= form_tag notifier_path, method: :put do %>
-      <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
-        <% @ownerships.each do |ownership| %>
-          <section class="py-4 first:pt-0 last:pb-0">
-            <h2 class="text-h4 mb-4"><%= ownership.rubygem.name %></h2>
+      <% if @ownerships.any? %>
+        <h2 class="text-h3 mb-4"><%= t('.gems_heading') %></h2>
+        <div class="divide-y divide-neutral-200 dark:divide-neutral-800 mb-8">
+          <% @ownerships.each do |ownership| %>
+            <section class="py-4 first:pt-0 last:pb-0">
+              <h3 class="text-h4 mb-4"><%= ownership.rubygem.name %></h3>
 
-            <div class="flex flex-col gap-8 sm:flex-row">
-              <fieldset class="flex-1">
+              <div class="flex flex-col gap-8 sm:flex-row">
+                <fieldset class="flex-1">
+                  <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.push_heading') %></legend>
+                  <div class="space-y-2">
+                    <%= label_tag(nil, nil, class: radio_label) do %>
+                      <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier?, class: radio_input %>
+                      <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                    <% end %>
+                    <%= label_tag(nil, nil, class: radio_label) do %>
+                      <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier?, class: radio_input %>
+                      <span><%= t('.off') %></span>
+                    <% end %>
+                  </div>
+                </fieldset>
+
+                <fieldset class="flex-1">
+                  <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.owner_heading') %></legend>
+                  <div class="space-y-3">
+                    <%= label_tag(nil, nil, class: radio_label) do %>
+                      <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier?, class: radio_input %>
+                      <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
+                    <% end %>
+                    <%= label_tag(nil, nil, class: radio_label) do %>
+                      <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier?, class: radio_input %>
+                      <span><%= t('.off') %></span>
+                    <% end %>
+                  </div>
+                </fieldset>
+              </div>
+            </section>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if @memberships.any? %>
+        <h2 class="text-h3 mb-2"><%= t('.organizations_heading') %></h2>
+        <p class="text-b2 text-neutral-700 dark:text-neutral-300 mb-4"><%= t('.organization_info') %></p>
+        <div class="divide-y divide-neutral-200 dark:divide-neutral-800">
+          <% @memberships.each do |membership| %>
+            <section class="py-4 first:pt-0 last:pb-0">
+              <h3 class="text-h4 mb-4"><%= membership.organization.handle %></h3>
+
+              <fieldset>
                 <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.push_heading') %></legend>
                 <div class="space-y-2">
                   <%= label_tag(nil, nil, class: radio_label) do %>
-                    <%= radio_button_tag "ownerships[#{ownership.id}][push]", :on, ownership.push_notifier?, class: radio_input %>
+                    <%= radio_button_tag "memberships[#{membership.id}][push]", :on, membership.push_notifier?, class: radio_input %>
                     <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
                   <% end %>
                   <%= label_tag(nil, nil, class: radio_label) do %>
-                    <%= radio_button_tag "ownerships[#{ownership.id}][push]", :off, !ownership.push_notifier?, class: radio_input %>
+                    <%= radio_button_tag "memberships[#{membership.id}][push]", :off, !membership.push_notifier?, class: radio_input %>
                     <span><%= t('.off') %></span>
                   <% end %>
                 </div>
               </fieldset>
-
-              <fieldset class="flex-1">
-                <legend class="<%= c.sub_heading_classes %> mb-2"><%= t('.owner_heading') %></legend>
-                <div class="space-y-3">
-                  <%= label_tag(nil, nil, class: radio_label) do %>
-                    <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :on, ownership.owner_notifier?, class: radio_input %>
-                    <span><%= t('.on') %> <span class="text-b3 text-neutral-600 dark:text-neutral-400">(<%= t('.recommended') %>)</span></span>
-                  <% end %>
-                  <%= label_tag(nil, nil, class: radio_label) do %>
-                    <%= radio_button_tag "ownerships[#{ownership.id}][owner]", :off, !ownership.owner_notifier?, class: radio_input %>
-                    <span><%= t('.off') %></span>
-                  <% end %>
-                </div>
-              </fieldset>
-            </div>
-          </section>
-        <% end %>
-      </div>
+            </section>
+          <% end %>
+        </div>
+      <% end %>
 
       <div class="flex justify-end my-4">
         <%= render ButtonComponent.new(t('.update'), type: :submit) %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -104,7 +104,7 @@
         <%= t("oidc.api_key_roles.index.api_key_roles") %>
       <% end %>
     <% end %>
-    <% if @user.ownerships.any? %>
+    <% if @user.ownerships.any? || @user.memberships.confirmed.any? %>
       <%= c.list_item_to(notifier_path) do %>
         <%= t("notifiers.show.title") %>
       <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -746,6 +746,9 @@ de:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -750,6 +750,9 @@ de:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -669,6 +669,9 @@ en:
       update: Update
       owner_heading: Ownership Notifications
       push_heading: Push Notifications
+      gems_heading: Gems
+      organizations_heading: Organizations
+      organization_info: Push notifications for all gems owned by this organization.
   webauthn_verifications:
     expired_or_already_used: The token in the link you used has either expired or been used already.
     no_port: No port provided. Please try again.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,6 +665,9 @@ en:
       update: Update
       owner_heading: Ownership Notifications
       push_heading: Push Notifications
+      gems_heading: Gems
+      organizations_heading: Organizations
+      organization_info: Push notifications for all gems owned by this organization.
   webauthn_verifications:
     expired_or_already_used: The token in the link you used has either expired or been used already.
     no_port: No port provided. Please try again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -732,6 +732,9 @@ es:
       update: Actualizar
       owner_heading: Notificaciones de propietarios
       push_heading: Notificaciones Push
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: El token del enlace utilizado ha expirado o ya ha sido
       utilizado.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -736,6 +736,9 @@ es:
       update: Actualizar
       owner_heading: Notificaciones de propietarios
       push_heading: Notificaciones Push
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: El token del enlace utilizado ha expirado o ya ha sido
       utilizado.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -679,6 +679,9 @@ fr:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -675,6 +675,9 @@ fr:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -675,6 +675,9 @@ ja:
       update: 更新
       owner_heading: 所有権の通知
       push_heading: プッシュ通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 使用されたリンク中のトークンは期限切れか既に使われています。
     no_port: ポートが与えられていません。再試行してください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -671,6 +671,9 @@ ja:
       update: 更新
       owner_heading: 所有権の通知
       push_heading: プッシュ通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 使用されたリンク中のトークンは期限切れか既に使われています。
     no_port: ポートが与えられていません。再試行してください。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -658,6 +658,9 @@ nl:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -662,6 +662,9 @@ nl:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -669,6 +669,9 @@ pt-BR:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -673,6 +673,9 @@ pt-BR:
       update:
       owner_heading:
       push_heading:
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used:
     no_port:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -663,6 +663,9 @@ zh-CN:
       update: 更新
       owner_heading: 所有权通知
       push_heading: 推送通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 您链接中使用的的令牌已过期或已被使用。
     no_port: 没有提供端口。请再试一次。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -667,6 +667,9 @@ zh-CN:
       update: 更新
       owner_heading: 所有权通知
       push_heading: 推送通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 您链接中使用的的令牌已过期或已被使用。
     no_port: 没有提供端口。请再试一次。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -661,6 +661,9 @@ zh-TW:
       update: 更新
       owner_heading: 所有權通知
       push_heading: 推送通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 您所使用的連結中的權杖已過期或被使用。
     no_port: 未提供連接埠。請再試一次。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -657,6 +657,9 @@ zh-TW:
       update: 更新
       owner_heading: 所有權通知
       push_heading: 推送通知
+      gems_heading:
+      organizations_heading:
+      organization_info:
   webauthn_verifications:
     expired_or_already_used: 您所使用的連結中的權杖已過期或被使用。
     no_port: 未提供連接埠。請再試一次。

--- a/db/migrate/20260803120000_add_push_notifier_to_memberships.rb
+++ b/db/migrate/20260803120000_add_push_notifier_to_memberships.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPushNotifierToMemberships < ActiveRecord::Migration[8.1]
+  def change
+    add_column :memberships, :push_notifier, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -437,6 +437,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
     t.datetime "invitation_expires_at"
     t.bigint "invited_by_id"
     t.bigint "organization_id", null: false
+    t.boolean "push_notifier", default: true, null: false
     t.integer "role", default: 50, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -439,6 +439,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_080444) do
     t.datetime "invitation_expires_at"
     t.bigint "invited_by_id"
     t.bigint "organization_id", null: false
+    t.boolean "push_notifier", default: true, null: false
     t.integer "role", default: 50, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/test/functional/notifiers_controller_test.rb
+++ b/test/functional/notifiers_controller_test.rb
@@ -98,5 +98,35 @@ class NotifiersControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "when user belongs to an organization" do
+      setup do
+        @organization = create(:organization, maintainers: [@user])
+        @membership = @user.memberships.sole
+      end
+
+      context "on GET to show" do
+        setup do
+          get :show
+        end
+
+        should "show organization push notification settings" do
+          assert_response :success
+          assert page.has_content? @organization.handle
+        end
+      end
+
+      context "on PUT to update" do
+        setup do
+          put :update, params: { memberships: { @membership.id => { push: "off" } } }
+        end
+
+        should redirect_to("the notifier page") { notifier_path }
+
+        should "disable push notifications for the membership" do
+          refute_predicate @membership.reload, :push_notifier?
+        end
+      end
+    end
   end
 end

--- a/test/integration/organization_push_notifications_test.rb
+++ b/test/integration/organization_push_notifications_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OrganizationPushNotificationsTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include GemspecYamlTemplateHelpers
+
+  setup do
+    @pusher = create(:user, email: "pusher@rubygems-test.org")
+    @member = create(:user, email: "member@rubygems-test.org")
+    @rubygem = create(:rubygem, name: "org-gem", number: "1.0.0")
+    @organization = create(:organization, owners: [@pusher], maintainers: [@member], rubygems: [@rubygem])
+    @api_key = create(:api_key, owner: @pusher)
+  end
+
+  test "sends gem pushed email to confirmed organization members with push_notifier enabled" do
+    push_version("2.0.0")
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+
+    assert_includes recipients, @pusher.email
+    assert_includes recipients, @member.email
+  end
+
+  test "does not send gem pushed email to organization members with push_notifier disabled" do
+    @member.memberships.find_by!(organization: @organization).update!(push_notifier: false)
+
+    push_version("2.0.0")
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+
+    assert_includes recipients, @pusher.email
+    assert_not_includes recipients, @member.email
+  end
+
+  test "does not send gem pushed email to unconfirmed organization members" do
+    unconfirmed_member = create(:user, email: "pending@rubygems-test.org")
+    create(:membership, :pending, user: unconfirmed_member, organization: @organization)
+
+    push_version("2.0.0")
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+
+    assert_not_includes recipients, unconfirmed_member.email
+  end
+
+  test "sends gem yanked email to confirmed organization members with push_notifier enabled" do
+    push_version("2.0.0")
+    version = @rubygem.versions.find_by!(number: "2.0.0")
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      Deletion.create!(version: version, user: @pusher)
+    end
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+
+    assert_includes recipients, @pusher.email
+    assert_includes recipients, @member.email
+  end
+
+  test "does not send gem yanked email to organization members with push_notifier disabled" do
+    @member.memberships.find_by!(organization: @organization).update!(push_notifier: false)
+
+    push_version("2.0.0")
+    version = @rubygem.versions.find_by!(number: "2.0.0")
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      Deletion.create!(version: version, user: @pusher)
+    end
+
+    recipients = ActionMailer::Base.deliveries.flat_map(&:to)
+
+    assert_includes recipients, @pusher.email
+    assert_not_includes recipients, @member.email
+  end
+
+  private
+
+  def push_version(number)
+    gem = build_gem(new_gemspec("org-gem", number, "Gemcutter", "ruby"))
+    Pusher.new(@api_key, gem).process
+    gem.close
+  end
+end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -69,4 +69,18 @@ class MembershipTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context ".update_push_notifier" do
+    should "enable and disable push_notifier for memberships" do
+      membership = Membership.create!(organization: @organization, user: @user, invited_by: @owner, confirmed_at: Time.zone.now)
+
+      Membership.update_push_notifier([membership.id], [])
+
+      assert_predicate membership.reload, :push_notifier?
+
+      Membership.update_push_notifier([], [membership.id])
+
+      refute_predicate membership.reload, :push_notifier?
+    end
+  end
 end

--- a/test/system/notification_settings_test.rb
+++ b/test/system/notification_settings_test.rb
@@ -67,6 +67,53 @@ class NotificationSettingsTest < ApplicationSystemTestCase
     assert_no_text I18n.t("notifiers.show.title")
   end
 
+  test "email notification settings shown to organization members" do
+    user = create(:user)
+    create(:organization, maintainers: [user])
+
+    visit edit_settings_path(as: user)
+
+    click_link I18n.t("notifiers.show.title")
+
+    membership = user.memberships.sole
+
+    assert_checked_field membership_notifier_on_radio(membership)
+    assert_unchecked_field membership_notifier_off_radio(membership)
+  end
+
+  test "changing organization email notification settings" do
+    user = create(:user)
+    organization = create(:organization, maintainers: [user])
+    membership = user.memberships.sole
+
+    visit edit_settings_path(as: user)
+
+    click_link I18n.t("notifiers.show.title")
+
+    notifier_form_selector = "form[action='/notifier']"
+
+    within_element notifier_form_selector do
+      choose membership_notifier_off_radio(membership)
+    end
+
+    perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
+      within_element notifier_form_selector do
+        click_button I18n.t("notifiers.show.update")
+      end
+
+      assert_selector "#flash_notice", text: I18n.t("notifiers.update.success")
+    end
+
+    assert_emails 1
+    assert_equal I18n.t("mailer.notifiers_changed.subject", host: Gemcutter::HOST_DISPLAY), last_email.subject
+    assert_includes last_email.body.raw_source, organization.handle
+
+    within_element notifier_form_selector do
+      assert_unchecked_field membership_notifier_on_radio(membership)
+      assert_checked_field membership_notifier_off_radio(membership)
+    end
+  end
+
   test "email notification setting does not show for yanked gems" do
     user = create(:user)
     create(:rubygem, number: "0.0.1", owners: [user])
@@ -87,5 +134,13 @@ class NotificationSettingsTest < ApplicationSystemTestCase
 
   def notifier_off_radio(ownership, type)
     "ownerships_#{ownership.id}_#{type}_off"
+  end
+
+  def membership_notifier_on_radio(membership)
+    "memberships_#{membership.id}_push_on"
+  end
+
+  def membership_notifier_off_radio(membership)
+    "memberships_#{membership.id}_push_off"
   end
 end


### PR DESCRIPTION
## Description

After migrating gems to an organization, members stopped receiving push/yank emails that used to go to personal ownership notifiers. This restores those notifications for confirmed organization members.

Closes #6329

## Approach

- Mirror the existing per-gem ownership notifier model with `memberships.push_notifier` (default `true`), instead of a shared org-level email field.
- On gem push/yank for an organization-owned gem, email confirmed members with `push_notifier` enabled.
- Let members toggle the setting on the existing Email notification settings page (Organizations section); the page is also available to users who only have org memberships.
- Include organization rows in the `notifiers_changed` confirmation email.

Note:
Happy to rework this to the org-level email field approach that was suggested later on the issue, if needed.

---

<img width="1280" height="1139" alt="image" src="https://github.com/user-attachments/assets/9be91bf6-9474-40a7-969d-cfe947a01391" />

