### PR TITLE
Style the organization invitation CTA as a button

### DIFF
--- a/app/views/mailer/_button.html.erb
+++ b/app/views/mailer/_button.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (url:, label:) -%>
+<!-- Button -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td align="center">
+      <table width="210" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center" bgcolor="#e9573f">
+            <table border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+                </td>
+                <td bgcolor="#e9573f">
+                  <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                    <a href="<%= url %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none"><%= label %></span></a>
+                  </div>
+                </td>
+                <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<!-- END Button -->

--- a/app/views/mailer/email_confirmation.html.erb
+++ b/app/views/mailer/email_confirmation.html.erb
@@ -47,32 +47,7 @@
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">Hi <%= @user.handle %>. Welcome to rubygems&#65279.org!<br> Please click on the button below to verify your email.</div>
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <!-- Button -->
-      <table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center">
-            <table width="210" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="center" bgcolor="#e9573f">
-                  <table border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-</td>
-                      <td bgcolor="#e9573f">
-                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href="<%= update_email_confirmations_url(token: @user.confirmation_token) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
-                        </div>
-                      </td>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <!-- END Button -->
+      <%= render "mailer/button", url: update_email_confirmations_url(token: @user.confirmation_token), label: "VERIFY" %>
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">

--- a/app/views/mailer/email_reset.erb
+++ b/app/views/mailer/email_reset.erb
@@ -16,32 +16,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <!-- Button -->
-      <table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center">
-            <table width="210" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="center" bgcolor="#e9573f">
-                  <table border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-</td>
-                      <td bgcolor="#e9573f">
-                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href=<%= update_email_confirmations_url(token: @user.confirmation_token.html_safe) %> target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
-                        </div>
-                      </td>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <!-- END Button -->
+      <%= render "mailer/button", url: update_email_confirmations_url(token: @user.confirmation_token), label: "VERIFY" %>
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">

--- a/app/views/organization_mailer/user_invited.html.erb
+++ b/app/views/organization_mailer/user_invited.html.erb
@@ -11,13 +11,11 @@
         <p>
           <%= @invited_by.handle.present? ? "#{@invited_by.handle} has invited you" : "You have been invited" %> to join the <%= @organization.handle %> organization on rubygems.org.
         </p>
-        <br/>
-        <p>
-          <%= link_to "Accept invitation", @accept_url %>
-        </p>
       </div>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <%= render "mailer/button", url: @accept_url, label: "ACCEPT INVITATION" %>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/app/views/owners_mailer/ownership_confirmation.html.erb
+++ b/app/views/owners_mailer/ownership_confirmation.html.erb
@@ -16,32 +16,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <!-- Button -->
-      <table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center">
-            <table width="210" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="center" bgcolor="#e9573f">
-                  <table border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-                      </td>
-                      <td bgcolor="#e9573f">
-                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href="<%= confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">VERIFY</span></a>
-                        </div>
-                      </td>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <!-- END Button -->
+      <%= render "mailer/button", url: confirm_rubygem_owners_url(@rubygem.slug, token: @ownership.token), label: "VERIFY" %>
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
       <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">

--- a/app/views/password_mailer/change_password.html.erb
+++ b/app/views/password_mailer/change_password.html.erb
@@ -16,32 +16,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <!-- Button -->
-      <table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center">
-            <table width="210" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="center" bgcolor="#e9573f">
-                  <table border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-</td>
-                      <td bgcolor="#e9573f">
-                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href="<%= edit_password_url(token: @user.confirmation_token) %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
-                        </div>
-                      </td>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <!-- END Button -->
+      <%= render "mailer/button", url: edit_password_url(token: @user.confirmation_token), label: "CHANGE PASSWORD" %>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/app/views/password_mailer/compromised_password_reset.html.erb
+++ b/app/views/password_mailer/compromised_password_reset.html.erb
@@ -22,32 +22,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <!-- Button -->
-      <table width="100%" border="0" cellspacing="0" cellpadding="0">
-        <tr>
-          <td align="center">
-            <table width="210" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td align="center" bgcolor="#e9573f">
-                  <table border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"><table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
-</td>
-                      <td bgcolor="#e9573f">
-                        <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
-                          <a href="<%= edit_password_url(token: @user.confirmation_token, reason: 'compromised') %>" target="_blank" rel="noopener" class="link-white" style="color:#ffffff; text-decoration:none"><span class="link-white" style="color:#ffffff; text-decoration:none">CHANGE PASSWORD</span></a>
-                        </div>
-                      </td>
-                      <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <!-- END Button -->
+      <%= render "mailer/button", url: edit_password_url(token: @user.confirmation_token, reason: "compromised"), label: "CHANGE PASSWORD" %>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 module EmailHelpers
+  BUTTON_WIDTH = "210"
+  BUTTON_BACKGROUND_COLOR = "#e9573f"
+  BUTTON_TEXT_COLOR = "#ffffff"
+
+  def assert_cta_button(url, label)
+    assert_select_email do
+      assert_select "table[width=?] td[bgcolor=?] div.text-btn a[href=?]",
+                    BUTTON_WIDTH, BUTTON_BACKGROUND_COLOR, url, count: 1, text: label do |links|
+        assert_equal BUTTON_TEXT_COLOR, effective_style_property(links.sole, "color")
+        assert_select "span", text: label do |spans|
+          assert_equal BUTTON_TEXT_COLOR, effective_style_property(spans.sole, "color")
+        end
+      end
+    end
+  end
+
+  # Roadie inlines the layout's `a { color:#e9573f }` rule ahead of the template's own color, so a delivered
+  # link declares `color` more than once and the last declaration is the one that renders.
+  def effective_style_property(element, property)
+    declarations = Crass.parse_properties(element[:style])
+    declaration = declarations.rfind { |node| node[:node] == :property && node[:name] == property }
+
+    declaration && declaration[:value]
+  end
+
   def last_email_link
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob
     confirmation_link

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class MailerTest < ActionMailer::TestCase
+  include Rails.application.routes.url_helpers
+
   setup do
     @user = create(:user)
   end
@@ -14,6 +16,24 @@ class MailerTest < ActionMailer::TestCase
       assert_emails(1) { email.deliver_now }
 
       assert_includes email.subject, Gemcutter::HOST_DISPLAY
+    end
+  end
+
+  context "#email_confirmation" do
+    should "render the confirmation link as a button" do
+      @user.generate_confirmation_token
+      Mailer.email_confirmation(@user).deliver_now
+
+      assert_cta_button update_email_confirmations_url(token: @user.confirmation_token, host: Gemcutter::HOST), "VERIFY"
+    end
+  end
+
+  context "#email_reset" do
+    should "render the confirmation link as a button" do
+      @user.update!(unconfirmed_email: "new@mailinator.com")
+      Mailer.email_reset(@user).deliver_now
+
+      assert_cta_button update_email_confirmations_url(token: @user.confirmation_token, host: Gemcutter::HOST), "VERIFY"
     end
   end
 end

--- a/test/mailers/organization_mailer_test.rb
+++ b/test/mailers/organization_mailer_test.rb
@@ -19,4 +19,14 @@ class OrganizationMailerTest < ActionMailer::TestCase
     assert_equal [user.email], email.to
     assert_equal "You've been invited to join #{organization.handle}", email.subject
   end
+
+  test "invitation email styles the accept link as a button" do
+    user = create(:user)
+    organization = create(:organization)
+    membership = create(:membership, organization: organization, user: user)
+
+    OrganizationMailer.user_invited(membership).deliver_now
+
+    assert_cta_button organization_invitation_url(organization, host: Gemcutter::HOST), "ACCEPT INVITATION"
+  end
 end

--- a/test/mailers/owners_test.rb
+++ b/test/mailers/owners_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class OwnersMailerTest < ActionMailer::TestCase
+  include Rails.application.routes.url_helpers
+
   setup do
     @owner = create(:user)
     @maintainer = create(:user)
@@ -17,6 +19,15 @@ class OwnersMailerTest < ActionMailer::TestCase
 
       assert_emails(1) { email.deliver_now }
       assert_equal email.subject, "Your role was updated for the #{@rubygem.name} gem"
+    end
+  end
+
+  context "#ownership_confirmation" do
+    should "render the confirmation link as a button" do
+      ownership = create(:ownership, :unconfirmed, rubygem: @rubygem)
+      OwnersMailer.ownership_confirmation(ownership).deliver_now
+
+      assert_cta_button confirm_rubygem_owners_url(@rubygem.slug, token: ownership.token, host: Gemcutter::HOST), "VERIFY"
     end
   end
 end

--- a/test/mailers/password_mailer_test.rb
+++ b/test/mailers/password_mailer_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class PasswordMailerTest < ActionMailer::TestCase
+  include Rails.application.routes.url_helpers
+
   test "change password with handle" do
     user = create(:user)
     user.forgot_password!
@@ -65,5 +67,23 @@ class PasswordMailerTest < ActionMailer::TestCase
     assert_match user.email, email.html_part.body.to_s
     assert_match "data breach", email.html_part.body.to_s
     assert_match "data breach", email.text_part.body.to_s
+  end
+
+  test "change password renders the change password link as a button" do
+    user = create(:user)
+    user.forgot_password!
+    user.save!
+    PasswordMailer.change_password(user).deliver_now
+
+    assert_cta_button edit_password_url(token: user.confirmation_token, host: Gemcutter::HOST), "CHANGE PASSWORD"
+  end
+
+  test "compromised password reset renders the change password link as a button" do
+    user = create(:user)
+    user.forgot_password!
+    user.save!
+    PasswordMailer.compromised_password_reset(user).deliver_now
+
+    assert_cta_button edit_password_url(token: user.confirmation_token, reason: "compromised", host: Gemcutter::HOST), "CHANGE PASSWORD"
   end
 end

--- a/test/system/invitation_test.rb
+++ b/test/system/invitation_test.rb
@@ -48,7 +48,7 @@ class InvitationTest < ApplicationSystemTestCase
 
     assert invitation.has_text? "#{@user.handle} has invited you to join the #{@organization.handle} organization on rubygems.org."
 
-    invitation_link = invitation.find(:link, "Accept invitation")[:href]
+    invitation_link = invitation.find(:link, "ACCEPT INVITATION")[:href]
     invitation_path = URI.parse(invitation_link).request_uri
 
     visit invitation_path


### PR DESCRIPTION
The "Accept invitation" call-to-action in the organization invitation email
was a bare `link_to`, which the mailer stylesheet renders as orange text
with no underline. It did not read as something to click, and at least one
recipient of the organizations rollout invitations (me! 🤣) missed it.

The link will render through `mailer/_button.html.erb` instead, matching the
button pattern the other five call-to-action emails use. Its text will
change to `ACCEPT INVITATION` to match those buttons, so the system test
that finds the link by name is updated to match.

Before | After
:---: | :---:
<img width="800" height="700" alt="invite-before" src="https://github.com/user-attachments/assets/b95afd24-1fc5-4e50-aa83-800591d9a94a" /> | <img width="800" height="700" alt="invite-after" src="https://github.com/user-attachments/assets/34912098-8851-4a43-ab7c-b1bf65023863" />

---

The first commit extracts that partial. Five mailer templates each carried
their own copy of the ~25-line nested table that renders the orange
call-to-action button:

- `app/views/mailer/email_confirmation.html.erb`
- `app/views/mailer/email_reset.erb`
- `app/views/owners_mailer/ownership_confirmation.html.erb`
- `app/views/password_mailer/change_password.html.erb`
- `app/views/password_mailer/compromised_password_reset.html.erb`

The copies were identical apart from whitespace, the link target, and the
button label. None of them asserted that the call to action rendered as a
button.

The markup will move to `app/views/mailer/_button.html.erb`, which declares
strict `url` and `label` locals, and the five templates will render it.
Rendered output is unchanged apart from whitespace.

Two incidental details in `email_reset.erb` also change: its `href`
attribute was unquoted and will now be quoted, and it called `.html_safe` on
the confirmation token. The quoting changes the emitted bytes but not the
link target, and dropping `.html_safe` changes nothing at all, because the
URL helper percent-encodes the token before ERB sees it.

A new `assert_cta_button` helper will assert that each of the five renders
its call to action inside the button table, as white text on the orange
background. It parses the `style` attribute with Crass and checks the last
`color` declaration, because Roadie inlines the layout's `a { color:#e9573f }`
rule ahead of the template's own color.
