### PR TITLE
Add MEMCACHED_ENDPOINT to versions-list-update-monthly CronJob

### DIFF
--- a/config/deploy/versions-list-update-monthly.yaml.erb
+++ b/config/deploy/versions-list-update-monthly.yaml.erb
@@ -99,5 +99,10 @@ spec:
                 secretKeyRef:
                   name: <%= environment %>
                   key: database_url
+            - name: MEMCACHED_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: <%= environment %>
+                  key: memcached_endpoint
             securityContext:
               privileged: false


### PR DESCRIPTION
Every other workload manifest sets `MEMCACHED_ENDPOINT` via `secretKeyRef`, but this CronJob for some reason does not? Since `production.rb` configures the cache store, a nil endpoint makes Dalli fall back to 127.0.0.1:11211 inside the pod, so `Rails.cache` calls made during the monthly versions-list job (e.g. via GemInfo) fail silently instead of reaching the  memcached cluster.