### PR TITLE
Add PodDisruptionBudget for the web deployment

### DIFF
--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -334,3 +334,14 @@ spec:
                 path: sigstore-signing-token
                 expirationSeconds: 600
                 audience: sigstore
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web
+spec:
+  maxUnavailable: "10%"
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels:
+      name: web

--- a/config/deploy/web.yaml.erb
+++ b/config/deploy/web.yaml.erb
@@ -340,7 +340,7 @@ kind: PodDisruptionBudget
 metadata:
   name: web
 spec:
-  maxUnavailable: "10%"
+  minAvailable: 1
   unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:


### PR DESCRIPTION
Limits voluntary evictions (node drains during Kubernetes/node-pool upgrades, autoscaler scale-down) so the site keeps serving while nodes are replaced during upgrades.