### PR TITLE
Push new gems to organizations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
     - db/**/*.rb
 
 Metrics/ClassLength:
-  Max: 357 # TODO: Lower to 100
+  Max: 360 # TODO: Lower to 100
   Exclude:
     - test/**/*
     - db/**/*.rb

--- a/app/avo/resources/api_key.rb
+++ b/app/avo/resources/api_key.rb
@@ -17,7 +17,7 @@ class Avo::Resources::ApiKey < Avo::BaseResource
     filter TrustedPublisherFilter, arguments: { default: { trusted_publisher: true, not_trusted_publisher: true } }
   end
 
-  def fields
+  def fields # rubocop:disable Metrics/MethodLength
     main_panel do
       field :id, as: :id, hide_on: :index
 
@@ -30,6 +30,7 @@ class Avo::Resources::ApiKey < Avo::BaseResource
       field :last_accessed_at, as: :date_time
       field :soft_deleted_at, as: :date_time
       field :soft_deleted_rubygem_name, as: :text
+      field :soft_deleted_organization_name, as: :text
       field :expires_at, as: :date_time
 
       field :enabled_scopes, as: :tags
@@ -49,7 +50,9 @@ class Avo::Resources::ApiKey < Avo::BaseResource
     end
 
     field :api_key_rubygem_scope, as: :has_one
-    field :ownership, as: :has_one
+    field :ownership, as: :has_one, visible: -> { resource.record.ownership.present? }
+    field :api_key_organization_scope, as: :has_one
+    field :membership, as: :has_one, visible: -> { resource.record.membership.present? }
     field :oidc_id_token, as: :has_one
   end
 end

--- a/app/avo/resources/api_key_organization_scope.rb
+++ b/app/avo/resources/api_key_organization_scope.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Avo::Resources::ApiKeyOrganizationScope < Avo::BaseResource
+  self.title = :cache_key
+  self.includes = []
+
+  def fields
+    field :id, as: :id
+
+    field :api_key, as: :belongs_to
+    field :membership, as: :belongs_to
+  end
+end

--- a/app/avo/resources/oidc_api_key_role.rb
+++ b/app/avo/resources/oidc_api_key_role.rb
@@ -16,6 +16,7 @@ class Avo::Resources::OIDCApiKeyRole < Avo::BaseResource
       field :valid_for, as: :text, format_using: -> { value&.iso8601 }
       field :scopes, as: :tags, suggestions: ApiKey::API_SCOPES.map { { label: it, value: it } }, enforce_suggestions: true
       field :gems, as: :tags, suggestions: -> { Rubygem.limit(10).pluck(:name).map { { value: it, label: it } } }
+      field :organization, as: :text
     end
     field :access_policy, as: :nested do
       field :statements, as: :array_of, field: :nested do

--- a/app/avo/resources/oidc_pending_trusted_publisher.rb
+++ b/app/avo/resources/oidc_pending_trusted_publisher.rb
@@ -15,6 +15,7 @@ class Avo::Resources::OIDCPendingTrustedPublisher < Avo::BaseResource
 
     field :rubygem_name, as: :text
     field :user, as: :belongs_to
+    field :organization, as: :belongs_to
     field :trusted_publisher, as: :belongs_to, polymorphic_as: :trusted_publisher
     field :expires_at, as: :date_time
   end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -27,7 +27,7 @@ class Api::BaseController < ApplicationController
   end
 
   def verify_api_key_gem_scope
-    return unless @api_key.rubygem && @api_key.rubygem != @rubygem
+    return if @api_key.scoped_to?(@rubygem)
 
     render_forbidden t(:api_key_insufficient_scope)
   end

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -91,7 +91,7 @@ class Api::V1::ApiKeysController < Api::BaseController
   end
 
   def api_key_create_params
-    ApiKeysHelper.api_key_params(params.permit(:name, *ApiKey::API_SCOPES, :mfa, :rubygem_name, :expires_at, scopes: [ApiKey::API_SCOPES]))
+    ApiKeysHelper.api_key_params(params.permit(:name, *ApiKey::API_SCOPES, :mfa, :rubygem_name, :organization, :expires_at, scopes: [ApiKey::API_SCOPES]))
   end
 
   def api_key_update_params(key)

--- a/app/controllers/api/v1/oidc/api_key_roles_controller.rb
+++ b/app/controllers/api/v1/oidc/api_key_roles_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::OIDC::ApiKeyRolesController < Api::BaseController
       api_key = @api_key_role.user.api_keys.create!(
         hashed_key: hashed_key(key),
         name: "#{@api_key_role.name}-#{@jwt[:jti]}",
-        **@api_key_role.api_key_permissions.create_params(@api_key_role.user)
+        **api_key_create_params
       )
       OIDC::IdToken.create!(
         api_key:,
@@ -56,11 +56,20 @@ class Api::V1::OIDC::ApiKeyRolesController < Api::BaseController
       name: api_key.name,
       scopes: api_key.scopes,
       gem: api_key.rubygem,
+      organization: api_key.organization&.handle,
       expires_at: api_key.expires_at
     }.compact, status: :created
+  rescue ActiveRecord::RecordNotFound
+    render json: {
+      errors: ["Unable to create API key: the configured gem or organization scope is no longer valid"]
+    }, status: :unprocessable_content
   end
 
   private
+
+  def api_key_create_params
+    @api_key_role.api_key_permissions.create_params(@api_key_role.user)
+  end
 
   def set_api_key_role
     @api_key_role = OIDC::ApiKeyRole.active.find_by!(token: params.expect(:token))

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -62,14 +62,8 @@ class ApiKeysController < ApplicationController
 
   def update
     @api_key = current_user.api_keys.find(params.expect(:id))
-    @api_key.assign_attributes(api_key_update_params(@api_key))
 
-    if @api_key.errors.present?
-      flash.now[:error] = @api_key.errors.full_messages.to_sentence
-      return render :edit
-    end
-
-    if @api_key.save
+    if save_api_key_updates
       redirect_to profile_api_keys_path, flash: { notice: t(".success") }
     else
       flash.now[:error] = @api_key.errors.full_messages.to_sentence
@@ -122,5 +116,12 @@ class ApiKeysController < ApplicationController
     ApiKeysHelper.api_key_params(
       params.expect(api_key: [*ApiKey::API_SCOPES, :mfa, :rubygem_id, :organization_id, scopes: ApiKey::API_SCOPES]), existing_api_key
     )
+  end
+
+  def save_api_key_updates
+    @api_key.with_transaction_returning_status do
+      @api_key.assign_attributes(api_key_update_params(@api_key))
+      @api_key.errors.empty? && @api_key.save
+    end
   end
 end

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -17,7 +17,7 @@ class ApiKeysController < ApplicationController
     api_keys = current_user.api_keys.not_oidc
     @has_expired_keys = api_keys.expired.exists?
     scope = @expired_view ? api_keys.expired.order(expires_at: :desc, id: :desc) : api_keys.unexpired
-    @api_keys = scope.preload(ownership: :rubygem).page(@page)
+    @api_keys = scope.preload(ownership: :rubygem, membership: :organization).page(@page)
     redirect_to new_profile_api_key_path if !@expired_view && @api_keys.empty? && !@has_expired_keys
   end
 
@@ -45,7 +45,7 @@ class ApiKeysController < ApplicationController
 
     if @api_key.errors.present?
       flash.now[:error] = @api_key.errors.full_messages.to_sentence
-      @api_key = current_user.api_keys.build(api_key_create_params.merge(rubygem_id: nil))
+      @api_key = current_user.api_keys.build(api_key_create_params.merge(rubygem_id: nil, organization_id: nil))
       return render :new
     end
 
@@ -115,12 +115,12 @@ class ApiKeysController < ApplicationController
   end
 
   def api_key_create_params
-    ApiKeysHelper.api_key_params(params.expect(api_key: [:name, *ApiKey::API_SCOPES, :mfa, :rubygem_id, :expires_at]))
+    ApiKeysHelper.api_key_params(params.expect(api_key: [:name, *ApiKey::API_SCOPES, :mfa, :rubygem_id, :organization_id, :expires_at]))
   end
 
   def api_key_update_params(existing_api_key = nil)
     ApiKeysHelper.api_key_params(
-      params.expect(api_key: [*ApiKey::API_SCOPES, :mfa, :rubygem_id, scopes: ApiKey::API_SCOPES]), existing_api_key
+      params.expect(api_key: [*ApiKey::API_SCOPES, :mfa, :rubygem_id, :organization_id, scopes: ApiKey::API_SCOPES]), existing_api_key
     )
   end
 end

--- a/app/controllers/avo/api_key_organization_scopes_controller.rb
+++ b/app/controllers/avo/api_key_organization_scopes_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ApiKeyOrganizationScopesController < Avo::ResourcesController
+end

--- a/app/controllers/oidc/api_key_roles_controller.rb
+++ b/app/controllers/oidc/api_key_roles_controller.rb
@@ -122,7 +122,7 @@ class OIDC::ApiKeyRolesController < ApplicationController
   PERMITTED_API_KEY_ROLE_PARAMS = [
     :name,
     :oidc_provider_id,
-    api_key_permissions: [:valid_for, scopes: [], gems: []],
+    api_key_permissions: [:valid_for, :organization, scopes: [], gems: []],
     access_policy: {
       statements_attributes: [[
         :effect,

--- a/app/controllers/oidc/pending_trusted_publishers_controller.rb
+++ b/app/controllers/oidc/pending_trusted_publishers_controller.rb
@@ -9,7 +9,7 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
 
   def index
     trusted_publishers = policy_scope(OIDC::PendingTrustedPublisher)
-      .unexpired.includes(:trusted_publisher)
+      .unexpired.includes(:trusted_publisher, :organization)
       .order(:rubygem_name, :created_at).page(@page).strict_loading
     add_breadcrumb(t("breadcrumbs.settings"), edit_settings_path)
     add_breadcrumb(t(".title"))
@@ -59,6 +59,7 @@ class OIDC::PendingTrustedPublishersController < ApplicationController
     params.expect(
       create_params_key => [
         :rubygem_name,
+        :organization_id,
         :trusted_publisher_type,
         trusted_publisher_attributes: @trusted_publisher_type.permitted_attributes
       ]

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -3,8 +3,15 @@
 module ApiKeysHelper
   def gem_scope(api_key)
     return invalid_gem_tooltip(api_key.soft_deleted_rubygem_name) if api_key.soft_deleted_by_ownership?
+    return invalid_organization_tooltip(api_key.soft_deleted_organization_name) if api_key.soft_deleted_by_organization?
 
-    api_key.rubygem ? api_key.rubygem.name : t("api_keys.all_gems")
+    if api_key.membership
+      api_key.organization&.name || t("api_keys.unavailable_organization")
+    elsif api_key.rubygem
+      api_key.rubygem.name
+    else
+      t("api_keys.all_gems")
+    end
   end
 
   def api_key_checkbox(form, api_scope)
@@ -34,6 +41,7 @@ module ApiKeysHelper
       end
     end
     params[:scopes] = scopes.sort
+    params[:organization_handle] = params.delete(:organization) if params.key?(:organization)
     params
   end
 
@@ -44,5 +52,14 @@ module ApiKeysHelper
                 name,
                 render(TooltipComponent.new(text: t("api_keys.gem_ownership_removed", rubygem_name: name))) { "[?]" }
               ], " ")
+  end
+
+  def invalid_organization_tooltip(name)
+    content_tag(
+      :span,
+      "#{name} [?]",
+      class: "cursor-help",
+      title: t("api_keys.organization_membership_removed", organization_name: name)
+    )
   end
 end

--- a/app/javascript/controllers/gem_scope_controller.js
+++ b/app/javascript/controllers/gem_scope_controller.js
@@ -1,44 +1,79 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["checkbox", "selector"];
+  static targets = ["checkbox", "gemSelector", "orgSelector"];
 
   connect() {
-    this.toggleSelector();
+    this.hiddenFields = {};
+    this.toggleSelectors();
   }
 
   checkboxTargetConnected(el) {
-    el.addEventListener("change", () => this.toggleSelector());
+    el.addEventListener("change", () => this.toggleSelectors());
   }
 
-  toggleSelector() {
+  gemSelectorTargetConnected(el) {
+    el.addEventListener("change", () => {
+      if (el.value && this.hasOrgSelectorTarget) {
+        this.orgSelectorTarget.value = "";
+      }
+    });
+  }
+
+  orgSelectorTargetConnected(el) {
+    el.addEventListener("change", () => {
+      if (el.value && this.hasGemSelectorTarget) {
+        this.gemSelectorTarget.value = "";
+      }
+    });
+  }
+
+  toggleSelectors() {
     const selected = this.checkboxTargets.find((target) => target.checked);
 
-    if (selected) {
-      this.selectorTarget.disabled = false;
-      this.removeHiddenRubygemField();
-    } else {
-      this.selectorTarget.value = "";
-      this.selectorTarget.disabled = true;
-      this.addHiddenRubygemField();
+    if (this.hasGemSelectorTarget) {
+      this.toggleSelector(
+        "api_key[rubygem_id]",
+        this.gemSelectorTarget,
+        selected,
+      );
+    }
+    if (this.hasOrgSelectorTarget) {
+      this.toggleSelector(
+        "api_key[organization_id]",
+        this.orgSelectorTarget,
+        selected,
+      );
     }
   }
 
-  addHiddenRubygemField() {
-    if (this.hiddenField) {
+  toggleSelector(fieldName, selectorTarget, enabled) {
+    if (enabled) {
+      selectorTarget.disabled = false;
+      this.removeHiddenField(fieldName);
+    } else {
+      selectorTarget.value = "";
+      selectorTarget.disabled = true;
+      this.addHiddenField(fieldName);
+    }
+  }
+
+  addHiddenField(fieldName) {
+    if (this.hiddenFields[fieldName]) {
       return;
     }
-    this.hiddenField = document.createElement("input");
-    this.hiddenField.type = "hidden";
-    this.hiddenField.name = "api_key[rubygem_id]";
-    this.hiddenField.value = "";
-    this.element.appendChild(this.hiddenField);
+
+    this.hiddenFields[fieldName] = document.createElement("input");
+    this.hiddenFields[fieldName].type = "hidden";
+    this.hiddenFields[fieldName].name = fieldName;
+    this.hiddenFields[fieldName].value = "";
+    this.element.appendChild(this.hiddenFields[fieldName]);
   }
 
-  removeHiddenRubygemField() {
-    if (this.hiddenField) {
-      this.hiddenField.remove();
-      this.hiddenField = null;
+  removeHiddenField(fieldName) {
+    if (this.hiddenFields[fieldName]) {
+      this.hiddenFields[fieldName].remove();
+      this.hiddenFields[fieldName] = null;
     }
   }
 }

--- a/app/javascript/controllers/gem_scope_controller.js
+++ b/app/javascript/controllers/gem_scope_controller.js
@@ -3,8 +3,11 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["checkbox", "gemSelector", "orgSelector"];
 
-  connect() {
+  initialize() {
     this.hiddenFields = {};
+  }
+
+  connect() {
     this.toggleSelectors();
   }
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -170,7 +170,8 @@ class ApiKey < ApplicationRecord
     update_columns(
       soft_deleted_at: Time.now.utc,
       soft_deleted_rubygem_name: ownership&.rubygem&.name,
-      soft_deleted_organization_name: membership&.organization&.name
+      soft_deleted_organization_name: membership&.organization&.name,
+      touch: true
     )
   end
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -15,6 +15,9 @@ class ApiKey < ApplicationRecord
 
   has_one :api_key_rubygem_scope, dependent: :destroy
   has_one :ownership, through: :api_key_rubygem_scope
+  has_one :api_key_organization_scope, dependent: :destroy
+  has_one :membership, through: :api_key_organization_scope
+  has_one :organization, through: :membership
   has_one :oidc_id_token, class_name: "OIDC::IdToken", dependent: :restrict_with_error
   has_one :oidc_api_key_role, class_name: "OIDC::ApiKeyRole", through: :oidc_id_token, source: :api_key_role, inverse_of: :api_keys
   has_many :pushed_versions, class_name: "Version", inverse_of: :pusher_api_key, foreign_key: :pusher_api_key_id, dependent: :nullify
@@ -34,6 +37,7 @@ class ApiKey < ApplicationRecord
   validate :not_expired?
 
   delegate :rubygem_id, :rubygem, to: :ownership, allow_nil: true
+  delegate :organization_id, to: :membership, allow_nil: true
 
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(Time.now.utc))) }
   scope :expired, -> { where(arel_table[:expires_at].lteq(Time.now.utc)) }

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -31,13 +31,16 @@ class ApiKey < ApplicationRecord
   validates :name, presence: true, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
   validates :hashed_key, presence: true, uniqueness: true
   validates :expires_at, inclusion: { in: -> { 1.minute.from_now.. } }, allow_nil: true, on: :create
-  validate :rubygem_scope_definition, if: :ownership
+  validate :gem_or_organization_scope_definition, if: -> { ownership || membership }
+  validate :exclusive_gem_and_organization_scope
   validate :known_scopes
   validate :not_soft_deleted?
   validate :not_expired?
 
+  validate :organization_manageable_by_owner, if: :organization_scope_requested?
+
   delegate :rubygem_id, :rubygem, to: :ownership, allow_nil: true
-  delegate :organization_id, to: :membership, allow_nil: true
+  delegate :organization_id, :organization, to: :membership, allow_nil: true
 
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(Time.now.utc))) }
   scope :expired, -> { where(arel_table[:expires_at].lteq(Time.now.utc)) }
@@ -59,11 +62,30 @@ class ApiKey < ApplicationRecord
 
   def scope?(scope, scoped_gem = nil)
     scope_enabled = scopes.include?(scope)
-    # TODO: once all calls to scope checks are changed, this check should
-    # fail if the api_key has a rubygem but scope? is called without a scoped_gem
-    scope_enabled = false if scoped_gem && rubygem_id && rubygem_id != scoped_gem.id
+    scope_enabled = false if scoped_gem && !scoped_to?(scoped_gem)
     return scope_enabled if !scope_enabled || new_record?
     touch :last_accessed_at
+  end
+
+  def scoped_to?(rubygem)
+    if rubygem_id
+      rubygem_id == rubygem.id
+    elsif membership
+      organization_allows_gem?(rubygem)
+    else
+      true
+    end
+  end
+
+  def organization_allows_gem?(rubygem)
+    return false if membership && organization.nil?
+    return true unless organization
+
+    if rubygem.owned_by_organization?
+      rubygem.organization == organization
+    else
+      rubygem.ownerships.none?
+    end
   end
 
   API_SCOPES.each do |scope|
@@ -115,15 +137,41 @@ class ApiKey < ApplicationRecord
     errors.add :rubygem, "must be a gem that you are an owner of"
   end
 
+  def organization_id=(id)
+    @requested_organization_id = id.presence
+
+    if id.blank?
+      self.membership = nil
+      association(:membership).reset
+      return
+    end
+
+    unless user?
+      errors.add :organization, "must be an organization you can manage"
+      return
+    end
+
+    self.membership = user.memberships.confirmed.with_minimum_role(:admin).find_by(organization_id: id)
+  end
+
+  def organization_handle=(handle)
+    self.organization_id = handle.blank? ? nil : Organization.find_by_handle!(handle).id
+  rescue ActiveRecord::RecordNotFound
+    errors.add :organization, "could not be found"
+  end
+
   def rubygem_name=(name)
     self.rubygem_id = name.blank? ? nil : Rubygem.find_by_name!(name).id
   rescue ActiveRecord::RecordNotFound
     errors.add :rubygem, "could not be found"
   end
 
-  def soft_delete!(ownership: nil)
-    update_attribute(:soft_deleted_at, Time.now.utc)
-    update_attribute(:soft_deleted_rubygem_name, ownership.rubygem.name) if ownership
+  def soft_delete!(ownership: nil, membership: nil)
+    update_columns(
+      soft_deleted_at: Time.now.utc,
+      soft_deleted_rubygem_name: ownership&.rubygem&.name,
+      soft_deleted_organization_name: membership&.organization&.name
+    )
   end
 
   def soft_deleted?
@@ -132,6 +180,10 @@ class ApiKey < ApplicationRecord
 
   def soft_deleted_by_ownership?
     soft_deleted? && soft_deleted_rubygem_name.present?
+  end
+
+  def soft_deleted_by_organization?
+    soft_deleted? && soft_deleted_organization_name.present?
   end
 
   def expired?
@@ -159,9 +211,28 @@ class ApiKey < ApplicationRecord
     errors.add :base, "Please enable at least one scope" if scopes.blank?
   end
 
-  def rubygem_scope_definition
+  def gem_or_organization_scope_definition
     return if APPLICABLE_GEM_API_SCOPES.intersect?(scopes)
-    errors.add :rubygem, "scope can only be set for push/yank rubygem, and add/remove owner scopes"
+
+    attribute = membership ? :organization : :rubygem
+    errors.add attribute, "scope can only be set for push/yank rubygem, and add/remove owner scopes"
+  end
+
+  def exclusive_gem_and_organization_scope
+    return unless ownership && membership
+
+    errors.add :base, "An API key cannot be scoped to both a gem and an organization"
+  end
+
+  def organization_scope_requested?
+    @requested_organization_id.present?
+  end
+
+  def organization_manageable_by_owner
+    return unless user?
+    return if user.manageable_organizations.exists?(id: @requested_organization_id)
+
+    errors.add :organization, "must be an organization you can manage"
   end
 
   def known_scopes
@@ -185,7 +256,7 @@ class ApiKey < ApplicationRecord
     case owner
     when User
       user.record_event!(Events::UserEvent::API_KEY_CREATED,
-          name:, scopes:, gem: rubygem&.name, mfa:, api_key_gid: to_gid)
+          name:, scopes:, gem: rubygem&.name, organization: organization&.handle, mfa:, api_key_gid: to_gid)
     end
   end
 

--- a/app/models/api_key_organization_scope.rb
+++ b/app/models/api_key_organization_scope.rb
@@ -5,6 +5,13 @@ class ApiKeyOrganizationScope < ApplicationRecord
   belongs_to :membership
 
   validates :membership_id, uniqueness: { scope: :api_key_id }
+  before_destroy :soft_delete_api_key!, if: :destroyed_by_association
 
   delegate :organization, to: :membership
+
+  private
+
+  def soft_delete_api_key!
+    api_key.soft_delete!(membership: membership)
+  end
 end

--- a/app/models/api_key_organization_scope.rb
+++ b/app/models/api_key_organization_scope.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ApiKeyOrganizationScope < ApplicationRecord
+  belongs_to :api_key
+  belongs_to :membership
+
+  validates :membership_id, uniqueness: { scope: :api_key_id }
+
+  delegate :organization, to: :membership
+end

--- a/app/models/events/user_event.rb
+++ b/app/models/events/user_event.rb
@@ -34,6 +34,7 @@ class Events::UserEvent < ApplicationRecord
     attribute :name, :string
     attribute :scopes, Types::ArrayOf.new(ActiveRecord::Type::String.new)
     attribute :gem, :string
+    attribute :organization, :string
     attribute :mfa, :boolean
 
     attribute :api_key_gid, :global_id

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,6 +4,8 @@ class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :organization
 
+  has_many :api_key_organization_scopes, dependent: :destroy
+
   belongs_to :invited_by, class_name: "User", optional: true
 
   scope :unconfirmed, -> { where(confirmed_at: nil) }

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -18,6 +18,7 @@ class Membership < ApplicationRecord
   validates :user, uniqueness: { scope: :organization }
 
   before_create :set_invitation_expire_time
+  after_update :revoke_org_scoped_api_keys!, if: :saved_change_to_role?
 
   def confirm!
     update_attribute(:confirmed_at, Time.zone.now)
@@ -33,6 +34,15 @@ class Membership < ApplicationRecord
   end
 
   private
+
+  def revoke_org_scoped_api_keys!
+    return if admin? || owner?
+
+    api_key_organization_scopes.includes(:api_key).find_each do |scope|
+      scope.api_key.soft_delete!(membership: self)
+      scope.destroy!
+    end
+  end
 
   def set_invitation_expire_time
     self.invitation_expires_at = Gemcutter::MEMBERSHIP_INVITE_EXPIRES_AFTER.from_now

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -18,7 +18,7 @@ class Membership < ApplicationRecord
   validates :user, uniqueness: { scope: :organization }
 
   before_create :set_invitation_expire_time
-  after_update :revoke_org_scoped_api_keys!, if: :saved_change_to_role?
+  after_update :revoke_org_scoped_api_keys_on_role_change!, if: :saved_change_to_role?
 
   def confirm!
     update_attribute(:confirmed_at, Time.zone.now)
@@ -33,15 +33,19 @@ class Membership < ApplicationRecord
     save!
   end
 
-  private
-
   def revoke_org_scoped_api_keys!
-    return if admin? || owner?
-
     api_key_organization_scopes.includes(:api_key).find_each do |scope|
       scope.api_key.soft_delete!(membership: self)
       scope.destroy!
     end
+  end
+
+  private
+
+  def revoke_org_scoped_api_keys_on_role_change!
+    return if admin? || owner?
+
+    revoke_org_scoped_api_keys!
   end
 
   def set_invitation_expire_time

--- a/app/models/oidc/api_key_permissions.rb
+++ b/app/models/oidc/api_key_permissions.rb
@@ -4,6 +4,10 @@ class OIDC::ApiKeyPermissions < ApplicationModel
   def create_params(user)
     params = { scopes: scopes }
     params[:ownership] = gems&.first&.then { user.ownerships.joins(:rubygem).find_by!(rubygem: { name: it }) }
+    if organization.present?
+      org = Organization.find_by_handle!(organization)
+      params[:membership] = user.memberships.confirmed.with_minimum_role(:admin).find_by!(organization_id: org.id)
+    end
     params[:expires_at] = DateTime.now.utc + valid_for
     params
   end
@@ -11,10 +15,12 @@ class OIDC::ApiKeyPermissions < ApplicationModel
   attribute :scopes, Types::ArrayOf.new(:string)
   attribute :valid_for, :duration, default: -> { 30.minutes.freeze }
   attribute :gems, Types::ArrayOf.new(:string)
+  attribute :organization, :string
 
   validates :scopes, presence: true
   validate :known_scopes?
   validate :scopes_must_be_unique
+  validate :exclusive_gems_and_organization
 
   validates :valid_for, presence: true, inclusion: { in: (5.minutes)..(1.day) }
 
@@ -28,6 +34,10 @@ class OIDC::ApiKeyPermissions < ApplicationModel
     end
   end
 
+  def organization=(value)
+    super(value.presence)
+  end
+
   def known_scopes?
     scopes&.each_with_index do |scope, idx|
       errors.add("scopes[#{idx}]", "unknown scope: #{scope}") unless ApiKey::API_SCOPES.include?(scope.to_sym)
@@ -39,5 +49,11 @@ class OIDC::ApiKeyPermissions < ApplicationModel
 
     errors.add(:scopes, "show_dashboard is exclusive") if scopes.include?("show_dashboard") && scopes.size > 1
     errors.add(:scopes, "must be unique") if scopes.dup.uniq!
+  end
+
+  def exclusive_gems_and_organization
+    return if gems.blank? || organization.blank?
+
+    errors.add(:base, "cannot be scoped to both a gem and an organization")
   end
 end

--- a/app/models/oidc/api_key_role.rb
+++ b/app/models/oidc/api_key_role.rb
@@ -29,6 +29,7 @@ class OIDC::ApiKeyRole < ApplicationRecord
   attribute :api_key_permissions, Types::JsonDeserializable.new(OIDC::ApiKeyPermissions)
   validates :api_key_permissions, presence: true, nested: true
   validate :gems_belong_to_user
+  validate :organization_manageable_by_user
 
   def github_actions_push?
     provider.github_actions? && api_key_permissions.scopes.include?("push_rubygem")
@@ -38,6 +39,16 @@ class OIDC::ApiKeyRole < ApplicationRecord
     Array.wrap(api_key_permissions&.gems).each_with_index do |name, idx|
       errors.add("api_key_permissions.gems[#{idx}]", "(#{name}) does not belong to user #{user.display_handle}") if user.rubygems.where(name:).empty?
     end
+  end
+
+  def organization_manageable_by_user
+    handle = api_key_permissions&.organization
+    return if handle.blank?
+
+    organization = Organization.find_by_handle(handle)
+    return if organization && user.manageable_organizations.exists?(id: organization.id)
+
+    errors.add("api_key_permissions.organization", "must be an organization you can manage")
   end
 
   before_validation :set_statement_principals

--- a/app/models/oidc/pending_trusted_publisher.rb
+++ b/app/models/oidc/pending_trusted_publisher.rb
@@ -3,6 +3,7 @@
 class OIDC::PendingTrustedPublisher < ApplicationRecord
   belongs_to :user
   belongs_to :trusted_publisher, polymorphic: true, optional: false
+  belongs_to :organization, optional: true
 
   accepts_nested_attributes_for :trusted_publisher
 
@@ -13,6 +14,7 @@ class OIDC::PendingTrustedPublisher < ApplicationRecord
     uniqueness: { case_sensitive: false, scope: %i[trusted_publisher_id trusted_publisher_type], conditions: -> { unexpired } }
 
   validate :available_rubygem_name, on: :create
+  validate :organization_manageable_by_user, if: :organization
 
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(Time.now.utc))) }
   scope :expired, -> { where(arel_table[:expires_at].lteq(Time.now.utc)) }
@@ -40,5 +42,11 @@ class OIDC::PendingTrustedPublisher < ApplicationRecord
     return if rubygem.nil? || rubygem.pushable?
 
     errors.add(:rubygem_name, :unavailable)
+  end
+
+  def organization_manageable_by_user
+    return if user.manageable_organizations.exists?(id: organization_id)
+
+    errors.add(:organization, "must be an organization you can manage")
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  include Discard::Model
   include Events::Recordable
+
+  self.discard_column = :deleted_at
 
   validates :handle, presence: true,
     uniqueness: { case_sensitive: false },
@@ -20,8 +23,11 @@ class Organization < ApplicationRecord
   has_one :organization_onboarding, foreign_key: :onboarded_organization_id, inverse_of: :organization, dependent: :destroy
 
   default_scope { not_deleted }
-  scope :not_deleted, -> { where(deleted_at: nil) }
-  scope :deleted, -> { unscoped.where.not(deleted_at: nil) }
+  scope :not_deleted, -> { kept }
+  scope :deleted, -> { with_discarded.discarded }
+  scope :with_deleted, -> { with_discarded }
+
+  before_discard :revoke_org_scoped_api_keys!
 
   after_create do
     record_event!(Events::OrganizationEvent::CREATED, actor_gid: memberships.first&.to_gid)
@@ -54,6 +60,10 @@ class Organization < ApplicationRecord
   end
 
   private
+
+  def revoke_org_scoped_api_keys!
+    memberships_including_unconfirmed.find_each(&:revoke_org_scoped_api_keys!)
+  end
 
   def handle_not_reserved
     return if handle.blank?

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -287,7 +287,7 @@ class Pusher
   def persist_version
     retries = 0
     begin
-      rubygem.transaction do
+      rubygem.transaction(requires_new: true) do
         rubygem.update_attributes_from_gem_specification!(version, spec)
         version.normalize_content_addressable_gem_metadata!
       end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -243,22 +243,40 @@ class Pusher
 
   def assign_ownership_for_unowned_gem
     if api_key.organization
-      return notify_unauthorized unless OrganizationPolicy.new(owner, api_key.organization).add_gem?
-
-      rubygem.update!(organization_id: api_key.organization.id)
+      assign_organization_ownership
     elsif api_key.user?
       rubygem.create_ownership(owner)
+      true
     elsif api_key.trusted_publisher?
-      pending_publisher = find_pending_trusted_publisher
-      return notify("No pending publisher found", 404) if pending_publisher.blank?
-
-      rubygem.transaction do
-        logger.info { "Reifying pending publisher" }
-        rubygem.create_ownership(pending_publisher.user)
-        owner.rubygem_trusted_publishers.create!(rubygem: rubygem)
-      end
+      reify_pending_trusted_publisher
     else
+      notify_unauthorized
+    end
+  end
+
+  def assign_organization_ownership
+    return notify_unauthorized unless OrganizationPolicy.new(owner, api_key.organization).add_gem?
+
+    rubygem.update!(organization_id: api_key.organization.id)
+    true
+  end
+
+  def reify_pending_trusted_publisher
+    pending_publisher = find_pending_trusted_publisher
+    return notify("No pending publisher found", 404) if pending_publisher.blank?
+
+    if pending_publisher.organization && !OrganizationPolicy.new(pending_publisher.user, pending_publisher.organization).add_gem?
       return notify_unauthorized
+    end
+
+    rubygem.transaction do
+      logger.info { "Reifying pending publisher" }
+      if pending_publisher.organization
+        rubygem.update!(organization_id: pending_publisher.organization.id)
+      else
+        rubygem.create_ownership(pending_publisher.user)
+      end
+      owner.rubygem_trusted_publishers.create!(rubygem: rubygem)
     end
 
     true

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -231,12 +231,14 @@ class Pusher
   end
 
   def update
-    rubygem.disown if rubygem.versions.indexed.none?
-    persist_version
-    return true unless rubygem.unowned?
+    Rubygem.transaction do
+      rubygem.disown if rubygem.versions.indexed.none?
+      persist_version
+      next true unless rubygem.unowned?
 
-    assign_ownership_for_unowned_gem
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique => e
+      assign_ownership_for_unowned_gem || raise(ActiveRecord::Rollback)
+    end
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
     logger.info { { message: "Error updating rubygem", exception: e } }
     false
   end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -13,7 +13,6 @@ class Pusher
 
   def initialize(api_key, body, request: nil, attestations: nil)
     @api_key = api_key
-    @scoped_rubygem = api_key.rubygem
 
     @body = StringIO.new(body.read)
     @attestations = attestations
@@ -27,7 +26,7 @@ class Pusher
       pull_spec &&
         find &&
         authorize &&
-        verify_gem_scope &&
+        verify_api_key_scope &&
         verify_mfa_requirement &&
         validate &&
         save
@@ -42,8 +41,8 @@ class Pusher
     notify_unauthorized
   end
 
-  def verify_gem_scope
-    return true unless @scoped_rubygem && rubygem != @scoped_rubygem
+  def verify_api_key_scope
+    return true if api_key.scoped_to?(rubygem)
 
     notify("This API key cannot perform the specified action on this gem.", 403)
   end
@@ -234,28 +233,35 @@ class Pusher
   def update
     rubygem.disown if rubygem.versions.indexed.none?
     persist_version
+    return true unless rubygem.unowned?
 
-    if rubygem.unowned?
-      if api_key.user?
-        rubygem.create_ownership(owner)
-      elsif api_key.trusted_publisher?
-        pending_publisher = find_pending_trusted_publisher
-        return notify("No pending publisher found", 404) if pending_publisher.blank?
-
-        rubygem.transaction do
-          logger.info { "Reifying pending publisher" }
-          rubygem.create_ownership(pending_publisher.user)
-          owner.rubygem_trusted_publishers.create!(rubygem: rubygem)
-        end
-      else
-        return notify_unauthorized
-      end
-    end
-
-    true
+    assign_ownership_for_unowned_gem
   rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique => e
     logger.info { { message: "Error updating rubygem", exception: e } }
     false
+  end
+
+  def assign_ownership_for_unowned_gem
+    if api_key.organization
+      return notify_unauthorized unless OrganizationPolicy.new(owner, api_key.organization).add_gem?
+
+      rubygem.update!(organization_id: api_key.organization.id)
+    elsif api_key.user?
+      rubygem.create_ownership(owner)
+    elsif api_key.trusted_publisher?
+      pending_publisher = find_pending_trusted_publisher
+      return notify("No pending publisher found", 404) if pending_publisher.blank?
+
+      rubygem.transaction do
+        logger.info { "Reifying pending publisher" }
+        rubygem.create_ownership(pending_publisher.user)
+        owner.rubygem_trusted_publishers.create!(rubygem: rubygem)
+      end
+    else
+      return notify_unauthorized
+    end
+
+    true
   end
 
   def persist_version

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -308,6 +308,10 @@ class User < ApplicationRecord
     rubygem.owned_by?(self)
   end
 
+  def manageable_organizations
+    Organization.where(id: memberships.confirmed.with_minimum_role(:admin).select(:organization_id)).order(:name)
+  end
+
   def acknowledge_policies!
     update(policies_acknowledged_at: Time.zone.now)
   end

--- a/app/policies/admin/api_key_organization_scope_policy.rb
+++ b/app/policies/admin/api_key_organization_scope_policy.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-class Admin::MembershipPolicy < Admin::ApplicationPolicy
+class Admin::ApiKeyOrganizationScopePolicy < Admin::ApplicationPolicy
   class Scope < Admin::ApplicationPolicy::Scope
     def resolve
       scope.all
     end
   end
 
-  has_association :api_key_organization_scopes
-
   def avo_show?
-    rubygems_org_admin?
+    policy!(user, record.membership).avo_show?
   end
 end

--- a/app/policies/admin/api_key_policy.rb
+++ b/app/policies/admin/api_key_policy.rb
@@ -9,6 +9,8 @@ class Admin::ApiKeyPolicy < Admin::ApplicationPolicy
 
   has_association :api_key_rubygem_scope
   has_association :ownership
+  has_association :api_key_organization_scope
+  has_association :membership
   has_association :oidc_id_token
 
   def avo_show?

--- a/app/policies/admin/oidc/pending_trusted_publisher_policy.rb
+++ b/app/policies/admin/oidc/pending_trusted_publisher_policy.rb
@@ -8,6 +8,7 @@ class Admin::OIDC::PendingTrustedPublisherPolicy < Admin::ApplicationPolicy
   end
 
   has_association :rubygem
+  has_association :organization
   has_association :trusted_publisher
 
   def avo_index? = rubygems_org_admin?

--- a/app/views/api_keys/_form.html.erb
+++ b/app/views/api_keys/_form.html.erb
@@ -47,11 +47,14 @@
     <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, class: field_class, data: { gem_scope_target: "gemSelector" } %>
   </div>
 
-  <div>
-    <%= f.label :organization_id, t(".organization_scope"), class: label_class %>
-    <p class="mb-2 text-b4 text-neutral-600 dark:text-neutral-400"><%= t(".organization_scope_info") %></p>
-    <%= f.collection_select :organization_id, current_user.manageable_organizations, :id, :name, { include_blank: t("api_keys.no_organization") }, class: field_class, data: { gem_scope_target: "orgSelector" } %>
-  </div>
+  <% organizations = current_user.manageable_organizations %>
+  <% if organizations.any? %>
+    <div>
+      <%= f.label :organization_id, t(".organization_scope"), class: label_class %>
+      <p class="mb-2 text-b4 text-neutral-600 dark:text-neutral-400"><%= t(".organization_scope_info") %></p>
+      <%= f.collection_select :organization_id, organizations, :id, :name, { include_blank: t("api_keys.no_organization") }, class: field_class, data: { gem_scope_target: "orgSelector" } %>
+    </div>
+  <% end %>
 
   <div>
     <%= f.label :expires_at, t(".expiration"), class: label_class %>

--- a/app/views/api_keys/_form.html.erb
+++ b/app/views/api_keys/_form.html.erb
@@ -44,7 +44,13 @@
   <div>
     <%= f.label :rubygem_id, t(".rubygem_scope"), class: label_class %>
     <p class="mb-2 text-b4 text-neutral-600 dark:text-neutral-400"><%= t(".rubygem_scope_info") %></p>
-    <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, selected: :rubygem_id, class: field_class, data: { gem_scope_target: "selector" } %>
+    <%= f.collection_select :rubygem_id, current_user.rubygems.by_name, :id, :name, { include_blank: t("api_keys.all_gems") }, class: field_class, data: { gem_scope_target: "gemSelector" } %>
+  </div>
+
+  <div>
+    <%= f.label :organization_id, t(".organization_scope"), class: label_class %>
+    <p class="mb-2 text-b4 text-neutral-600 dark:text-neutral-400"><%= t(".organization_scope_info") %></p>
+    <%= f.collection_select :organization_id, current_user.manageable_organizations, :id, :name, { include_blank: t("api_keys.no_organization") }, class: field_class, data: { gem_scope_target: "orgSelector" } %>
   </div>
 
   <div>

--- a/app/views/components/events/user_event/api_key/created_component.rb
+++ b/app/views/components/events/user_event/api_key/created_component.rb
@@ -4,10 +4,10 @@ class Events::UserEvent::ApiKey::CreatedComponent < Events::TableDetailsComponen
   def view_template
     div { t(".api_key_name", name: additional.name) }
     div { t(".api_key_scopes", scopes: additional.scopes&.to_sentence) }
-    if additional.gem.present?
-      div do
-        t(".api_key_gem_html", gem: link_to(additional.gem, rubygem_path(additional.gem)))
-      end
+    raw t(".api_key_gem_html", gem: view_context.link_to(additional.gem, rubygem_path(additional.gem))) if additional.gem.present?
+    if additional.organization.present?
+      raw t(".api_key_organization_html",
+        organization: view_context.link_to(additional.organization, organization_path(additional.organization)))
     end
     div { t(".api_key_mfa", mfa: additional.mfa ? t(".required") : t(".not_required")) } if additional.has_attribute?(:mfa)
   end

--- a/app/views/components/events/user_event/api_key/created_component.rb
+++ b/app/views/components/events/user_event/api_key/created_component.rb
@@ -4,10 +4,16 @@ class Events::UserEvent::ApiKey::CreatedComponent < Events::TableDetailsComponen
   def view_template
     div { t(".api_key_name", name: additional.name) }
     div { t(".api_key_scopes", scopes: additional.scopes&.to_sentence) }
-    raw t(".api_key_gem_html", gem: view_context.link_to(additional.gem, rubygem_path(additional.gem))) if additional.gem.present?
+    if additional.gem.present?
+      div do
+        t(".api_key_gem_html", gem: view_context.link_to(additional.gem, rubygem_path(additional.gem)))
+      end
+    end
     if additional.organization.present?
-      raw t(".api_key_organization_html",
-        organization: view_context.link_to(additional.organization, organization_path(additional.organization)))
+      div do
+        t(".api_key_organization_html",
+          organization: view_context.link_to(additional.organization, organization_path(additional.organization)))
+      end
     end
     div { t(".api_key_mfa", mfa: additional.mfa ? t(".required") : t(".not_required")) } if additional.has_attribute?(:mfa)
   end

--- a/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
+++ b/app/views/oidc/api_key_permissions/_api_key_permissions.html.erb
@@ -18,4 +18,13 @@
       ) %>
     </dd>
   </div>
+  <% if api_key_permissions.organization.present? %>
+    <div>
+      <dt class="<%= heading %>"><%= api_key_permissions.class.human_attribute_name :organization %></dt>
+      <dd class="mt-1">
+        <%= link_to api_key_permissions.organization, organization_path(api_key_permissions.organization),
+              class: "text-orange-500 hover:underline dark:text-orange-400" %>
+      </dd>
+    </div>
+  <% end %>
 </dl>

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -50,6 +50,11 @@
           <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.rubygem_scope_info") %></p>
           <%= f.collection_select :gems, current_user.rubygems.by_name, :name, :name, { include_blank: t("api_keys.all_gems"), include_hidden: false }, selected: :name, class: input_class, multiple: true %>
         </div>
+        <div class="mt-6">
+          <%= f.label :organization, t("api_keys.form.organization_scope"), class: label_class %>
+          <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.organization_scope_info") %></p>
+          <%= f.collection_select :organization, current_user.manageable_organizations, :handle, :name, { include_blank: t("api_keys.no_organization") }, class: input_class %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/oidc/api_key_roles/_form.html.erb
+++ b/app/views/oidc/api_key_roles/_form.html.erb
@@ -50,11 +50,14 @@
           <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.rubygem_scope_info") %></p>
           <%= f.collection_select :gems, current_user.rubygems.by_name, :name, :name, { include_blank: t("api_keys.all_gems"), include_hidden: false }, selected: :name, class: input_class, multiple: true %>
         </div>
-        <div class="mt-6">
-          <%= f.label :organization, t("api_keys.form.organization_scope"), class: label_class %>
-          <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.organization_scope_info") %></p>
-          <%= f.collection_select :organization, current_user.manageable_organizations, :handle, :name, { include_blank: t("api_keys.no_organization") }, class: input_class %>
-        </div>
+        <% organizations = current_user.manageable_organizations %>
+        <% if organizations.any? %>
+          <div class="mt-6">
+            <%= f.label :organization, t("api_keys.form.organization_scope"), class: label_class %>
+            <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-2"><%= t("api_keys.form.organization_scope_info") %></p>
+            <%= f.collection_select :organization, organizations, :handle, :name, { include_blank: t("api_keys.no_organization") }, class: input_class %>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/oidc/pending_trusted_publishers/index_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/index_view.rb
@@ -60,6 +60,12 @@ class OIDC::PendingTrustedPublishers::IndexView < ApplicationView
         raw t(".valid_for_html",
           time_html: view_context.time_tag(pending_trusted_publisher.expires_at,
             view_context.distance_of_time_in_words_to_now(pending_trusted_publisher.expires_at)))
+        if pending_trusted_publisher.organization
+          whitespace
+          plain "·"
+          whitespace
+          plain pending_trusted_publisher.organization.name
+        end
       end
 
       render pending_trusted_publisher.trusted_publisher

--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -39,9 +39,12 @@ class OIDC::PendingTrustedPublishers::NewView < ApplicationView
   end
 
   def organization_field(form)
+    organizations = current_user.manageable_organizations
+    return if organizations.none?
+
     div class: "py-4" do
       form.label :organization_id, t("oidc.trusted_publisher.pending.organization_scope"), class: label_class
-      form.collection_select :organization_id, current_user.manageable_organizations, :id, :name,
+      form.collection_select :organization_id, organizations, :id, :name,
         { include_blank: t("api_keys.no_organization") }, class: field_class
       p(class: note_class) { t("oidc.trusted_publisher.pending.organization_scope_info") }
     end

--- a/app/views/oidc/pending_trusted_publishers/new_view.rb
+++ b/app/views/oidc/pending_trusted_publishers/new_view.rb
@@ -16,36 +16,46 @@ class OIDC::PendingTrustedPublishers::NewView < ApplicationView
     h1(class: "text-h2 mb-10") { t(".title") }
 
     render CardComponent.new do
-      form_with(
-        model: pending_trusted_publisher,
-        url: profile_oidc_pending_trusted_publishers_path
-      ) do |f|
-        div class: "py-4" do
-          f.label :rubygem_name, class: label_class
-          f.text_field :rubygem_name, class: field_class, autocomplete: :off
-          p(class: note_class) { t("oidc.trusted_publisher.pending.rubygem_name_help_html") }
-        end
-
-        div class: "py-4" do
-          f.label :trusted_publisher_type, class: label_class
-          f.select :trusted_publisher_type,
-            OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
-            {},
-            class: field_class
-        end
-
-        render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(
-          github_action_form: f
-        )
-
+      form_with(model: pending_trusted_publisher, url: profile_oidc_pending_trusted_publishers_path) do |form|
+        rubygem_name_field(form)
+        organization_field(form)
+        trusted_publisher_type_field(form)
+        render OIDC::TrustedPublisher::GitHubAction::FormComponent.new(github_action_form: form)
         render ButtonComponent.new do
-          f.submit
+          form.submit
         end
       end
     end
   end
 
   private
+
+  def rubygem_name_field(form)
+    div class: "py-4" do
+      form.label :rubygem_name, class: label_class
+      form.text_field :rubygem_name, class: field_class, autocomplete: :off
+      p(class: note_class) { t("oidc.trusted_publisher.pending.rubygem_name_help_html") }
+    end
+  end
+
+  def organization_field(form)
+    div class: "py-4" do
+      form.label :organization_id, t("oidc.trusted_publisher.pending.organization_scope"), class: label_class
+      form.collection_select :organization_id, current_user.manageable_organizations, :id, :name,
+        { include_blank: t("api_keys.no_organization") }, class: field_class
+      p(class: note_class) { t("oidc.trusted_publisher.pending.organization_scope_info") }
+    end
+  end
+
+  def trusted_publisher_type_field(form)
+    div class: "py-4" do
+      form.label :trusted_publisher_type, class: label_class
+      form.select :trusted_publisher_type,
+        OIDC::TrustedPublisher.all.map { |type| [type.publisher_name, type.polymorphic_name] },
+        {},
+        class: field_class
+    end
+  end
 
   def label_class
     "block text-b4 font-semibold text-neutral-800 dark:text-neutral-200 mb-2"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -186,6 +186,8 @@ de:
       rubygem_scope: Gem-Bereich
       rubygem_scope_info: Dieser Bereich beschränkt die Befehle gem push/yank und
         owner add/remove auf ein bestimmtes Gem.
+      organization_scope:
+      organization_scope_info:
       multifactor_auth: Mehrfaktor-Authentifizierung
       enable_mfa: MFA aktivieren
       expiration:
@@ -237,8 +239,11 @@ de:
         löschen Sie ihn und erstellen Sie einen neuen.
       expired_key:
     all_gems: Alle Gems
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed: Die Eigentümerschaft von %{rubygem_name} wurde nach der
       Zuordnung zu diesem Schlüssel entfernt.
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: Erstellen
@@ -1175,6 +1180,8 @@ de:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1236,6 +1243,7 @@ de:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,8 @@ en:
       exclusive_scopes: Exclusive Scopes
       rubygem_scope: Gem Scope
       rubygem_scope_info: This scope restricts gem push/yank and owner add/remove commands to a specific gem.
+      organization_scope: Organization Scope
+      organization_scope_info: New gems pushed with this key are owned by the selected organization.
       multifactor_auth: Multi-factor authentication
       enable_mfa: Enable MFA
       expiration: Expiration
@@ -226,7 +228,10 @@ en:
       invalid_key: An invalid API key cannot be edited. Please delete it and create a new one.
       expired_key: An expired API key cannot be edited. Please create a new one.
     all_gems: All Gems
+    no_organization: No Organization
+    unavailable_organization: Unavailable Organization
     gem_ownership_removed: Ownership of the %{rubygem_name} gem has been removed after being scoped to this key.
+    organization_membership_removed: Membership in the %{organization_name} organization has been removed after being scoped to this key.
   dashboards:
     show:
       creating_link_text: creating
@@ -1106,6 +1111,8 @@ en:
           Leave blank if the workflow is defined in the same repository as above (the common case).
       pending:
         rubygem_name_help_html: "The gem (on RubyGems.org) that will be created when this publisher is used"
+        organization_scope: Organization Scope
+        organization_scope_info: New gems published with this trusted publisher are owned by the selected organization.
   duration:
     minutes:
       other: "%{count} minutes"
@@ -1167,6 +1174,7 @@ en:
         api_key_name: "Name: %{name}"
         api_key_scopes: "Scopes: %{scopes}"
         api_key_gem_html: "Gem: %{gem}"
+        api_key_organization_html: "Organization: %{organization}"
         api_key_mfa: "MFA: %{mfa}"
         not_required: "Not required"
       password:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -182,6 +182,8 @@ es:
       rubygem_scope: Ámbito de aplicación
       rubygem_scope_info: Este alcance restringe los comandos de añadir/eliminar gemas
         y añadir/eliminar propietarios a una gema específica.
+      organization_scope:
+      organization_scope_info:
       multifactor_auth: Autenticación multifactor
       enable_mfa: Activar AMF
       expiration:
@@ -234,8 +236,11 @@ es:
         y crea una nueva.
       expired_key:
     all_gems: Todas las gemas
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed: Se ha eliminado la propiedad de %{rubygem_name} tras haber
       sido añadida a esta clave.
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: crear
@@ -1219,6 +1224,8 @@ es:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other: "%{count} minutos"
@@ -1280,6 +1287,7 @@ es:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -177,6 +177,8 @@ fr:
       exclusive_scopes:
       rubygem_scope:
       rubygem_scope_info:
+      organization_scope:
+      organization_scope_info:
       multifactor_auth:
       enable_mfa:
       expiration:
@@ -226,7 +228,10 @@ fr:
       invalid_key:
       expired_key:
     all_gems:
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed:
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: création
@@ -1130,6 +1135,8 @@ fr:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1191,6 +1198,7 @@ fr:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -173,6 +173,8 @@ ja:
       exclusive_scopes: 除外するスコープ
       rubygem_scope: gemのスコープ
       rubygem_scope_info: このスコープはgemのプッシュ・ヤンクないし所有者の追加・削除のコマンドを特定のgemに制限します。
+      organization_scope:
+      organization_scope_info:
       multifactor_auth: 多要素認証
       enable_mfa: MFAを有効にする
       expiration: 期限
@@ -222,7 +224,10 @@ ja:
       invalid_key: 正しくないAPIキーは編集できません。削除して新規作成してください。
       expired_key:
     all_gems: 全てのgem
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed: このキーのスコープにあった%{rubygem_name}の所有権が削除されました。
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: 作成
@@ -1121,6 +1126,8 @@ ja:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html: "（RubyGems.orgの）gemはこの発行元が使われたときに作られます"
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other: "%{count}分"
@@ -1182,6 +1189,7 @@ ja:
         api_key_name: 名前：%{name}
         api_key_scopes: スコープ：%{scopes}
         api_key_gem_html: gem：%{gem}
+        api_key_organization_html:
         api_key_mfa: MFA：%{mfa}
         not_required: 必要ではありません
       password:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -172,6 +172,8 @@ nl:
       exclusive_scopes:
       rubygem_scope:
       rubygem_scope_info:
+      organization_scope:
+      organization_scope_info:
       multifactor_auth:
       enable_mfa:
       expiration:
@@ -221,7 +223,10 @@ nl:
       invalid_key:
       expired_key:
     all_gems:
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed:
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: aanmaken
@@ -1087,6 +1092,8 @@ nl:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1148,6 +1155,7 @@ nl:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -178,6 +178,8 @@ pt-BR:
       exclusive_scopes:
       rubygem_scope:
       rubygem_scope_info:
+      organization_scope:
+      organization_scope_info:
       multifactor_auth:
       enable_mfa:
       expiration:
@@ -227,7 +229,10 @@ pt-BR:
       invalid_key:
       expired_key:
     all_gems:
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed:
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: Criar
@@ -1110,6 +1115,8 @@ pt-BR:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1171,6 +1178,7 @@ pt-BR:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -173,6 +173,8 @@ zh-CN:
       exclusive_scopes:
       rubygem_scope: Gem 作用范围
       rubygem_scope_info: 该作用范围仅允许对一个 Gem 进行 [推送/撤回] 以及对所有者的 [添加/移除]
+      organization_scope:
+      organization_scope_info:
       multifactor_auth: 多因素验证（MFA）——身份认证
       enable_mfa: 启用多因素验证（MFA）
       expiration:
@@ -222,7 +224,10 @@ zh-CN:
       invalid_key: 已作废的 API 密钥不能被编辑，请删除它并创建一个新的 API 密钥。
       expired_key:
     all_gems: 所有 Gem
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed: 对 %{rubygem_name} 的所有权已经被移除（在使用此 API 密钥决定作用范围后）
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: 创建
@@ -1101,6 +1106,8 @@ zh-CN:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1162,6 +1169,7 @@ zh-CN:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -172,6 +172,8 @@ zh-TW:
       exclusive_scopes:
       rubygem_scope:
       rubygem_scope_info:
+      organization_scope:
+      organization_scope_info:
       multifactor_auth:
       enable_mfa:
       expiration:
@@ -221,7 +223,10 @@ zh-TW:
       invalid_key: 無法編輯無效的 API 金鑰。請刪除此金鑰並重新建立。
       expired_key:
     all_gems: 所有 Gems
+    no_organization:
+    unavailable_organization:
     gem_ownership_removed:
+    organization_membership_removed:
   dashboards:
     show:
       creating_link_text: Gem 建立
@@ -1089,6 +1094,8 @@ zh-TW:
         workflow_repository_name_help_html:
       pending:
         rubygem_name_help_html:
+        organization_scope:
+        organization_scope_info:
   duration:
     minutes:
       other:
@@ -1150,6 +1157,7 @@ zh-TW:
         api_key_name:
         api_key_scopes:
         api_key_gem_html:
+        api_key_organization_html:
         api_key_mfa:
         not_required:
       password:

--- a/db/migrate/20260811130000_create_api_key_organization_scopes.rb
+++ b/db/migrate/20260811130000_create_api_key_organization_scopes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateApiKeyOrganizationScopes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :api_key_organization_scopes do |t|
+      t.references :api_key, null: false, index: { unique: true },
+        foreign_key: { to_table: :api_keys, name: "api_key_organization_scopes_api_key_id_fk" }
+      t.references :membership, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_column :api_keys, :soft_deleted_organization_name, :string
+  end
+end

--- a/db/migrate/20260811131904_add_organization_to_oidc_pending_trusted_publishers.rb
+++ b/db/migrate/20260811131904_add_organization_to_oidc_pending_trusted_publishers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddOrganizationToOIDCPendingTrustedPublishers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :oidc_pending_trusted_publishers, :organization, null: true, index: { algorithm: :concurrently }
+    add_foreign_key :oidc_pending_trusted_publishers, :organizations, column: :organization_id, on_delete: :nullify, validate: false
+  end
+end

--- a/db/migrate/20260811161000_validate_organization_foreign_key_on_oidc_pending_trusted_publishers.rb
+++ b/db/migrate/20260811161000_validate_organization_foreign_key_on_oidc_pending_trusted_publishers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateOrganizationForeignKeyOnOIDCPendingTrustedPublishers < ActiveRecord::Migration[8.1]
+  def change
+    validate_foreign_key :oidc_pending_trusted_publishers, :organizations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -487,11 +487,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
   create_table "oidc_pending_trusted_publishers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at", precision: nil, null: false
+    t.bigint "organization_id"
     t.string "rubygem_name"
     t.bigint "trusted_publisher_id", null: false
     t.string "trusted_publisher_type", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["organization_id"], name: "index_oidc_pending_trusted_publishers_on_organization_id"
     t.index ["trusted_publisher_type", "trusted_publisher_id"], name: "index_oidc_pending_trusted_publishers_on_trusted_publisher"
     t.index ["user_id"], name: "index_oidc_pending_trusted_publishers_on_user_id"
   end
@@ -824,6 +826,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
   add_foreign_key "oidc_api_key_roles", "users"
   add_foreign_key "oidc_id_tokens", "api_keys"
   add_foreign_key "oidc_id_tokens", "oidc_api_key_roles"
+  add_foreign_key "oidc_pending_trusted_publishers", "organizations", on_delete: :nullify
   add_foreign_key "oidc_pending_trusted_publishers", "users"
   add_foreign_key "oidc_rubygem_trusted_publishers", "rubygems"
   add_foreign_key "organization_invites", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
     t.index ["github_id"], name: "index_admin_github_users_on_github_id", unique: true
   end
 
+  create_table "api_key_organization_scopes", force: :cascade do |t|
+    t.bigint "api_key_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "membership_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_key_id"], name: "index_api_key_organization_scopes_on_api_key_id", unique: true
+    t.index ["membership_id"], name: "index_api_key_organization_scopes_on_membership_id"
+  end
+
   create_table "api_key_rubygem_scopes", force: :cascade do |t|
     t.bigint "api_key_id", null: false
     t.datetime "created_at", null: false
@@ -48,6 +57,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
     t.string "owner_type"
     t.string "scopes", array: true
     t.datetime "soft_deleted_at"
+    t.string "soft_deleted_organization_name"
     t.string "soft_deleted_rubygem_name"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["hashed_key"], name: "index_api_keys_on_hashed_key", unique: true
@@ -792,6 +802,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
     t.index ["user_id"], name: "index_webauthn_verifications_on_user_id", unique: true
   end
 
+  add_foreign_key "api_key_organization_scopes", "api_keys", name: "api_key_organization_scopes_api_key_id_fk"
+  add_foreign_key "api_key_organization_scopes", "memberships"
   add_foreign_key "api_key_rubygem_scopes", "api_keys", name: "api_key_rubygem_scopes_api_key_id_fk"
   add_foreign_key "attestations", "versions"
   add_foreign_key "audits", "admin_github_users", name: "audits_admin_github_user_id_fk"

--- a/test/components/previews/events/user_event/api_key/created_component_preview.rb
+++ b/test/components/previews/events/user_event/api_key/created_component_preview.rb
@@ -5,13 +5,15 @@ class Events::UserEvent::ApiKey::CreatedComponentPreview < Lookbook::Preview
   # @param scopes [Array<String>]
   # @param mfa toggle
   # @param gem text
-  def default(name: "example", scopes: ["push"], mfa: false, gem: nil)
+  # @param organization text
+  def default(name: "example", scopes: ["push"], mfa: false, gem: nil, organization: nil)
     event = FactoryBot.build(:events_user_event, tag: Events::UserEvent::API_KEY_CREATED, additional:
     {
       name:,
       scopes:,
       mfa:,
-      gem: gem.presence
+      gem: gem.presence,
+      organization: organization.presence
     })
     render Events::UserEvent::ApiKey::CreatedComponent.new(
       event:

--- a/test/factories/api_key.rb
+++ b/test/factories/api_key.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     transient do
       sequence(:key, &:to_s)
       rubygem { nil }
+      scoped_organization { nil }
     end
 
     owner factory: %i[user]
@@ -17,6 +18,7 @@ FactoryBot.define do
 
     after(:build) do |api_key, evaluator|
       api_key.rubygem_id = evaluator.rubygem.id if evaluator.rubygem
+      api_key.organization_id = evaluator.scoped_organization.id if evaluator.scoped_organization
     end
 
     trait :trusted_publisher do

--- a/test/factories/api_key_organization_scope.rb
+++ b/test/factories/api_key_organization_scope.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_key_organization_scope do
+    membership
+    api_key { association(:api_key, key: SecureRandom.hex(24)) }
+  end
+end

--- a/test/functional/api/v1/api_keys_controller_test.rb
+++ b/test/functional/api/v1/api_keys_controller_test.rb
@@ -269,6 +269,58 @@ class Api::V1::ApiKeysControllerTest < ActionController::TestCase
           end
         end
       end
+
+      context "with organization param set" do
+        setup do
+          @organization = create(:organization, owners: [@user])
+        end
+
+        context "with applicable scope enabled" do
+          setup do
+            post :create,
+              params: { name: "org-scoped-key", push_rubygem: "true", organization: @organization.handle },
+              format: "text"
+          end
+
+          should_return_api_key_successfully
+
+          should "have an organization associated" do
+            created_key = @user.api_keys.find_by(name: "org-scoped-key")
+
+            assert_equal @organization, created_key.organization
+          end
+        end
+
+        context "with applicable scope disabled" do
+          setup do
+            post :create,
+              params: { name: "org-scoped-key", index_rubygems: "true", organization: @organization.handle },
+              format: "text"
+          end
+
+          should respond_with :unprocessable_content
+
+          should "respond with an error" do
+            assert_equal "Organization scope can only be set for push/yank rubygem, and add/remove owner scopes", response.body
+          end
+        end
+
+        context "with an organization the user cannot manage" do
+          setup do
+            organization = create(:organization, owners: [create(:user)])
+
+            post :create,
+              params: { name: "org-scoped-key", push_rubygem: "true", organization: organization.handle },
+              format: "text"
+          end
+
+          should respond_with :unprocessable_content
+
+          should "respond with an error" do
+            assert_equal "Organization must be an organization you can manage", response.body
+          end
+        end
+      end
     end
 
     context "when a user provides an OTP code" do

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -320,6 +320,43 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
         end
       end
 
+      context "with api key organization scoped" do
+        setup do
+          @organization = create(:organization, owners: [@user])
+          @api_key = create(:api_key, name: "org-scoped-delete-key", key: "123456", scopes: %i[yank_rubygem],
+            owner: @user, scoped_organization: @organization)
+          @request.env["HTTP_AUTHORIZATION"] = "123456"
+        end
+
+        context "to an organization gem" do
+          setup do
+            @rubygem.update!(organization: @organization)
+            @ownership.destroy!
+            delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
+          end
+
+          should respond_with :success
+        end
+
+        context "to a personal gem" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
+          end
+
+          should respond_with :forbidden
+        end
+
+        context "to a gem in another organization" do
+          setup do
+            @rubygem.update!(organization: create(:organization))
+            @ownership.destroy!
+            delete :create, params: { gem_name: @rubygem.slug, version: @v1.number }
+          end
+
+          should respond_with :forbidden
+        end
+      end
+
       context "when mfa is required" do
         setup do
           User.any_instance.stubs(:mfa_required?).returns true

--- a/test/functional/api/v1/owners_controller_test.rb
+++ b/test/functional/api/v1/owners_controller_test.rb
@@ -401,6 +401,50 @@ class Api::V1::OwnersControllerTest < ActionController::TestCase
         end
       end
 
+      context "with api key organization scoped" do
+        setup do
+          @organization = create(:organization, owners: [@user])
+          @api_key = create(:api_key, key: "org123", scopes: %i[add_owner], owner: @user, scoped_organization: @organization)
+          @request.env["HTTP_AUTHORIZATION"] = "org123"
+        end
+
+        context "to an organization gem" do
+          setup do
+            @rubygem.update!(organization: @organization)
+            @ownership.destroy!
+            post :create, params: { rubygem_id: @rubygem.slug, email: @second_user.email }
+          end
+
+          should respond_with :success
+
+          should "add other user as gem owner" do
+            assert_includes @rubygem.owners_including_unconfirmed, @second_user
+          end
+        end
+
+        context "to a personal gem" do
+          setup do
+            post :create, params: { rubygem_id: @rubygem.slug, email: @second_user.email }
+          end
+
+          should respond_with :forbidden
+
+          should "not add other user as gem owner" do
+            refute_includes @rubygem.owners_including_unconfirmed, @second_user
+          end
+        end
+
+        context "to a gem in another organization" do
+          setup do
+            @rubygem.update!(organization: create(:organization))
+            @ownership.destroy!
+            post :create, params: { rubygem_id: @rubygem.slug, email: @second_user.email }
+          end
+
+          should respond_with :forbidden
+        end
+      end
+
       context "with a soft deleted api key" do
         setup do
           @api_key.soft_delete!

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -943,6 +943,19 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       should respond_with :success
     end
 
+    context "when the organization is discarded" do
+      setup do
+        @organization.discard!
+        post :create, body: gem_file(&:read)
+      end
+
+      should respond_with :forbidden
+
+      should "#render_soft_deleted_api_key and display an error" do
+        assert_equal "An invalid API key cannot be used. Please delete it and create a new one.", @response.body
+      end
+    end
+
     context "when membership is only maintainer" do
       setup do
         @user = create(:user)

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -887,4 +887,80 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "push with api key scoped to an organization" do
+    setup do
+      @user = create(:user)
+      @organization = create(:organization, owners: [@user])
+      @api_key = create(:api_key, key: "12345", owner: @user, scoped_organization: @organization, scopes: %i[push_rubygem])
+      @request.env["HTTP_AUTHORIZATION"] = "12345"
+    end
+
+    context "for a new gem" do
+      setup do
+        post :create, body: gem_file(&:read)
+      end
+
+      should respond_with :success
+
+      should "assign the gem to the organization" do
+        rubygem = Rubygem.last
+
+        assert_equal @organization, rubygem.organization
+        assert_empty rubygem.ownerships
+      end
+    end
+
+    context "for a personal gem" do
+      setup do
+        create(:ownership, user: create(:user), rubygem: create(:rubygem, name: "test"))
+        post :create, body: gem_file("test-1.0.0.gem", &:read)
+      end
+
+      should respond_with :forbidden
+
+      should "say organization scope is invalid" do
+        assert_equal "This API key cannot perform the specified action on this gem.", @response.body
+      end
+    end
+
+    context "for a gem in another organization" do
+      setup do
+        other_org = create(:organization)
+        create(:rubygem, name: "test", organization: other_org)
+        post :create, body: gem_file("test-1.0.0.gem", &:read)
+      end
+
+      should respond_with :forbidden
+    end
+
+    context "for an existing org gem" do
+      setup do
+        create(:rubygem, name: "test", organization: @organization)
+        post :create, body: gem_file("test-1.0.0.gem", &:read)
+      end
+
+      should respond_with :success
+    end
+
+    context "when membership is only maintainer" do
+      setup do
+        @user = create(:user)
+        @organization = create(:organization, maintainers: [@user])
+        @membership = @user.memberships.find_by!(organization: @organization)
+        key = SecureRandom.hex(24)
+        @api_key = create(:api_key, key: key, owner: @user, scopes: %i[push_rubygem])
+        create(:api_key_organization_scope, api_key: @api_key, membership: @membership)
+        @request.env["HTTP_AUTHORIZATION"] = key
+
+        post :create, body: gem_file(&:read)
+      end
+
+      should respond_with :forbidden
+
+      should "deny creating a new org gem" do
+        assert_match "You do not have permission to push to this gem.", @response.body
+      end
+    end
+  end
 end

--- a/test/functional/api/v1/rubygems_controller_test.rb
+++ b/test/functional/api/v1/rubygems_controller_test.rb
@@ -973,6 +973,7 @@ class Api::V1::RubygemsControllerTest < ActionController::TestCase
 
       should "deny creating a new org gem" do
         assert_match "You do not have permission to push to this gem.", @response.body
+        assert_nil Rubygem.find_by(name: "test")
       end
     end
   end

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -314,6 +314,22 @@ class ApiKeysControllerTest < ActionController::TestCase
           assert_equal "Rubygem scope can only be set for push/yank rubygem, and add/remove owner scopes", flash[:error]
           assert_empty @user.reload.api_keys
         end
+
+        should "not create a key scoped to both a gem and an organization" do
+          organization = create(:organization, owners: [@user])
+
+          post :create, params: {
+            api_key: {
+              name: "both scopes",
+              push_rubygem: true,
+              rubygem_id: @ownership.rubygem.id,
+              organization_id: organization.id
+            }
+          }
+
+          assert_equal "An API key cannot be scoped to both a gem and an organization", flash[:error]
+          assert_empty @user.reload.api_keys
+        end
       end
 
       context "with an expiration" do
@@ -438,6 +454,36 @@ class ApiKeysControllerTest < ActionController::TestCase
           end
           assert_equal "Please enable at least one scope and Rubygem scope can only be set for push/yank rubygem, and add/remove owner scopes",
                        flash[:error]
+        end
+
+        should "not persist either scope when a request sends a gem and an organization together" do
+          organization = create(:organization, owners: [@user])
+
+          patch :update, params: {
+            id: @api_key.id,
+            api_key: { push_rubygem: true, rubygem_id: @ownership.rubygem.id, organization_id: organization.id }
+          }
+
+          @api_key.reload
+
+          assert_equal "An API key cannot be scoped to both a gem and an organization", flash[:error]
+          assert_equal @ownership.rubygem, @api_key.rubygem
+          assert_nil @api_key.organization
+        end
+
+        should "switch from a gem scope to an organization scope" do
+          organization = create(:organization, owners: [@user])
+
+          patch :update, params: {
+            id: @api_key.id,
+            api_key: { push_rubygem: true, rubygem_id: nil, organization_id: organization.id }
+          }
+
+          @api_key.reload
+
+          assert_redirected_to profile_api_keys_path
+          assert_nil @api_key.rubygem
+          assert_equal organization, @api_key.organization
         end
       end
 

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -221,6 +221,33 @@ class ApiKeysControllerTest < ActionController::TestCase
       should "render new api key form" do
         assert page.has_content? "New API key"
       end
+
+      should "hide organization field when user has no manageable organizations" do
+        refute page.has_select?("api_key_organization_id")
+      end
+    end
+
+    context "on GET to new when user can manage an organization" do
+      setup do
+        @organization = create(:organization, owners: [@user])
+        get :new
+      end
+
+      should "show organization field" do
+        assert page.has_select?("api_key_organization_id",
+          options: ["No Organization", @organization.name])
+      end
+    end
+
+    context "on GET to new when user is only a maintainer" do
+      setup do
+        create(:organization, maintainers: [@user])
+        get :new
+      end
+
+      should "hide organization field" do
+        refute page.has_select?("api_key_organization_id")
+      end
     end
 
     context "on POST to create" do

--- a/test/integration/api/v1/oidc/api_key_roles_test.rb
+++ b/test/integration/api/v1/oidc/api_key_roles_test.rb
@@ -25,7 +25,7 @@ class Api::V1::OIDC::ApiKeyRolesTest < ActionDispatch::IntegrationTest
         "token" => @role.token,
         "oidc_provider_id" => @role.oidc_provider_id,
         "user_id" => @user.id,
-        "api_key_permissions" =>   { "scopes" => ["push_rubygem"], "valid_for" => 1800, "gems" => nil },
+        "api_key_permissions" =>   { "scopes" => ["push_rubygem"], "valid_for" => 1800, "gems" => nil, "organization" => nil },
         "name" => @role.name,
         "access_policy" =>  { "statements" => [
           "effect" => "allow",
@@ -63,7 +63,7 @@ class Api::V1::OIDC::ApiKeyRolesTest < ActionDispatch::IntegrationTest
           "token" => @role.token,
           "oidc_provider_id" => @role.oidc_provider_id,
           "user_id" => @user.id,
-          "api_key_permissions" =>   { "scopes" => ["push_rubygem"], "valid_for" => 1800, "gems" => nil },
+          "api_key_permissions" =>   { "scopes" => ["push_rubygem"], "valid_for" => 1800, "gems" => nil, "organization" => nil },
           "name" => @role.name,
           "access_policy" =>  { "statements" => [
             "effect" => "allow",
@@ -295,6 +295,64 @@ class Api::V1::OIDC::ApiKeyRolesTest < ActionDispatch::IntegrationTest
 
           assert_equal hashed_key, Digest::SHA256.hexdigest(resp["rubygems_api_key"])
           assert_equal gem_name, @user.api_keys.sole.ownership.rubygem.name
+        end
+      end
+
+      context "with permissions scoped to an organization" do
+        should "return API key scoped to the organization" do
+          organization = create(:organization, owners: [@role.user])
+          permissions = @role.api_key_permissions
+          permissions.organization = organization.handle
+          @role.api_key_permissions = permissions
+          @role.save!
+
+          post assume_role_api_v1_oidc_api_key_role_path(@role.token),
+              params: {
+                jwt: jwt.to_s
+              },
+              headers: {}
+
+          assert_response :created
+
+          resp = response.parsed_body
+
+          assert_match(/^rubygems_/, resp["rubygems_api_key"])
+          assert_equal_hash(
+            { "rubygems_api_key" => resp["rubygems_api_key"],
+              "name" => "#{@role.name}-79685b65-945d-450a-a3d8-a36bcf72c23d",
+              "scopes" => ["push_rubygem"],
+              "organization" => organization.handle,
+              "expires_at" => 30.minutes.from_now },
+            resp
+          )
+          api_key = @user.api_keys.sole
+
+          assert_equal Digest::SHA256.hexdigest(resp["rubygems_api_key"]), api_key.hashed_key
+          assert_equal organization, api_key.organization
+        end
+
+        should "return unprocessable when membership is no longer admin" do
+          organization = create(:organization, owners: [@role.user])
+          permissions = @role.api_key_permissions
+          permissions.organization = organization.handle
+          @role.api_key_permissions = permissions
+          @role.save!
+
+          membership = @role.user.memberships.find_by!(organization: organization)
+          membership.update!(role: :maintainer)
+
+          post assume_role_api_v1_oidc_api_key_role_path(@role.token),
+              params: {
+                jwt: jwt.to_s
+              },
+              headers: {}
+
+          assert_response :unprocessable_content
+          assert_equal(
+            { "errors" => ["Unable to create API key: the configured gem or organization scope is no longer valid"] },
+            response.parsed_body
+          )
+          assert_empty @user.api_keys
         end
       end
 

--- a/test/integration/avo/api_keys_test.rb
+++ b/test/integration/avo/api_keys_test.rb
@@ -30,4 +30,18 @@ class Avo::ApiKeysTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Revoke API Key — #{Avo::Actions::RevokeApiKey.already_revoked_reason}")
     assert_select "a[data-action-name^='Revoke API Key'][data-disabled='true']", count: 1
   end
+
+  test "showing an organization-scoped API key without a rubygem ownership" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    organization = create(:organization)
+    user = create(:user)
+    create(:membership, :admin, organization: organization, user: user)
+    api_key = create(:api_key, name: "org-push", owner: user, scopes: %w[push_rubygem],
+      scoped_organization: organization)
+
+    get avo.resources_api_key_path(api_key)
+
+    assert_response :success
+    assert_includes response.body, "org-push"
+  end
 end

--- a/test/integration/oidc/api_key_roles_controller_test.rb
+++ b/test/integration/oidc/api_key_roles_controller_test.rb
@@ -38,6 +38,26 @@ class OIDC::ApiKeyRolesControllerIntegrationTest < ActionDispatch::IntegrationTe
       get new_profile_oidc_api_key_role_url
 
       assert_response :success
+      refute page.has_select?("oidc_api_key_role_api_key_permissions_organization")
+    end
+
+    should "show organization field on new when user can manage an organization" do
+      organization = create(:organization, owners: [@user])
+
+      get new_profile_oidc_api_key_role_url
+
+      assert_response :success
+      assert page.has_select?("oidc_api_key_role_api_key_permissions_organization",
+        options: ["No Organization", organization.name])
+    end
+
+    should "hide organization field on new when user is only a maintainer" do
+      create(:organization, maintainers: [@user])
+
+      get new_profile_oidc_api_key_role_url
+
+      assert_response :success
+      refute page.has_select?("oidc_api_key_role_api_key_permissions_organization")
     end
 
     should "get new scoped to a rubygem" do

--- a/test/integration/oidc/pending_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/pending_trusted_publishers_controller_test.rb
@@ -40,6 +40,26 @@ class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::Integration
       get new_profile_oidc_pending_trusted_publisher_url
 
       assert_response :success
+      refute page.has_select?("oidc_pending_trusted_publisher_organization_id")
+    end
+
+    should "show organization field on new when user can manage an organization" do
+      organization = create(:organization, owners: [@user])
+
+      get new_profile_oidc_pending_trusted_publisher_url
+
+      assert_response :success
+      assert page.has_select?("oidc_pending_trusted_publisher_organization_id",
+        options: ["No Organization", organization.name])
+    end
+
+    should "hide organization field on new when user is only a maintainer" do
+      create(:organization, maintainers: [@user])
+
+      get new_profile_oidc_pending_trusted_publisher_url
+
+      assert_response :success
+      refute page.has_select?("oidc_pending_trusted_publisher_organization_id")
     end
 
     should "create trusted publisher" do

--- a/test/integration/oidc/pending_trusted_publishers_controller_test.rb
+++ b/test/integration/oidc/pending_trusted_publishers_controller_test.rb
@@ -25,6 +25,17 @@ class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::Integration
       refute page.has_content?(@expired_trusted_publisher.rubygem_name)
     end
 
+    should "show organization name on index when pending publisher targets an organization" do
+      organization = create(:organization, owners: [@user])
+      create(:oidc_pending_trusted_publisher, user: @user, organization: organization, rubygem_name: "org-scoped-gem")
+
+      get profile_oidc_pending_trusted_publishers_url
+
+      assert_response :success
+      assert page.has_content?("org-scoped-gem")
+      assert page.has_content?(organization.name)
+    end
+
     should "get new" do
       get new_profile_oidc_pending_trusted_publisher_url
 
@@ -47,6 +58,27 @@ class OIDC::PendingTrustedPublishersControllerTest < ActionDispatch::Integration
       end
 
       assert_redirected_to profile_oidc_pending_trusted_publishers_url
+    end
+
+    should "create trusted publisher for an organization" do
+      organization = create(:organization, owners: [@user])
+      stub_request(:get, "https://api.github.com/users/example")
+        .to_return(status: 200, body: { id: "54321" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      assert_difference("OIDC::PendingTrustedPublisher.count") do
+        trusted_publisher = build(:oidc_pending_trusted_publisher)
+        post profile_oidc_pending_trusted_publishers_url, params: {
+          oidc_pending_trusted_publisher: {
+            rubygem_name: trusted_publisher.rubygem_name,
+            organization_id: organization.id,
+            trusted_publisher_type: trusted_publisher.trusted_publisher_type,
+            trusted_publisher_attributes: trusted_publisher.trusted_publisher.as_json
+          }
+        }
+      end
+
+      assert_redirected_to profile_oidc_pending_trusted_publishers_url
+      assert_equal organization, OIDC::PendingTrustedPublisher.order(:id).last.organization
     end
 
     should "error creating trusted publisher with type" do

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -199,6 +199,25 @@ class PushTest < ActionDispatch::IntegrationTest
     assert rubygem.oidc_rubygem_trusted_publishers.exists?(trusted_publisher: pending_trusted_publisher.trusted_publisher)
   end
 
+  test "pushing a new gem with a pending trusted publisher into an organization" do
+    organization = create(:organization, owners: [@user])
+    pending_trusted_publisher = create(:oidc_pending_trusted_publisher, rubygem_name: "sandworm", user: @user, organization: organization)
+
+    @key = "543321"
+    create(:api_key, owner: pending_trusted_publisher.trusted_publisher, key: @key, scopes: %i[push_rubygem])
+
+    push_gem build_gem(new_gemspec("sandworm", "2.0.0", "Gemcutter", "ruby"))
+
+    assert_response :success
+
+    rubygem = Rubygem.find_by!(name: "sandworm")
+
+    assert_equal organization, rubygem.organization
+    assert_empty rubygem.ownerships
+    assert rubygem.owned_by?(@user)
+    assert rubygem.oidc_rubygem_trusted_publishers.exists?(trusted_publisher: pending_trusted_publisher.trusted_publisher)
+  end
+
   test "pushing a new gem with a pending trusted publisher case insensitive" do
     pending_trusted_publisher = create(:oidc_pending_trusted_publisher, rubygem_name: "SaNdWoRm", user: @user)
 

--- a/test/integration/push_test.rb
+++ b/test/integration/push_test.rb
@@ -218,6 +218,20 @@ class PushTest < ActionDispatch::IntegrationTest
     assert rubygem.oidc_rubygem_trusted_publishers.exists?(trusted_publisher: pending_trusted_publisher.trusted_publisher)
   end
 
+  test "pushing a new gem with a pending trusted publisher into an organization is rejected when the user cannot add gems" do
+    organization = create(:organization, owners: [@user])
+    pending_trusted_publisher = create(:oidc_pending_trusted_publisher, rubygem_name: "sandworm", user: @user, organization: organization)
+    @user.memberships.find_by!(organization: organization).update_columns(role: Access::MAINTAINER)
+
+    @key = "543321"
+    create(:api_key, owner: pending_trusted_publisher.trusted_publisher, key: @key, scopes: %i[push_rubygem])
+
+    push_gem build_gem(new_gemspec("sandworm", "2.0.0", "Gemcutter", "ruby"))
+
+    assert_response :forbidden
+    assert_nil Rubygem.find_by(name: "sandworm")
+  end
+
   test "pushing a new gem with a pending trusted publisher case insensitive" do
     pending_trusted_publisher = create(:oidc_pending_trusted_publisher, rubygem_name: "SaNdWoRm", user: @user)
 

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -522,6 +522,43 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       assert @cutter.save
     end
 
+    should "retry a database content_address unique violation inside the outer transaction" do
+      colliding_address = "aabbccdd"
+      occupant = create(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "x86_64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-x86_64-darwin-25-3.4"),
+        pusher_api_key: @cutter.api_key
+      )
+      occupant.update_columns(
+        content_address: colliding_address,
+        full_name: "#{@rubygem.name}-1.0.0-occupant"
+      )
+
+      @version.content_address = nil
+      @version.stubs(:generate_content_address).returns(colliding_address, "11223344")
+
+      sequence = sequence("database content address collision retry")
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec)
+        .in_sequence(sequence) do |version, _spec|
+          version.save!
+        end
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec)
+        .in_sequence(sequence) do |version, _spec|
+          version.save!
+        end
+
+      StatsD.stubs(:increment)
+      StatsD.expects(:increment).with("push.content_address_collision", tags: { rubygem: @rubygem.name }).once
+
+      assert @cutter.save
+      assert_equal "11223344", @version.reload.content_address
+    end
+
     should "not retry on an unrelated unique violation" do
       @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec).once
         .raises(ActiveRecord::RecordNotUnique.new(

--- a/test/models/api_key_organization_scope_test.rb
+++ b/test/models/api_key_organization_scope_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApiKeyOrganizationScopeTest < ActiveSupport::TestCase
+  setup do
+    @api_key_organization_scope = create(:api_key_organization_scope)
+  end
+
+  subject { @api_key_organization_scope }
+
+  should belong_to :api_key
+  should belong_to :membership
+  should validate_uniqueness_of(:membership_id).scoped_to(:api_key_id)
+
+  should "be valid with factory" do
+    assert_predicate build(:api_key_organization_scope), :valid?
+  end
+
+  should "delegate organization to membership" do
+    organization = create(:organization)
+    membership = create(:membership, :admin, organization: organization)
+    scope = build(:api_key_organization_scope, membership: membership)
+
+    assert_equal organization, scope.organization
+  end
+end

--- a/test/models/api_key_organization_scope_test.rb
+++ b/test/models/api_key_organization_scope_test.rb
@@ -4,10 +4,14 @@ require "test_helper"
 
 class ApiKeyOrganizationScopeTest < ActiveSupport::TestCase
   setup do
-    @api_key_organization_scope = create(:api_key_organization_scope)
+    @user = create(:user)
+    @organization = create(:organization, owners: [@user])
+    @membership = @user.memberships.find_by!(organization: @organization)
+    @api_key = create(:api_key, owner: @user, scopes: %w[push_rubygem], scoped_organization: @organization)
+    @api_key_scope = @api_key.api_key_organization_scope
   end
 
-  subject { @api_key_organization_scope }
+  subject { @api_key_scope }
 
   should belong_to :api_key
   should belong_to :membership
@@ -18,10 +22,44 @@ class ApiKeyOrganizationScopeTest < ActiveSupport::TestCase
   end
 
   should "delegate organization to membership" do
-    organization = create(:organization)
-    membership = create(:membership, :admin, organization: organization)
-    scope = build(:api_key_organization_scope, membership: membership)
+    assert_equal @organization, @api_key_scope.organization
+  end
 
-    assert_equal organization, scope.organization
+  context "#soft_delete_api_key!" do
+    should "be called if destroyed by association" do
+      @membership.destroy!
+
+      assert_nil @api_key.reload.api_key_organization_scope
+      assert_predicate @api_key, :soft_deleted?
+      assert_predicate @api_key, :soft_deleted_by_organization?
+      assert_equal @organization.name, @api_key.reload.soft_deleted_organization_name
+    end
+
+    should "not soft delete if not destroyed by association" do
+      @api_key.update(membership: nil)
+
+      assert_nil @api_key.reload.api_key_organization_scope
+      refute_predicate @api_key, :soft_deleted?
+      refute_predicate @api_key, :soft_deleted_by_organization?
+      assert_nil @api_key.reload.soft_deleted_organization_name
+    end
+  end
+
+  context "when role is downgraded below admin" do
+    should "soft delete org scoped api keys" do
+      @membership.update!(role: :maintainer)
+
+      assert_nil @api_key.reload.api_key_organization_scope
+      assert_predicate @api_key, :soft_deleted?
+      assert_predicate @api_key, :soft_deleted_by_organization?
+      assert_equal @organization.name, @api_key.soft_deleted_organization_name
+    end
+
+    should "not soft delete org scoped api keys when role remains admin" do
+      @membership.update!(role: :admin)
+
+      assert_predicate @api_key.reload.api_key_organization_scope, :present?
+      refute_predicate @api_key, :soft_deleted?
+    end
   end
 end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -341,10 +341,12 @@ class ApiKeyTest < ActiveSupport::TestCase
     should "set soft_deleted_at" do
       api_key = create(:api_key)
 
+      travel 1.second
       freeze_time do
         api_key.soft_delete!
 
         assert_equal Time.now.utc, api_key.soft_deleted_at
+        assert_equal Time.now.utc, api_key.updated_at
       end
     end
   end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -282,7 +282,7 @@ class ApiKeyTest < ActiveSupport::TestCase
       end
 
       should "reject all gems when the scoped organization is soft-deleted" do
-        @organization.update!(deleted_at: Time.current)
+        @organization.update_column(:deleted_at, Time.current)
         rubygem = create(:rubygem, owners: [@user])
 
         refute @api_key.reload.scoped_to?(rubygem)

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -211,6 +211,18 @@ class ApiKeyTest < ActiveSupport::TestCase
       assert_contains api_key.errors[:base], "An API key cannot be scoped to both a gem and an organization"
     end
 
+    should "not persist either new scope when a gem and an organization are assigned together" do
+      ownership = create(:ownership, user: @user)
+      api_key = create(:api_key, scopes: %i[push_rubygem], owner: @user, rubygem: ownership.rubygem)
+
+      refute api_key.update(rubygem_id: ownership.rubygem.id, organization_id: @organization.id)
+
+      api_key.reload
+
+      assert_equal ownership.rubygem, api_key.rubygem
+      assert_nil api_key.organization
+    end
+
     should "be invalid when user cannot manage the organization" do
       api_key = build(:api_key, scopes: %w[push_rubygem], owner: @user, scoped_organization: @other_organization)
 

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -7,6 +7,7 @@ class ApiKeyTest < ActiveSupport::TestCase
   should validate_presence_of(:name)
   should validate_presence_of(:hashed_key)
   should have_one(:api_key_rubygem_scope).dependent(:destroy)
+  should have_one(:api_key_organization_scope).dependent(:destroy)
 
   should "be valid with factory" do
     assert_predicate build(:api_key), :valid?
@@ -187,6 +188,142 @@ class ApiKeyTest < ActiveSupport::TestCase
     end
   end
 
+  context "organization scope" do
+    setup do
+      @user = create(:user)
+      @organization = create(:organization, owners: [@user])
+      @other_organization = create(:organization, owners: [create(:user)])
+      @api_key = create(:api_key, scopes: %w[push_rubygem], owner: @user, scoped_organization: @organization)
+    end
+
+    should "be invalid if non applicable API scope is enabled" do
+      api_key = build(:api_key, scopes: %w[index_rubygems], owner: @user, scoped_organization: @organization)
+
+      refute_predicate api_key, :valid?
+      assert_contains api_key.errors[:organization], "scope can only be set for push/yank rubygem, and add/remove owner scopes"
+    end
+
+    should "be invalid when scoped to both a gem and an organization" do
+      ownership = create(:ownership, user: @user)
+      api_key = build(:api_key, scopes: %w[push_rubygem], owner: @user, scoped_organization: @organization, rubygem: ownership.rubygem)
+
+      refute_predicate api_key, :valid?
+      assert_contains api_key.errors[:base], "An API key cannot be scoped to both a gem and an organization"
+    end
+
+    should "be invalid when user cannot manage the organization" do
+      api_key = build(:api_key, scopes: %w[push_rubygem], owner: @user, scoped_organization: @other_organization)
+
+      refute_predicate api_key, :valid?
+      assert_contains api_key.errors[:organization], "must be an organization you can manage"
+    end
+
+    should "be invalid when user is only a maintainer" do
+      organization = create(:organization, maintainers: [@user])
+      api_key = build(:api_key, scopes: %w[push_rubygem], owner: @user, scoped_organization: organization)
+
+      refute_predicate api_key, :valid?
+      assert_contains api_key.errors[:organization], "must be an organization you can manage"
+    end
+
+    context "#organization_id=" do
+      should "set membership to an organization" do
+        api_key = create(:api_key, key: SecureRandom.hex(24), scopes: %i[push_rubygem], owner: @user, organization_id: @organization.id)
+
+        assert_equal @organization, api_key.organization
+      end
+
+      should "set membership to nil when id is nil" do
+        @api_key.organization_id = nil
+
+        assert_nil @api_key.organization
+      end
+
+      should "add error when owner is not a user" do
+        api_key = build(:api_key, :trusted_publisher, scopes: %i[push_rubygem])
+        api_key.organization_id = @organization.id
+
+        assert_contains api_key.errors[:organization], "must be an organization you can manage"
+        assert_nil api_key.membership
+      end
+    end
+
+    context "#organization_handle=" do
+      should "set membership to an organization" do
+        api_key = create(:api_key, key: SecureRandom.hex(24), scopes: %i[push_rubygem], owner: @user, organization_handle: @organization.handle)
+
+        assert_equal @organization, api_key.organization
+      end
+
+      should "add error when handle is not found" do
+        api_key = ApiKey.new(hashed_key: SecureRandom.hex(24), scopes: %i[push_rubygem], owner: @user, organization_handle: "missing-org")
+
+        assert_contains api_key.errors[:organization], "could not be found"
+      end
+    end
+
+    context "#scoped_to?" do
+      should "allow gems owned by the scoped organization" do
+        rubygem = create(:rubygem, organization: @organization)
+
+        assert @api_key.scoped_to?(rubygem)
+      end
+
+      should "reject personally owned gems" do
+        rubygem = create(:rubygem, owners: [create(:user)])
+
+        refute @api_key.scoped_to?(rubygem)
+      end
+
+      should "reject gems owned by another organization" do
+        rubygem = create(:rubygem, organization: @other_organization)
+
+        refute @api_key.scoped_to?(rubygem)
+      end
+
+      should "reject all gems when the scoped organization is soft-deleted" do
+        @organization.update!(deleted_at: Time.current)
+        rubygem = create(:rubygem, owners: [@user])
+
+        refute @api_key.reload.scoped_to?(rubygem)
+        refute @api_key.organization_allows_gem?(rubygem)
+      end
+    end
+
+    context "#scope?" do
+      should "deny yank scope for personally owned gems" do
+        rubygem = create(:rubygem, owners: [@user])
+        api_key = create(:api_key, scopes: %i[yank_rubygem], owner: @user, scoped_organization: @organization)
+
+        refute api_key.scope?(:yank_rubygem, rubygem)
+      end
+
+      should "allow yank scope for organization gems" do
+        rubygem = create(:rubygem, organization: @organization)
+        api_key = create(:api_key, scopes: %i[yank_rubygem], owner: @user, scoped_organization: @organization)
+
+        assert api_key.scope?(:yank_rubygem, rubygem)
+      end
+    end
+  end
+
+  context "API_KEY_CREATED event" do
+    should "include organization handle when scoped to an organization" do
+      organization = create(:organization, owners: [create(:user)])
+      user = organization.users.first
+
+      api_key = create(:api_key, scopes: %w[push_rubygem], owner: user, scoped_organization: organization)
+
+      assert_event Events::UserEvent::API_KEY_CREATED, {
+        name: api_key.name,
+        scopes: ["push_rubygem"],
+        organization: organization.handle,
+        mfa: false,
+        api_key_gid: api_key.to_global_id.to_s
+      }, user.events.where(tag: Events::UserEvent::API_KEY_CREATED).sole
+    end
+  end
+
   context "#soft_deleted?" do
     should "return true if soft_deleted_at is set" do
       api_key = create(:api_key)
@@ -225,6 +362,25 @@ class ApiKeyTest < ActiveSupport::TestCase
       api_key = create(:api_key)
 
       refute_predicate api_key, :soft_deleted_by_ownership?
+    end
+  end
+
+  context "#soft_deleted_by_organization?" do
+    setup do
+      @user = create(:user)
+      @organization = create(:organization, owners: [@user])
+    end
+
+    should "return true if soft deleted organization name is present" do
+      membership = @user.memberships.find_by!(organization: @organization)
+      api_key = create(:api_key, scopes: %i[push_rubygem], owner: @user, scoped_organization: @organization)
+      api_key.soft_delete!(membership: membership)
+
+      assert_predicate api_key, :soft_deleted_by_organization?
+    end
+
+    should "return false if key not soft deleted" do
+      refute_predicate create(:api_key), :soft_deleted_by_organization?
     end
   end
 

--- a/test/models/oidc/api_key_permissions_test.rb
+++ b/test/models/oidc/api_key_permissions_test.rb
@@ -28,4 +28,22 @@ class OIDC::ApiKeyPermissionsTest < ActiveSupport::TestCase
 
     assert_equal ["may include at most 1 gem"], permissions.errors.messages[:gems]
   end
+
+  test "validates gems and organization are mutually exclusive" do
+    permissions = OIDC::ApiKeyPermissions.new(scopes: ["push_rubygem"], gems: ["a"], organization: "org")
+    permissions.validate
+
+    assert_equal ["cannot be scoped to both a gem and an organization"], permissions.errors.messages[:base]
+  end
+
+  test "create_params includes membership for organization" do
+    user = create(:user)
+    organization = create(:organization, owners: [user])
+    permissions = OIDC::ApiKeyPermissions.new(scopes: ["push_rubygem"], organization: organization.handle)
+
+    params = permissions.create_params(user)
+
+    assert_equal user.memberships.find_by!(organization: organization), params[:membership]
+    assert_nil params[:ownership]
+  end
 end

--- a/test/models/oidc/api_key_role_test.rb
+++ b/test/models/oidc/api_key_role_test.rb
@@ -53,6 +53,20 @@ class OIDC::ApiKeyRoleTest < ActiveSupport::TestCase
     assert_equal ["(does_not_exist) does not belong to user #{@role.user.handle}"], @role.errors.messages[:"api_key_permissions.gems[0]"]
   end
 
+  test "validates organization is manageable by the user" do
+    @role.api_key_permissions.organization = create(:organization).handle
+    @role.validate
+
+    assert_equal ["must be an organization you can manage"], @role.errors.messages[:"api_key_permissions.organization"]
+  end
+
+  test "allows organization the user can manage" do
+    organization = create(:organization, owners: [@role.user])
+    @role.api_key_permissions.organization = organization.handle
+
+    assert_predicate @role, :valid?
+  end
+
   test "validates condition claims are known" do
     @role.access_policy.statements = [OIDC::AccessPolicy::Statement.new(
       effect: "allow",

--- a/test/models/oidc/pending_trusted_publisher_test.rb
+++ b/test/models/oidc/pending_trusted_publisher_test.rb
@@ -10,6 +10,7 @@ class OIDC::PendingTrustedPublisherTest < ActiveSupport::TestCase
 
   should belong_to(:trusted_publisher)
   should belong_to(:user)
+  should belong_to(:organization).optional
 
   should validate_presence_of(:rubygem_name)
   should validate_uniqueness_of(:rubygem_name).scoped_to(:trusted_publisher_id, :trusted_publisher_type).case_insensitive
@@ -35,5 +36,20 @@ class OIDC::PendingTrustedPublisherTest < ActiveSupport::TestCase
 
     refute_predicate publisher, :valid?
     assert_equal ["is reserved"], publisher.errors[:rubygem_name]
+  end
+
+  test "validates organization is manageable by the user" do
+    publisher = build(:oidc_pending_trusted_publisher, organization: create(:organization))
+
+    refute_predicate publisher, :valid?
+    assert_equal ["must be an organization you can manage"], publisher.errors[:organization]
+  end
+
+  test "allows organization the user can manage" do
+    user = create(:user)
+    organization = create(:organization, owners: [user])
+    publisher = build(:oidc_pending_trusted_publisher, user: user, organization: organization)
+
+    assert_predicate publisher, :valid?
   end
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -116,6 +116,49 @@ class OrganizationTest < ActiveSupport::TestCase
     end
   end
 
+  context "discarding" do
+    setup do
+      @user = create(:user)
+      @organization = create(:organization, owners: [@user])
+      @api_key = create(:api_key, owner: @user, scopes: %i[push_rubygem], scoped_organization: @organization)
+      @other_organization = create(:organization, owners: [@user])
+      @other_api_key = create(:api_key, owner: @user, scopes: %i[push_rubygem], scoped_organization: @other_organization)
+      @unscoped_api_key = create(:api_key, owner: @user, scopes: %i[push_rubygem])
+    end
+
+    should "soft delete organization-scoped API keys" do
+      @organization.discard!
+
+      assert_predicate @organization, :discarded?
+      assert_nil @api_key.reload.api_key_organization_scope
+      assert_predicate @api_key, :soft_deleted?
+      assert_predicate @api_key, :soft_deleted_by_organization?
+      assert_equal @organization.name, @api_key.soft_deleted_organization_name
+    end
+
+    should "keep memberships" do
+      @organization.discard!
+
+      assert Membership.exists?(organization_id: @organization.id, user: @user)
+    end
+
+    should "not affect keys scoped to other organizations or unscoped keys" do
+      @organization.discard!
+
+      refute_predicate @other_api_key.reload, :soft_deleted?
+      assert_predicate @other_api_key.api_key_organization_scope, :present?
+      refute_predicate @unscoped_api_key.reload, :soft_deleted?
+    end
+
+    should "not restore API keys when the organization is undiscarded" do
+      @organization.discard!
+      @organization.undiscard!
+
+      assert_predicate @api_key.reload, :soft_deleted?
+      assert_nil @api_key.api_key_organization_scope
+    end
+  end
+
   context "#flipper_id" do
     should "return org:handle" do
       organization = create(:organization)

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -609,6 +609,32 @@ class PusherTest < ActiveSupport::TestCase
     end
   end
 
+  context "assigning ownership for unowned gems" do
+    should "reject unexpected owner types" do
+      @cutter.stubs(:rubygem).returns(Rubygem.new(name: "newgem"))
+      @api_key.update_columns(owner_id: 0, owner_type: "stub")
+      @cutter.stubs(:owner).returns(stub("owner", to_gid: nil))
+
+      refute @cutter.send(:assign_ownership_for_unowned_gem)
+      assert_equal "You are not allowed to push this gem.", @cutter.message
+      assert_equal 403, @cutter.code
+    end
+
+    should "reject pending trusted publisher when user cannot add gem to organization" do
+      organization = create(:organization, owners: [@user])
+      pending_publisher = create(:oidc_pending_trusted_publisher, rubygem_name: "newgem", user: @user, organization: organization)
+      @user.memberships.find_by!(organization: organization).update!(role: :maintainer)
+
+      api_key = create(:api_key, owner: pending_publisher.trusted_publisher, key: SecureRandom.hex(24), scopes: %i[push_rubygem])
+      cutter = Pusher.new(api_key, @gem)
+      cutter.stubs(:rubygem).returns(Rubygem.new(name: "newgem"))
+
+      refute cutter.send(:reify_pending_trusted_publisher)
+      assert_equal "You are not allowed to push this gem.", cutter.message
+      assert_equal 403, cutter.code
+    end
+  end
+
   context "with attestations" do
     should "not push gem if api key owner is not a trusted publisher" do
       @cutter.stubs(:attestations).returns([{}])

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -49,7 +49,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns true
         @cutter.stubs(:verify_mfa_requirement).returns true
-        @cutter.stubs(:verify_gem_scope).returns true
+        @cutter.stubs(:verify_api_key_scope).returns true
         @cutter.stubs(:validate).returns true
         @cutter.stubs(:verify_sigstore).returns true
         @cutter.stubs(:sign_sigstore).returns true
@@ -62,7 +62,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:pull_spec).returns false
         @cutter.stubs(:find).never
         @cutter.stubs(:authorize).never
-        @cutter.stubs(:verify_gem_scope).never
+        @cutter.stubs(:verify_api_key_scope).never
         @cutter.stubs(:verify_mfa_requirement).never
         @cutter.stubs(:save).never
         @cutter.process
@@ -72,18 +72,18 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find)
         @cutter.stubs(:authorize).never
-        @cutter.stubs(:verify_gem_scope).never
+        @cutter.stubs(:verify_api_key_scope).never
         @cutter.stubs(:verify_mfa_requirement).never
         @cutter.stubs(:save).never
 
         @cutter.process
       end
 
-      should "not attempt to check gem scope if not authorized" do
+      should "not attempt to check api key scope if not authorized" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns false
-        @cutter.stubs(:verify_gem_scope).never
+        @cutter.stubs(:verify_api_key_scope).never
         @cutter.stubs(:verify_mfa_requirement).never
         @cutter.stubs(:validate).never
         @cutter.stubs(:save).never
@@ -91,11 +91,11 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.process
       end
 
-      should "not attempt to check mfa requirement if scoped to another gem" do
+      should "not attempt to check mfa requirement if api key scope check failed" do
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns true
-        @cutter.stubs(:verify_gem_scope).returns false
+        @cutter.stubs(:verify_api_key_scope).returns false
         @cutter.stubs(:verify_mfa_requirement).never
         @cutter.stubs(:validate).never
         @cutter.stubs(:save).never
@@ -107,7 +107,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns true
-        @cutter.stubs(:verify_gem_scope).returns true
+        @cutter.stubs(:verify_api_key_scope).returns true
         @cutter.stubs(:verify_mfa_requirement).returns false
         @cutter.stubs(:validate).never
         @cutter.stubs(:save).never
@@ -119,7 +119,7 @@ class PusherTest < ActiveSupport::TestCase
         @cutter.stubs(:pull_spec).returns true
         @cutter.stubs(:find).returns true
         @cutter.stubs(:authorize).returns true
-        @cutter.stubs(:verify_gem_scope).returns true
+        @cutter.stubs(:verify_api_key_scope).returns true
         @cutter.stubs(:verify_mfa_requirement).returns true
         @cutter.stubs(:validate).returns false
         @cutter.stubs(:save).never
@@ -548,7 +548,7 @@ class PusherTest < ActiveSupport::TestCase
       cutter = Pusher.new(@api_key, @gem)
       cutter.stubs(:rubygem).returns @rubygem
 
-      assert cutter.verify_gem_scope
+      assert cutter.verify_api_key_scope
     end
 
     should "does not push gem if scoped to another gem" do
@@ -557,7 +557,55 @@ class PusherTest < ActiveSupport::TestCase
       cutter = Pusher.new(@api_key, @gem)
       cutter.stubs(:rubygem).returns @rubygem
 
-      refute cutter.verify_gem_scope
+      refute cutter.verify_api_key_scope
+    end
+  end
+
+  context "organization scope" do
+    setup do
+      @user = create(:user)
+      @organization = create(:organization, owners: [@user])
+      @api_key = create(:api_key, owner: @user, scoped_organization: @organization, scopes: %i[push_rubygem])
+      @rubygem = Rubygem.new(name: "org-gem")
+      @cutter = Pusher.new(@api_key, @gem)
+      @cutter.stubs(:rubygem).returns(@rubygem)
+    end
+
+    should "allow pushing unowned gems" do
+      @rubygem.stubs(:owned_by_organization?).returns(false)
+      @rubygem.stubs(:ownerships).returns(stub(none?: true))
+
+      assert @cutter.verify_api_key_scope
+    end
+
+    should "allow pushing gems owned by the scoped organization" do
+      @rubygem.stubs(:owned_by_organization?).returns(true)
+      @rubygem.stubs(:organization).returns(@organization)
+      @rubygem.stubs(:ownerships).returns(stub(any?: false))
+
+      assert @cutter.verify_api_key_scope
+    end
+
+    should "reject gems owned by another organization" do
+      @rubygem.stubs(:owned_by_organization?).returns(true)
+      @rubygem.stubs(:organization).returns(create(:organization))
+      @rubygem.stubs(:ownerships).returns(stub(any?: false))
+
+      refute @cutter.verify_api_key_scope
+    end
+
+    should "reject personally owned gems" do
+      @rubygem.stubs(:owned_by_organization?).returns(false)
+      @rubygem.stubs(:ownerships).returns(stub(none?: false))
+
+      refute @cutter.verify_api_key_scope
+    end
+
+    should "reject gems when the scoped organization is soft-deleted" do
+      @organization.update!(deleted_at: Time.current)
+      @api_key.reload
+
+      refute @cutter.verify_api_key_scope
     end
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -626,6 +626,40 @@ class PusherTest < ActiveSupport::TestCase
       assert_equal "You are not allowed to push this gem.", cutter.message
       assert_equal 403, cutter.code
     end
+
+    should "not persist the rubygem or version when organization ownership is denied" do
+      organization = create(:organization, owners: [@user])
+      api_key = create(:api_key, owner: @user, scoped_organization: organization, scopes: %i[push_rubygem])
+      @user.memberships.find_by!(organization: organization).update_columns(role: Access::MAINTAINER)
+
+      cutter = Pusher.new(api_key, build_gem(new_gemspec("sandworm", "1.0.0", "summary", "ruby")))
+
+      refute cutter.process
+      assert_equal 403, cutter.code
+      assert_nil Rubygem.find_by(name: "sandworm")
+    end
+
+    should "not disown an existing gem when organization ownership is denied" do
+      original_owner = create(:user)
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:ownership, rubygem: rubygem, user: original_owner)
+      create(:version, rubygem: rubygem, number: "0.1.0", indexed: false)
+
+      organization = create(:organization, owners: [@user])
+      api_key = create(:api_key, owner: @user, scoped_organization: organization, scopes: %i[push_rubygem])
+      @user.memberships.find_by!(organization: organization).update_columns(role: Access::MAINTAINER)
+
+      cutter = Pusher.new(api_key, build_gem(new_gemspec("sandworm", "1.0.0", "summary", "ruby")))
+      cutter.stubs(:verify_api_key_scope).returns(true)
+
+      refute cutter.process
+      assert_equal 403, cutter.code
+
+      rubygem.reload
+
+      assert_includes rubygem.owners, original_owner
+      assert_nil rubygem.versions.find_by(number: "1.0.0")
+    end
   end
 
   context "with attestations" do

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -600,13 +600,6 @@ class PusherTest < ActiveSupport::TestCase
 
       refute @cutter.verify_api_key_scope
     end
-
-    should "reject gems when the scoped organization is soft-deleted" do
-      @organization.update!(deleted_at: Time.current)
-      @api_key.reload
-
-      refute @cutter.verify_api_key_scope
-    end
   end
 
   context "assigning ownership for unowned gems" do

--- a/test/policies/admin/api_key_organization_scope_policy_test.rb
+++ b/test/policies/admin/api_key_organization_scope_policy_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::ApiKeyOrganizationScopePolicyTest < AdminPolicyTestCase
+  setup do
+    @scope = FactoryBot.create(:api_key_organization_scope)
+    @admin = FactoryBot.create(:admin_github_user, :is_admin)
+    @non_admin = FactoryBot.create(:admin_github_user)
+  end
+
+  def test_scope
+    assert_equal [@scope], policy_scope!(
+      @admin,
+      ApiKeyOrganizationScope
+    ).to_a
+  end
+
+  def test_avo_index
+    refute_authorizes @admin, ApiKeyOrganizationScope, :avo_index?
+    refute_authorizes @non_admin, ApiKeyOrganizationScope, :avo_index?
+  end
+
+  def test_avo_show
+    assert_authorizes @admin, @scope, :avo_show?
+
+    refute_authorizes @non_admin, @scope, :avo_show?
+  end
+
+  def test_avo_create
+    refute_authorizes @admin, ApiKeyOrganizationScope, :avo_create?
+    refute_authorizes @non_admin, ApiKeyOrganizationScope, :avo_create?
+  end
+
+  def test_avo_update
+    refute_authorizes @admin, @scope, :avo_update?
+    refute_authorizes @non_admin, @scope, :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_authorizes @admin, @scope, :avo_destroy?
+    refute_authorizes @non_admin, @scope, :avo_destroy?
+  end
+end

--- a/test/policies/admin/api_key_policy_test.rb
+++ b/test/policies/admin/api_key_policy_test.rb
@@ -19,6 +19,8 @@ class Admin::ApiKeyPolicyTest < AdminPolicyTestCase
   def test_associations
     assert_association @admin, @api_key, :api_key_rubygem_scope, Admin::ApiKeyPolicy
     assert_association @admin, @api_key, :ownership, Admin::OwnershipPolicy
+    assert_association @admin, @api_key, :api_key_organization_scope, Admin::ApiKeyPolicy
+    assert_association @admin, @api_key, :membership, Admin::MembershipPolicy
     assert_association @admin, @api_key, :oidc_id_token, Admin::OIDC::IdTokenPolicy
   end
 

--- a/test/policies/admin/membership_policy_test.rb
+++ b/test/policies/admin/membership_policy_test.rb
@@ -13,6 +13,10 @@ class Admin::MembershipPolicyTest < AdminPolicyTestCase
     assert_equal [@membership], policy_scope!(@admin, Membership).to_a
   end
 
+  def test_associations
+    assert_association @admin, @membership, :api_key_organization_scopes, Admin::ApiKeyOrganizationScopePolicy
+  end
+
   def test_avo_index
     refute_authorizes @admin, Membership, :avo_index?
     refute_authorizes @non_admin, Membership, :avo_index?

--- a/test/policies/admin/oidc/pending_trusted_publisher_policy_test.rb
+++ b/test/policies/admin/oidc/pending_trusted_publisher_policy_test.rb
@@ -17,6 +17,10 @@ class Admin::OIDC::PendingTrustedPublisherPolicyTest < AdminPolicyTestCase
     ).to_a
   end
 
+  def test_associations
+    assert_association @admin, @pending_trusted_publisher, :organization, Admin::OrganizationPolicy
+  end
+
   def test_avo_index
     assert_authorizes @admin, OIDC::PendingTrustedPublisher, :avo_index?
 

--- a/test/system/api_keys_test.rb
+++ b/test/system/api_keys_test.rb
@@ -61,6 +61,23 @@ class ApiKeysTest < ApplicationSystemTestCase
     assert_nil @user.api_keys.last.rubygem
   end
 
+  test "creating new api key scoped to an organization" do
+    organization = create(:organization, owners: [@user])
+
+    visit_profile_api_keys_path
+
+    fill_in "api_key[name]", with: "test"
+    check "api_key[push_rubygem]"
+
+    assert page.has_select? "api_key_organization_id", selected: "No Organization"
+    page.select organization.name
+    click_button "Create API Key"
+
+    assert_text "Note that we won't be able to show the key to you again. New API key:"
+    assert_equal organization.name, page.find('td[data-title="Gem"]').text
+    assert_equal organization, @user.api_keys.last.organization
+  end
+
   test "creating new api key scoped to a gem" do
     visit_profile_api_keys_path
 

--- a/test/system/oidc_test.rb
+++ b/test/system/oidc_test.rb
@@ -126,7 +126,8 @@ class OIDCTest < ApplicationSystemTestCase
       "api_key_permissions" => {
         "scopes" => ["push_rubygem"],
         "valid_for" => 1800,
-        "gems" => [rubygem.name]
+        "gems" => [rubygem.name],
+        "organization" => nil
       },
       "access_policy" => {
         "statements" => [
@@ -195,7 +196,7 @@ class OIDCTest < ApplicationSystemTestCase
     expected.merge!(
       "name" => "Push gems",
       "api_key_permissions" => {
-        "scopes" => %w[push_rubygem yank_rubygem], "valid_for" => 1800, "gems" => nil
+        "scopes" => %w[push_rubygem yank_rubygem], "valid_for" => 1800, "gems" => nil, "organization" => nil
       },
       "access_policy" => {
         "statements" => [
@@ -289,7 +290,8 @@ class OIDCTest < ApplicationSystemTestCase
       "api_key_permissions" => {
         "scopes" => ["push_rubygem"],
         "valid_for" => 1800,
-        "gems" => [rubygem.name]
+        "gems" => [rubygem.name],
+        "organization" => nil
       },
       "access_policy" => {
         "statements" => [

--- a/test/unit/helpers/api_keys_helper_test.rb
+++ b/test/unit/helpers/api_keys_helper_test.rb
@@ -29,6 +29,29 @@ class ApiKeysHelperTest < ActionView::TestCase
       assert_equal "[?]", trigger.text
       assert_equal "Ownership of the #{rubygem_name} gem has been removed after being scoped to this key.", bubble.text
     end
+
+    should "return error tooltip if organization membership is removed" do
+      user = create(:user)
+      organization = create(:organization, owners: [user])
+      membership = user.memberships.find_by!(organization: organization)
+      api_key = create(:api_key, scopes: %i[push_rubygem], owner: user, scoped_organization: organization)
+      api_key.soft_delete!(membership: membership)
+
+      dom = Capybara.string(gem_scope(api_key.reload))
+
+      assert_equal "#{organization.name} [?]", dom.text
+      assert_equal "cursor-help", dom.find("span")[:class]
+      assert_equal "Membership in the #{organization.name} organization has been removed after being scoped to this key.",
+        dom.find("span")[:title]
+    end
+
+    should "return organization name when scoped to an organization" do
+      user = create(:user)
+      organization = create(:organization, owners: [user])
+      api_key = create(:api_key, scopes: %i[push_rubygem], owner: user, scoped_organization: organization)
+
+      assert_equal organization.name, gem_scope(api_key)
+    end
   end
 
   def expected_checkbox(scope, exclusive: false, gem_scope: false)

--- a/test/views/events/user_event/api_key/created_component_test.rb
+++ b/test/views/events/user_event/api_key/created_component_test.rb
@@ -8,4 +8,11 @@ class Events::UserEvent::ApiKey::CreatedComponentTest < ComponentTest
 
     assert_text "Name: example\nScopes: push\nMFA: Not required", exact: true, normalize_ws: false
   end
+
+  should "render organization when present" do
+    preview(organization: "rubygems")
+
+    assert_text "Organization: rubygems"
+    assert_link "rubygems", href: "/organizations/rubygems"
+  end
 end


### PR DESCRIPTION
## Description

Closes https://github.com/rubygems/rubygems.org/issues/6328

Right now pushing a new gem always creates personal ownership for the pusher. Getting it into an organization means transferring/onboarding afterward.

This adds an optional **organization scope** on API keys (and the OIDC / trusted-publishing equivalents) so a first push can assign the gem to the org directly. Scope goes through the user's admin/owner membership, so it goes away when they lose that role.

Covers all three publish paths: classic `gem push`, OIDC `assume_role`, and pending trusted publishers.

## Approach

- New `api_key_organization_scopes` table linking an API key to a `Membership` (admin/owner only). Mutually exclusive with gem scope.
- On push of an unowned gem with an org-scoped key: set `rubygem.organization_id` instead of creating personal ownership.
- Same idea for OIDC roles (`api_key_permissions.organization`) and pending trusted publishers (`organization_id`).
- Yank/owner endpoints honor the org scope via `ApiKey#scoped_to?`.
- Demote below admin or remove membership and the key is soft-deleted (same pattern as gem-scoped keys when ownership is removed).
- Create keys from the profile UI (new org selector) or `POST /api/v1/api_keys` with `organization=<handle>`.

## How to test

### 1. Profile UI key + `gem push`

1. Sign in as an org admin. Go to **Settings / API keys / New**.
2. Enable `Push rubygem`, pick the org under **Organization Scope**. Create the key and copy it.
3. Build and push a gem that doesn't exist yet:
   ```bash
   gem build your.gemspec
   GEM_HOST_API_KEY=<key> gem push your-gem-0.1.0.gem
   ```
4. Open the gem page / console: `Rubygem.find_by!(name: "your-gem").organization` should be the org, and `ownerships` should be empty. You should still be able to manage it as an org member.
5. Push another version of the same gem; it should succeed.
6. Try pushing someone else's gem (or a gem in a different org) with the same key; expect 403.

Also worth checking:
- Maintainer cannot create an org-scoped key for that org.
- After demoting the admin to maintainer (or removing them), the key shows as invalid in the API keys list and push with it fails.

### 2. HTTP API key creation

```bash
curl -u "$USER:$PASSWORD" -X POST https://rubygems.org/api/v1/api_keys \
  -d "name=org-push" -d "push_rubygem=true" -d "organization=your-org-handle"
```

Same push checks as above. Bad handle / org you don't admin should 422.

### 3. OIDC assume_role

1. Create an OIDC API key role, set **Organization Scope** to the org (no gem), scopes include `push_rubygem`.
2. assume_role with a valid JWT; response should include `"organization": "<handle>"`.
3. Push a new gem with the short-lived key; gem ends up under the org.
4. Demote the role owner below admin and assume_role again; expect 422 (not a confusing 404).

### 4. Trusted publishing

1. **Settings / Pending Trusted Publishers / New**, fill in the gem name + GitHub Action config, select the org.
2. Index page should show the org next to the pending publisher.
3. Push the first version via that trusted publisher; gem owned by the org, trusted publisher attached, no personal ownership.
