### PR TITLE
Allow gems to be preserved when deleting users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ REVISION
 # CodeQL
 codeql-db/
 codeql-results.sarif
+vendor/bundle

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -6,9 +6,15 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
     current_user.team_member?("rubygems-org") && view == :show
   }
 
+  def fields
+    field :keep_gems_published, as: :boolean,
+      help: "Skip yanking gems for which this user is the only owner. Published versions will remain available without an owner."
+    super
+  end
+
   self.message = lambda {
     "Are you sure you would like to delete user #{record.display_handle} with #{record.email}? " \
-      "This action can't be undone and will use the same account deletion process available from the user's profile."
+      "This action can't be undone. By default, gems for which this user is the only owner will be yanked."
   }
 
   self.confirm_button_label = "Delete User"
@@ -17,30 +23,13 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
     I18n.t("admin.delete_user.blocked_reason")
   end
 
-  def enabled?
-    super && !blocked?
-  end
-
-  def action_name
-    return super unless blocked?
-
-    "#{super} — #{self.class.blocked_reason}"
-  end
-
   class ActionHandler < Avo::Actions::ActionHandler
     def handle_record(user)
-      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_ineligible_gem_versions?
+      keep_gems_published = ActiveModel::Type::Boolean.new.cast(fields[:keep_gems_published]) == true
+      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_ineligible_gem_versions? && !keep_gems_published
 
-      DeleteUserJob.perform_later(user:, actor: current_user)
+      DeleteUserJob.perform_later(user:, actor: current_user, keep_gems_published:)
       succeed("Account deletion for #{user.display_handle} has been scheduled")
     end
-  end
-
-  private
-
-  def blocked?
-    return @blocked if defined?(@blocked)
-
-    @blocked = record.sole_owner_of_ineligible_gem_versions?
   end
 end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -14,7 +14,8 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
 
   self.message = lambda {
     "Are you sure you would like to delete user #{record.display_handle} with #{record.email}? " \
-      "This action can't be undone. By default, gems for which this user is the only owner will be yanked."
+      "This action can't be undone. By default, gems for which this user is the only owner will be yanked. " \
+      "Check 'Keep gems published' to preserve those gems as published without an owner."
   }
 
   self.confirm_button_label = "Delete User"

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -4,10 +4,10 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
   queue_with_priority PRIORITIES.fetch(:profile_deletion)
 
-  def perform(user:, actor:)
+  def perform(user:, actor:, keep_gems_published: false)
     email = user.email
     return if user.discarded?
-    user.discard!
+    user.delete_account!(keep_gems_published:)
     Mailer.deletion_complete(email).deliver_later if self_service_deletion?(user, actor)
   rescue ActiveRecord::ActiveRecordError, Discard::RecordNotDiscarded => e
     # Catch the exception so we can log it, otherwise using `destroy` would give

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   after_update :record_email_verified_event, if: -> { saved_change_to_email? && email_confirmed? }
   after_update :record_password_update_event, if: :saved_change_to_encrypted_password?
   after_update :record_policies_acknowledged_event, if: :saved_change_to_policies_acknowledged_at?
-  before_discard :yank_gems
+  before_discard :yank_gems, unless: :keep_gems_published?
   before_discard :expire_all_api_keys
   before_discard :destroy_associations_for_discard
   before_discard :clear_personal_attributes
@@ -255,6 +255,13 @@ class User < ApplicationRecord
       .exists?
   end
 
+  def delete_account!(keep_gems_published: false)
+    @keep_gems_published = keep_gems_published
+    discard!
+  ensure
+    @keep_gems_published = false
+  end
+
   def remember_me!
     self.remember_token = Clearance::Token.new
     self.remember_token_expires_at = Gemcutter::REMEMBER_FOR.from_now
@@ -309,6 +316,10 @@ class User < ApplicationRecord
   end
 
   private
+
+  def keep_gems_published?
+    @keep_gems_published == true
+  end
 
   def update_email
     update(email: unconfirmed_email, unconfirmed_email: nil, mail_fails: 0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   admin:
     delete_user:
-      blocked_reason: Blocked because this user is the sole owner of gem versions published more than 30 days ago or with more than 100,000 downloads.
+      blocked_reason: Select Keep gems published because this user is the sole owner of gem versions published more than 30 days ago or with more than 100,000 downloads.
   credentials_required: Credentials required
   copied: Copied!
   copy_to_clipboard: Copy to clipboard

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -35,7 +35,7 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     assert page.has_content? "Delete User"
   end
 
-  test "disabling the delete action when the user is the sole owner of an old gem version" do
+  test "enabling the delete action when the user is the sole owner of an old gem version" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)
     rubygem = create(:rubygem, name: "admin-delete-blocked-old-gem", owners: [user])
@@ -44,14 +44,10 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     get avo.resources_user_path(user)
 
     assert_response :success
-    assert page.has_content?(
-      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago " \
-      "or with more than 100,000 downloads."
-    )
-    assert_select "a[data-action-name^='Delete User'][data-disabled='true']", count: 1
+    assert_select "a[data-action-name='Delete User'][data-disabled='false']", count: 1
   end
 
-  test "disabling the delete action when the user is the sole owner of a gem version with too many downloads" do
+  test "enabling the delete action when the user is the sole owner of a gem version with too many downloads" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)
     rubygem = create(:rubygem, name: "admin-delete-blocked-popular-gem", owners: [user])
@@ -61,11 +57,7 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     get avo.resources_user_path(user)
 
     assert_response :success
-    assert page.has_content?(
-      "Delete User — Blocked because this user is the sole owner of gem versions published more than 30 days ago " \
-      "or with more than 100,000 downloads."
-    )
-    assert_select "a[data-action-name^='Delete User'][data-disabled='true']", count: 1
+    assert_select "a[data-action-name='Delete User'][data-disabled='false']", count: 1
   end
 
   test "enabling the delete action when an old gem version has another owner" do

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -41,6 +41,22 @@ class DeleteUserJobTest < ActiveJob::TestCase
     assert_predicate user.reload, :discarded?
   end
 
+  test "admin can delete sole owner while keeping gem published" do
+    user = create(:user)
+    actor = create(:admin_github_user, :is_admin)
+    rubygem = create(:rubygem, name: "admin-preserved-unowned-gem", owners: [user])
+    version = create(:version, rubygem:, created_at: 31.days.ago)
+
+    Mailer.expects(:deletion_complete).never
+    User.any_instance.expects(:yank_gems).never
+    DeleteUserJob.new(user:, actor:, keep_gems_published: true).perform(user:, actor:, keep_gems_published: true)
+
+    assert_predicate user.reload, :discarded?
+    assert_predicate rubygem.reload, :indexed?
+    assert_predicate rubygem, :unowned?
+    assert_predicate version.reload, :indexed?
+  end
+
   test "does not send deletion failed when deletion is initiated by an admin" do
     user = create(:user)
     actor = create(:admin_github_user, :is_admin)

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -23,7 +23,7 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @current_user]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @current_user, keep_gems_published: false]) do
       @action.handle(**args)
     end
   end
@@ -45,6 +45,25 @@ class DeleteUserTest < ActiveSupport::TestCase
       @action.handle(**args)
     end
     assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
+  end
+
+  should "enqueue deletion for a sole owner when keeping gems published" do
+    rubygem = create(:rubygem, name: "old-gem-preserved-for-deleted-user", owners: [@user])
+    create(:version, rubygem:, created_at: 31.days.ago)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user],
+      fields: {
+        comment: "Deleting at the user's request",
+        keep_gems_published: "1"
+      },
+      query: nil
+    }
+
+    assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @current_user, keep_gems_published: true]) do
+      @action.handle(**args)
+    end
   end
 
   should "not enqueue deletion when the user is the sole owner of a gem version with too many downloads" do


### PR DESCRIPTION
#6739 added the ability for rubygems.org operations to delete a user in Avo, with a rule blocking deletion when that user has published gems. That rule is too strict. A published gem is fine without an owner attached, and we should allow it when someone asks for their profile to be deleted but wants their gems to stay up.

This relaxes the rule to allow that. It's a middle ground for now. When the gem archive/deprecation work gets picked up, I expect this state becomes properly formalised