### PR TITLE
Allow operators to rename API keys

### DIFF
--- a/app/avo/actions/change_api_key_name.rb
+++ b/app/avo/actions/change_api_key_name.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Avo::Actions::ChangeApiKeyName < Avo::Actions::ApplicationAction
+  def fields
+    field :new_name, name: "Name", as: :text, required: true, default: -> { record.name }
+    super
+  end
+
+  self.name = "Change API Key Name"
+  self.visible = lambda {
+    Admin::ApiKeyPolicy.new(current_user, resource.record).act_on? && view == :show
+  }
+  self.authorize = lambda {
+    Admin::ApiKeyPolicy.new(current_user, action.record).act_on?
+  }
+  self.message = lambda {
+    "Change the name of API key #{record.name.inspect} (##{record.id})?"
+  }
+  self.confirm_button_label = "Change API Key Name"
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_record(api_key)
+      api_key.name = fields[:new_name]
+      api_key.valid?
+
+      return error(api_key.errors.full_messages_for(:name).to_sentence) if api_key.errors[:name].any?
+
+      # API keys may be expired or soft-deleted by the time a privacy request is
+      # handled. Only bypass those lifecycle validations for this name-only edit.
+      api_key.update_attribute!(:name, api_key.name)
+
+      succeed("API key ##{api_key.id} has been renamed to #{api_key.name.inspect}")
+    end
+  end
+end

--- a/app/avo/resources/api_key.rb
+++ b/app/avo/resources/api_key.rb
@@ -8,6 +8,7 @@ class Avo::Resources::ApiKey < Avo::BaseResource
   class TrustedPublisherFilter < Avo::Filters::ScopeBooleanFilter; end
 
   def actions
+    action Avo::Actions::ChangeApiKeyName
     action Avo::Actions::RevokeApiKey
   end
 

--- a/test/integration/avo/api_keys_test.rb
+++ b/test/integration/avo/api_keys_test.rb
@@ -7,13 +7,14 @@ class Avo::ApiKeysTest < ActionDispatch::IntegrationTest
 
   setup { requires_avo_pro }
 
-  test "showing the revoke action to rubygems.org operators on the API key page" do
+  test "showing API key actions to rubygems.org operators on the API key page" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     api_key = create(:api_key, name: "compromised-deploy-key")
 
     get avo.resources_api_key_path(api_key)
 
     assert_response :success
+    assert_select "a[data-action-name='Change API Key Name'][data-disabled='false']", count: 1
     assert_select "a[data-action-name='Revoke API Key'][data-disabled='false']", count: 1
   end
 
@@ -25,6 +26,7 @@ class Avo::ApiKeysTest < ActionDispatch::IntegrationTest
     get avo.resources_api_key_path(api_key)
 
     assert_response :success
+    assert_select "a[data-action-name='Change API Key Name'][data-disabled='false']", count: 1
     assert page.has_content?("Revoke API Key — #{Avo::Actions::RevokeApiKey.already_revoked_reason}")
     assert_select "a[data-action-name^='Revoke API Key'][data-disabled='true']", count: 1
   end

--- a/test/unit/avo/actions/change_api_key_name_test.rb
+++ b/test/unit/avo/actions/change_api_key_name_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ChangeApiKeyNameTest < ActiveSupport::TestCase
+  setup do
+    @api_key = create(:api_key, name: "person@example.com")
+    @current_user = create(:admin_github_user, :is_admin)
+    Avo::Current.stubs(:user).returns(@current_user)
+    @resource = Avo::Resources::ApiKey.new.hydrate(record: @api_key)
+    @action = Avo::Actions::ChangeApiKeyName.new(record: @api_key, resource: @resource, user: @current_user, view: :show)
+  end
+
+  should "ask for confirmation naming the API key" do
+    message = @action.get_message
+
+    assert_includes message, @api_key.name
+    assert_includes message, "##{@api_key.id}"
+  end
+
+  should "be registered on the API key resource" do
+    action_classes = Avo::Resources::ApiKey.new.get_actions.pluck(:class)
+
+    assert_includes action_classes, Avo::Actions::ChangeApiKeyName
+  end
+
+  should "prefill the current name and require the standard audited comment" do
+    @action.fields
+    fields = @action.get_field_definitions.index_by(&:id)
+    name_field = fields.fetch(:new_name).hydrate(record: @api_key, resource: @resource)
+
+    assert name_field.required
+    assert_equal @api_key.name, name_field.computed_default_value
+    assert fields.fetch(:comment).required
+  end
+
+  should "change the API key name and record an Avo audit" do
+    comment = "Removing personal information at the owner's request"
+
+    @action.handle(**action_args(new_name: "redacted-key", comment:))
+
+    assert_equal "redacted-key", @api_key.reload.name
+
+    audit = Audit.sole
+
+    assert_equal comment, audit.comment
+    assert_equal "Change API Key Name", audit.action
+    assert_equal ["person@example.com", "redacted-key"],
+      audit.audited_changes.dig("records", @api_key.to_global_id.uri.to_s, "changes", "name")
+    assert_equal({ "new_name" => "redacted-key" }, audit.audited_changes.fetch("fields"))
+    assert_equal "API key ##{@api_key.id} has been renamed to \"redacted-key\"", @action.response.dig(:messages, 0, :body)
+  end
+
+  should "change the name of an expired API key" do
+    @api_key.update_column(:expires_at, 1.hour.ago)
+
+    @action.handle(**action_args(new_name: "redacted-key", comment: "Removing PII from an expired API key"))
+
+    assert_equal "redacted-key", @api_key.reload.name
+    assert_equal "Change API Key Name", Audit.sole.action
+  end
+
+  should "reject an invalid API key name" do
+    @action.handle(**action_args(new_name: "", comment: "Attempting to remove PII from this API key"))
+
+    assert_equal "person@example.com", @api_key.reload.name
+    assert_equal :error, @action.response.dig(:messages, 0, :type)
+    assert_equal "Name can't be blank", @action.response.dig(:messages, 0, :body)
+  end
+
+  should "be visible and authorized for rubygems.org operators on the API key page" do
+    action_context = Data.define(:current_user, :resource, :view).new(
+      current_user: @current_user,
+      resource: @resource,
+      view: Avo::ViewInquirer.new(:show)
+    )
+
+    assert action_context.instance_exec(&Avo::Actions::ChangeApiKeyName.visible)
+    assert_predicate @action, :authorized?
+  end
+
+  should "not be visible or authorized for operators outside the rubygems.org team" do
+    info_data = @current_user.info_data.deep_dup
+    info_data[:viewer][:organization][:teams][:edges].reject! { |edge| edge.dig(:node, :slug) == "rubygems-org" }
+    @current_user.update!(info_data:)
+    action_context = Data.define(:current_user, :resource, :view).new(
+      current_user: @current_user,
+      resource: @resource,
+      view: Avo::ViewInquirer.new(:show)
+    )
+
+    refute action_context.instance_exec(&Avo::Actions::ChangeApiKeyName.visible)
+    refute_predicate @action, :authorized?
+  end
+
+  private
+
+  def action_args(new_name:, comment:)
+    {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@api_key],
+      fields: { new_name:, comment: },
+      query: nil
+    }
+  end
+end

--- a/test/unit/avo/actions/change_api_key_name_test.rb
+++ b/test/unit/avo/actions/change_api_key_name_test.rb
@@ -60,6 +60,15 @@ class ChangeApiKeyNameTest < ActiveSupport::TestCase
     assert_equal "Change API Key Name", Audit.sole.action
   end
 
+  should "change the name of a soft-deleted API key" do
+    @api_key.update_column(:soft_deleted_at, 1.hour.ago)
+
+    @action.handle(**action_args(new_name: "redacted-key", comment: "Removing PII from a soft-deleted API key"))
+
+    assert_equal "redacted-key", @api_key.reload.name
+    assert_equal "Change API Key Name", Audit.sole.action
+  end
+
   should "reject an invalid API key name" do
     @action.handle(**action_args(new_name: "", comment: "Attempting to remove PII from this API key"))
 


### PR DESCRIPTION
## What changed

- adds an operator-only Avo action to change an API key name
- prefills and validates the replacement name while requiring an audit comment
- supports renaming expired or soft-deleted keys so privacy requests can still be completed
- covers authorization, auditing, validation, expired keys, and action rendering

## Why

API key names are user-supplied and can contain personally identifiable information. RubyGems.org operators need a narrow, audited way to replace those names when someone requests removal.

## Validation

- `bin/rails test test/unit/avo/actions/change_api_key_name_test.rb test/unit/avo/actions/revoke_api_key_test.rb test/integration/avo/api_keys_test.rb` — 21 runs, 68 assertions, 0 failures; 2 Avo Pro integration tests skipped because Avo Pro is unavailable locally
- `bin/rubocop --cache false app/avo/actions/change_api_key_name.rb app/avo/resources/api_key.rb test/unit/avo/actions/change_api_key_name_test.rb test/integration/avo/api_keys_test.rb` — no offenses