### PR TITLE
Fix GoodJob StatsD result counter

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -114,6 +114,7 @@ ActiveSupport::Notifications.subscribe("perform_job.good_job") do |event|
   statsd_measure_performance event.name,
     event.payload.merge(
       measurement: result,
+      value: 1,
       statsd_tags:
     )
 end

--- a/test/jobs/good_job_statsd_job_test.rb
+++ b/test/jobs/good_job_statsd_job_test.rb
@@ -37,6 +37,15 @@ class GoodJobStatsDJobTest < ActiveSupport::TestCase
     end
   end
 
+  class ReturnValueJob < ApplicationJob
+    self.queue_adapter = ActiveJob::QueueAdapters::GoodJobAdapter.new(execution_mode: :async)
+    queue_as :return_value
+
+    def perform
+      "synthetic\nredacted result"
+    end
+  end
+
   class ConcurrencyLimitedJob < ApplicationJob
     self.queue_adapter = ActiveJob::QueueAdapters::GoodJobAdapter.new(execution_mode: :async)
     queue_as :concurrency_limited
@@ -57,6 +66,14 @@ class GoodJobStatsDJobTest < ActiveSupport::TestCase
   setup do
     GoodJobStatsDJob.disable_test_adapter
     GoodJobStatsDJob.stubs(:queue_adapter).returns(ActiveJob::QueueAdapters::GoodJobAdapter.new(execution_mode: :async))
+  end
+
+  test "reports a numeric result counter when a job returns a non-numeric value" do
+    ReturnValueJob.perform_later
+
+    assert_statsd_increment "rails.perform_job.good_job.success", 1 do
+      GoodJob.perform_inline("return_value")
+    end
   end
 
   test "reports metrics to statsd" do


### PR DESCRIPTION
GoodJob puts a job's return value into the perform_job.good_job notification payload as :value. Our StatsD helper was reusing that as the result counter, so any job returning something non-numeric produced a malformed DogStatsD metric. Those metrics were dropped, and on the way through they could expose application content in Agent logs.

This increments the GoodJob result counters by 1 instead. Generic Active Job notifications aren't affected, and duration, allocation and latency metrics keep the values they had.

There's a regression test that runs a job returning a multiline string and checks the success counter stays numeric.