### PR TITLE
Fix gem transfer when co-owners are already organization members

### DIFF
--- a/app/models/rubygem_transfer.rb
+++ b/app/models/rubygem_transfer.rb
@@ -42,7 +42,11 @@ class RubygemTransfer < ApplicationRecord
   end
 
   def approved_invites
-    invites.includes(:user).select { |invite| invite.user.present? && invite.role.present? }
+    reviewable_invites.select { |invite| invite.role.present? }
+  end
+
+  def reviewable_invites
+    invites.includes(:user).select { |invite| invite.user.present? && !existing_organization_member?(invite.user) }
   end
 
   def available_rubygems
@@ -61,11 +65,18 @@ class RubygemTransfer < ApplicationRecord
 
   private
 
-  def remove_ownerships_for_joining_members
-    invited_users = invites.includes(:user).reject { |invite| invite.role.nil? || invite.outside_contributor? }.map(&:user)
-    invited_users << created_by
+  def existing_organization_member?(user)
+    member_user_ids.include?(user.id)
+  end
 
-    Ownership.includes(:rubygem, :user, :api_key_rubygem_scopes).where(user: invited_users, rubygem: selected_rubygems).destroy_all
+  def remove_ownerships_for_joining_members
+    joining_user_ids = invites.filter_map do |invite|
+      invite.user_id if member_user_ids.include?(invite.user_id) || (invite.role.present? && !invite.outside_contributor?)
+    end
+
+    Ownership.includes(:rubygem, :user, :api_key_rubygem_scopes)
+      .where(user_id: [created_by_id, *joining_user_ids], rubygem: selected_rubygems)
+      .destroy_all
   end
 
   def demote_outside_contributors_to_maintainer
@@ -87,6 +98,12 @@ class RubygemTransfer < ApplicationRecord
   def sync_invites
     existing_invites = invites.includes(:user).index_by(&:user_id)
     self.invites = users_for_rubygem.map { |user| existing_invites[user.id] || OrganizationInvite.new(user: user) }
+  end
+
+  def member_user_ids
+    return [] if organization_id.nil?
+
+    @member_user_ids ||= Membership.where(organization_id: organization_id).pluck(:user_id)
   end
 
   def rubygems_owned_by_transferrer

--- a/app/views/rubygems/transfer/users/edit.html.erb
+++ b/app/views/rubygems/transfer/users/edit.html.erb
@@ -62,9 +62,9 @@
 
 <%= form_with(model: @rubygem_transfer, url: users_transfer_rubygems_path, method: :patch) do |form| %>
   <%= render "rubygems/transfer/error", transfer: @rubygem_transfer if @rubygem_transfer.errors.any? %>
-  <% if @rubygem_transfer.invites.any? %>
+  <% if @rubygem_transfer.reviewable_invites.any? %>
   <ul>
-    <%= form.fields_for :invites do |invite_fields| %>
+    <%= form.fields_for :invites, @rubygem_transfer.reviewable_invites do |invite_fields| %>
       <% user = invite_fields.object.user %>
       <li class="flex w-full py-3 pl-3 justify-between items-center" data-user-handle="<%= user.handle %>">
         <%= invite_fields.label :role, class: "flex flex-row items-center h-11" do %>

--- a/test/functional/rubygems/transfer/users_controller_test.rb
+++ b/test/functional/rubygems/transfer/users_controller_test.rb
@@ -65,4 +65,16 @@ class Rubygems::Transfer::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to confirm_transfer_rubygems_path
   end
+
+  test "GET /transfer/users omits existing organization members" do
+    existing_member = @maintainers.first
+    other_maintainer = @maintainers.last
+    create(:membership, :admin, user: existing_member, organization: @organization)
+
+    get users_transfer_rubygems_path(as: @owner)
+
+    assert_response :success
+    assert_select %(li[data-user-handle="#{existing_member.handle}"]), count: 0
+    assert_select %(li[data-user-handle="#{other_maintainer.handle}"])
+  end
 end

--- a/test/models/rubygem_transfer_test.rb
+++ b/test/models/rubygem_transfer_test.rb
@@ -133,4 +133,82 @@ class RubygemTransferTest < ActiveSupport::TestCase
     assert_not @transfer.valid?
     assert_includes @transfer.errors[:rubygems], "#{@rubygem.name} is already owned by an organization"
   end
+
+  test "skips existing members instead of creating a duplicate or changing their role" do
+    co_owner = create(:user)
+    create(:ownership, rubygem: @rubygem, user: co_owner, role: :owner)
+    membership = create(:membership, :maintainer, user: co_owner, organization: @organization)
+    @transfer.invites.create!(user: co_owner, role: :admin)
+
+    OrganizationMailer.expects(:user_invited).never
+
+    assert_no_difference -> { Membership.unscoped.where(organization: @organization).count } do
+      @transfer.transfer!
+    end
+
+    assert_predicate @transfer, :completed?
+    assert_equal "maintainer", membership.reload.role
+    assert_not Ownership.exists?(user: co_owner, rubygem: @rubygem)
+    assert_equal @organization, @rubygem.reload.organization
+  end
+
+  test "removes ownership for existing members even when invite is outside contributor" do
+    co_owner = create(:user)
+    create(:ownership, rubygem: @rubygem, user: co_owner, role: :owner)
+    membership = create(:membership, :admin, user: co_owner, organization: @organization)
+    @transfer.invites.create!(user: co_owner, role: :outside_contributor)
+
+    @transfer.transfer!
+
+    assert_equal "admin", membership.reload.role
+    assert_not Ownership.exists?(user: co_owner, rubygem: @rubygem)
+  end
+
+  test "creates membership for new invitee and leaves existing member unchanged" do
+    existing_member = create(:user)
+    new_invitee = create(:user)
+    create(:ownership, rubygem: @rubygem, user: existing_member, role: :owner)
+    create(:ownership, rubygem: @rubygem, user: new_invitee, role: :owner)
+    membership = create(:membership, :maintainer, user: existing_member, organization: @organization)
+    @transfer.invites.create!(user: existing_member, role: :owner)
+    @transfer.invites.create!(user: new_invitee, role: :admin)
+
+    OrganizationMailer.expects(:user_invited).once.returns(stub(deliver_later: true))
+
+    assert_difference -> { Membership.unscoped.where(organization: @organization).count }, 1 do
+      @transfer.transfer!
+    end
+
+    assert_equal "maintainer", membership.reload.role
+    assert Membership.exists?(user: new_invitee, organization: @organization, role: :admin)
+    assert_not Ownership.exists?(user: existing_member, rubygem: @rubygem)
+    assert_not Ownership.exists?(user: new_invitee, rubygem: @rubygem)
+  end
+
+  test "removes ownership for existing members even without an invite role" do
+    co_owner = create(:user)
+    create(:ownership, rubygem: @rubygem, user: co_owner, role: :owner)
+    membership = create(:membership, :admin, user: co_owner, organization: @organization)
+    @transfer.invites.create!(user: co_owner, role: nil)
+
+    @transfer.transfer!
+
+    assert_equal "admin", membership.reload.role
+    assert_not Ownership.exists?(user: co_owner, rubygem: @rubygem)
+  end
+
+  test "does not review existing organization members on the users step" do
+    co_owner = create(:user)
+    outsider = create(:user)
+    other_rubygem = create(:rubygem, owners: [@owner, co_owner, outsider])
+    create(:membership, :admin, user: co_owner, organization: @organization)
+
+    @transfer.rubygems = [other_rubygem.id]
+    @transfer.save!
+
+    reviewable_user_ids = @transfer.reviewable_invites.map(&:user_id)
+
+    assert_includes reviewable_user_ids, outsider.id
+    assert_not_includes reviewable_user_ids, co_owner.id
+  end
 end


### PR DESCRIPTION
## Description
Closes https://github.com/rubygems/rubygems.org/issues/6740

Transfer used to always insert new memberships from approved invites. That failed when a co-owner was already in the target org: the duplicate `Membership` was invalid and unsaved, then `OrganizationMailer.user_invited` raised `ActiveJob::SerializationError`.

Existing members are now skipped. They stay off the users step, their org role is unchanged, and they are not emailed. Their individual gem ownership is still removed so they access the gem through the organization. Role changes continue to go through organization management. New invitees are created and emailed as before.

## How to test
1. Transfer a gem whose co-owner is already in the org (seeded `rubygem1` / `gem-maintainer` to `RubyGems`). Confirm succeeds; membership role is unchanged; gem ownership is removed; no invite email; the user does not appear on the users step.
2. Mix of new invitee + existing member: new membership created + emailed; existing member unchanged except gem ownership removed.
3. Non-member set to **Outside Contributor**: no membership; gem ownership demoted to maintainer.
4. `bin/rails test test/models/rubygem_transfer_test.rb test/functional/rubygems/transfer/users_controller_test.rb`