### PR TITLE
Password reset token hardening

### DIFF
--- a/app/avo/actions/create_user.rb
+++ b/app/avo/actions/create_user.rb
@@ -21,7 +21,6 @@ class Avo::Actions::CreateUser < Avo::Actions::ApplicationAction
         password: SecureRandom.hex(16),
         email_confirmed: true
       )
-      user.generate_confirmation_token
       user.save!
 
       ::PasswordMailer.change_password(user).deliver_later

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,13 +7,11 @@ class PasswordsController < ApplicationController
 
   before_action :ensure_email_present, only: %i[create]
 
-  before_action :no_referrer, only: %i[edit otp_edit webauthn_edit]
-  before_action :validate_confirmation_token, only: %i[edit otp_edit webauthn_edit]
-  before_action :require_mfa, only: %i[edit], unless: -> { params[:reason] == "compromised" }
+  before_action :no_referrer, only: :edit
+  before_action :begin_password_reset, only: :edit
+  before_action :load_password_reset, only: %i[reset otp_edit webauthn_edit update]
   before_action :validate_otp, only: %i[otp_edit]
   before_action :validate_webauthn, only: %i[webauthn_edit]
-  before_action :password_reset_session_verified, only: %i[edit otp_edit webauthn_edit]
-  before_action :set_compromised_flag, only: %i[edit otp_edit webauthn_edit]
   after_action :delete_mfa_expiry_session, only: %i[otp_edit webauthn_edit]
 
   before_action :validate_password_reset_session, only: :update
@@ -23,6 +21,14 @@ class PasswordsController < ApplicationController
   end
 
   def edit
+    redirect_to reset_password_path
+  end
+
+  def reset
+    return require_mfa if password_reset_requires_mfa?
+
+    verify_password_reset_session unless password_reset_session_verified?
+    set_compromised_flag
     render :edit
   end
 
@@ -30,7 +36,7 @@ class PasswordsController < ApplicationController
     user = User.find_by_normalized_email(@email)
 
     if user
-      user.forgot_password!
+      user.invalidate_password_reset!
       ::PasswordMailer.change_password(user).deliver_later
     end
 
@@ -38,25 +44,29 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if @user.update_password reset_params[:password]
+    case @user.update_password_with_token(reset_params[:password], token: session[:password_reset_token])
+    when :updated
       @user.reset_api_key! if reset_params[:reset_api_key] == "true" # singular
       @user.api_keys.expire_all! if reset_params[:reset_api_keys] == "true" # plural
       StatsD.increment "login.password_compromised.reset_completed" if session[:password_reset_reason] == "compromised"
       delete_password_reset_session
       flash[:notice] = t(".success")
       redirect_to signed_in? ? dashboard_path : sign_in_path
-    else
+    when :invalid_password
+      set_compromised_flag
       flash.now[:alert] = t(".failure")
       render :edit, status: :unprocessable_content
+    else
+      login_failure(t("passwords.edit.token_failure"))
     end
   end
 
   def otp_edit
-    render :edit
+    complete_password_reset_verification
   end
 
   def webauthn_edit
-    render :edit
+    complete_password_reset_verification
   end
 
   private
@@ -73,37 +83,54 @@ class PasswordsController < ApplicationController
     render template: "passwords/new", status: :unprocessable_content
   end
 
-  def validate_confirmation_token
-    confirmation_token = params.permit(:token).fetch(:token, "").to_s
-    return login_failure(t("passwords.edit.token_failure")) if confirmation_token.blank?
-    @user = User.find_by(confirmation_token:)
-    return login_failure(t("passwords.edit.token_failure")) unless @user&.valid_confirmation_token?
-    session[:password_reset_reason] = "compromised" if params[:reason] == "compromised"
+  def begin_password_reset
+    token = params.permit(:token).fetch(:token, "").to_s
+    @user = User.find_by_password_reset_token(token)
+    return login_failure(t("passwords.edit.token_failure")) unless @user&.valid_password_reset_token?(token)
+
+    compromised = @user.valid_compromised_password_reset_reason?(params[:reason], token:)
     sign_out if signed_in? && @user != current_user
+    reset_session
+    session[:password_reset_user] = @user.id
+    session[:password_reset_token] = token
+    session[:password_reset_reason] = "compromised" if compromised
   end
 
-  # The order of these methods intends to leave the session fully reset if we
-  # fail to invalidate the token for some reason, since this would indicate
-  # something is wrong with the user, necessitating help from an admin.
-  def password_reset_session_verified
-    reason = session[:password_reset_reason]
-    reset_session
-    @user.update!(confirmation_token: nil)
-    session[:password_reset_verified_user] = @user.id
+  def load_password_reset
+    token = session[:password_reset_token]
+    @user = User.find_by_password_reset_token(token)
+    return if @user && @user.id == session[:password_reset_user] && @user.valid_password_reset_token?(token)
+
+    login_failure(t("passwords.edit.token_failure"))
+  end
+
+  def password_reset_requires_mfa?
+    @user.mfa_enabled? && session[:password_reset_reason] != "compromised" && !password_reset_session_verified?
+  end
+
+  def verify_password_reset_session
     session[:password_reset_verified] = Gemcutter::PASSWORD_VERIFICATION_EXPIRY.from_now
-    session[:password_reset_reason] = reason if reason.present?
+  end
+
+  def complete_password_reset_verification
+    delete_mfa_session
+    verify_password_reset_session
+    redirect_to reset_password_path
+  end
+
+  def password_reset_session_verified?
+    session[:password_reset_verified].present? && Time.current.before?(session[:password_reset_verified])
   end
 
   def validate_password_reset_session
     return login_failure(t("passwords.edit.token_failure")) if session[:password_reset_verified].nil?
-    return login_failure(t("verification_expired")) if Time.current.after?(session[:password_reset_verified])
-    @user = User.find_by(id: session[:password_reset_verified_user])
-    login_failure(t("verification_expired")) unless @user
+    login_failure(t("verification_expired")) if Time.current.after?(session[:password_reset_verified])
   end
 
   def delete_password_reset_session
     delete_mfa_session
-    session.delete(:password_reset_verified_user)
+    session.delete(:password_reset_user)
+    session.delete(:password_reset_token)
     session.delete(:password_reset_verified)
     session.delete(:password_reset_reason)
   end
@@ -122,10 +149,10 @@ class PasswordsController < ApplicationController
   end
 
   def otp_verification_url
-    otp_edit_password_url(token: @user.confirmation_token)
+    otp_edit_password_url
   end
 
   def webauthn_verification_url
-    webauthn_edit_password_url(token: @user.confirmation_token)
+    webauthn_edit_password_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -237,7 +237,7 @@ class SessionsController < Clearance::SessionsController
   end
 
   def initiate_compromised_password_reset!(user)
-    user.forgot_password!
+    user.invalidate_password_reset!
     PasswordMailer.compromised_password_reset(user).deliver_later
   end
 

--- a/app/mailers/password_mailer.rb
+++ b/app/mailers/password_mailer.rb
@@ -3,6 +3,7 @@
 class PasswordMailer < ApplicationMailer
   def change_password(user)
     @user = user
+    @token = user.issue_password_reset!
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t("clearance.models.clearance_mailer.change_password") do |format|
@@ -13,6 +14,8 @@ class PasswordMailer < ApplicationMailer
 
   def compromised_password_reset(user)
     @user = user
+    @token = user.issue_password_reset!
+    @reason = user.compromised_password_reset_reason_for(@token)
     mail from: Clearance.configuration.mailer_sender,
          to: @user.email,
          subject: I18n.t("password_mailer.compromised_password_reset.subject", host: Gemcutter::HOST_DISPLAY) do |format|

--- a/app/models/concerns/password_resettable.rb
+++ b/app/models/concerns/password_resettable.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module PasswordResettable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def find_by_password_reset_token(token)
+      return if token.blank?
+
+      find_by(password_reset_token_digest: password_reset_token_digest(token))
+    end
+
+    def password_reset_token_digest(token)
+      OpenSSL::Digest::SHA256.hexdigest(token)
+    end
+  end
+
+  def issue_password_reset!
+    token = SecureRandom.hex(24)
+    update_columns(
+      password_reset_token_digest: self.class.password_reset_token_digest(token),
+      password_reset_token_expires_at: Gemcutter::EMAIL_TOKEN_EXPIRES_AFTER.from_now,
+      confirmation_token: nil,
+      token_expires_at: nil,
+      unconfirmed_email: nil
+    )
+    token
+  end
+
+  def invalidate_password_reset!
+    update_columns(
+      password_reset_token_digest: nil,
+      password_reset_token_expires_at: nil,
+      confirmation_token: nil,
+      token_expires_at: nil,
+      unconfirmed_email: nil
+    )
+  end
+
+  def valid_password_reset_token?(token)
+    return false if token.blank? || password_reset_token_digest.blank? || password_reset_token_expires_at.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(
+      password_reset_token_digest,
+      self.class.password_reset_token_digest(token)
+    ) && Time.current.before?(password_reset_token_expires_at)
+  end
+
+  def update_password_with_token(new_password, token:)
+    with_lock do
+      if token.blank? || !valid_password_reset_token?(token)
+        :invalid_token
+      else
+        self.password = new_password
+        if valid?
+          self.confirmation_token = nil
+          self.password_reset_token_digest = nil
+          self.password_reset_token_expires_at = nil
+          generate_remember_token
+          save ? :updated : :invalid_password
+        else
+          :invalid_password
+        end
+      end
+    end
+  end
+
+  def compromised_password_reset_reason_for(token)
+    return if token.blank? || password_reset_token_expiry(token).blank?
+
+    Rails.application.message_verifier(:compromised_password_reset).generate(
+      token,
+      expires_at: password_reset_token_expiry(token)
+    )
+  end
+
+  def valid_compromised_password_reset_reason?(reason, token:)
+    return false unless reason.is_a?(String) && token.present?
+
+    Rails.application.message_verifier(:compromised_password_reset).verified(reason) == token
+  end
+
+  private
+
+  def password_reset_token_expiry(token)
+    password_reset_token_expires_at if valid_password_reset_token?(token)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   include Events::Recordable
   include Gravtastic
   include UserMultifactorMethods
+  include PasswordResettable
 
   is_gravtastic default: "retro"
 
@@ -15,7 +16,7 @@ class User < ApplicationRecord
   default_scope { not_deleted }
 
   before_save :_generate_confirmation_token_no_reset_unconfirmed_email, if: :will_save_change_to_unconfirmed_email?
-  before_create :_generate_confirmation_token_no_reset_unconfirmed_email
+  before_create :_generate_confirmation_token_no_reset_unconfirmed_email, unless: :email_confirmed?
   after_create :record_create_event
   after_update :record_email_update_event, if: :email_was_updated?
   after_update :record_email_verified_event, if: -> { saved_change_to_email? && email_confirmed? }

--- a/app/views/password_mailer/change_password.html.erb
+++ b/app/views/password_mailer/change_password.html.erb
@@ -16,7 +16,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <%= render "mailer/button", url: edit_password_url(token: @user.confirmation_token), label: "CHANGE PASSWORD" %>
+      <%= render "mailer/button", url: edit_password_url(token: @token), label: "CHANGE PASSWORD" %>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/app/views/password_mailer/change_password.text.erb
+++ b/app/views/password_mailer/change_password.text.erb
@@ -1,4 +1,4 @@
 <%= t(".subtitle", handle: @user.name) %>
 
 <%= t(".opening") %>
-<%= edit_password_url(token: @user.confirmation_token.html_safe) %>
+<%= edit_password_url(token: @token) %>

--- a/app/views/password_mailer/compromised_password_reset.html.erb
+++ b/app/views/password_mailer/compromised_password_reset.html.erb
@@ -22,7 +22,7 @@
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 
-      <%= render "mailer/button", url: edit_password_url(token: @user.confirmation_token, reason: "compromised"), label: "CHANGE PASSWORD" %>
+      <%= render "mailer/button", url: edit_password_url(token: @token, reason: @reason), label: "CHANGE PASSWORD" %>
 
       <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
 

--- a/app/views/password_mailer/compromised_password_reset.text.erb
+++ b/app/views/password_mailer/compromised_password_reset.text.erb
@@ -4,6 +4,6 @@
 
 <%= t(".reassurance") %>
 
-<%= edit_password_url(token: @user.confirmation_token, reason: 'compromised') %>
+<%= edit_password_url(token: @token, reason: @reason) %>
 
 <%= t(".closing_text") %>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -128,9 +128,9 @@ class Rack::Attack
         # otp_create doesn't have remember_token set. use session[:mfa_user]
         if protected_route?([otp_create_action], req.path, req.request_method)
           action_dispatch_req.session.fetch("mfa_user", "").presence
-        # password#otp_edit has unique confirmation token
+        # password#otp_edit has the reset user bound to the session
         elsif protected_route?([mfa_password_edit_action], req.path, req.request_method)
-          req.params.fetch("token", "").presence
+          action_dispatch_req.session.fetch("password_reset_user", "").presence
         else
           User.find_by_remember_token(action_dispatch_req.cookie_jar.signed["remember_token"])&.email.presence
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,7 @@ Rails.application.routes.draw do
     end
 
     resource :password, only: %i[new create edit update] do
+      get 'reset', to: 'passwords#reset', as: :reset
       post 'otp_edit', to: 'passwords#otp_edit', as: :otp_edit
       post 'webauthn_edit', to: 'passwords#webauthn_edit', as: :webauthn_edit
     end

--- a/db/migrate/20260814000000_add_password_reset_token_digest_to_users.rb
+++ b/db/migrate/20260814000000_add_password_reset_token_digest_to_users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddPasswordResetTokenDigestToUsers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :password_reset_token_digest
+      t.datetime :password_reset_token_expires_at
+    end
+    add_index :users, :password_reset_token_digest, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -666,6 +666,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
     t.integer "mail_fails", default: 0
     t.string "mfa_hashed_recovery_codes", default: [], array: true
     t.integer "mfa_level", default: 0
+    t.string "password_reset_token_digest"
+    t.datetime "password_reset_token_expires_at"
     t.datetime "policies_acknowledged_at"
     t.boolean "public_email", default: false, null: false
     t.string "remember_token", limit: 128
@@ -684,6 +686,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"
     t.index ["id", "token"], name: "index_users_on_id_and_token"
     t.index ["id"], name: "index_users_on_policies_not_acknowledged", where: "(policies_acknowledged_at IS NULL)"
+    t.index ["password_reset_token_digest"], name: "index_users_on_password_reset_token_digest", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token"
     t.index ["token"], name: "index_users_on_token"
     t.index ["webauthn_id"], name: "index_users_on_webauthn_id", unique: true

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -25,16 +25,38 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "with valid params" do
-      should "set a valid confirmation_token" do
+      should "enqueue the mail without putting the raw token in job arguments" do
+        @user = create(:user)
+
+        assert_enqueued_email_with PasswordMailer, :change_password, args: [@user] do
+          post password_path, params: { password: { email: @user.email } }
+        end
+      end
+
+      should "invalidate an existing reset token before the mail job runs" do
+        @user = create(:user)
+        token = @user.issue_password_reset!
+
+        post password_path, params: { password: { email: @user.email } }
+
+        refute @user.reload.valid_password_reset_token?(token)
+        assert_nil @user.password_reset_token_digest
+        assert_nil @user.password_reset_token_expires_at
+      end
+
+      should "store only a digest of the password reset token" do
         @user = create(:user)
 
         assert_nil @user.confirmation_token
 
-        post password_path, params: { password: { email: @user.email } }
+        perform_enqueued_jobs do
+          post password_path, params: { password: { email: @user.email } }
+        end
 
         assert_select "p", "You will receive an email within the next few minutes. It contains instructions for changing your password."
-        assert_not_nil @user.reload.confirmation_token
-        assert_predicate @user, :valid_confirmation_token?
+        assert_not_nil @user.reload.password_reset_token_digest
+        assert_nil @user.confirmation_token
+        assert_in_delta 3.hours.from_now, @user.password_reset_token_expires_at, 2.seconds
       end
     end
   end
@@ -42,7 +64,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   context "on GET to edit" do
     setup do
       @user = create(:user)
-      @user.forgot_password!
+      @token = @user.issue_password_reset!
     end
 
     context "with incorrect token" do
@@ -55,33 +77,28 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "with valid confirmation_token" do
+    context "with a valid password reset token" do
       context "when not signed in" do
         should "presents the password edit form" do
-          get edit_password_path, params: { token: @user.confirmation_token }
+          begin_password_reset
 
           assert_response :success
           assert_new_password_form
 
-          assert_nil @user.reload.confirmation_token
+          assert @user.reload.valid_password_reset_token?(@token)
           refute_signed_in
-
-          # instruct the browser not to send referrer that contains the token" do
-          assert_equal "no-referrer", response.headers["Referrer-Policy"]
+          assert_equal reset_password_path, request.path
         end
       end
 
       context "when signed in as the user" do
         should "presents the password edit form" do
-          get edit_password_path(as: @user), params: { token: @user.confirmation_token }
+          begin_password_reset(as: @user)
 
           assert_response :success
           assert_new_password_form
 
-          assert_nil @user.reload.confirmation_token
-
-          # instruct the browser not to send referrer that contains the token" do
-          assert_equal "no-referrer", response.headers["Referrer-Policy"]
+          assert @user.reload.valid_password_reset_token?(@token)
         end
       end
 
@@ -89,42 +106,58 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         should "presents the password edit form for the token identified user, signing the other user out" do
           @other_user = create(:user, api_key: "otheruserkey")
 
-          get edit_password_path(as: @other_user), params: { token: @user.confirmation_token }
+          begin_password_reset(as: @other_user)
 
           assert_response :success
           assert_new_password_form
 
           refute_signed_in
-          assert_nil @user.reload.confirmation_token
-
-          # instruct the browser not to send referrer that contains the token" do
-          assert_equal "no-referrer", response.headers["Referrer-Policy"]
+          assert @user.reload.valid_password_reset_token?(@token)
         end
       end
     end
 
-    context "with reason=compromised param" do
+    context "with a signed compromised reason" do
       should "show compromised warning banner" do
-        get edit_password_path, params: { token: @user.confirmation_token, reason: "compromised" }
+        @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+        begin_password_reset(reason: @user.compromised_password_reset_reason_for(@token))
 
         assert_response :success
+        assert_new_password_form
         assert page.has_content?(I18n.t("passwords.edit.compromised_heading"))
+      end
+    end
+
+    context "with an unsigned compromised reason" do
+      should "not treat the reset as compromised" do
+        begin_password_reset(reason: "compromised")
+
+        assert_response :success
+        assert_not page.has_content?(I18n.t("passwords.edit.compromised_heading"))
+      end
+
+      should "not bypass enabled MFA" do
+        @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
+        begin_password_reset(reason: "compromised")
+
+        assert_response :success
+        assert_otp_form
       end
     end
 
     context "without reason param" do
       should "not show compromised warning banner" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
 
         assert_response :success
         assert_not page.has_content?(I18n.t("passwords.edit.compromised_heading"))
       end
     end
 
-    context "with expired confirmation_token" do
+    context "with an expired password reset token" do
       should "redirect to the sign in page" do
-        @user.update_attribute(:token_expires_at, 1.minute.ago)
-        get edit_password_path, params: { token: @user.confirmation_token }
+        @user.update_attribute(:password_reset_token_expires_at, 1.minute.ago)
+        get edit_password_path, params: { token: @token }
 
         assert_redirected_to sign_in_path
         assert_equal I18n.t("passwords.edit.token_failure"), flash[:alert]
@@ -135,7 +168,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     context "with totp enabled" do
       should "display otp form" do
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
 
         assert_response :success
         assert_otp_form
@@ -148,7 +181,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         create(:webauthn_credential, user: @user)
         @user.update!(new_mfa_recovery_codes: nil, mfa_hashed_recovery_codes: [])
 
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
 
         assert_response :success
         assert_webauthn_form
@@ -160,11 +193,11 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     context "when user has webauthn credentials and recovery codes" do
       should "display webauthn prompt and recovery code prompt" do
         create(:webauthn_credential, user: @user)
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
 
         assert_response :success
         assert_webauthn_form
-        assert_select "form[action=?]", otp_edit_password_url(token: @user.confirmation_token) do
+        assert_select "form[action=?]", otp_edit_password_url do
           assert_select "input[type=text][autocomplete=off]" # no autocomplete for recovery code only
           assert_select "input[type=submit][value=?]", I18n.t("authenticate")
         end
@@ -178,7 +211,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         @user.enable_totp!(ROTP::Base32.random_base32, :ui_and_api)
         create(:webauthn_credential, user: @user)
 
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
 
         assert_response :success
         assert_webauthn_form
@@ -192,7 +225,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   context "on POST to otp_edit" do
     setup do
       @user = create(:user)
-      @user.forgot_password!
+      @token = @user.issue_password_reset!
     end
 
     context "when providing incorrect token" do
@@ -211,22 +244,23 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
       context "when OTP is correct" do
         should "display edit form" do
-          get edit_password_path, params: { token: @user.confirmation_token }
-          post otp_edit_password_path, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+          begin_password_reset
+          post otp_edit_password_path, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
+          follow_redirect!
 
           assert_response :success
           assert_new_password_form
 
           refute_signed_in
-          assert_nil @user.reload.confirmation_token
+          assert @user.reload.valid_password_reset_token?(@token)
           assert_nil session[:mfa_expires_at]
         end
       end
 
       context "when OTP is incorrect" do
         should "display error message and prompt for MFA again" do
-          get edit_password_path, params: { token: @user.confirmation_token }
-          post otp_edit_password_path, params: { token: @user.confirmation_token, otp: "wrong" }
+          begin_password_reset
+          post otp_edit_password_path, params: { otp: "wrong" }
 
           assert_response :unauthorized
           assert page.has_content?("Your OTP code is incorrect.")
@@ -238,9 +272,9 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
       context "when the OTP session is expired" do
         should "redirect to the sign in page" do
-          get edit_password_path, params: { token: @user.confirmation_token }
+          begin_password_reset
           travel 16.minutes do
-            post otp_edit_password_path, params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+            post otp_edit_password_path, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
           end
 
           assert_redirected_to sign_in_path
@@ -256,7 +290,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   context "on POST to webauthn_edit" do
     setup do
       @user = create(:user)
-      @user.forgot_password!
+      @token = @user.issue_password_reset!
       @webauthn_credential = create(:webauthn_credential, user: @user)
 
       @origin = WebAuthn.configuration.allowed_origins.first
@@ -266,26 +300,27 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with correct webauthn" do
       should "display edit form" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         post webauthn_edit_password_path, params: {
-          token: @user.confirmation_token, credentials: webauthn_result
+          credentials: webauthn_result
         }
+        follow_redirect!
 
         assert_response :success
         assert_new_password_form
 
         refute_signed_in
-        assert_nil @user.reload.confirmation_token
+        assert @user.reload.valid_password_reset_token?(@token)
         assert_nil session[:mfa_expires_at]
       end
     end
 
-    context "when providing incorrect confirmation_token" do
+    context "when the password reset token has been invalidated" do
       should "redirect to the sign in page" do
-        get edit_password_path, params: { token: @user.confirmation_token }
-        post webauthn_edit_password_path, params: {
-          token: "wrongtoken", credentials: webauthn_result
-        }
+        begin_password_reset
+        credentials = webauthn_result
+        @user.invalidate_password_reset!
+        post webauthn_edit_password_path, params: { credentials: }
 
         assert_redirected_to sign_in_path
         assert_equal "Please double check the URL or try submitting a new password reset.", flash[:alert]
@@ -297,8 +332,8 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "when not providing credentials" do
       should "display error message and prompt for MFA again" do
-        get edit_password_path, params: { token: @user.confirmation_token }
-        post webauthn_edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
+        post webauthn_edit_password_path
 
         assert_response :unauthorized
         assert page.has_content?("Credentials required")
@@ -310,10 +345,10 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "when providing wrong credential" do
       should "display error message and prompt for MFA again" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         wrong_challenge = SecureRandom.hex
         post webauthn_edit_password_path, params: {
-          token: @user.confirmation_token, credentials: webauthn_result(wrong_challenge)
+          credentials: webauthn_result(wrong_challenge)
         }
 
         assert_response :unauthorized
@@ -326,10 +361,10 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "when webauthn session is expired" do
       should "redirect to the sign in page" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         travel 16.minutes do
           post webauthn_edit_password_path, params: {
-            token: @user.confirmation_token, credentials: webauthn_result
+            credentials: webauthn_result
           }
         end
 
@@ -344,7 +379,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   context "on PUT to update" do
     setup do
       @user = create(:user)
-      @user.forgot_password!
+      @token = @user.issue_password_reset!
       @api_key = @user.api_key
       @new_api_key = create(:api_key, owner: @user)
       @old_encrypted_password = @user.encrypted_password
@@ -370,7 +405,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "when verification has expired" do
       should "redirect to the sign in page" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         travel 16.minutes do
           put password_path, params: {
             password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
@@ -388,9 +423,26 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "when the reset token expires after opening the form" do
+      should "reject the password update" do
+        @user.update!(password_reset_token_expires_at: 1.minute.from_now)
+        begin_password_reset
+
+        travel 2.minutes do
+          put password_path, params: {
+            password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
+          }
+        end
+
+        assert_redirected_to sign_in_path
+        assert_equal I18n.t("passwords.edit.token_failure"), flash[:alert]
+        assert_equal @old_encrypted_password, @user.reload.encrypted_password
+      end
+    end
+
     context "with invalid password" do
       should "redisplay edit form and not change password" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         put password_path, params: {
           password_reset: { reset_api_key: "true", password: "pass" }
         }
@@ -412,7 +464,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with valid password without reset_api_key" do
       should "change password but not change api_key" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         put password_path, params: {
           password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
@@ -429,7 +481,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with valid password with reset_api_key false" do
       should "change password but not change api_key" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         put password_path, params: {
           password_reset: { reset_api_key: "false", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
@@ -446,7 +498,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with valid password with reset_api_key" do
       should "change password and reset api_key" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         put password_path, params: {
           password_reset: { reset_api_key: "true", password: PasswordHelpers::SECURE_TEST_PASSWORD }
         }
@@ -466,7 +518,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with valid password with reset_api_key and reset_api_keys" do
       should "change password, reset legacy api_key, and expire all api_keys" do
-        get edit_password_path, params: { token: @user.confirmation_token }
+        begin_password_reset
         put password_path, params: {
           password_reset: { reset_api_key: "true", reset_api_keys: "true",
                             password: PasswordHelpers::SECURE_TEST_PASSWORD }
@@ -487,6 +539,18 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
   private
 
+  def begin_password_reset(as: nil, reason: nil)
+    path = as ? edit_password_path(as:) : edit_password_path
+    reset_params = { token: @token }
+    reset_params[:reason] = reason if reason
+
+    get path, params: reset_params
+
+    assert_equal "no-referrer", response.headers["Referrer-Policy"]
+    assert_redirected_to reset_password_path
+    follow_redirect!
+  end
+
   def webauthn_result(challenge = nil)
     challenge ||= session["webauthn_authentication"]["challenge"]
     WebauthnHelpers.create_credential(webauthn_credential: @webauthn_credential, client: @client)
@@ -495,7 +559,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
   def assert_otp_form
     assert_select "h2", I18n.t("multifactor_auths.prompt.otp_code")
-    assert_select "form[action=?]", otp_edit_password_url(token: @user.confirmation_token) do
+    assert_select "form[action=?]", otp_edit_password_url do
       assert_select "input[type=text][autocomplete=one-time-code]"
       assert_select "input[type=submit][value=?]", I18n.t("authenticate")
     end
@@ -504,7 +568,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   def assert_webauthn_form
     assert_select "h2", I18n.t("multifactor_auths.prompt.security_device")
     assert_select "p", I18n.t("multifactor_auths.prompt.webauthn_credential_note")
-    assert_select "form.js-webauthn-session--form[action=?]", webauthn_edit_password_url(token: @user.confirmation_token) do
+    assert_select "form.js-webauthn-session--form[action=?]", webauthn_edit_password_url do
       assert_select "input[type=submit][value=?]", I18n.t("multifactor_auths.prompt.sign_in_with_webauthn_credential")
     end
   end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -864,7 +864,8 @@ class SessionsControllerTest < ActionController::TestCase
     context "when user has no MFA" do
       context "on POST to create" do
         setup do
-          @original_confirmation_token = @user.confirmation_token
+          @original_password_reset_token = @user.issue_password_reset!
+          @original_password_reset_token_digest = @user.password_reset_token_digest
           post :create, params: { session: { who: "compromised_user", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         end
 
@@ -890,8 +891,16 @@ class SessionsControllerTest < ActionController::TestCase
           assert_enqueued_email_with PasswordMailer, :compromised_password_reset, args: [@user]
         end
 
-        should "rotate the password reset confirmation token" do
-          assert_not_equal @original_confirmation_token, @user.reload.confirmation_token
+        should "invalidate the existing reset token before the mail job runs" do
+          refute @user.reload.valid_password_reset_token?(@original_password_reset_token)
+          assert_nil @user.password_reset_token_digest
+          assert_nil @user.password_reset_token_expires_at
+        end
+
+        should "rotate the password reset token digest" do
+          perform_enqueued_jobs
+
+          assert_not_equal @original_password_reset_token_digest, @user.reload.password_reset_token_digest
         end
       end
     end
@@ -935,7 +944,8 @@ class SessionsControllerTest < ActionController::TestCase
 
       context "after successful MFA" do
         setup do
-          @original_confirmation_token = @user.confirmation_token
+          @original_password_reset_token = @user.issue_password_reset!
+          @original_password_reset_token_digest = @user.password_reset_token_digest
           post :create, params: { session: { who: "compromised_user", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
           @controller.session[:mfa_user] = @user.id
           post :otp_create, params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
@@ -955,8 +965,16 @@ class SessionsControllerTest < ActionController::TestCase
           assert_enqueued_email_with PasswordMailer, :compromised_password_reset, args: [@user]
         end
 
-        should "rotate the password reset confirmation token after MFA succeeds" do
-          assert_not_equal @original_confirmation_token, @user.reload.confirmation_token
+        should "invalidate the existing reset token before the mail job runs" do
+          refute @user.reload.valid_password_reset_token?(@original_password_reset_token)
+          assert_nil @user.password_reset_token_digest
+          assert_nil @user.password_reset_token_expires_at
+        end
+
+        should "rotate the password reset token digest after MFA succeeds" do
+          perform_enqueued_jobs
+
+          assert_not_equal @original_password_reset_token_digest, @user.reload.password_reset_token_digest
         end
       end
     end
@@ -980,7 +998,7 @@ class SessionsControllerTest < ActionController::TestCase
 
       context "after successful WebAuthn" do
         setup do
-          @original_confirmation_token = @user.confirmation_token
+          @original_password_reset_token_digest = @user.password_reset_token_digest
           post :create, params: { session: { who: "compromised_user", password: PasswordHelpers::SECURE_TEST_PASSWORD } }
 
           @challenge = session[:webauthn_authentication]["challenge"]
@@ -1018,8 +1036,10 @@ class SessionsControllerTest < ActionController::TestCase
           assert_enqueued_email_with PasswordMailer, :compromised_password_reset, args: [@user]
         end
 
-        should "rotate the password reset confirmation token after WebAuthn succeeds" do
-          assert_not_equal @original_confirmation_token, @user.reload.confirmation_token
+        should "issue a password reset token digest after WebAuthn succeeds" do
+          perform_enqueued_jobs
+
+          assert_not_equal @original_password_reset_token_digest, @user.reload.password_reset_token_digest
         end
       end
     end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -207,14 +207,15 @@ class RackAttackTest < ActionDispatch::IntegrationTest
         end
 
         should "allow mfa forgot password" do
-          @user.forgot_password!
+          token = @user.issue_password_reset!
           get "/password/edit",
-            params: { token: @user.confirmation_token, user_id: @user.id }
+            params: { token:, user_id: @user.id }
+          follow_redirect!
           post "/password/otp_edit",
-            params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now },
+            params: { otp: ROTP::TOTP.new(@user.totp_seed).now },
             headers: { REMOTE_ADDR: @ip_address }
 
-          assert_response :ok
+          assert_redirected_to "/password/reset"
         end
 
         should "allow reverse_dependencies index" do
@@ -610,11 +611,12 @@ class RackAttackTest < ActionDispatch::IntegrationTest
 
         should "throttle for mfa forgot password per user at level #{level}" do
           freeze_time do
-            @user.forgot_password!
-            exceed_exponential_user_limit_for("clearance/user/#{level}", @user.confirmation_token, level)
+            token = @user.issue_password_reset!
+            get "/password/edit", params: { token:, user_id: @user.id }
+            exceed_exponential_user_limit_for("clearance/user/#{level}", @user.id, level)
 
             post "/password/otp_edit",
-              params: { token: @user.confirmation_token, otp: ROTP::TOTP.new(@user.totp_seed).now }
+              params: { otp: ROTP::TOTP.new(@user.totp_seed).now }
 
             assert_throttle_at(level)
           end

--- a/test/mailers/password_mailer_test.rb
+++ b/test/mailers/password_mailer_test.rb
@@ -7,7 +7,6 @@ class PasswordMailerTest < ActionMailer::TestCase
 
   test "change password with handle" do
     user = create(:user)
-    user.forgot_password!
     email = PasswordMailer.change_password(user)
 
     assert_emails 1 do
@@ -21,7 +20,6 @@ class PasswordMailerTest < ActionMailer::TestCase
 
   test "change password without handle should show email" do
     user = create(:user, handle: nil)
-    user.forgot_password!
     email = PasswordMailer.change_password(user)
 
     assert_emails 1 do
@@ -35,7 +33,6 @@ class PasswordMailerTest < ActionMailer::TestCase
 
   test "compromised password reset with handle" do
     user = create(:user)
-    user.forgot_password!
     email = PasswordMailer.compromised_password_reset(user)
 
     assert_emails 1 do
@@ -47,15 +44,14 @@ class PasswordMailerTest < ActionMailer::TestCase
     assert_match user.handle, email.html_part.body.to_s
     assert_match "data breach", email.html_part.body.to_s
     assert_match "data breach", email.text_part.body.to_s
-    assert_match "reason=compromised", email.html_part.body.to_s
-    assert_match "reason=compromised", email.text_part.body.to_s
+    assert_match "reason=", email.html_part.body.to_s
+    assert_match "reason=", email.text_part.body.to_s
     assert_no_match "Someone", email.html_part.body.to_s
     assert_no_match "Someone", email.text_part.body.to_s
   end
 
   test "compromised password reset without handle should show email" do
     user = create(:user, handle: nil)
-    user.forgot_password!
     email = PasswordMailer.compromised_password_reset(user)
 
     assert_emails 1 do
@@ -71,19 +67,33 @@ class PasswordMailerTest < ActionMailer::TestCase
 
   test "change password renders the change password link as a button" do
     user = create(:user)
-    user.forgot_password!
-    user.save!
-    PasswordMailer.change_password(user).deliver_now
+    email = PasswordMailer.change_password(user)
+    email.deliver_now
+    url = password_reset_url(email)
+    token = password_reset_url_params(url).fetch("token")
 
-    assert_cta_button edit_password_url(token: user.confirmation_token, host: Gemcutter::HOST), "CHANGE PASSWORD"
+    assert user.reload.valid_password_reset_token?(token)
+    assert_cta_button url, "CHANGE PASSWORD"
   end
 
   test "compromised password reset renders the change password link as a button" do
     user = create(:user)
-    user.forgot_password!
-    user.save!
-    PasswordMailer.compromised_password_reset(user).deliver_now
+    email = PasswordMailer.compromised_password_reset(user)
+    email.deliver_now
+    url = password_reset_url(email)
+    url_params = password_reset_url_params(url)
 
-    assert_cta_button edit_password_url(token: user.confirmation_token, reason: "compromised", host: Gemcutter::HOST), "CHANGE PASSWORD"
+    assert user.reload.valid_compromised_password_reset_reason?(url_params.fetch("reason"), token: url_params.fetch("token"))
+    assert_cta_button url, "CHANGE PASSWORD"
+  end
+
+  private
+
+  def password_reset_url(email)
+    Nokogiri::HTML(email.html_part.body.decoded).at_css("div.text-btn a")["href"]
+  end
+
+  def password_reset_url_params(url)
+    Rack::Utils.parse_nested_query(URI.parse(url).query)
   end
 end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -2,7 +2,9 @@
 
 class MailerPreview < ActionMailer::Preview
   def email_reset
-    Mailer.email_reset(User.first)
+    user = User.first
+    user.generate_confirmation_token(reset_unconfirmed_email: false)
+    Mailer.email_reset(user)
   end
 
   def email_reset_update
@@ -10,18 +12,18 @@ class MailerPreview < ActionMailer::Preview
   end
 
   def email_confirmation
-    Mailer.email_confirmation(User.last)
+    user = User.last
+    user.generate_confirmation_token(reset_unconfirmed_email: false)
+    Mailer.email_confirmation(user)
   end
 
   def change_password
     user = User.last
-    user.forgot_password!
     PasswordMailer.change_password(user)
   end
 
   def compromised_password_reset
     user = User.last
-    user.forgot_password!
     PasswordMailer.compromised_password_reset(user)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -534,6 +534,59 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
+    context "password reset tokens" do
+      should "store only a digest and expire the token after three hours" do
+        @user.update!(unconfirmed_email: "pending@rubygems-test.org")
+
+        token = @user.issue_password_reset!
+
+        refute_equal token, @user.reload.password_reset_token_digest
+        assert_equal User.password_reset_token_digest(token), @user.password_reset_token_digest
+        assert_in_delta 3.hours.from_now, @user.password_reset_token_expires_at, 2.seconds
+        assert_nil @user.unconfirmed_email
+        assert_equal @user, User.find_by_password_reset_token(token)
+        assert @user.valid_password_reset_token?(token)
+      end
+
+      should "reject an expired password reset token" do
+        token = @user.issue_password_reset!
+        @user.update!(password_reset_token_expires_at: 1.second.ago)
+
+        refute @user.valid_password_reset_token?(token)
+      end
+
+      should "reject an email confirmation token" do
+        @user.update!(unconfirmed_email: "pending@rubygems-test.org")
+        token = @user.confirmation_token
+
+        assert_nil User.find_by_password_reset_token(token)
+        refute @user.valid_password_reset_token?(token)
+      end
+
+      should "consume the token only after a valid password is saved" do
+        token = @user.issue_password_reset!
+
+        assert_equal :invalid_password, @user.update_password_with_token("short", token:)
+        assert @user.reload.valid_password_reset_token?(token)
+
+        assert_equal :updated, @user.update_password_with_token(PasswordHelpers::SECURE_TEST_PASSWORD, token:)
+        assert_nil @user.reload.password_reset_token_digest
+        assert_nil @user.password_reset_token_expires_at
+        assert @user.authenticated?(PasswordHelpers::SECURE_TEST_PASSWORD)
+        assert_equal :invalid_token,
+          @user.update_password_with_token(PasswordHelpers::SECURE_TEST_PASSWORD, token:)
+      end
+
+      should "bind the compromised-reset authorization to the reset token" do
+        token = @user.issue_password_reset!
+        reason = @user.compromised_password_reset_reason_for(token)
+
+        assert @user.valid_compromised_password_reset_reason?(reason, token:)
+        refute @user.valid_compromised_password_reset_reason?("compromised", token:)
+        refute @user.valid_compromised_password_reset_reason?(reason, token: "different-token")
+      end
+    end
+
     context "two factor authentication" do
       should "disable mfa by default" do
         refute_predicate @user, :mfa_enabled?

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -569,9 +569,14 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
     end
 
     page.assert_text "Action ran successfully!"
+    user = User.sole
+    created_user_attributes = user.attributes
+
+    assert_nil created_user_attributes["confirmation_token"]
+
     perform_enqueued_jobs
 
-    user = User.sole
+    user.reload
     audit = user.audits.sole
     event = user.events.where(tag: Events::UserEvent::CREATED).sole
 
@@ -583,7 +588,7 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
       {
         "records" => {
           "gid://gemcutter/User/#{user.id}" => {
-            "changes" =>   user.attributes.transform_values { [nil, it.as_json] },
+            "changes" =>   created_user_attributes.transform_values { [nil, it.as_json] },
             "unchanged" => {}
           },
           event.to_gid.as_json => {

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -38,7 +38,7 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     visit password_reset_link
 
-    assert_current_path edit_password_path, ignore_query: true
+    assert_current_path reset_password_path
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
@@ -51,6 +51,27 @@ class PasswordResetTest < ApplicationSystemTestCase
     click_button "Sign in"
 
     assert_text "Dashboard"
+  end
+
+  test "opening the reset link more than once does not consume it" do
+    forgot_password_with @user.email
+    link = password_reset_link
+
+    visit link
+
+    assert_current_path reset_password_path
+    assert_text "Reset password"
+
+    visit link
+
+    assert_current_path reset_password_path
+    assert_text "Reset password"
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Save this password"
+
+    assert_current_path sign_in_path
+    assert @user.reload.authenticated?(PasswordHelpers::SECURE_TEST_PASSWORD)
   end
 
   test "resetting a password with a blank or short password" do


### PR DESCRIPTION
## Why

Password reset tokens were invalidated as soon as the link was opened. Email security scanners, link previews, browser prefetching, or just an accidental first click could consume the token before the user ever reached the password form. This is causing confusion among users when they go visit the link, but find that it's invalid.

## What changed

A reset token is now consumed when the password is successfully changed, not when the link is opened. The compromised-password MFA exception also is now binds to a signed, token-specific value instead of trusting reason=compromised.