### PR TITLE
Fix password reset token migration

### DIFF
--- a/db/migrate/20260814000000_add_password_reset_token_digest_to_users.rb
+++ b/db/migrate/20260814000000_add_password_reset_token_digest_to_users.rb
@@ -4,10 +4,9 @@ class AddPasswordResetTokenDigestToUsers < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def change
-    change_table :users, bulk: true do |t|
-      t.string :password_reset_token_digest
-      t.datetime :password_reset_token_expires_at
-    end
+    # Strong Migrations cannot inspect change_table blocks.
+    add_column :users, :password_reset_token_digest, :string
+    add_column :users, :password_reset_token_expires_at, :datetime
     add_index :users, :password_reset_token_digest, unique: true, algorithm: :concurrently
   end
 end


### PR DESCRIPTION
## What changed

- Replace the `change_table` block with explicit `add_column` calls.
- Keep the unique password reset token digest index concurrent.

## Why

The password-reset deployment failed on staging because Strong Migrations cannot inspect operations inside a `change_table` block and stops the migration before running it.

Using explicit column additions lets Strong Migrations inspect each operation while preserving the schema produced by the original migration.

## Impact

This unblocks deployment of the password-reset hardening migration. There is no resulting schema change compared with the merged migration, so `db/schema.rb` does not need another update.

## Validation

- Ruby syntax check passed.
- Full RuboCop run passed from a clean verification checkout using the repository's unmodified configuration: 1,358 files inspected with no offenses.
- Reproduced the original Strong Migrations rejection and verified the revised migration avoids the unsupported `change_table` path.
- A full PostgreSQL migration could not be run locally because PostgreSQL/Docker is unavailable; staging should be redeployed after merge to verify the migration end to end.