### PR TITLE
Remove default_url_options[]= in ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,8 +5,6 @@ class ApplicationMailer < ActionMailer::Base
   include Roadie::Rails::Automatic
 
   default from: Gemcutter::MAIL_SENDER
-  default_url_options[:host] = Gemcutter::HOST
-  default_url_options[:protocol] = Gemcutter::PROTOCOL
 
   layout "mailer"
 


### PR DESCRIPTION
The mutation predates the other method of configuring these values: it first [appeared][1] on `ProfileMailer` in 2009, while `config.action_mailer.default_url_options` was only added to the [test][2] environment in 2010, to [production][3] in 2014, and to [development][4] in 2015. The per-mailer mutations were then copy-pasted into each new mailer until they were [consolidated][5] into `ApplicationMailer` in 2024.

Since every environment sets `config.action_mailer.default_url_options`, the `ApplicationMailer` mutation just rewrites the same values into the same hash and can be removed.

[1]: https://github.com/rubygems/rubygems.org/commit/e69fa4ca610bbc803e8ee829d9b362e0f150e4b1
[2]: https://github.com/rubygems/rubygems.org/commit/823514768d665ef079296f718196ff9a71e4631b
[3]: https://github.com/rubygems/rubygems.org/commit/4dc8e0a68e7bcfb0d76e571cb527ca1ba15be83c
[4]: https://github.com/rubygems/rubygems.org/commit/06f4a5fb0885e89c0aed5b8b18803bb7d840b013
[5]: https://github.com/rubygems/rubygems.org/commit/372b7f94fa17c37c4a587faf0a08aa019f1d57ed