### PR TITLE
Add maintenance task to remove users by API key name

### DIFF
--- a/app/tasks/maintenance/yank_and_block_users_by_api_key_task.rb
+++ b/app/tasks/maintenance/yank_and_block_users_by_api_key_task.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Maintenance::YankAndBlockUsersByApiKeyTask < MaintenanceTasks::Task
+  include SemanticLogger::Loggable
+
+  attribute :api_key_name, :string
+  attribute :created_within_hours, :integer, default: 24
+  attribute :min_user_id, :integer
+  attribute :max_user_id, :integer
+
+  validates :api_key_name, presence: true
+  validates :created_within_hours,
+    numericality: { only_integer: true, greater_than: 0 }
+  validate :max_user_id_not_before_min
+
+  def collection
+    scope = User.kept.where(blocked_email: nil)
+      .where(id: matching_api_keys.select(:owner_id))
+    scope = scope.where(id: min_user_id..) if min_user_id.present?
+    scope = scope.where(id: ..max_user_id) if max_user_id.present?
+    scope
+  end
+
+  def process(user)
+    return if user.blocked? || user.discarded?
+
+    logger.tagged(user_id: user.id, handle: user.handle) do
+      YankRubygemsForUserJob.perform_later(user: user)
+      user.block!
+      logger.info "Yanked gems and blocked user"
+    end
+  rescue ActiveRecord::ActiveRecordError => e
+    Rails.error.report(e, context: { user_id: user.id }, handled: true)
+  end
+
+  private
+
+  def matching_api_keys
+    ApiKey.where(owner_type: "User")
+      .where("name ILIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(api_key_name)}%")
+      .where(created_at: created_within_hours.hours.ago..)
+  end
+
+  def max_user_id_not_before_min
+    return if min_user_id.blank? || max_user_id.blank?
+    return if max_user_id >= min_user_id
+
+    errors.add(:max_user_id, "must be greater than or equal to min_user_id")
+  end
+end

--- a/test/tasks/maintenance/yank_and_block_users_by_api_key_task_test.rb
+++ b/test/tasks/maintenance/yank_and_block_users_by_api_key_task_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Maintenance::YankAndBlockUsersByApiKeyTaskTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @task = Maintenance::YankAndBlockUsersByApiKeyTask.new
+    @task.api_key_name = "key-to-remove"
+  end
+
+  context "#collection" do
+    should "include users with a recently created matching API key" do
+      user = create(:user)
+      create(:api_key, owner: user, name: "key-to-remove", created_at: 1.hour.ago)
+
+      assert_includes @task.collection, user
+    end
+
+    should "match API key name case-insensitively" do
+      user = create(:user)
+      create(:api_key, owner: user, name: "KEY-TO-REMOVE-123", created_at: 1.hour.ago)
+
+      assert_includes @task.collection, user
+    end
+
+    should "exclude users whose matching API key is outside the time window" do
+      user = create(:user)
+      create(:api_key, owner: user, name: "key-to-remove", created_at: 2.days.ago)
+
+      assert_not_includes @task.collection, user
+    end
+
+    should "exclude users without a matching API key name" do
+      user = create(:user)
+      create(:api_key, owner: user, name: "ci-key", created_at: 1.hour.ago)
+
+      assert_not_includes @task.collection, user
+    end
+
+    should "exclude already blocked users" do
+      user = create(:user, :blocked)
+      create(:api_key, owner: user, name: "key-to-remove", created_at: 1.hour.ago)
+
+      assert_not_includes @task.collection, user
+    end
+
+    should "exclude discarded users" do
+      user = create(:user)
+      user.discard!
+      create(:api_key, owner: user, name: "key-to-remove", created_at: 1.hour.ago)
+
+      assert_not_includes @task.collection, user
+    end
+
+    should "exclude users whose matching key is not user-owned" do
+      user = create(:user)
+      trusted_key = create(:api_key, :trusted_publisher, name: "key-to-remove", created_at: 1.hour.ago)
+      trusted_key.update_column(:owner_id, user.id)
+
+      assert_not_includes @task.collection, user
+    end
+
+    should "deduplicate users with multiple matching API keys" do
+      user = create(:user)
+      create(:api_key, owner: user, name: "key-to-remove-one", created_at: 1.hour.ago)
+      create(:api_key, owner: user, name: "key-to-remove-two", created_at: 1.hour.ago)
+
+      assert_equal [user], @task.collection.to_a
+    end
+
+    should "honor a custom created_within_hours window" do
+      @task.created_within_hours = 48
+      user = create(:user)
+      create(:api_key, owner: user, name: "key-to-remove", created_at: 30.hours.ago)
+
+      assert_includes @task.collection, user
+    end
+  end
+
+  context "#collection user id bounds" do
+    setup do
+      @users = create_list(:user, 3).sort_by(&:id)
+      @users.each do |user|
+        create(:api_key, owner: user, name: "key-to-remove", created_at: 1.hour.ago)
+      end
+    end
+
+    should "apply min_user_id as an inclusive lower bound" do
+      @task.min_user_id = @users[1].id
+
+      assert_equal @users[1..], @task.collection.order(:id).to_a
+    end
+
+    should "apply max_user_id as an inclusive upper bound" do
+      @task.max_user_id = @users[1].id
+
+      assert_equal @users[0..1], @task.collection.order(:id).to_a
+    end
+
+    should "be invalid when max_user_id is below min_user_id" do
+      @task.min_user_id = 10
+      @task.max_user_id = 5
+
+      refute_predicate @task, :valid?
+      assert_includes @task.errors[:max_user_id], "must be greater than or equal to min_user_id"
+    end
+  end
+
+  context "#process" do
+    should "enqueue a yank job and block the user" do
+      user = create(:user)
+
+      assert_enqueued_jobs(1, only: YankRubygemsForUserJob) do
+        @task.process(user)
+      end
+
+      assert_predicate user.reload, :blocked?
+    end
+
+    should "skip already blocked users" do
+      user = create(:user, :blocked)
+
+      assert_no_enqueued_jobs(only: YankRubygemsForUserJob) do
+        @task.process(user)
+      end
+    end
+
+    should "skip discarded users" do
+      user = create(:user)
+      user.discard!
+
+      assert_no_enqueued_jobs(only: YankRubygemsForUserJob) do
+        @task.process(user)
+      end
+
+      assert_not user.reload.blocked?
+    end
+
+    should "report and swallow ActiveRecord failures without raising" do
+      user = create(:user)
+      User.any_instance.expects(:block!).raises(ActiveRecord::RecordNotSaved)
+
+      assert_error_reported(ActiveRecord::RecordNotSaved) do
+        assert_nothing_raised { @task.process(user) }
+      end
+      assert_not user.reload.blocked?
+    end
+  end
+
+  context "validations" do
+    should "require api_key_name" do
+      task = Maintenance::YankAndBlockUsersByApiKeyTask.new
+
+      refute_predicate task, :valid?
+      assert_includes task.errors[:api_key_name], "can't be blank"
+    end
+
+    should "require a positive created_within_hours" do
+      @task.created_within_hours = 0
+
+      refute_predicate @task, :valid?
+      assert_includes @task.errors[:created_within_hours], "must be greater than 0"
+    end
+  end
+end


### PR DESCRIPTION
Add a maintenance task that would yank users if they own a key with a specific name. Excludes already deleted and blocked users.