### PR TITLE
Fix Avo unblock user action

### DIFF
--- a/app/avo/actions/unblock_user.rb
+++ b/app/avo/actions/unblock_user.rb
@@ -3,7 +3,7 @@
 class Avo::Actions::UnblockUser < Avo::Actions::ApplicationAction
   self.name = "Unblock User"
   self.visible = lambda {
-    current_user.team_member?("rubygems-org") && view == :show && record.blocked?
+    current_user.team_member?("rubygems-org") && view == :show && resource.record.blocked?
   }
 
   self.message = lambda {

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -16,6 +16,7 @@ class Avo::Resources::User < Avo::BaseResource
     action Avo::Actions::DeleteUser
     action Avo::Actions::ResetApiKey
     action Avo::Actions::ResetUser2fa
+    action Avo::Actions::UnblockUser
     action Avo::Actions::YankRubygemsForUser
     action Avo::Actions::YankUser
   end

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -33,6 +33,16 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     assert page.has_content? "Delete User"
   end
 
+  test "showing the unblock action for a blocked user" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    user = create(:user, :blocked)
+
+    get avo.resources_user_path(user)
+
+    assert_response :success
+    assert page.has_content? "Unblock User"
+  end
+
   test "enabling the delete action when the user is the sole owner of an old gem version" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)

--- a/test/unit/avo/actions/unblock_user_test.rb
+++ b/test/unit/avo/actions/unblock_user_test.rb
@@ -36,7 +36,7 @@ class UnblockUserTest < ActiveSupport::TestCase
   end
 
   should "be visible" do
-    action_mock = Data.define(:current_user, :view, :record).new(current_user: @current_user, view: :show, record: @user)
+    action_mock = Data.define(:current_user, :view, :resource).new(current_user: @current_user, view: :show, resource: @resource)
 
     assert action_mock.instance_exec(&Avo::Actions::UnblockUser.visible)
   end
@@ -47,7 +47,8 @@ class UnblockUserTest < ActiveSupport::TestCase
     end
 
     should "not be visible" do
-      action_mock = Data.define(:current_user, :view, :record).new(current_user: @current_user, view: :show, record: @user)
+      resource = Avo::Resources::User.new.hydrate(record: @user)
+      action_mock = Data.define(:current_user, :view, :resource).new(current_user: @current_user, view: :show, resource:)
 
       refute action_mock.instance_exec(&Avo::Actions::UnblockUser.visible)
     end


### PR DESCRIPTION
## Summary
- register the existing Unblock User action on the Avo user resource
- use Avo’s resource context when checking whether the user is blocked
- add request-level coverage for action visibility

## Tests
- `PARALLEL_WORKERS=1 bin/rails test test/integration/avo/users_test.rb`
- `PARALLEL_WORKERS=1 bin/rails test test/unit/avo/actions/unblock_user_test.rb`
- `bin/rubocop app/avo/actions/unblock_user.rb app/avo/resources/user.rb test/unit/avo/actions/unblock_user_test.rb test/integration/avo/users_test.rb`