### PR TITLE
Add bulk user deletion to Avo

### DIFF
--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -3,34 +3,85 @@
 class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
   self.name = "Delete User"
   self.visible = lambda {
-    current_user.team_member?("rubygems-org") && view == :show
+    current_user.team_member?("rubygems-org") && view.in?(%i[index show])
   }
 
   def fields
     field :keep_gems_published, as: :boolean,
-      help: "Skip yanking gems for which this user is the only owner. Published versions will remain available without an owner."
+      help: "Skip yanking gems for which a selected user is the only owner. Published versions will remain available without an owner."
     super
   end
 
   self.message = lambda {
-    "Are you sure you would like to delete user #{record.display_handle} with #{record.email}? " \
-      "This action can't be undone. By default, gems for which this user is the only owner will be yanked. " \
+    users = record ? "user #{record.display_handle} with #{record.email}" : "#{query.count} selected users"
+    owner = record ? "this user is" : "a selected user is"
+    "Are you sure you would like to delete #{users}? " \
+      "This action can't be undone. By default, gems for which #{owner} the only owner will be yanked. " \
       "Check 'Keep gems published' to preserve those gems as published without an owner."
   }
 
-  self.confirm_button_label = "Delete User"
+  self.confirm_button_label = -> { record ? "Delete User" : "Delete Users" }
 
   def self.blocked_reason
     I18n.t("admin.delete_user.blocked_reason")
   end
 
   class ActionHandler < Avo::Actions::ActionHandler
-    def handle_record(user)
-      keep_gems_published = ActiveModel::Type::Boolean.new.cast(fields[:keep_gems_published]) == true
-      return error(Avo::Actions::DeleteUser.blocked_reason) if user.sole_owner_of_ineligible_gem_versions? && !keep_gems_published
+    def handle
+      @keep_gems_published = ActiveModel::Type::Boolean.new.cast(fields[:keep_gems_published]) == true
+      @scheduled_user_count = @blocked_user_count = @failed_user_count = 0
 
-      DeleteUserJob.perform_later(user:, actor: current_user, keep_gems_published:)
-      succeed("Account deletion for #{user.display_handle} has been scheduled")
+      records.each { |user| process_user(user) }
+      add_summary_messages
+      redirect_to Avo::Current.view_context.avo.resources_audit_path(@last_audit) if @last_audit
+    end
+
+    private
+
+    def process_user(user)
+      if user.sole_owner_of_ineligible_gem_versions? && !@keep_gems_published
+        @blocked_user_count += 1
+        return
+      end
+
+      _, @last_audit = in_audited_transaction(
+        auditable: user,
+        admin_github_user: current_user,
+        action: action_name,
+        fields:,
+        arguments:,
+        models: [user]
+      ) do
+        enqueued_job = DeleteUserJob.perform_later(user:, actor: current_user, keep_gems_published: @keep_gems_published)
+        raise ActiveJob::EnqueueError, "DeleteUserJob failed to enqueue" unless enqueued_job
+
+        enqueued_job
+      end
+      @scheduled_user_count += 1
+    rescue StandardError => e
+      @failed_user_count += 1
+      Rails.error.report(e, handled: true, context: { user_id: user.id })
+    end
+
+    def add_summary_messages
+      succeed("Account deletion has been scheduled for #{user_count(@scheduled_user_count)}") if @scheduled_user_count.positive?
+
+      issues = []
+      if @blocked_user_count.positive?
+        issues << "Deletion was not scheduled for #{user_count(@blocked_user_count)}. #{Avo::Actions::DeleteUser.blocked_reason}"
+      end
+      if @failed_user_count.positive?
+        failure_report = @failed_user_count == 1 ? "The failure has" : "The failures have"
+        issues << "Deletion could not be scheduled for #{user_count(@failed_user_count)}. #{failure_report} been reported."
+      end
+      return if issues.empty?
+
+      issue_message = issues.join(" ")
+      @scheduled_user_count.positive? ? inform(issue_message) : error(issue_message)
+    end
+
+    def user_count(count)
+      "#{count} #{'user'.pluralize(count)}"
     end
   end
 end

--- a/app/avo/actions/delete_user.rb
+++ b/app/avo/actions/delete_user.rb
@@ -13,7 +13,13 @@ class Avo::Actions::DeleteUser < Avo::Actions::ApplicationAction
   end
 
   self.message = lambda {
-    users = record ? "user #{record.display_handle} with #{record.email}" : "#{query.count} selected users"
+    users = if record
+              "user #{record.display_handle} with #{record.email}"
+            elsif query
+              "#{query.count} selected users"
+            else
+              "the selected users"
+            end
     owner = record ? "this user is" : "a selected user is"
     "Are you sure you would like to delete #{users}? " \
       "This action can't be undone. By default, gems for which #{owner} the only owner will be yanked. " \

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -9,6 +9,39 @@ class Avo::Resources::User < Avo::BaseResource
            }
   }
 
+  class ApiKeyNameFilter < Avo::Filters::TextFilter
+    self.name = "API key name"
+    self.button_label = "Filter by API key name"
+
+    def apply(_request, query, value)
+      return query if value.blank?
+
+      api_keys = ApiKey.where(owner_type: "User")
+        .where("name ILIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(value)}%")
+      query.where(id: api_keys.select(:owner_id))
+    end
+  end
+
+  class CreatedAtFilter < Avo::Filters::DateTimeFilter
+    self.name = "Account creation time (UTC)"
+    self.button_label = "Filter by creation time"
+
+    def apply(_request, query, value)
+      return query if value.blank?
+
+      start_value, end_value = value.split(" to ", 2)
+      return query.none if start_value.blank? || end_value.blank?
+
+      start_at = Time.zone.strptime(start_value, "%Y-%m-%d %H:%M:%S")
+      end_at = Time.zone.strptime(end_value, "%Y-%m-%d %H:%M:%S")
+      return query.none if start_at > end_at
+
+      query.where(created_at: start_at..end_at)
+    rescue ArgumentError
+      query.none
+    end
+  end
+
   def actions
     action Avo::Actions::BlockUser
     action Avo::Actions::CreateUser
@@ -18,6 +51,11 @@ class Avo::Resources::User < Avo::BaseResource
     action Avo::Actions::ResetUser2fa
     action Avo::Actions::YankRubygemsForUser
     action Avo::Actions::YankUser
+  end
+
+  def filters
+    filter ApiKeyNameFilter
+    filter CreatedAtFilter
   end
 
   def fields # rubocop:disable Metrics

--- a/db/migrate/20260817043732_add_api_key_name_trigram_index.rb
+++ b/db/migrate/20260817043732_add_api_key_name_trigram_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddApiKeyNameTrigramIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    enable_extension "pg_trgm"
+    add_index :api_keys, :name,
+      using: :gin,
+      opclass: :gin_trgm_ops,
+      where: "owner_type = 'User'",
+      name: :index_api_keys_on_name_trigram_for_users,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :api_keys,
+      name: :index_api_keys_on_name_trigram_for_users,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_043732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
 
   create_table "admin_github_users", force: :cascade do |t|
@@ -50,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
     t.string "soft_deleted_rubygem_name"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["hashed_key"], name: "index_api_keys_on_hashed_key", unique: true
+    t.index ["name"], name: "index_api_keys_on_name_trigram_for_users", opclass: :gin_trgm_ops, where: "((owner_type)::text = 'User'::text)", using: :gin
     t.index ["owner_type", "owner_id"], name: "index_api_keys_on_owner"
     t.check_constraint "owner_id IS NOT NULL", name: "api_keys_owner_id_null"
     t.check_constraint "owner_type IS NOT NULL", name: "api_keys_owner_type_null"

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -85,13 +85,13 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     refute page.has_content? Avo::Actions::DeleteUser.blocked_reason
   end
 
-  test "not showing the delete action on the users index" do
+  test "showing the delete action to rubygems.org operators on the users index" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
 
     get avo.resources_users_path
 
     assert_response :success
-    refute page.has_content? "Delete User"
+    assert page.has_content? "Delete User"
   end
 
   test "redirecting operators outside the rubygems.org team" do

--- a/test/system/avo/users_test.rb
+++ b/test/system/avo/users_test.rb
@@ -7,6 +7,98 @@ class Avo::UsersSystemTest < ApplicationSystemTestCase
 
   include ActiveJob::TestHelper
 
+  test "bulk delete users" do
+    admin_user = create(:admin_github_user, :is_admin)
+    users = create_list(:user, 2)
+    avo_sign_in_as admin_user
+
+    visit avo.resources_users_path
+
+    users.each do |user|
+      find("tr[data-resource-id='#{user.id}'] input[type='checkbox']").check
+    end
+    click_button "Actions"
+    click_on "Delete User"
+
+    within("[role='dialog']") do
+      assert_text "delete 2 selected users"
+      fill_in "Comment", with: "Deleting users from a malicious campaign"
+      click_button "Delete Users"
+    end
+
+    assert_text "Account deletion has been scheduled for 2 users"
+    assert_enqueued_jobs 2, only: DeleteUserJob
+  end
+
+  test "bulk delete confirmation counts all matching users across pages" do
+    admin_user = create(:admin_github_user, :is_admin)
+    # Cross-page behavior requires more than Avo's 24-row page size.
+    users = create_list(:user, 25) # rubocop:disable FactoryBot/ExcessiveCreateList
+    users.each { |user| create(:api_key, owner: user, name: "cross-page-campaign-key") }
+    unrelated_user = create(:user)
+    avo_sign_in_as admin_user
+
+    visit avo.resources_users_path
+    click_on "Filters"
+    fill_in id: "avo_filters_api_key_name", with: "cross-page-campaign"
+    click_on "Filter by API key name"
+
+    assert_no_text unrelated_user.email
+    find("input[type='checkbox'][name='Select all']").check
+
+    assert_text "Select all matching"
+    click_on "Select all matching"
+
+    assert_text "25 records selected from all pages"
+    click_button "Actions"
+    click_on "Delete User"
+
+    within("[role='dialog']") do
+      assert_text "delete 25 selected users"
+    end
+  end
+
+  test "filter users by campaign API key and creation time" do
+    admin_user = create(:admin_github_user, :is_admin)
+    matching_created_at = 1.day.ago.change(hour: 11)
+    range_start = 2.days.ago.to_date
+    range_end = Time.zone.today
+    matching_user = create(:user, created_at: matching_created_at)
+    create(:api_key, owner: matching_user, name: "recent-campaign-key")
+
+    old_user = create(:user, created_at: 3.days.ago.change(hour: 11))
+    create(:api_key, owner: old_user, name: "recent-campaign-key")
+
+    unrelated_user = create(:user, created_at: matching_created_at)
+    create(:api_key, owner: unrelated_user, name: "unrelated-key")
+    avo_sign_in_as admin_user
+
+    visit avo.resources_users_path
+
+    click_on "Filters"
+
+    assert_text "Account creation time (UTC)"
+    fill_in id: "avo_filters_api_key_name", with: "recent-campaign"
+    click_on "Filter by API key name"
+
+    assert_text matching_user.email
+    assert_text old_user.email
+    assert_no_text unrelated_user.email
+
+    click_on "Filters"
+    find("[data-controller='date-time-filter'] input").click
+    within ".flatpickr-calendar.open" do
+      find(".flatpickr-day[aria-label='#{range_start.strftime('%B %-d, %Y')}']").click
+      find(".flatpickr-day[aria-label='#{range_end.strftime('%B %-d, %Y')}']").click
+    end
+    find("body").send_keys(:escape)
+    click_on "Filter by creation time"
+
+    assert_text matching_user.email
+    assert_no_text old_user.email
+    assert_no_text unrelated_user.email
+  end
+
   test "reset mfa" do
     Minitest::Test.make_my_diffs_pretty!
     admin_user = create(:admin_github_user, :is_admin)

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -13,6 +13,7 @@ class DeleteUserTest < ActiveSupport::TestCase
   end
 
   should "enqueue an admin-initiated deletion" do
+    stub_audit_redirect
     args = {
       current_user: @current_user,
       resource: @resource,
@@ -28,6 +29,92 @@ class DeleteUserTest < ActiveSupport::TestCase
     end
   end
 
+  should "enqueue and audit a deletion for every selected user" do
+    stub_audit_redirect
+
+    other_user = create(:user)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user, other_user],
+      fields: {
+        comment: "Deleting users from a malicious campaign"
+      },
+      query: nil
+    }
+
+    assert_difference "Audit.count", 2 do
+      assert_enqueued_jobs 2, only: DeleteUserJob do
+        @action.handle(**args)
+      end
+    end
+    audit_models = Audit.order(:id).map { |audit| audit.audited_changes.fetch("models") }
+
+    assert_equal [
+      [@user.to_global_id.uri.to_s],
+      [other_user.to_global_id.uri.to_s]
+    ], audit_models
+    assert_equal ["Account deletion has been scheduled for 2 users"],
+      @action.response[:messages].pluck(:body)
+  end
+
+  should "continue deleting eligible users when another selected user is protected" do
+    stub_audit_redirect
+    protected_user = create(:user)
+    rubygem = create(:rubygem, name: "protected-gem-in-bulk-deletion", owners: [protected_user])
+    create(:version, rubygem:, created_at: 31.days.ago)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [protected_user, @user],
+      fields: {
+        comment: "Deleting users from a malicious campaign"
+      },
+      query: nil
+    }
+
+    assert_difference "Audit.count", 1 do
+      assert_enqueued_with(job: DeleteUserJob, args: [user: @user, actor: @current_user, keep_gems_published: false]) do
+        @action.handle(**args)
+      end
+    end
+    assert_equal [@user], Audit.all.map(&:auditable)
+    assert_equal [
+      "Account deletion has been scheduled for 1 user",
+      "Deletion was not scheduled for 1 user. #{Avo::Actions::DeleteUser.blocked_reason}"
+    ], @action.response[:messages].pluck(:body)
+  end
+
+  should "continue deleting users after an enqueue failure without auditing the failure" do
+    stub_audit_redirect
+    failing_user = create(:user)
+    other_user = create(:user)
+    args = {
+      current_user: @current_user,
+      resource: @resource,
+      records: [@user, failing_user, other_user],
+      fields: {
+        comment: "Deleting users from a malicious campaign"
+      },
+      query: nil
+    }
+
+    reject_enqueue_for(failing_user) do
+      assert_error_reported(ActiveJob::EnqueueError) do
+        assert_difference "Audit.count", 2 do
+          assert_enqueued_jobs 2, only: DeleteUserJob do
+            @action.handle(**args)
+          end
+        end
+      end
+    end
+    assert_equal [@user, other_user].sort_by(&:id), Audit.all.map(&:auditable).sort_by(&:id)
+    assert_equal [
+      "Account deletion has been scheduled for 2 users",
+      "Deletion could not be scheduled for 1 user. The failure has been reported."
+    ], @action.response[:messages].pluck(:body)
+  end
+
   should "not enqueue deletion when the user is the sole owner of an old gem version" do
     rubygem = create(:rubygem, name: "old-gem-owned-by-deleted-user", owners: [@user])
     create(:version, rubygem:, created_at: 31.days.ago)
@@ -41,13 +128,16 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_no_enqueued_jobs only: DeleteUserJob do
-      @action.handle(**args)
+    assert_no_difference "Audit.count" do
+      assert_no_enqueued_jobs only: DeleteUserJob do
+        @action.handle(**args)
+      end
     end
-    assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
+    assert_includes @action.response.dig(:messages, 0, :body), Avo::Actions::DeleteUser.blocked_reason
   end
 
   should "enqueue deletion for a sole owner when keeping gems published" do
+    stub_audit_redirect
     rubygem = create(:rubygem, name: "old-gem-preserved-for-deleted-user", owners: [@user])
     create(:version, rubygem:, created_at: 31.days.ago)
     args = {
@@ -80,10 +170,12 @@ class DeleteUserTest < ActiveSupport::TestCase
       query: nil
     }
 
-    assert_no_enqueued_jobs only: DeleteUserJob do
-      @action.handle(**args)
+    assert_no_difference "Audit.count" do
+      assert_no_enqueued_jobs only: DeleteUserJob do
+        @action.handle(**args)
+      end
     end
-    assert_equal Avo::Actions::DeleteUser.blocked_reason, @action.response.dig(:messages, 0, :body)
+    assert_includes @action.response.dig(:messages, 0, :body), Avo::Actions::DeleteUser.blocked_reason
   end
 
   should "ask for confirmation naming the user" do
@@ -99,5 +191,35 @@ class DeleteUserTest < ActiveSupport::TestCase
     message = @action.get_message
 
     assert_includes message, "delete user ##{@user.id} with #{@user.email}"
+  end
+
+  should "ask for confirmation for multiple selected users" do
+    other_user = create(:user)
+    query = User.where(id: [@user.id, other_user.id])
+    action = Avo::Actions::DeleteUser.new(record: nil, resource: @resource, user: @current_user, view: :index, query:)
+
+    assert_includes action.get_message, "delete 2 selected users"
+    assert_equal "Delete Users", action.confirm_button_label
+  end
+
+  private
+
+  def stub_audit_redirect
+    view_context = mock
+    avo = mock
+    view_context.stubs(:avo).returns(avo)
+    avo.stubs(:resources_audit_path).returns("resources_audit_path")
+    Avo::Current.stubs(:view_context).returns(view_context)
+  end
+
+  def reject_enqueue_for(user)
+    callback = lambda do |job|
+      throw :abort if job.arguments.first.fetch(:user) == user
+    end
+    DeleteUserJob.set_callback(:enqueue, :before, callback)
+
+    yield
+  ensure
+    DeleteUserJob.skip_callback(:enqueue, :before, callback)
   end
 end

--- a/test/unit/avo/actions/delete_user_test.rb
+++ b/test/unit/avo/actions/delete_user_test.rb
@@ -202,6 +202,12 @@ class DeleteUserTest < ActiveSupport::TestCase
     assert_equal "Delete Users", action.confirm_button_label
   end
 
+  should "ask for confirmation without a selection query" do
+    action = Avo::Actions::DeleteUser.new(record: nil, resource: @resource, user: @current_user, view: :index, query: nil)
+
+    assert_includes action.get_message, "delete the selected users"
+  end
+
   private
 
   def stub_audit_redirect

--- a/test/unit/avo/filters/user_filters_test.rb
+++ b/test/unit/avo/filters/user_filters_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UserFiltersTest < ActiveSupport::TestCase
+  setup do
+    @api_key_filter = Avo::Resources::User::ApiKeyNameFilter.new
+    @created_at_filter = Avo::Resources::User::CreatedAtFilter.new
+  end
+
+  test "API key name filter matches user-owned keys case-insensitively" do
+    matching_user = create(:user)
+    create(:api_key, owner: matching_user, name: "RECENT-CAMPAIGN-key")
+    create(:api_key, owner: matching_user, name: "recent-campaign-second-key")
+
+    create(:api_key, owner: create(:user), name: "unrelated-key")
+
+    user_with_trusted_key_id = create(:user)
+    trusted_key = create(:api_key, :trusted_publisher, name: "recent-campaign-key")
+    trusted_key.update_column(:owner_id, user_with_trusted_key_id.id)
+
+    result = @api_key_filter.apply(nil, User.all, "recent-campaign")
+
+    assert_equal [matching_user], result.to_a
+  end
+
+  test "API key name filter treats SQL wildcard characters literally" do
+    matching_user = create(:user)
+    create(:api_key, owner: matching_user, name: "campaign-100%-key")
+    create(:api_key, owner: create(:user), name: "campaign-1000-key")
+
+    result = @api_key_filter.apply(nil, User.all, "100%")
+
+    assert_equal [matching_user], result.to_a
+  end
+
+  test "created at filter includes both ends of the selected range" do
+    assert_equal "Account creation time (UTC)", @created_at_filter.name
+
+    start_at = Time.zone.local(2026, 8, 15, 10)
+    end_at = Time.zone.local(2026, 8, 15, 12)
+    users = [
+      create(:user, created_at: start_at),
+      create(:user, created_at: end_at)
+    ]
+    create(:user, created_at: start_at - 1.second)
+    create(:user, created_at: end_at + 1.second)
+
+    value = "2026-08-15 10:00:00 to 2026-08-15 12:00:00"
+    result = @created_at_filter.apply(nil, User.all, value)
+
+    assert_equal users.sort_by(&:id), result.order(:id).to_a
+  end
+
+  test "filters combine to identify users in the campaign and creation window" do
+    matching_user = create(:user, created_at: Time.zone.local(2026, 8, 15, 11))
+    create(:api_key, owner: matching_user, name: "recent-campaign-key")
+
+    old_user = create(:user, created_at: Time.zone.local(2026, 8, 14, 11))
+    create(:api_key, owner: old_user, name: "recent-campaign-key")
+
+    unrelated_user = create(:user, created_at: Time.zone.local(2026, 8, 15, 11))
+    create(:api_key, owner: unrelated_user, name: "unrelated-key")
+
+    query = @api_key_filter.apply(nil, User.all, "recent-campaign")
+    result = @created_at_filter.apply(nil, query, "2026-08-15 10:00:00 to 2026-08-15 12:00:00")
+
+    assert_equal [matching_user], result.to_a
+  end
+
+  test "blank values do not filter users" do
+    users = create_list(:user, 2).sort_by(&:id)
+
+    assert_equal users, @api_key_filter.apply(nil, User.all, "").order(:id).to_a
+    assert_equal users, @created_at_filter.apply(nil, User.all, "").order(:id).to_a
+  end
+
+  test "created at filter fails closed for invalid ranges" do
+    create_list(:user, 2)
+
+    invalid_values = [
+      "2026-08-15 10:00:00",
+      "not a date to 2026-08-15 12:00:00",
+      "2026-08-15 12:00:00 to 2026-08-15 10:00:00"
+    ]
+
+    invalid_values.each do |value|
+      assert_empty @created_at_filter.apply(nil, User.all, value), value
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add bulk user deletion to the Avo users index.
- Add filters for:
  - Case-insensitive API key name substring.
  - Account creation time range, explicitly in UTC.
- Support selecting users individually or selecting all filtered users across pages.
- Show the expanded user count in the deletion confirmation.
- Preserve existing sole-owner safeguards and the option to keep gems published.
- Process users independently so protected users or enqueue failures do not stop the remaining batch.
- Create one audit per successfully scheduled deletion and report aggregate success/failure counts.
- Add a concurrent partial trigram GIN index for user-owned API key names.