### PR TITLE
Search blocked emails in Avo users

### DIFF
--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -5,7 +5,8 @@ class Avo::Resources::User < Avo::BaseResource
   self.includes = []
   self.search = {
     query: lambda {
-             query.where("email LIKE ? OR handle LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%")
+             search_term = "%#{params[:q]}%"
+             query.where("email LIKE ? OR handle LIKE ? OR blocked_email LIKE ?", search_term, search_term, search_term)
            }
   }
 

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -5,7 +5,7 @@ class Avo::Resources::User < Avo::BaseResource
   self.includes = []
   self.search = {
     query: lambda {
-             search_term = "%#{params[:q]}%"
+             search_term = "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%"
              query.where("email LIKE ? OR handle LIKE ? OR blocked_email LIKE ?", search_term, search_term, search_term)
            }
   }

--- a/db/migrate/20260817080442_add_user_email_search_trigram_index.rb
+++ b/db/migrate/20260817080442_add_user_email_search_trigram_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddUserEmailSearchTrigramIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :users, :email,
+      using: :gin,
+      opclass: :gin_trgm_ops,
+      name: :index_users_on_email_trigram,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, name: :index_users_on_email_trigram, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260817080443_add_user_handle_search_trigram_index.rb
+++ b/db/migrate/20260817080443_add_user_handle_search_trigram_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddUserHandleSearchTrigramIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :users, :handle,
+      using: :gin,
+      opclass: :gin_trgm_ops,
+      name: :index_users_on_handle_trigram,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, name: :index_users_on_handle_trigram, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260817080444_add_user_blocked_email_search_trigram_index.rb
+++ b/db/migrate/20260817080444_add_user_blocked_email_search_trigram_index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddUserBlockedEmailSearchTrigramIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :users, :blocked_email,
+      using: :gin,
+      opclass: :gin_trgm_ops,
+      where: "blocked_email IS NOT NULL",
+      name: :index_users_on_blocked_email_trigram,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, name: :index_users_on_blocked_email_trigram, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_043732) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_080444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -683,8 +683,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_043732) do
     t.datetime "updated_at", precision: nil
     t.string "webauthn_id"
     t.index "lower((email)::text) varchar_pattern_ops", name: "index_users_on_lower_email"
+    t.index ["blocked_email"], name: "index_users_on_blocked_email_trigram", opclass: :gin_trgm_ops, where: "(blocked_email IS NOT NULL)", using: :gin
     t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "index_users_on_email_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["handle"], name: "index_users_on_handle"
+    t.index ["handle"], name: "index_users_on_handle_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"
     t.index ["id", "token"], name: "index_users_on_id_and_token"
     t.index ["id"], name: "index_users_on_policies_not_acknowledged", where: "(policies_acknowledged_at IS NULL)"

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -25,10 +25,10 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
 
   test "searching users by blocked email" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
-    blocked_user = create(:user, :blocked, blocked_email: "blocked-user@example.com")
-    create(:user)
+    blocked_user = create(:user, :blocked, blocked_email: "blocked_user@rubygems-test.org")
+    create(:user, email: "blockedXuser@rubygems-test.org")
 
-    get avo.avo_api_path(resource_name: "users"), params: { q: "user@example" }
+    get avo.avo_api_path(resource_name: "users"), params: { q: "blocked_user@rubygems-test" }
 
     assert_response :success
     assert_equal [blocked_user.to_param], response.parsed_body.dig("users", "results").pluck("_id")

--- a/test/integration/avo/users_test.rb
+++ b/test/integration/avo/users_test.rb
@@ -23,6 +23,17 @@ class Avo::UsersTest < ActionDispatch::IntegrationTest
     assert page.has_content? user.created_at.utc.iso8601
   end
 
+  test "searching users by blocked email" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+    blocked_user = create(:user, :blocked, blocked_email: "blocked-user@example.com")
+    create(:user)
+
+    get avo.avo_api_path(resource_name: "users"), params: { q: "user@example" }
+
+    assert_response :success
+    assert_equal [blocked_user.to_param], response.parsed_body.dig("users", "results").pluck("_id")
+  end
+
   test "showing the delete action to rubygems.org operators on the user page" do
     admin_sign_in_as create(:admin_github_user, :is_admin)
     user = create(:user)


### PR DESCRIPTION
## Summary
- include `blocked_email` in Avo user search
- add concurrent GIN trigram indexes for all three substring-search fields
- keep the sparse blocked-email index partial and split index builds into retry-safe migrations
- cover blocked-email substring lookup through Avo's search endpoint

## Verification
- `RAILS_ENV=test bin/rails test test/integration/avo/users_test.rb` (10 runs, 25 assertions, 0 failures, 1 skip)
- `bin/rubocop app/avo/resources/user.rb test/integration/avo/users_test.rb db/migrate/20260817080442_add_user_email_search_trigram_index.rb db/migrate/20260817080443_add_user_handle_search_trigram_index.rb db/migrate/20260817080444_add_user_blocked_email_search_trigram_index.rb` (5 files, no offenses)
- all three migrations passed Strong Migrations 2.8.0 in both directions and produced ready, valid PostgreSQL indexes