### PR TITLE
Organizations can reserve gems 

### DIFF
--- a/app/avo/resources/gem_name_reservation.rb
+++ b/app/avo/resources/gem_name_reservation.rb
@@ -12,6 +12,7 @@ class Avo::Resources::GemNameReservation < Avo::BaseResource
   def fields
     field :id, as: :id
     field :name, as: :text
+    field :organization, as: :belongs_to
     field :audits, as: :has_many
   end
 end

--- a/app/avo/resources/organization.rb
+++ b/app/avo/resources/organization.rb
@@ -31,6 +31,7 @@ class Avo::Resources::Organization < Avo::BaseResource
       field :unconfirmed_memberships, as: :has_many
       field :users, as: :has_many
       field :rubygems, as: :has_many
+      field :gem_name_reservations, as: :has_many
       field :organization_onboarding, as: :belongs_to
     end
   end

--- a/app/controllers/organizations/gem_name_reservations_controller.rb
+++ b/app/controllers/organizations/gem_name_reservations_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Organizations::GemNameReservationsController < Organizations::BaseController
+  PER_PAGE = 50
+
+  before_action :set_page, only: :index
+
+  rescue_from Pundit::NotAuthorizedError, with: :render_not_found
+
+  def index
+    authorize @organization, :list_gem_name_reservations?
+
+    reservations = @organization.gem_name_reservations.order(:name)
+    @gem_name_reservations_count = reservations.count
+    @gem_name_reservations = reservations.page(@page).per(PER_PAGE)
+  end
+
+  def new
+    @gem_name_reservation = @organization.gem_name_reservations.build
+    authorize @gem_name_reservation, :new?
+  end
+
+  def create
+    @gem_name_reservation = @organization.gem_name_reservations.build(gem_name_reservation_params)
+    authorize @gem_name_reservation, :create?
+
+    if @gem_name_reservation.save
+      redirect_to organization_gem_name_reservations_path(@organization), notice: t(".gem_name_reserved")
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @gem_name_reservation = @organization.gem_name_reservations.find(params.expect(:id))
+    authorize @gem_name_reservation, :destroy?
+
+    @gem_name_reservation.destroy!
+
+    redirect_to organization_gem_name_reservations_path(@organization), notice: t(".gem_name_reservation_removed")
+  end
+
+  private
+
+  def find_organization
+    @organization = Organization.find_by_handle!(params[:organization_id])
+  end
+
+  def gem_name_reservation_params
+    params.expect(gem_name_reservation: [:name])
+  end
+end

--- a/app/controllers/organizations/gem_name_reservations_controller.rb
+++ b/app/controllers/organizations/gem_name_reservations_controller.rb
@@ -42,10 +42,6 @@ class Organizations::GemNameReservationsController < Organizations::BaseControll
 
   private
 
-  def find_organization
-    @organization = Organization.find_by_handle!(params[:organization_id])
-  end
-
   def gem_name_reservation_params
     params.expect(gem_name_reservation: [:name])
   end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -3,6 +3,7 @@
 class FeatureFlag
   ORGANIZATIONS = :organizations
   CONTENT_ADDRESSABLE_GEM_PUSHES = :content_addressable_gem_pushes
+  UNLIMITED_GEM_NAME_RESERVATIONS = :unlimited_gem_name_reservations
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/gem_name_reservation.rb
+++ b/app/models/gem_name_reservation.rb
@@ -3,7 +3,10 @@
 class GemNameReservation < ApplicationRecord
   ORGANIZATION_LIMIT = 25
 
-  validates :name, uniqueness: { case_sensitive: false }, presence: true, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validates :name,
+    uniqueness: { case_sensitive: false },
+    presence: true,
+    length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
   validate :downcase_name_check
   validate :rubygem_name_available, if: :needs_name_validation?
   validate :organization_within_limit, if: :needs_limit_validation?
@@ -18,8 +21,10 @@ class GemNameReservation < ApplicationRecord
 
   private
 
+  # NOTE: For the Admin purposes we don't need this validation. We want admin
+  # to be able to reserve a gem and have it stop any users from pushing the gem
   def needs_name_validation?
-    new_record? || name_changed?
+    organization.present? && (new_record? || name_changed?)
   end
 
   def needs_limit_validation?

--- a/app/models/gem_name_reservation.rb
+++ b/app/models/gem_name_reservation.rb
@@ -3,6 +3,7 @@
 class GemNameReservation < ApplicationRecord
   validates :name, uniqueness: { case_sensitive: false }, presence: true, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
   validate :downcase_name_check
+  validate :rubygem_name_available, if: :needs_name_validation?
 
   has_many :audits, as: :auditable, inverse_of: :auditable, dependent: :nullify
 
@@ -11,6 +12,15 @@ class GemNameReservation < ApplicationRecord
   end
 
   private
+
+  def needs_name_validation?
+    new_record? || name_changed?
+  end
+
+  def rubygem_name_available
+    return unless Rubygem.where("lower(name) = ?", name&.downcase).any?
+    errors.add(:name, "rubygem exists with name")
+  end
 
   def downcase_name_check
     return unless name.to_s != name.to_s.downcase

--- a/app/models/gem_name_reservation.rb
+++ b/app/models/gem_name_reservation.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class GemNameReservation < ApplicationRecord
+  ORGANIZATION_LIMIT = 25
+
   validates :name, uniqueness: { case_sensitive: false }, presence: true, length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
   validate :downcase_name_check
   validate :rubygem_name_available, if: :needs_name_validation?
+  validate :organization_within_limit, if: :needs_limit_validation?
 
   has_many :audits, as: :auditable, inverse_of: :auditable, dependent: :nullify
 
@@ -17,6 +20,17 @@ class GemNameReservation < ApplicationRecord
 
   def needs_name_validation?
     new_record? || name_changed?
+  end
+
+  def needs_limit_validation?
+    organization.present? && (new_record? || organization_id_changed?)
+  end
+
+  def organization_within_limit
+    return if organization.gem_name_reservations_unlimited?
+    return if organization.gem_name_reservations.count < ORGANIZATION_LIMIT
+
+    errors.add(:base, :organization_limit_reached, count: ORGANIZATION_LIMIT)
   end
 
   def rubygem_name_available

--- a/app/models/gem_name_reservation.rb
+++ b/app/models/gem_name_reservation.rb
@@ -7,6 +7,8 @@ class GemNameReservation < ApplicationRecord
 
   has_many :audits, as: :auditable, inverse_of: :auditable, dependent: :nullify
 
+  belongs_to :organization, optional: true
+
   def self.reserved?(name)
     where(name: name.downcase).any?
   end

--- a/app/models/gem_name_reservation.rb
+++ b/app/models/gem_name_reservation.rb
@@ -7,6 +7,8 @@ class GemNameReservation < ApplicationRecord
     uniqueness: { case_sensitive: false },
     presence: true,
     length: { maximum: Gemcutter::MAX_FIELD_LENGTH }
+  validates :name, name_format: true, if: :needs_name_validation?
+
   validate :downcase_name_check
   validate :rubygem_name_available, if: :needs_name_validation?
   validate :organization_within_limit, if: :needs_limit_validation?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -54,6 +54,20 @@ class Organization < ApplicationRecord
     "org:#{handle}"
   end
 
+  def gem_name_reservations_unlimited?
+    FeatureFlag.enabled?(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, self)
+  end
+
+  def gem_name_reservation_limit
+    GemNameReservation::ORGANIZATION_LIMIT unless gem_name_reservations_unlimited?
+  end
+
+  def gem_name_reservations_remaining
+    return if gem_name_reservations_unlimited?
+
+    [GemNameReservation::ORGANIZATION_LIMIT - gem_name_reservations.count, 0].max
+  end
+
   private
 
   def handle_not_reserved

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,6 +16,7 @@ class Organization < ApplicationRecord
   has_many :memberships_including_unconfirmed, class_name: "Membership", dependent: :destroy, inverse_of: :organization
   has_many :users, through: :memberships
   has_many :rubygems, dependent: :nullify
+  has_many :gem_name_reservations, dependent: :destroy
   has_many :audits, as: :auditable, dependent: :nullify
   has_one :organization_onboarding, foreign_key: :onboarded_organization_id, inverse_of: :organization, dependent: :destroy
 

--- a/app/models/organization/handle.rb
+++ b/app/models/organization/handle.rb
@@ -333,16 +333,15 @@ class Organization::Handle
   ].freeze
 
   RESERVED = [
-    *FUTURE_ROUTES,
-    *HELD_FOR_CLAIM
-    *INFRASTRUCTURE,
-    *REGISTRY_IDENTITY,
-    *RESERVED_WORDS,
     *RESTFUL_ACTIONS,
     *ROUTES,
-    *RUBY_CORE,
     *STATIC_PATHS,
-    *TRUST_AND_SAFETY
+    *FUTURE_ROUTES,
+    *REGISTRY_IDENTITY,
+    *RUBY_CORE,
+    *TRUST_AND_SAFETY,
+    *INFRASTRUCTURE,
+    *RESERVED_WORDS
   ].freeze
 
   # Indexed on the normalized form so lookups stay O(1) and every separator

--- a/app/models/organization/handle.rb
+++ b/app/models/organization/handle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Organization::Handle # rubocop:disable Metrics/ClassLength
+class Organization::Handle
   # Handles are compared without separators
   # ex "rubygems" reserves "ruby-gems" and "ruby_gems"
   def self.normalize(handle)
@@ -334,6 +334,7 @@ class Organization::Handle # rubocop:disable Metrics/ClassLength
 
   RESERVED = [
     *FUTURE_ROUTES,
+    *HELD_FOR_CLAIM
     *INFRASTRUCTURE,
     *REGISTRY_IDENTITY,
     *RESERVED_WORDS,

--- a/app/models/organization/handle.rb
+++ b/app/models/organization/handle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Organization::Handle
+class Organization::Handle # rubocop:disable Metrics/ClassLength
   # Handles are compared without separators
   # ex "rubygems" reserves "ruby-gems" and "ruby_gems"
   def self.normalize(handle)
@@ -333,15 +333,15 @@ class Organization::Handle
   ].freeze
 
   RESERVED = [
+    *FUTURE_ROUTES,
+    *INFRASTRUCTURE,
+    *REGISTRY_IDENTITY,
+    *RESERVED_WORDS,
     *RESTFUL_ACTIONS,
     *ROUTES,
-    *STATIC_PATHS,
-    *FUTURE_ROUTES,
-    *REGISTRY_IDENTITY,
     *RUBY_CORE,
-    *TRUST_AND_SAFETY,
-    *INFRASTRUCTURE,
-    *RESERVED_WORDS
+    *STATIC_PATHS,
+    *TRUST_AND_SAFETY
   ].freeze
 
   # Indexed on the normalized form so lookups stay O(1) and every separator

--- a/app/models/organization_onboarding.rb
+++ b/app/models/organization_onboarding.rb
@@ -13,7 +13,7 @@ class OrganizationOnboarding < ApplicationRecord
   validates :organization_handle, presence: true,
     uniqueness: { case_sensitive: false },
     length: { within: 2..40 },
-    format: { with: Patterns::HANDLE_PATTERN }
+    format: { with: Patterns::ORGANIZATION_HANDLE_PATTERN }
 
   validates :organization_name, presence: true, length: { within: 2..255 }
 

--- a/app/policies/gem_name_reservation_policy.rb
+++ b/app/policies/gem_name_reservation_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class GemNameReservationPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+  end
+
+  alias gem_name_reservation record
+  delegate :organization, to: :gem_name_reservation
+
+  def create?
+    organization_member_with_role?(user, :admin) || deny(t(:forbidden))
+  end
+
+  alias new? create?
+
+  def destroy?
+    organization_member_with_role?(user, :admin) || deny(t(:forbidden))
+  end
+end

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -42,6 +42,14 @@ class OrganizationPolicy < ApplicationPolicy
     organization_member_with_role?(user, :admin) || deny(t(:forbidden))
   end
 
+  def list_gem_name_reservations?
+    organization_member_with_role?(user, :maintainer) || deny(t(:forbidden))
+  end
+
+  def manage_gem_name_reservations?
+    organization_member_with_role?(user, :admin) || deny(t(:forbidden))
+  end
+
   def destroy?
     false # For now organizations cannot be deleted
   end

--- a/app/views/organizations/_subject.html.erb
+++ b/app/views/organizations/_subject.html.erb
@@ -19,6 +19,9 @@
   <%= nav.link t("organizations.show.history"), organization_path(@organization), name: :subscriptions, icon: "notifications" %>
   <%= nav.link t("organizations.show.gems"), organization_gems_path(@organization), name: :gems, icon: "gems" %>
   <%= nav.link t("organizations.show.members"), organization_memberships_path(@organization), name: :members, icon: "organizations" %>
+  <% if policy(@organization).list_gem_name_reservations? %>
+    <%= nav.link t("organizations.show.reservations"), organization_gem_name_reservations_path(@organization), name: :gem_name_reservations, icon: "description" %>
+  <% end %>
   <% if policy(@organization).edit? %>
     <%= nav.link t("layouts.application.header.settings"), edit_organization_path(@organization), name: :settings, icon: "settings" %>
   <% end %>

--- a/app/views/organizations/gem_name_reservations/index.html.erb
+++ b/app/views/organizations/gem_name_reservations/index.html.erb
@@ -1,0 +1,54 @@
+<%
+  add_breadcrumb "Dashboard", dashboard_path
+  add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(@organization)
+  add_breadcrumb t("breadcrumbs.reservations"), organization_gem_name_reservations_path(@organization)
+%>
+
+<% content_for :subject do %>
+  <%= render "organizations/subject", organization: @organization, current: :gem_name_reservations %>
+<% end %>
+
+<h1 class="text-h2 mb-10"><%= t("organizations.show.reservations") %></h1>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title t("organizations.show.reservations"), icon: "description", count: @gem_name_reservations_count %>
+    <% if policy(@organization).manage_gem_name_reservations? %>
+      <%= render ButtonComponent.new t(".reserve"), new_organization_gem_name_reservation_path(@organization), type: :link, size: :small, data: { testid: "reserve-gem-name" } %>
+    <% end %>
+  <% end %>
+
+  <p class="text-b3 text-neutral-600 dark:text-neutral-400 mb-6"><%= t(".description") %></p>
+
+  <% if @gem_name_reservations.empty? %>
+    <%= prose do %>
+      <i><%= t(".no_reservations") %></i>
+    <% end %>
+  <% else %>
+    <%= c.divided_list do %>
+      <% @gem_name_reservations.each do |gem_name_reservation| %>
+        <%= c.list_item(data: { testid: "gem-name-reservation" }) do %>
+          <div class="flex flex-row w-full items-center justify-between">
+            <p class="text-neutral-800 dark:text-white"><%= gem_name_reservation.name %></p>
+            <% if policy(gem_name_reservation).destroy? %>
+              <%= render ButtonComponent.new(
+                t(".remove"),
+                organization_gem_name_reservation_path(@organization, gem_name_reservation),
+                method: :delete,
+                style: :plain,
+                color: :red,
+                size: :small,
+                data: {
+                  testid: "remove-gem-name-reservation",
+                  turbo_confirm: t(".confirm_remove", name: gem_name_reservation.name)
+                }
+              ) %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <div class="mt-6"><%= paginate @gem_name_reservations, theme: "hammy" %></div>
+  <% end %>
+<% end %>

--- a/app/views/organizations/gem_name_reservations/new.html.erb
+++ b/app/views/organizations/gem_name_reservations/new.html.erb
@@ -38,6 +38,19 @@
         </div>
       </div>
     <% end %>
+    <div class="mb-4 text-b3 text-neutral-600 dark:text-neutral-400 space-y-2" data-testid="gem-name-reservation-limit">
+      <p>
+        <% if @organization.gem_name_reservations_unlimited? %>
+          <%= t(".unlimited") %>
+        <% elsif @organization.gem_name_reservations_remaining.zero? %>
+          <%= t(".limit_reached_html", limit: @organization.gem_name_reservation_limit, support_email: mail_to("support@rubygems.org", class: "text-orange-600 underline hover:text-orange-800")) %>
+        <% else %>
+          <%= t(".limit_html", limit: @organization.gem_name_reservation_limit, remaining: @organization.gem_name_reservations_remaining, support_email: mail_to("support@rubygems.org", class: "text-orange-600 underline hover:text-orange-800")) %>
+        <% end %>
+      </p>
+      <p data-testid="gem-name-reservation-disclaimer"><%= t(".disclaimer") %></p>
+    </div>
+
     <div class="mb-4">
       <%= f.label :name, t(".name"), class: 'block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2' %>
       <%= f.text_field :name, class: "block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:focus:border-indigo-400", placeholder: "my-gem-name", data: { testid: "gem-name-reservation-name" } %>

--- a/app/views/organizations/gem_name_reservations/new.html.erb
+++ b/app/views/organizations/gem_name_reservations/new.html.erb
@@ -1,0 +1,50 @@
+<%
+  add_breadcrumb "Dashboard", dashboard_path
+  add_breadcrumb t("breadcrumbs.org_name", name: @organization.handle), organization_path(@organization)
+  add_breadcrumb t("breadcrumbs.reservations"), organization_gem_name_reservations_path(@organization)
+  add_breadcrumb t("breadcrumbs.reserve_gem_name")
+%>
+
+<% content_for :subject do %>
+  <%= render "organizations/subject", organization: @organization, current: :gem_name_reservations %>
+<% end %>
+
+<h1 class="text-h2 mb-10"><%= t("organizations.show.reservations") %></h1>
+
+<%= render CardComponent.new do |c| %>
+  <%= c.head do %>
+    <%= c.title t(".title"), icon: "description" %>
+  <% end %>
+
+  <%= form_with(model: @gem_name_reservation, url: organization_gem_name_reservations_path(@organization), method: :post) do |f| %>
+    <% if @gem_name_reservation.errors.any? %>
+      <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <%= icon_tag("error", size: 5, class: "text-red-400") %>
+          </div>
+          <div class="ml-3">
+            <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
+              <%= pluralize(@gem_name_reservation.errors.count, "error") %> prohibited this reservation from being saved:
+            </h3>
+            <div class="mt-2 text-sm text-red-700 dark:text-red-300">
+              <ul class="list-disc pl-5 space-y-1">
+                <% @gem_name_reservation.errors.full_messages.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <div class="mb-4">
+      <%= f.label :name, t(".name"), class: 'block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2' %>
+      <%= f.text_field :name, class: "block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:focus:border-indigo-400", placeholder: "my-gem-name", data: { testid: "gem-name-reservation-name" } %>
+      <p class="mt-2 text-b3 text-neutral-600 dark:text-neutral-400"><%= t(".name_hint") %></p>
+    </div>
+    <div class="flex justify-end">
+      <%= render ButtonComponent.new t(".reserve"), type: :submit, style: :outline, class: "px-4 py-2 dark:border-gray-400 dark:text-gray-100" %>
+    </div>
+  <% end %>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -353,6 +353,8 @@ de:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: Bitte bestätigen Sie Ihre E-Mail-Adresse mit dem Link, der
       an Ihre E-Mail gesendet wurde.
@@ -519,6 +521,7 @@ de:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -544,6 +547,22 @@ de:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -120,6 +120,10 @@ de:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -563,6 +567,10 @@ de:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,10 @@ en:
           attributes:
             expires_at:
               inclusion: "must be in the future"
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached: "Your organization has reached its limit of %{count} reserved gem names."
         organization:
           attributes:
             handle:
@@ -519,6 +523,10 @@ en:
         name: Gem name
         name_hint: Lowercase letters, numbers, dashes and underscores only. The name must not already be taken by an existing gem.
         reserve: Reserve
+        limit_html: Your organization can reserve up to <b>%{limit}</b> gem names and has <b>%{remaining}</b> left. Email %{support_email} if you need more.
+        limit_reached_html: Your organization has used all <b>%{limit}</b> of its gem name reservations. Email %{support_email} if you need more.
+        unlimited: Your organization can reserve an unlimited number of gem names.
+        disclaimer: The RubyGems.org team reserves the right to deny any requested name reservation.
     invitations:
       show:
         accept: Accept

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,8 @@ en:
     gems: Gems
     members: Members
     invite_member: Invite Member
+    reservations: Reserved Names
+    reserve_gem_name: Reserve a Name
   mailer:
     confirm_your_email: Please confirm your email address with the link sent to your email.
     confirmation_subject: Please confirm your email address with %{host}
@@ -475,6 +477,7 @@ en:
       add_member: Invite Member
       invite: Invite
       transfer: Transfer
+      reservations: Reserved Names
     members:
       create:
         user_already_invited: User already invited to the organization.
@@ -500,6 +503,22 @@ en:
         role: Role
         create: Create
         invite: Invite
+    gem_name_reservations:
+      create:
+        gem_name_reserved: Gem name reserved.
+      destroy:
+        gem_name_reservation_removed: Gem name reservation removed.
+      index:
+        description: Reserved names cannot be pushed by anyone else. Reserve a name to hold it for your organization.
+        no_reservations: No reserved names yet
+        reserve: Reserve a Name
+        remove: Remove
+        confirm_remove: Are you sure you want to remove the reservation for %{name}?
+      new:
+        title: Reserve a Name
+        name: Gem name
+        name_hint: Lowercase letters, numbers, dashes and underscores only. The name must not already be taken by an existing gem.
+        reserve: Reserve
     invitations:
       show:
         accept: Accept

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,7 +513,7 @@ en:
       destroy:
         gem_name_reservation_removed: Gem name reservation removed.
       index:
-        description: Reserved names cannot be pushed by anyone else. Reserve a name to hold it for your organization.
+        description: Reserved names cannot be pushed by anyone. Reserve a name to hold it for your organization. Remove the reservation to be able to push a gem with this name.
         no_reservations: No reserved names yet
         reserve: Reserve a Name
         remove: Remove

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -350,6 +350,8 @@ es:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: Por favor confirma tu dirección de correo con el enlace enviado.
     confirmation_subject: Por favor confirma tu dirección de correo con %{host}
@@ -512,6 +514,7 @@ es:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -537,6 +540,22 @@ es:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -116,6 +116,10 @@ es:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -556,6 +560,10 @@ es:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -113,6 +113,10 @@ fr:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -524,6 +528,10 @@ fr:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -341,6 +341,8 @@ fr:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: Veuillez confirmer votre adresse email avec le lien qui vous
       a été envoyé par email.
@@ -480,6 +482,7 @@ fr:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -505,6 +508,22 @@ fr:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,6 +109,10 @@ ja:
           attributes:
             expires_at:
               inclusion: 未来でなければなりません
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -522,6 +526,10 @@ ja:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept: 承認

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -334,6 +334,8 @@ ja:
     gems: gem
     members: メンバー
     invite_member: メンバーを招待
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: Eメールに送信されたリンクからEメールアドレスを確認してください。
     confirmation_subject: "%{host}に登録されたメールアドレスを確認してください"
@@ -478,6 +480,7 @@ ja:
       add_member: メンバーを招待
       invite: 招待
       transfer: 移動
+      reservations:
     members:
       create:
         user_already_invited: ユーザーは既に組織に招待されています。
@@ -503,6 +506,22 @@ ja:
         role: ロール
         create: 作成
         invite: 招待
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept: 承認

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -335,6 +335,8 @@ nl:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email:
     confirmation_subject:
@@ -467,6 +469,7 @@ nl:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -492,6 +495,22 @@ nl:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -108,6 +108,10 @@ nl:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -511,6 +515,10 @@ nl:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -114,6 +114,10 @@ pt-BR:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -523,6 +527,10 @@ pt-BR:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -340,6 +340,8 @@ pt-BR:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: Por favor, confirme seu endereço de email através do link
       que enviamos para o seu endereço de email.
@@ -479,6 +481,7 @@ pt-BR:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -504,6 +507,22 @@ pt-BR:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -333,6 +333,8 @@ zh-CN:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: 请在发送到您的邮件中点击链接，确认您的邮箱地址。
     confirmation_subject: 请确认您的邮箱地址
@@ -481,6 +483,7 @@ zh-CN:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -506,6 +509,22 @@ zh-CN:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -109,6 +109,10 @@ zh-CN:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -525,6 +529,10 @@ zh-CN:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -332,6 +332,8 @@ zh-TW:
     gems:
     members:
     invite_member:
+    reservations:
+    reserve_gem_name:
   mailer:
     confirm_your_email: 已寄送連結，請點擊連結來確認您的電子郵件地址。
     confirmation_subject: "%{host} 電子郵件地址確認"
@@ -472,6 +474,7 @@ zh-TW:
       add_member:
       invite:
       transfer:
+      reservations:
     members:
       create:
         user_already_invited:
@@ -497,6 +500,22 @@ zh-TW:
         role:
         create:
         invite:
+    gem_name_reservations:
+      create:
+        gem_name_reserved:
+      destroy:
+        gem_name_reservation_removed:
+      index:
+        description:
+        no_reservations:
+        reserve:
+        remove:
+        confirm_remove:
+      new:
+        title:
+        name:
+        name_hint:
+        reserve:
     invitations:
       show:
         accept:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -108,6 +108,10 @@ zh-TW:
           attributes:
             expires_at:
               inclusion:
+        gem_name_reservation:
+          attributes:
+            base:
+              organization_limit_reached:
         organization:
           attributes:
             handle:
@@ -516,6 +520,10 @@ zh-TW:
         name:
         name_hint:
         reserve:
+        limit_html:
+        limit_reached_html:
+        unlimited:
+        disclaimer:
     invitations:
       show:
         accept:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,6 +310,8 @@ Rails.application.routes.draw do
       end
       resource :invitation, only: %i[show update], constraints: { id: Patterns::ROUTE_PATTERN }, controller: "organizations/invitations"
       resources :gems, only: :index, controller: 'organizations/gems'
+      resources :gem_name_reservations, only: %i[index new create destroy], path: 'reservations',
+        controller: 'organizations/gem_name_reservations'
     end
   end
 

--- a/db/migrate/20260817145939_add_organizations_to_gem_name_reservation.rb
+++ b/db/migrate/20260817145939_add_organizations_to_gem_name_reservation.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddOrganizationsToGemNameReservation < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference(:gem_name_reservations,
+                  :organization,
+                  null: true,
+                  index: { algorithm: :concurrently })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -253,8 +253,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
   create_table "gem_name_reservations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
+    t.bigint "organization_id"
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_gem_name_reservations_on_name", unique: true
+    t.index ["organization_id"], name: "index_gem_name_reservations_on_organization_id"
   end
 
   create_table "gem_typo_exceptions", force: :cascade do |t|

--- a/test/factories/gem_name_reservations.rb
+++ b/test/factories/gem_name_reservations.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :gem_name_reservation do
-    name { "rail-ties" }
+    sequence(:name) { |n| "rail-ties-#{n}" }
   end
 end

--- a/test/functional/organizations/gem_name_reservations_controller_test.rb
+++ b/test/functional/organizations/gem_name_reservations_controller_test.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Organizations::GemNameReservationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @organization = create(:organization)
+    @user = create(:user)
+    @membership = create(:membership, organization: @organization, user: @user, role: :admin)
+
+    post session_path(session: { who: @user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+  end
+
+  test "GET /organizations/:organization_handle/reservations" do
+    create(:gem_name_reservation, organization: @organization, name: "zeta-gem")
+    create(:gem_name_reservation, organization: @organization, name: "alpha-gem")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_select "h1", text: "Reserved Names"
+    assert_equal %w[alpha-gem zeta-gem], css_select("[data-testid=gem-name-reservation] p").map(&:text)
+  end
+
+  test "GET /organizations/:organization_handle/reservations as an owner" do
+    @membership.update!(role: "owner")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+  end
+
+  test "GET /organizations/:organization_handle/reservations as a maintainer" do
+    @membership.update!(role: "maintainer")
+    create(:gem_name_reservation, organization: @organization, name: "alpha-gem")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_equal ["alpha-gem"], css_select("[data-testid=gem-name-reservation] p").map(&:text)
+  end
+
+  test "GET /organizations/:organization_handle/reservations as a maintainer hides the reserve and remove buttons" do
+    @membership.update!(role: "maintainer")
+    create(:gem_name_reservation, organization: @organization, name: "alpha-gem")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_empty css_select("[data-testid=reserve-gem-name]")
+    assert_empty css_select("[data-testid=remove-gem-name-reservation]")
+  end
+
+  test "GET /organizations/:organization_handle/reservations as an admin shows the reserve and remove buttons" do
+    create(:gem_name_reservation, organization: @organization, name: "alpha-gem")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_equal 1, css_select("[data-testid=reserve-gem-name]").size
+    assert_equal 1, css_select("[data-testid=remove-gem-name-reservation]").size
+  end
+
+  test "GET /organizations/:organization_handle/reservations as a guest" do
+    guest = create(:user)
+    post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :not_found
+  end
+
+  test "GET /organizations/:organization_handle/reservations when signed out" do
+    delete sign_out_path
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_redirected_to sign_in_path
+  end
+
+  test "GET /organizations/:organization_handle/reservations for an unknown organization" do
+    get organization_gem_name_reservations_path("not-an-organization")
+
+    assert_response :not_found
+  end
+
+  test "GET /organizations/:organization_handle/reservations with no reservations" do
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert page.has_content? "No reserved names yet"
+  end
+
+  test "GET /organizations/:organization_handle/reservations only lists this organization's reservations" do
+    create(:gem_name_reservation, organization: @organization, name: "ours")
+    create(:gem_name_reservation, organization: create(:organization), name: "theirs")
+    create(:gem_name_reservation, name: "unowned")
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_equal ["ours"], css_select("[data-testid=gem-name-reservation] p").map(&:text)
+  end
+
+  test "GET /organizations/:organization_handle/reservations paginates after 50" do
+    names = Array.new(51) { |i| format("gem-%02d", i) }
+    names.each { |name| create(:gem_name_reservation, organization: @organization, name: name) }
+
+    get organization_gem_name_reservations_path(@organization)
+
+    assert_response :success
+    assert_equal names.first(50), css_select("[data-testid=gem-name-reservation] p").map(&:text)
+
+    get organization_gem_name_reservations_path(@organization, page: 2)
+
+    assert_response :success
+    assert_equal names.last(1), css_select("[data-testid=gem-name-reservation] p").map(&:text)
+  end
+
+  test "GET /organizations/:organization_handle/reservations/new" do
+    get new_organization_gem_name_reservation_path(@organization)
+
+    assert_response :success
+    assert_select "h3", text: "Reserve a Name"
+  end
+
+  test "GET /organizations/:organization_handle/reservations/new as a maintainer" do
+    @membership.update!(role: "maintainer")
+
+    get new_organization_gem_name_reservation_path(@organization)
+
+    assert_response :not_found
+  end
+
+  test "GET /organizations/:organization_handle/reservations/new as a guest" do
+    guest = create(:user)
+    post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    get new_organization_gem_name_reservation_path(@organization)
+
+    assert_response :not_found
+  end
+
+  test "POST /organizations/:organization_handle/reservations" do
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_redirected_to organization_gem_name_reservations_path(@organization)
+    assert_equal "Gem name reserved.", flash[:notice]
+    assert_equal @organization, GemNameReservation.find_by!(name: "sandworm").organization
+  end
+
+  test "POST /organizations/:organization_handle/reservations as an owner" do
+    @membership.update!(role: "owner")
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_redirected_to organization_gem_name_reservations_path(@organization)
+    assert GemNameReservation.reserved?("sandworm")
+  end
+
+  test "POST /organizations/:organization_handle/reservations with an uppercase name" do
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "Sandworm" } }
+
+    assert_response :unprocessable_content
+    assert page.has_content? "Name must be all lowercase"
+    assert_empty @organization.gem_name_reservations
+  end
+
+  test "POST /organizations/:organization_handle/reservations for an existing gem" do
+    create(:rubygem, name: "sandworm")
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_response :unprocessable_content
+    assert page.has_content? "Name rubygem exists with name"
+    assert_empty @organization.gem_name_reservations
+  end
+
+  test "POST /organizations/:organization_handle/reservations for an already reserved name" do
+    create(:gem_name_reservation, organization: create(:organization), name: "sandworm")
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_response :unprocessable_content
+    assert_empty @organization.gem_name_reservations
+  end
+
+  test "POST /organizations/:organization_handle/reservations as a maintainer" do
+    @membership.update!(role: "maintainer")
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_response :not_found
+    refute GemNameReservation.reserved?("sandworm")
+  end
+
+  test "POST /organizations/:organization_handle/reservations as a guest" do
+    guest = create(:user)
+    post session_path(session: { who: guest.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_response :not_found
+    refute GemNameReservation.reserved?("sandworm")
+  end
+
+  test "DELETE /organizations/:organization_handle/reservations/:id" do
+    reservation = create(:gem_name_reservation, organization: @organization, name: "sandworm")
+
+    delete organization_gem_name_reservation_path(@organization, reservation)
+
+    assert_redirected_to organization_gem_name_reservations_path(@organization)
+    assert_equal "Gem name reservation removed.", flash[:notice]
+    refute GemNameReservation.reserved?("sandworm")
+  end
+
+  test "DELETE /organizations/:organization_handle/reservations/:id as a maintainer" do
+    @membership.update!(role: "maintainer")
+    reservation = create(:gem_name_reservation, organization: @organization, name: "sandworm")
+
+    delete organization_gem_name_reservation_path(@organization, reservation)
+
+    assert_response :not_found
+    assert GemNameReservation.reserved?("sandworm")
+  end
+
+  test "DELETE /organizations/:organization_handle/reservations/:id belonging to another organization" do
+    reservation = create(:gem_name_reservation, organization: create(:organization), name: "sandworm")
+
+    delete organization_gem_name_reservation_path(@organization, reservation)
+
+    assert_response :not_found
+    assert GemNameReservation.reserved?("sandworm")
+  end
+
+  test "DELETE /organizations/:organization_handle/reservations/:id not owned by any organization" do
+    reservation = create(:gem_name_reservation, name: "sandworm")
+
+    delete organization_gem_name_reservation_path(@organization, reservation)
+
+    assert_response :not_found
+    assert GemNameReservation.reserved?("sandworm")
+  end
+end

--- a/test/functional/organizations/gem_name_reservations_controller_test.rb
+++ b/test/functional/organizations/gem_name_reservations_controller_test.rb
@@ -104,7 +104,9 @@ class Organizations::GemNameReservationsControllerTest < ActionDispatch::Integra
 
   test "GET /organizations/:organization_handle/reservations paginates after 50" do
     names = Array.new(51) { |i| format("gem-%02d", i) }
-    names.each { |name| create(:gem_name_reservation, organization: @organization, name: name) }
+    with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: @organization) do
+      names.each { |name| create(:gem_name_reservation, organization: @organization, name: name) }
+    end
 
     get organization_gem_name_reservations_path(@organization)
 
@@ -183,6 +185,27 @@ class Organizations::GemNameReservationsControllerTest < ActionDispatch::Integra
 
     assert_response :unprocessable_content
     assert_empty @organization.gem_name_reservations
+  end
+
+  test "POST /organizations/:organization_handle/reservations beyond the limit" do
+    create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: @organization)
+
+    post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+
+    assert_response :unprocessable_content
+    assert page.has_content? "Your organization has reached its limit of 25 reserved gem names."
+    refute GemNameReservation.reserved?("sandworm")
+  end
+
+  test "POST /organizations/:organization_handle/reservations beyond the limit with the feature flag enabled" do
+    create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: @organization)
+
+    with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: @organization) do
+      post organization_gem_name_reservations_path(@organization), params: { gem_name_reservation: { name: "sandworm" } }
+    end
+
+    assert_redirected_to organization_gem_name_reservations_path(@organization)
+    assert GemNameReservation.reserved?("sandworm")
   end
 
   test "POST /organizations/:organization_handle/reservations as a maintainer" do

--- a/test/models/gem_name_reservation_test.rb
+++ b/test/models/gem_name_reservation_test.rb
@@ -16,6 +16,14 @@ class GemNameReservationTest < ActiveSupport::TestCase
     should allow_value("abc").for(:name)
     should validate_uniqueness_of(:name).case_insensitive
     should validate_length_of(:name).is_at_most(Gemcutter::MAX_FIELD_LENGTH)
+
+    should "not save when there's an existing rubygem with the same name" do
+      create(:rubygem, name: "bounce-haus")
+
+      reservation = build(:gem_name_reservation, name: "bounce-haus")
+
+      refute reservation.save
+    end
   end
 
   context "#reserved?" do

--- a/test/models/gem_name_reservation_test.rb
+++ b/test/models/gem_name_reservation_test.rb
@@ -24,6 +24,14 @@ class GemNameReservationTest < ActiveSupport::TestCase
 
       refute reservation.save
     end
+
+    should "not save when there's an existing rubygem with the case matched name" do
+      create(:rubygem, name: "bounce-haus")
+
+      reservation = build(:gem_name_reservation, name: "BoUnCe-HAaus")
+
+      refute reservation.save
+    end
   end
 
   context "#reserved?" do

--- a/test/models/gem_name_reservation_test.rb
+++ b/test/models/gem_name_reservation_test.rb
@@ -34,6 +34,61 @@ class GemNameReservationTest < ActiveSupport::TestCase
     end
   end
 
+  context "organization reservation limit" do
+    setup do
+      @organization = create(:organization)
+    end
+
+    should "allow reserving up to the limit" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT - 1, organization: @organization)
+
+      assert_predicate build(:gem_name_reservation, organization: @organization), :valid?
+    end
+
+    should "not allow reserving beyond the limit" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: @organization)
+
+      reservation = build(:gem_name_reservation, organization: @organization)
+
+      refute_predicate reservation, :valid?
+      assert_equal ["Your organization has reached its limit of 25 reserved gem names."], reservation.errors.full_messages
+    end
+
+    should "allow reserving beyond the limit when the feature flag is enabled for the organization" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: @organization)
+
+      with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: @organization) do
+        assert_predicate build(:gem_name_reservation, organization: @organization), :valid?
+      end
+    end
+
+    should "not count another organization's reservations toward the limit" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: create(:organization))
+
+      assert_predicate build(:gem_name_reservation, organization: @organization), :valid?
+    end
+
+    should "not limit reservations without an organization" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT)
+
+      assert_predicate build(:gem_name_reservation), :valid?
+    end
+
+    should "not block renaming an existing reservation for an organization at the limit" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT - 1, organization: @organization)
+      reservation = create(:gem_name_reservation, organization: @organization)
+
+      assert reservation.update(name: "some-other-name")
+    end
+
+    should "not allow moving a reservation into an organization at the limit" do
+      create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT, organization: @organization)
+      reservation = create(:gem_name_reservation)
+
+      refute reservation.update(organization: @organization)
+    end
+  end
+
   context "#reserved?" do
     should "recognize reserved gem name" do
       create(:gem_name_reservation, name: "reserved-gem-name")

--- a/test/models/gem_name_reservation_test.rb
+++ b/test/models/gem_name_reservation_test.rb
@@ -17,12 +17,21 @@ class GemNameReservationTest < ActiveSupport::TestCase
     should validate_uniqueness_of(:name).case_insensitive
     should validate_length_of(:name).is_at_most(Gemcutter::MAX_FIELD_LENGTH)
 
-    should "not save when there's an existing rubygem with the same name" do
+    should "for an organization reservation not save when there's an existing rubygem with the same name " do
+      organization = create(:organization)
+      create(:rubygem, name: "bounce-haus")
+
+      reservation = build(:gem_name_reservation, name: "bounce-haus", organization:)
+
+      refute reservation.save
+    end
+
+    should "reservation save when there's an existing rubygem with the same name " do
       create(:rubygem, name: "bounce-haus")
 
       reservation = build(:gem_name_reservation, name: "bounce-haus")
 
-      refute reservation.save
+      assert reservation.save
     end
 
     should "not save when there's an existing rubygem with the case matched name" do

--- a/test/models/organization_onboarding_test.rb
+++ b/test/models/organization_onboarding_test.rb
@@ -103,7 +103,6 @@ class OrganizationOnboardingTest < ActiveSupport::TestCase
     context "organization_handle" do
       should allow_value("CapsLOCK").for(:organization_handle)
       should_not allow_value(nil).for(:organization_handle)
-      should_not allow_value("1abcde").for(:organization_handle)
       should_not allow_value("abc^%def").for(:organization_handle)
       should_not allow_value("abc\n<script>bad").for(:organization_handle)
 

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -173,4 +173,44 @@ class OrganizationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "gem name reservation limits" do
+    setup do
+      @organization = create(:organization)
+    end
+
+    should "report the default limit" do
+      refute_predicate @organization, :gem_name_reservations_unlimited?
+      assert_equal GemNameReservation::ORGANIZATION_LIMIT, @organization.gem_name_reservation_limit
+      assert_equal GemNameReservation::ORGANIZATION_LIMIT, @organization.gem_name_reservations_remaining
+    end
+
+    should "subtract existing reservations from the remaining count" do
+      create_list(:gem_name_reservation, 2, organization: @organization)
+
+      assert_equal GemNameReservation::ORGANIZATION_LIMIT - 2, @organization.gem_name_reservations_remaining
+    end
+
+    should "never report a negative remaining count" do
+      with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: @organization) do
+        create_list(:gem_name_reservation, GemNameReservation::ORGANIZATION_LIMIT + 1, organization: @organization)
+      end
+
+      assert_equal 0, @organization.gem_name_reservations_remaining
+    end
+
+    should "report no limit when the feature flag is enabled for the organization" do
+      with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: @organization) do
+        assert_predicate @organization, :gem_name_reservations_unlimited?
+        assert_nil @organization.gem_name_reservation_limit
+        assert_nil @organization.gem_name_reservations_remaining
+      end
+    end
+
+    should "not report no limit when the feature flag is enabled for another organization" do
+      with_feature(FeatureFlag::UNLIMITED_GEM_NAME_RESERVATIONS, actor: create(:organization)) do
+        refute_predicate @organization, :gem_name_reservations_unlimited?
+      end
+    end
+  end
 end

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -494,30 +494,6 @@ class PusherTest < ActiveSupport::TestCase
         assert @cutter.authorize
       end
 
-      # TODO BRIAN; we are changing this assumption, is that cool?
-      should "be false if gem is pushable but is reserved" do
-        rubygem_name = "geminino"
-        create(:gem_name_reservation, name: rubygem_name)
-        rubygem = create(:rubygem, name: rubygem_name)
-        create(:version, rubygem:, number: "0.1.1", indexed: false)
-
-        refute @cutter.authorize
-        assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message
-        assert_equal 403, @cutter.code
-      end
-
-      # TODO BRIAN this one also
-      should "be false if gem is owned by user but is reserved" do
-        rubygem_name = "geminino"
-        create(:gem_name_reservation, name: rubygem_name)
-        rubygem = create(:rubygem, name: rubygem_name)
-        create(:ownership, rubygem:, user: @user)
-
-        refute @cutter.authorize
-        assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message
-        assert_equal 403, @cutter.code
-      end
-
       context "version metadata has rubygems_mfa_required set" do
         setup do
           spec = mock

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -494,6 +494,24 @@ class PusherTest < ActiveSupport::TestCase
         assert @cutter.authorize
       end
 
+      should "be false if gem is pushable but is reserved" do
+        create(:version, rubygem: @rubygem, number: "0.1.1", indexed: false)
+        create(:gem_name_reservation, name: @rubygem.name.downcase)
+
+        refute @cutter.authorize
+        assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message
+        assert_equal 403, @cutter.code
+      end
+
+      should "be false if gem is owned by user but is reserved" do
+        create(:ownership, rubygem: @rubygem, user: @user)
+        create(:gem_name_reservation, name: @rubygem.name.downcase)
+
+        refute @cutter.authorize
+        assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message
+        assert_equal 403, @cutter.code
+      end
+
       context "version metadata has rubygems_mfa_required set" do
         setup do
           spec = mock

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -494,18 +494,24 @@ class PusherTest < ActiveSupport::TestCase
         assert @cutter.authorize
       end
 
+      # TODO BRIAN; we are changing this assumption, is that cool?
       should "be false if gem is pushable but is reserved" do
-        create(:version, rubygem: @rubygem, number: "0.1.1", indexed: false)
-        create(:gem_name_reservation, name: @rubygem.name.downcase)
+        rubygem_name = "geminino"
+        create(:gem_name_reservation, name: rubygem_name)
+        rubygem = create(:rubygem, name: rubygem_name)
+        create(:version, rubygem:, number: "0.1.1", indexed: false)
 
         refute @cutter.authorize
         assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message
         assert_equal 403, @cutter.code
       end
 
+      # TODO BRIAN this one also
       should "be false if gem is owned by user but is reserved" do
-        create(:ownership, rubygem: @rubygem, user: @user)
-        create(:gem_name_reservation, name: @rubygem.name.downcase)
+        rubygem_name = "geminino"
+        create(:gem_name_reservation, name: rubygem_name)
+        rubygem = create(:rubygem, name: rubygem_name)
+        create(:ownership, rubygem:, user: @user)
 
         refute @cutter.authorize
         assert_equal "This gem name is reserved. You are not allowed to push this gem.", @cutter.message

--- a/test/policies/gem_name_reservation_policy_test.rb
+++ b/test/policies/gem_name_reservation_policy_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+class GemNameReservationPolicyTest < PolicyTestCase
+  setup do
+    @owner = create(:user, handle: "owner")
+    @admin = create(:user, handle: "admin")
+    @maintainer = create(:user, handle: "maintainer")
+    @guest = create(:user)
+    @organization = create(:organization, owners: [@owner], admins: [@admin], maintainers: [@maintainer])
+    @gem_name_reservation = create(:gem_name_reservation, organization: @organization)
+  end
+
+  def policy!(user)
+    Pundit.policy!(user, @gem_name_reservation)
+  end
+
+  context "#new?" do
+    should "be authorized for org admins and owners" do
+      assert_authorized @owner, :new?
+      assert_authorized @admin, :new?
+
+      refute_authorized @maintainer, :new?
+      refute_authorized @guest, :new?
+    end
+  end
+
+  context "#create?" do
+    should "be authorized for org admins and owners" do
+      assert_authorized @owner, :create?
+      assert_authorized @admin, :create?
+
+      refute_authorized @maintainer, :create?
+      refute_authorized @guest, :create?
+    end
+  end
+
+  context "#destroy?" do
+    should "be authorized for org admins and owners" do
+      assert_authorized @owner, :destroy?
+      assert_authorized @admin, :destroy?
+
+      refute_authorized @maintainer, :destroy?
+      refute_authorized @guest, :destroy?
+    end
+  end
+
+  context "with a reservation that has no organization" do
+    setup do
+      @gem_name_reservation = create(:gem_name_reservation, organization: nil)
+    end
+
+    should "not be authorized for anyone" do
+      refute_authorized @owner, :create?
+      refute_authorized @owner, :destroy?
+    end
+  end
+end

--- a/test/policies/organization_policy_test.rb
+++ b/test/policies/organization_policy_test.rb
@@ -90,4 +90,24 @@ class OrganizationPolicyTest < PolicyTestCase
       refute_authorized @guest, :list_memberships?
     end
   end
+
+  context "#list_gem_name_reservations?" do
+    should "only be authorized if the user is a member of the organization" do
+      assert_authorized @owner, :list_gem_name_reservations?
+      assert_authorized @admin, :list_gem_name_reservations?
+      assert_authorized @maintainer, :list_gem_name_reservations?
+
+      refute_authorized @guest, :list_gem_name_reservations?
+    end
+  end
+
+  context "#manage_gem_name_reservations?" do
+    should "only be authorized if the user is an admin or owner" do
+      assert_authorized @owner, :manage_gem_name_reservations?
+      assert_authorized @admin, :manage_gem_name_reservations?
+
+      refute_authorized @maintainer, :manage_gem_name_reservations?
+      refute_authorized @guest, :manage_gem_name_reservations?
+    end
+  end
 end


### PR DESCRIPTION
While we are still in Beta with our organizations approach we don't have gates on how many gem reservations can be made (yet) because we don't have a concept of "tiers" for organizations (yet).  

- Add a UI for Organizations to reserve gem names which haven't already been taken. 
- Add the AVO pages for management 
- Add an optional relationship to gem_name_reservations for organizations 
- Ensure that the Admin reservation will still take over existing gems. Org level ones should not 

<img width="1507" height="1167" alt="image" src="https://github.com/user-attachments/assets/09675340-da92-4cf9-ab30-2854829b188a" />
<img width="1507" height="1167" alt="image" src="https://github.com/user-attachments/assets/35616c6b-4a58-4b6c-b697-5bba6271c05a" />
