### PR TITLE
Make version index cleanup retry-safe

### DIFF
--- a/db/migrate/20260818000003_remove_old_version_unique_indexes.rb
+++ b/db/migrate/20260818000003_remove_old_version_unique_indexes.rb
@@ -6,10 +6,12 @@ class RemoveOldVersionUniqueIndexes < ActiveRecord::Migration[8.1]
   def up
     remove_index :versions,
       name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      if_exists: true,
       algorithm: :concurrently
 
     remove_index :versions,
       name: "index_versions_on_rubygem_id_and_number_and_platform",
+      if_exists: true,
       algorithm: :concurrently
   end
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a0f4cd5f-ac8e-4390-b739-63fc3b126d06","source":"chat","resourceId":"61405d71-c21b-40af-a0cb-dd02b5c17bff","workflowId":"21dcfaf9-d8b6-47a3-b9f6-0695338a7310","codeChangeId":"21dcfaf9-d8b6-47a3-b9f6-0695338a7310","sourceType":"bits_ai_sre"} -->
## Motivation/Summary

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/eab3f015-4cdd-45f7-9492-c9b66ea1019e)

The version-index deployment migration could fail when a legacy index was already absent, leaving retries unsuccessful during a lock-sensitive production migration. This change makes the cleanup safe to rerun.

## Changes
- Make both legacy `versions` index removals idempotent with `if_exists: true` while retaining concurrent DDL.

## Testing/Validation
- Ruby syntax check passed with Ruby 3.4.4.
- `git diff --check` passed.
- RuboCop could not run because Ruby 4.0.6 is not installed in the environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/61405d71-c21b-40af-a0cb-dd02b5c17bff)