### PR TITLE
Add `versions.content_address` and `deletions.ruby_abi` columns

### DIFF
--- a/db/migrate/20260819155803_add_content_address_to_versions.rb
+++ b/db/migrate/20260819155803_add_content_address_to_versions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddContentAddressToVersions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_column :versions, :content_address, :string, if_not_exists: true
+
+    add_index :versions,
+      %i[rubygem_id number content_address],
+      unique: true,
+      where: "content_address IS NOT NULL",
+      name: "index_versions_number_content_address",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :versions,
+      name: "index_versions_number_content_address",
+      algorithm: :concurrently,
+      if_exists: true
+
+    remove_column :versions, :content_address, if_exists: true
+  end
+end

--- a/db/migrate/20260819155903_add_ruby_abi_to_deletions.rb
+++ b/db/migrate/20260819155903_add_ruby_abi_to_deletions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToDeletions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :deletions, :ruby_abi, :string, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_155903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_000002) do
     t.datetime "created_at", precision: nil, null: false
     t.string "number"
     t.string "platform"
+    t.string "ruby_abi"
     t.string "rubygem"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
@@ -702,6 +703,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_000002) do
     t.datetime "built_at", precision: nil
     t.string "canonical_number"
     t.text "cert_chain"
+    t.string "content_address"
     t.datetime "created_at", precision: nil
     t.text "description"
     t.string "full_name"
@@ -744,6 +746,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_000002) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
+    t.index ["rubygem_id", "number", "content_address"], name: "index_versions_number_content_address", unique: true, where: "(content_address IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -101,7 +101,7 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
               "updated_at" => [deletion.updated_at.as_json, nil],
               "version_id" => [version.id, nil]
             },
-            "unchanged" => {}
+            "unchanged" => { "ruby_abi" => nil }
           },
           version_unyank_event.to_gid.to_s => {
             "changes" => version_unyank_event.attributes.transform_values { [nil, it] }.as_json,


### PR DESCRIPTION
## Summary

Adds the remaining **additive** schema changes for content-addressable gem support, complementing the `versions.ruby_abi` column and partial unique indexes already kept on master (via #6784) after the incident revert.

- `versions.content_address` — nullable string; the persisted SHA-256 prefix identifying a skinny variant. `NULL` for fat/source gems.
- `index_versions_number_content_address` — unique partial index on `(rubygem_id, number, content_address) WHERE content_address IS NOT NULL`, so two skinny variants cannot share a content address.
- `deletions.ruby_abi` — nullable string; snapshots the ABI of the yanked variant for auditing.

## Safety

- Purely additive — no application code references these columns yet (the #6674 app code was reverted), so this is safe to deploy with the current running code.
- Idempotent (`if_not_exists` / `if_exists`); index built `CONCURRENTLY`, matching the post-incident convention established in `20260818000002`.
- **Does not** drop any existing index. The destructive old-index removal is deferred to a separate, deployment-gated branch.

## Stack

Foundation PR of a 4-PR stacked rollout for #6674 (re-applied after the August incident):

1. **#6785 (this)** — add `content_address` + `deletions.ruby_abi` columns and the `index_versions_number_content_address` partial unique
2. #6788 — add non-unique serving indexes (safety net for the index drop)
3. #6790 — remove the old full unique indexes (enables ABI-variant coexistence)
4. #6789 — content-addressable gem support
