### PR TITLE
Add non-unique version serving indexes

### DIFF
--- a/db/migrate/20260819160002_add_nonunique_version_indexes.rb
+++ b/db/migrate/20260819160002_add_nonunique_version_indexes.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddNonuniqueVersionIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :versions,
+      %i[rubygem_id number platform],
+      name: "index_versions_number_platform",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      name: "index_versions_canonical_platform",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :versions,
+      name: "index_versions_canonical_platform",
+      algorithm: :concurrently,
+      if_exists: true
+
+    remove_index :versions,
+      name: "index_versions_number_platform",
+      algorithm: :concurrently,
+      if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_155903) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_160002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -736,6 +736,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_155903) do
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_canonical_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
+    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
     t.index ["created_at"], name: "index_versions_on_created_at"
@@ -748,6 +749,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_155903) do
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
     t.index ["rubygem_id", "number", "content_address"], name: "index_versions_number_content_address", unique: true, where: "(content_address IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
+    t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]


### PR DESCRIPTION
## Summary

Adds two **non-unique serving indexes** on `versions`, mirroring the existing full unique indexes but without the uniqueness constraint:

- `index_versions_number_platform` on `(rubygem_id, number, platform)`
- `index_versions_canonical_platform` on `(canonical_number, rubygem_id, platform)`

Both created `CONCURRENTLY` + `if_not_exists`. Migration-only — no application code.

## Why

This is the safety net for #6790, which drops the full unique indexes whose uniqueness constraint blocks ABI-variant coexistence (a skinny `ruby_abi=3.4` variant and a fat `ruby_abi=nil` version at the same gem/number/platform cannot both exist under a single unique constraint).

With these non-unique indexes in place **before** the unique ones are dropped, the hot
`(rubygem_id, number, platform)` and `(canonical_number, rubygem_id, platform)` lookups keep a
fast access path **independent of whether the lookups are scoped by `ruby_abi`**.

Uniqueness is still enforced by the ABI-partitioned partial unique indexes (`…_no_abi` / `…_abi`)
from the base branch (#6785 / #6784). The non-unique indexes added here intentionally do **not**
enforce uniqueness — they exist only to serve lookups.

## Alternatives considered

- **Drop-only, rely on a lookup "soak" + partial indexes** (the original plan): rejected as the
  safety path — it's only as safe as the soak is complete, dev EXPLAIN ≠ prod, and future code
  could add unscoped lookups. The soak is still how the non-unique indexes get dropped later, but
  it's no longer the thing that makes the drop safe.
- **Permanent non-unique replacement** (keep forever): rejected — permanently redundant index with
  write amplification on every version insert (versions is write-heavy on push).
- **Chosen: temporary non-unique safety net**, dropped in a later follow-up once the lookups are
  confirmed scoped and production EXPLAIN shows the partials serving them.

## Stack

Second PR of a 4-PR stacked rollout for #6674:

1. #6785 — add `content_address` + `deletions.ruby_abi` columns (foundation, base of this PR)
2. **#6788 (this)** — add non-unique serving indexes
3. #6790 — remove the old full unique indexes
4. #6789 — content-addressable gem server feature (flag off)

## Testing
The state immediately after #6788 ships, before #6790 drops the old uniques. The planner picks the
**#6788 non-unique indexes** for 5 of 6 lookups — the old full uniques are already redundant — and
uses the `_no_abi` partial as an Index-Only Scan for `exists?`. All sub-millisecond, 4–30 buffers.

**`find_version!` (platform path)** — `Pusher#find` republish check is the same shape
```
 Limit  (actual time=0.040..0.041 rows=1)   Buffers: shared hit=3 read=1
   ->  Index Scan using index_versions_number_platform on versions  (actual time=0.039..0.039 rows=1)
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.068 ms
```

**`find_public_version` (platform path)**
```
 Limit  (actual time=0.024..0.024 rows=1)   Buffers: shared hit=10
   ->  Sort  Sort Key: position, created_at DESC
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.007..0.008 rows=1)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.038 ms
```

**`find_public_version` (no platform — 27-platform worst case)**
```
 Limit  (actual time=0.068..0.068 rows=1)   Buffers: shared hit=30
   ->  Sort  Sort Key: position, created_at DESC
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.009..0.062 rows=27)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.080 ms
```

**`Pusher#find` republish check**
```
 Limit  (actual time=0.021..0.021 rows=1)   Buffers: shared hit=4
   ->  Index Scan using index_versions_number_platform on versions  (actual time=0.021..0.021 rows=1)
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.027 ms
```

**uniqueness `exists?`** 
```
 Limit  (actual time=0.064..0.065 rows=1)   Buffers: shared hit=1 read=3
   ->  Index Only Scan using index_versions_number_platform_no_abi on versions
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Heap Fetches: 0
 Execution Time: 0.069 ms
```

**`unique_canonical_number`**
```
 Limit  (actual time=0.024..0.024 rows=1)   Buffers: shared hit=4
   ->  Index Scan using index_versions_canonical_platform on versions
         Index Cond: (canonical_number = '1.76') AND (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.030 ms
```

