### PR TITLE
Add content-addressable gem support

### DIFF
--- a/app/avo/resources/deletion.rb
+++ b/app/avo/resources/deletion.rb
@@ -10,6 +10,7 @@ class Avo::Resources::Deletion < Avo::BaseResource
     field :rubygem, as: :text
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
     field :user, as: :belongs_to
     field :version, as: :belongs_to
   end

--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -34,6 +34,8 @@ class Avo::Resources::Version < Avo::BaseResource
     field :slug, as: :text, hide_on: :index
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
+    field :content_address, as: :text
 
     field :canonical_number, as: :text
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::DeletionsController < Api::BaseController
   before_action :verify_user_api_key
   before_action :find_rubygem_by_name
   before_action :verify_api_key_gem_scope
+  before_action :validate_ruby_abi
   before_action :validate_gem_and_version
   before_action :verify_with_otp
 
@@ -40,11 +41,27 @@ class Api::V1::DeletionsController < Api::BaseController
       begin
         version = params.expect(:version)
         platform = params.permit(:platform).fetch(:platform, nil)
-        @version = @rubygem.find_version!(number: version, platform: platform)
+        ruby_abi = params.permit(:ruby_abi).fetch(:ruby_abi, nil).presence
+
+        @version = @rubygem.find_version!(number: version, platform: platform, ruby_abi: ruby_abi)
       rescue ActiveRecord::RecordNotFound
-        render plain: response_with_mfa_warning("The version #{version}#{" (#{platform})" if platform.present?} does not exist."),
+        details = "#{" (#{platform})" if platform.present?}#{" (Ruby ABI #{ruby_abi})" if ruby_abi.present?}"
+        render plain: response_with_mfa_warning("The version #{version}#{details} does not exist."),
                status: :not_found
       end
+    end
+  end
+
+  def validate_ruby_abi
+    ruby_abi = params.permit(:ruby_abi).fetch(:ruby_abi, nil).presence
+    return unless ruby_abi
+
+    if !ruby_abi.match?(/\A\d+\.\d+\z/)
+      render plain: response_with_mfa_warning("The ruby_abi param must be in the format X.Y (e.g., 3.2)."),
+             status: :bad_request
+    elsif params.permit(:platform).fetch(:platform, nil).blank?
+      render plain: response_with_mfa_warning("The platform param is required when ruby_abi is specified."),
+             status: :bad_request
     end
   end
 end

--- a/app/controllers/api/v2/contents_controller.rb
+++ b/app/controllers/api/v2/contents_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V2::ContentsController < Api::BaseController
   before_action :find_rubygem_by_name, only: [:index]
+  before_action :validate_ruby_abi, only: [:index]
 
   def index
     return unless stale?(@rubygem)
@@ -24,14 +25,29 @@ class Api::V2::ContentsController < Api::BaseController
   protected
 
   def find_version
-    version_params = params.permit(:version_number, :platform)
-    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform])
+    version_params = params.permit(:version_number, :platform, :ruby_abi)
+    ruby_abi = version_params[:ruby_abi].presence
+
+    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform], ruby_abi)
     render plain: "This version could not be found.", status: :not_found unless @version
   end
 
   def checksums_payload(checksums_file)
     ShasumFormat.parse(checksums_file).transform_values do |checksum|
       { VersionManifest::DEFAULT_DIGEST => checksum }
+    end
+  end
+
+  private
+
+  def validate_ruby_abi
+    ruby_abi = params.permit(:ruby_abi).fetch(:ruby_abi, nil).presence
+    return unless ruby_abi
+
+    if !ruby_abi.match?(/\A\d+\.\d+\z/)
+      render plain: "The ruby_abi param must be in the format X.Y (e.g., 3.2).", status: :bad_request
+    elsif params[:platform].blank?
+      render plain: "The platform param is required when ruby_abi is specified.", status: :bad_request
     end
   end
 end

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -2,13 +2,16 @@
 
 class Api::V2::VersionsController < Api::BaseController
   before_action :find_rubygem_by_name, only: [:show]
+  before_action :validate_ruby_abi, only: [:show]
 
   def show
     return unless stale?(@rubygem)
     cache_expiry_headers
     set_surrogate_key "gem/#{@rubygem.name}"
 
-    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform])
+    ruby_abi = version_params[:ruby_abi].presence
+
+    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform], ruby_abi)
     if version
       respond_to do |format|
         format.json { render json: version }
@@ -22,6 +25,19 @@ class Api::V2::VersionsController < Api::BaseController
   protected
 
   def version_params
-    params.permit(:platform, :number)
+    params.permit(:platform, :number, :ruby_abi)
+  end
+
+  private
+
+  def validate_ruby_abi
+    ruby_abi = version_params[:ruby_abi].presence
+    return unless ruby_abi
+
+    if !ruby_abi.match?(/\A\d+\.\d+\z/)
+      render plain: "The ruby_abi param must be in the format X.Y (e.g., 3.2).", status: :bad_request
+    elsif version_params[:platform].blank?
+      render plain: "The platform param is required when ruby_abi is specified.", status: :bad_request
+    end
   end
 end

--- a/app/models/concerns/compact_index_versions.rb
+++ b/app/models/concerns/compact_index_versions.rb
@@ -9,17 +9,20 @@ module CompactIndexVersions
       checksum_column = config[:checksum_column]
       yanked_checksum_column = config[:yanked_checksum_column]
 
-      query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.full_name
-                FROM rubygems AS r, versions AS v
-                WHERE v.rubygem_id = r.id AND
-                      v.created_at > ?)
-                UNION
-                (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform, v.ruby_abi, v.full_name
-                FROM rubygems AS r, versions AS v
-                WHERE v.rubygem_id = r.id AND
-                      v.indexed is false AND
-                      v.yanked_at > ?)
-                ORDER BY date, number, platform, ruby_abi, full_name, name", date, date]
+      query = ["SELECT * FROM (
+                  (SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.content_address
+                  FROM rubygems AS r, versions AS v
+                  WHERE v.rubygem_id = r.id AND
+                        v.created_at > ?)
+                  UNION
+                  (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number,
+                          v.platform, v.ruby_abi, v.content_address
+                  FROM rubygems AS r, versions AS v
+                  WHERE v.rubygem_id = r.id AND
+                        v.indexed is false AND
+                        v.yanked_at > ?)
+                ) AS u
+                ORDER BY date, number, platform, ruby_abi, content_address, name", date, date]
 
       map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] }, version:)
     end
@@ -35,11 +38,11 @@ module CompactIndexVersions
 
       query = ["SELECT r.name, v.indexed, COALESCE(v.yanked_at, v.created_at) as stamp,
                        v.sha256, COALESCE(v.#{yanked_checksum_column}, v.#{checksum_column}) as info_checksum,
-                       v.number, v.platform, v.ruby_abi, v.full_name
+                       v.number, v.platform, v.ruby_abi, v.content_address
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       (v.created_at <= ? OR v.yanked_at <= ?)
-                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform, v.ruby_abi, v.full_name", updated_at, updated_at]
+                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform, v.ruby_abi, v.content_address", updated_at, updated_at]
 
       execute_raw_sql(query)
         .chunk_while { |a, b| a["name"] == b["name"] }
@@ -78,22 +81,12 @@ module CompactIndexVersions
           checksum: version_row["sha256"],
           info_checksum: version_row["info_checksum"],
           ruby_abi: version_row["ruby_abi"],
-          content_address: content_address_for(version_row["ruby_abi"], version_row["full_name"])
+          content_address: version_row["content_address"]
         }
         args = args.slice(*version_class.members)
         version_class.new(**args)
       end
       CompactIndex::Gem.new(gem_name, compact_index_versions)
-    end
-
-    def content_address_for(ruby_abi, full_name)
-      return if ruby_abi.blank?
-      return if full_name.blank?
-
-      content_address = full_name.split("-").last
-      return unless content_address.match?(/\A[0-9a-f]{#{Version::DEFAULT_CONTENT_ADDRESS_LENGTH},64}\z/o)
-
-      content_address
     end
 
     private :map_gem_versions, :public_compact_index_gem, :build_compact_index_gem, :execute_raw_sql

--- a/app/models/concerns/compact_index_versions.rb
+++ b/app/models/concerns/compact_index_versions.rb
@@ -9,17 +9,17 @@ module CompactIndexVersions
       checksum_column = config[:checksum_column]
       yanked_checksum_column = config[:yanked_checksum_column]
 
-      query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform
+      query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.full_name
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       v.created_at > ?)
                 UNION
-                (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform
+                (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform, v.ruby_abi, v.full_name
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       v.indexed is false AND
                       v.yanked_at > ?)
-                ORDER BY date, number, platform, name", date, date]
+                ORDER BY date, number, platform, ruby_abi, full_name, name", date, date]
 
       map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] }, version:)
     end
@@ -35,11 +35,11 @@ module CompactIndexVersions
 
       query = ["SELECT r.name, v.indexed, COALESCE(v.yanked_at, v.created_at) as stamp,
                        v.sha256, COALESCE(v.#{yanked_checksum_column}, v.#{checksum_column}) as info_checksum,
-                       v.number, v.platform
+                       v.number, v.platform, v.ruby_abi, v.full_name
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       (v.created_at <= ? OR v.yanked_at <= ?)
-                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform", updated_at, updated_at]
+                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform, v.ruby_abi, v.full_name", updated_at, updated_at]
 
       execute_raw_sql(query)
         .chunk_while { |a, b| a["name"] == b["name"] }
@@ -76,12 +76,24 @@ module CompactIndexVersions
           number: version_row["number"],
           platform: version_row["platform"],
           checksum: version_row["sha256"],
-          info_checksum: version_row["info_checksum"]
+          info_checksum: version_row["info_checksum"],
+          ruby_abi: version_row["ruby_abi"],
+          content_address: content_address_for(version_row["ruby_abi"], version_row["full_name"])
         }
         args = args.slice(*version_class.members)
         version_class.new(**args)
       end
       CompactIndex::Gem.new(gem_name, compact_index_versions)
+    end
+
+    def content_address_for(ruby_abi, full_name)
+      return if ruby_abi.blank?
+      return if full_name.blank?
+
+      content_address = full_name.split("-").last
+      return unless content_address.match?(/\A[0-9a-f]{#{Version::DEFAULT_CONTENT_ADDRESS_LENGTH},64}\z/o)
+
+      content_address
     end
 
     private :map_gem_versions, :public_compact_index_gem, :build_compact_index_gem, :execute_raw_sql

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -54,6 +54,7 @@ class Deletion < ApplicationRecord
       reason: ineligible_reason,
       number: version.number,
       platform: version.platform,
+      ruby_abi: version.ruby_abi,
       yanked_by: user.display_handle,
       actor_gid: user.to_gid,
       version_gid: version.to_gid
@@ -75,6 +76,7 @@ class Deletion < ApplicationRecord
     errors.add(:rubygem, "does not match version rubygem name") unless rubygem == version.rubygem.name
     errors.add(:number, "does not match version number") unless number == version.number
     errors.add(:platform, "does not match version platform") unless platform == version.platform
+    errors.add(:ruby_abi, "does not match version Ruby ABI") unless ruby_abi == version.ruby_abi
   end
 
   def rubygem_name
@@ -85,6 +87,7 @@ class Deletion < ApplicationRecord
     self.rubygem = rubygem_name
     self.number = version.number
     self.platform = version.platform
+    self.ruby_abi = version.ruby_abi
   end
 
   def expire_cache
@@ -155,11 +158,11 @@ class Deletion < ApplicationRecord
 
   def record_yank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_YANKED, number: version.number, platform: version.platform,
-yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
+      ruby_abi: version.ruby_abi, yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
   end
 
   def record_unyank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_UNYANKED, number: version.number, platform: version.platform,
-version_gid: version.to_gid)
+      ruby_abi: version.ruby_abi, version_gid: version.to_gid)
   end
 end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -19,6 +19,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANKED = define_event "rubygem:version:yanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -30,6 +31,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANK_FORBIDDEN = define_event "rubygem:version:yank_forbidden" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -41,6 +43,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_UNYANKED = define_event "rubygem:version:unyanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :version_gid, :global_id
   end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -8,6 +8,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_PUSHED = define_event "rubygem:version:pushed" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
     attribute :sha256, :string
 
     attribute :pushed_by, :string

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -2,6 +2,7 @@
 
 class FeatureFlag
   ORGANIZATIONS = :organizations
+  CONTENT_ADDRESSABLE_GEM_PUSHES = :content_addressable_gem_pushes
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -49,9 +49,9 @@ class GemInfo
 
   private
 
-  DEPENDENCY_NAMES_INDEX = 8
+  DEPENDENCY_NAMES_INDEX = 10
 
-  DEPENDENCY_REQUIREMENTS_INDEX = 7
+  DEPENDENCY_REQUIREMENTS_INDEX = 9
 
   # Marshal.load of pre-deploy cache entries fails when GemVersion grows a Struct field.
   def read_cache(cache_key)
@@ -72,11 +72,21 @@ class GemInfo
         end
       end
 
-      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = row
+      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, full_name, = row
       version_class = VERSIONS.dig(version, :klass)
       checksum = Version._sha256_hex(checksum)
       created_at = created_at&.utc&.iso8601
-      args = { number:, platform:, checksum:, info_checksum:, dependencies:, ruby_version:, rubygems_version:, created_at: }
+      content_address = self.class.content_address_for(ruby_abi, full_name)
+      args = { number:,
+              platform:,
+              checksum:,
+              info_checksum:,
+              dependencies:,
+              ruby_version:,
+              rubygems_version:,
+              created_at:,
+              ruby_abi:,
+              content_address: }
       args = args.slice(*version_class.members)
       version_class.new(**args)
     end
@@ -91,7 +101,7 @@ class GemInfo
     checksum_column = VERSIONS.fetch(version).fetch(:checksum_column)
     group_by_columns = [
       "number", "platform", "sha256", checksum_column,
-      "required_ruby_version", "required_rubygems_version", "versions.created_at"
+      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "full_name"
     ]
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
@@ -105,7 +115,7 @@ class GemInfo
           AND dependencies.scope = 'runtime'")
       .where("rubygems.name = ? AND versions.indexed = true", @rubygem_name)
       .group(*group_by_columns)
-      .order(Arel.sql("versions.created_at, number, platform, dep_name"))
+      .order(Arel.sql("versions.created_at, number, platform, ruby_abi, full_name, dep_name"))
       .pluck(*group_by_columns, Arel.sql(dep_req_agg), Arel.sql(dep_name_agg))
   end
 end

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -72,11 +72,10 @@ class GemInfo
         end
       end
 
-      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, full_name, = row
+      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, content_address, = row
       version_class = VERSIONS.dig(version, :klass)
       checksum = Version._sha256_hex(checksum)
       created_at = created_at&.utc&.iso8601
-      content_address = self.class.content_address_for(ruby_abi, full_name)
       args = { number:,
               platform:,
               checksum:,
@@ -101,7 +100,7 @@ class GemInfo
     checksum_column = VERSIONS.fetch(version).fetch(:checksum_column)
     group_by_columns = [
       "number", "platform", "sha256", checksum_column,
-      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "full_name"
+      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "content_address"
     ]
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
@@ -115,7 +114,7 @@ class GemInfo
           AND dependencies.scope = 'runtime'")
       .where("rubygems.name = ? AND versions.indexed = true", @rubygem_name)
       .group(*group_by_columns)
-      .order(Arel.sql("versions.created_at, number, platform, ruby_abi, full_name, dep_name"))
+      .order(Arel.sql("versions.created_at, number, platform, ruby_abi, content_address, dep_name"))
       .pluck(*group_by_columns, Arel.sql(dep_req_agg), Arel.sql(dep_name_agg))
   end
 end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -130,13 +130,16 @@ class Pusher
         pusher_api_key: api_key
       )
 
+    version.required_ruby_version = spec.required_ruby_version.to_s
+    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version)
+
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
 
       # If the gem is yanked, we can't repush it
       # Additionally, we don't allow overwriting existing versions
-      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform))
+      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_abi: version.ruby_abi))
         return republish_notification(existing)
       end
 

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -60,7 +60,7 @@ class Pusher
 
     return notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403) unless rubygem.valid? && version.valid?
 
-    unless version.full_name == spec.original_name && version.gem_full_name == spec.full_name
+    unless uploaded_spec_matches_version?
       return notify("There was a problem saving your gem: the uploaded spec has malformed platform attributes", 409)
     end
 
@@ -131,8 +131,7 @@ class Pusher
       )
 
     version.required_ruby_version = spec.required_ruby_version.to_s
-    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version)
-
+    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version) if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, owner)
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
@@ -205,6 +204,12 @@ class Pusher
 
   private
 
+  def uploaded_spec_matches_version?
+    return version.full_name == spec.original_name && version.gem_full_name == spec.full_name unless version.content_addressable?
+
+    version.platform == spec.original_platform.to_s && version.gem_platform == spec.platform.to_s
+  end
+
   def after_write
     GemCachePurger.call(rubygem.name)
     RackAttackReset.gem_push_backoff(@request.remote_ip, owner.to_gid) if @request&.remote_ip.present?
@@ -224,6 +229,7 @@ class Pusher
   def update
     rubygem.disown if rubygem.versions.indexed.none?
     rubygem.update_attributes_from_gem_specification!(version, spec)
+    version.normalize_content_addressable_gem_metadata!
 
     if rubygem.unowned?
       if api_key.user?

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -131,7 +131,7 @@ class Pusher
       )
 
     version.required_ruby_version = spec.required_ruby_version.to_s
-    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version) if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, owner)
+    version.ruby_abi = version.derive_ruby_abi if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, owner)
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
@@ -228,8 +228,7 @@ class Pusher
 
   def update
     rubygem.disown if rubygem.versions.indexed.none?
-    rubygem.update_attributes_from_gem_specification!(version, spec)
-    version.normalize_content_addressable_gem_metadata!
+    persist_version
 
     if rubygem.unowned?
       if api_key.user?
@@ -252,6 +251,29 @@ class Pusher
   rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback, ActiveRecord::RecordNotUnique => e
     logger.info { { message: "Error updating rubygem", exception: e } }
     false
+  end
+
+  def persist_version
+    retries = 0
+    begin
+      rubygem.transaction do
+        rubygem.update_attributes_from_gem_specification!(version, spec)
+        version.normalize_content_addressable_gem_metadata!
+      end
+    rescue ActiveRecord::RecordNotUnique => e
+      raise e unless e.message.include?("index_versions_number_content_address")
+
+      if retries >= 3
+        StatsD.increment("push.content_address_collision_exhausted", tags: { rubygem: rubygem.name })
+        notify("There was a problem saving your gem: could not generate a unique content address after multiple attempts. Please try again.", 409)
+        raise e
+      end
+
+      StatsD.increment("push.content_address_collision", tags: { rubygem: rubygem.name })
+      version.content_address = nil
+      retries += 1
+      retry
+    end
   end
 
   def republish_notification(version)

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -117,12 +117,18 @@ class Pusher
     sha256 = Digest::SHA2.base64digest(body.string)
     spec_sha256 = Digest::SHA2.base64digest(spec_contents)
 
+    ruby_abi =
+      if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, api_key.user)
+        Version.ruby_abi_for(spec.original_platform.to_s, spec.required_ruby_version.to_s)
+      end
+
     version = @rubygem.versions
       .create_with(indexed: false, cert_chain: spec.cert_chain)
       .find_or_initialize_by(
         number: spec.version.to_s,
         platform: spec.original_platform.to_s,
         gem_platform: spec.platform.to_s,
+        ruby_abi: ruby_abi,
         size: size,
         sha256: sha256,
         spec_sha256: spec_sha256,
@@ -131,7 +137,6 @@ class Pusher
       )
 
     version.required_ruby_version = spec.required_ruby_version.to_s
-    version.ruby_abi = version.derive_ruby_abi if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, owner)
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -350,7 +350,8 @@ class Rubygem < ApplicationRecord
   def find_or_initialize_version_from_spec(spec)
     version = versions.find_or_initialize_by(number: spec.version.to_s,
                                              platform: spec.original_platform.to_s,
-                                             gem_platform: spec.platform.to_s)
+                                             gem_platform: spec.platform.to_s,
+                                             ruby_abi: nil)
     version.rubygem = self
     version
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -263,6 +263,7 @@ class Rubygem < ApplicationRecord
       "version_created_at" => version.created_at,
       "version_downloads"  => version.downloads_count,
       "platform"           => version.platform,
+      "ruby_abi"           => version.ruby_abi,
       "authors"            => version.authors,
       "info"               => version.info,
       "licenses"           => version.licenses,

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -186,22 +186,22 @@ class Rubygem < ApplicationRecord
 
   # NB: this intentionally does not default the platform to ruby.
   # Without platform, finds the most recent version by (position, created_at) ignoring platform.
-  def find_public_version(number, platform = nil)
+  def find_public_version(number, platform = nil, ruby_abi = nil)
     if platform
-      public_versions.find_by(number:, platform:)
+      public_versions.find_by(number:, platform:, ruby_abi:)
     else
-      public_versions.find_by(number:)
+      public_versions.find_by(number:, ruby_abi:)
     end
   end
 
-  def public_version_payload(number, platform = nil)
-    version = find_public_version(number, platform)
+  def public_version_payload(number, platform = nil, ruby_abi = nil)
+    version = find_public_version(number, platform, ruby_abi)
     payload(version).merge!(version.as_json) if version
   end
 
-  def find_version!(number:, platform:)
+  def find_version!(number:, platform:, ruby_abi: nil)
     platform = platform.presence || "ruby"
-    versions.find_by!(number: number, platform: platform)
+    versions.find_by!(number: number, platform: platform, ruby_abi: ruby_abi)
   end
 
   def find_version_by_slug!(slug)
@@ -374,8 +374,8 @@ class Rubygem < ApplicationRecord
     user.mfa_enabled? || !metadata_mfa_required?
   end
 
-  def version_manifest(number, platform = nil)
-    VersionManifest.new(gem: name, number: number, platform: platform)
+  def version_manifest(number, platform = nil, content_address: nil)
+    VersionManifest.new(gem: name, number: number, platform: platform, content_address: content_address)
   end
 
   def file_content(fingerprint)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -329,7 +329,7 @@ class Rubygem < ApplicationRecord
     versions_of_platforms = versions
       .release
       .indexed
-      .group_by(&:platform)
+      .group_by { |version| [version.platform, version.ruby_abi] }
 
     Version.default_scoped.where(id: versions_of_platforms.values.map! { |v| v.max.id }).update_all(latest: true)
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -18,6 +18,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -49,6 +50,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     length: { minimum: 0, maximum: Gemcutter::MAX_TEXT_FIELD_LENGTH },
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
+  validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },
@@ -455,6 +457,33 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def set_ruby_abi
+    self.ruby_abi = derive_ruby_abi
+  end
+
+  def derive_ruby_abi
+    return if required_ruby_version.blank?
+
+    requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
+    requirements = requirement.requirements
+
+    return unless requirements.one?
+
+    operator, version = requirements.first
+    return unless operator == "~>"
+
+    segments = version.segments
+    return unless segments.length == 3
+
+    patch = segments[2]
+    return unless patch.is_a?(Integer)
+    return unless patch.zero?
+
+    "#{segments[0]}.#{segments[1]}"
+  rescue Gem::Requirement::BadRequirementError
+    nil
+  end
 
   def update_prerelease
     self[:prerelease] = prerelease

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,6 +5,7 @@ require "digest/sha2"
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
   DEFAULT_CONTENT_ADDRESS_LENGTH = 8
+  CONTENT_ADDRESS_FORMAT = /\A[0-9a-f]{#{DEFAULT_CONTENT_ADDRESS_LENGTH},64}\z/
   CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION = ">= 4.1.0.beta1"
 
   belongs_to :rubygem, touch: true
@@ -20,6 +21,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :content_addressify!
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -52,7 +54,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
   validates :sha256, presence: true, if: :content_addressable?
+  validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
+  validates :content_address, absence: true, unless: :content_addressable?
   validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
+  validates :ruby_abi, absence: true, unless: :platformed?
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },
@@ -220,7 +225,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def platformed?
-    platform != "ruby"
+    Version.platformed?(platform)
   end
 
   delegate :reorder_versions, to: :rubygem
@@ -460,18 +465,21 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{full_name}.gem"
   end
 
-  def self.ruby_abi_for(required_ruby_version)
+  def content_addressable?
+    platformed? && ruby_abi.present?
+  end
+
+  def derive_ruby_abi
+    return unless platformed?
     return if required_ruby_version.blank?
 
-    requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
-    requirements = requirement.requirements
-
+    requirements = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/)).requirements
     return unless requirements.one?
 
-    operator, version = requirements.first
+    operator, requirement_version = requirements.first
     return unless operator == "~>"
 
-    segments = version.segments
+    segments = requirement_version.segments
     return unless segments.length == 3
 
     patch = segments[2]
@@ -483,14 +491,13 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
-  def content_addressable?
-    platformed? && ruby_abi.present?
+  def self.platformed?(platform)
+    platform.present? && platform != "ruby"
   end
 
   def normalize_content_addressable_gem_metadata!
     return unless content_addressable?
     return if required_rubygems_version_satisfies_content_addressable_floor?
-
     preserved = required_rubygems_version.to_s.split(/\s*,\s*/).filter_map do |req|
       req = req.strip
       if req.start_with?("~>")
@@ -574,7 +581,15 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.gem_full_name = platform_identity(gem_platform)
   end
 
-  def content_address
+  def content_addressify!
+    return if rubygem.nil?
+    return unless content_addressable?
+    return if sha256.blank?
+
+    self.content_address ||= generate_content_address
+  end
+
+  def generate_content_address
     digest = sha256_hex
     raise ArgumentError, "Could not generate unique content-address" if digest.blank?
 
@@ -592,7 +607,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def platform_identity(platform_value)
-    return content_addressed_full_name if content_addressable? && sha256.present?
+    return content_addressed_full_name if content_addressable? && content_address.present?
 
     identity = "#{rubygem.name}-#{number}"
     identity << "-#{platform_value}" unless platform_value == "ruby"

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -149,6 +149,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .release
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end
@@ -157,6 +158,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .latest
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end
@@ -165,6 +167,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .prerelease
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -462,7 +462,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   alias prerelease prerelease?
 
   def manifest
-    rubygem.version_manifest(number, platformed? ? platform : nil)
+    rubygem.version_manifest(number, platformed? ? platform : nil, content_address: content_address)
   end
 
   def gem_file_name

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -473,8 +473,8 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     platformed? && ruby_abi.present?
   end
 
-  def derive_ruby_abi
-    return unless platformed?
+  def self.ruby_abi_for(platform, required_ruby_version)
+    return unless platformed?(platform)
     return if required_ruby_version.blank?
 
     requirements = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/)).requirements

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -458,17 +458,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{full_name}.gem"
   end
 
-  private
-
-  def content_addressable?
-    platformed? && ruby_abi.present?
-  end
-
-  def set_ruby_abi
-    self.ruby_abi = derive_ruby_abi
-  end
-
-  def derive_ruby_abi
+  def self.ruby_abi_for(required_ruby_version)
     return if required_ruby_version.blank?
 
     requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
@@ -491,19 +481,42 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
+  private
+
+  def content_addressable?
+    platformed? && ruby_abi.present?
+  end
+
+  def set_ruby_abi
+    self.ruby_abi = Version.ruby_abi_for(required_ruby_version)
+  end
+
   def update_prerelease
     self[:prerelease] = prerelease
   end
 
   def platform_and_number_are_unique
-    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)
-    errors.add(:base, "A version already exists with this number or platform.")
+    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_abi: ruby_abi)
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, platform and Ruby ABI."
+              else
+                "A version already exists with this number or platform."
+              end
+
+    errors.add(:base, message)
   end
 
   def gem_platform_and_number_are_unique
-    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform).pluck(:platform)
+    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_abi: ruby_abi).pluck(:platform)
     return if platforms.empty?
-    errors.add(:base, "A version already exists with this number and resolved platform #{platforms}")
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, Ruby ABI and resolved platform #{platforms}"
+              else
+                "A version already exists with this number and resolved platform #{platforms}"
+              end
+    errors.add(:base, message)
   end
 
   def original_platform_resolves_to_gem_platform
@@ -584,7 +597,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def unique_canonical_number
-    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_abi: ruby_abi)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,6 +5,7 @@ require "digest/sha2"
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
   DEFAULT_CONTENT_ADDRESS_LENGTH = 8
+  CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION = ">= 4.1.0.beta1"
 
   belongs_to :rubygem, touch: true
   has_many :dependencies, lambda {
@@ -19,7 +20,6 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
-  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -382,7 +382,9 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def to_title
-    if platformed?
+    if content_addressable?
+      "#{rubygem.name} (#{number}-#{content_address}, Platform: #{platform}, Ruby ABI #{ruby_abi})"
+    elsif platformed?
       "#{rubygem.name} (#{number}-#{platform})"
     else
       "#{rubygem.name} (#{number})"
@@ -481,15 +483,42 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
-  private
-
   def content_addressable?
     platformed? && ruby_abi.present?
   end
 
-  def set_ruby_abi
-    self.ruby_abi = Version.ruby_abi_for(required_ruby_version)
+  def normalize_content_addressable_gem_metadata!
+    return unless content_addressable?
+    return if required_rubygems_version_satisfies_content_addressable_floor?
+
+    preserved = required_rubygems_version.to_s.split(/\s*,\s*/).filter_map do |req|
+      req = req.strip
+      if req.start_with?("~>")
+        "< #{Gem::Version.new(req[2..].strip).bump}"
+      elsif req.start_with?("<", "!=")
+        req
+      end
+    end
+    update!(required_rubygems_version: [CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, *preserved].join(", "))
   end
+
+  def required_rubygems_version_satisfies_content_addressable_floor?
+    requirements = required_rubygems_version.presence&.split(/\s*,\s*/) || [">= 0"]
+    requirement = Gem::Requirement.new(requirements)
+
+    requirement.requirements.any? do |operator, required_version|
+      case operator
+      when ">=", "~>", "=", ">"
+        Gem::Requirement.new(CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION).satisfied_by?(required_version)
+      else
+        false
+      end
+    end
+  rescue Gem::Requirement::BadRequirementError
+    false
+  end
+
+  private
 
   def update_prerelease
     self[:prerelease] = prerelease
@@ -550,15 +579,20 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     raise ArgumentError, "Could not generate unique content-address" if digest.blank?
 
     (DEFAULT_CONTENT_ADDRESS_LENGTH..digest.length).each do |length|
-      identity = "#{rubygem.name}-#{number}-#{digest.first(length)}"
-      return identity unless Version.where(full_name: identity).where.not(id: id).exists?
+      candidate = digest.first(length)
+      identity = "#{rubygem.name}-#{number}-#{candidate}"
+      return candidate unless Version.where(full_name: identity).where.not(id: id).exists?
     end
 
     raise ArgumentError, "Could not generate unique content-address"
   end
 
+  def content_addressed_full_name
+    "#{rubygem.name}-#{number}-#{content_address}"
+  end
+
   def platform_identity(platform_value)
-    return content_address if content_addressable? && sha256.present?
+    return content_addressed_full_name if content_addressable? && sha256.present?
 
     identity = "#{rubygem.name}-#{number}"
     identity << "-#{platform_value}" unless platform_value == "ruby"

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -669,8 +669,8 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def record_push_event
-    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, sha256: sha256_hex,
-      pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
+    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, ruby_abi: ruby_abi,
+      sha256: sha256_hex, pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
   end
 
   def enqueue_web_hook_jobs

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -372,6 +372,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
       "rubygems_version"           => required_rubygems_version,
       "ruby_version"               => required_ruby_version,
       "prerelease"                 => prerelease,
+      "ruby_abi"                   => ruby_abi,
       "licenses"                   => licenses,
       "requirements"               => requirements,
       "sha"                        => sha256_hex,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,7 @@ require "digest/sha2"
 
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
+  DEFAULT_CONTENT_ADDRESS_LENGTH = 8
 
   belongs_to :rubygem, touch: true
   has_many :dependencies, lambda {
@@ -50,6 +51,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     length: { minimum: 0, maximum: Gemcutter::MAX_TEXT_FIELD_LENGTH },
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
+  validates :sha256, presence: true, if: :content_addressable?
   validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
@@ -458,6 +460,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   private
 
+  def content_addressable?
+    platformed? && ruby_abi.present?
+  end
+
   def set_ruby_abi
     self.ruby_abi = derive_ruby_abi
   end
@@ -516,15 +522,34 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def full_nameify!
     return if rubygem.nil?
-    self.full_name = "#{rubygem.name}-#{number}"
-    full_name << "-#{platform}" if platformed?
+    self.full_name = platform_identity(platform)
   end
 
   def gem_full_nameify!
     return if gem_platform.blank?
     return if rubygem.nil?
-    self.gem_full_name = "#{rubygem.name}-#{number}"
-    gem_full_name << "-#{gem_platform}" unless gem_platform == "ruby"
+
+    self.gem_full_name = platform_identity(gem_platform)
+  end
+
+  def content_address
+    digest = sha256_hex
+    raise ArgumentError, "Could not generate unique content-address" if digest.blank?
+
+    (DEFAULT_CONTENT_ADDRESS_LENGTH..digest.length).each do |length|
+      identity = "#{rubygem.name}-#{number}-#{digest.first(length)}"
+      return identity unless Version.where(full_name: identity).where.not(id: id).exists?
+    end
+
+    raise ArgumentError, "Could not generate unique content-address"
+  end
+
+  def platform_identity(platform_value)
+    return content_address if content_addressable? && sha256.present?
+
+    identity = "#{rubygem.name}-#{number}"
+    identity << "-#{platform_value}" unless platform_value == "ruby"
+    identity
   end
 
   def set_canonical_number

--- a/app/models/version_manifest.rb
+++ b/app/models/version_manifest.rb
@@ -8,9 +8,14 @@ class VersionManifest
 
   delegate :gem, :fs, to: :contents
 
-  def initialize(gem:, number:, platform: nil)
-    platform = nil if platform == "ruby"
-    @version = [number, platform.presence].compact.join("-")
+  def initialize(gem:, number:, platform: nil, content_address: nil)
+    @version = if content_address.present?
+                 "#{number}-#{content_address}"
+               elsif platform.nil? || platform == "ruby"
+                 number
+               else
+                 "#{number}-#{platform}"
+               end
     raise ArgumentError, "version number-platform must be valid: #{@version.inspect}" unless @version.match?(Rubygem::NAME_PATTERN)
     @contents = RubygemContents.new(gem: gem)
   end

--- a/app/views/components/events/rubygem_event/version/pushed_component.rb
+++ b/app/views/components/events/rubygem_event/version/pushed_component.rb
@@ -6,7 +6,7 @@ class Events::RubygemEvent::Version::PushedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     if additional.sha256.present?
       sha256 = capture { code(class: "break-all") { additional.sha256 } }

--- a/app/views/components/events/rubygem_event/version/unyanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/unyanked_component.rb
@@ -2,6 +2,6 @@
 
 class Events::RubygemEvent::Version::UnyankedComponent < Events::TableDetailsComponent
   def view_template
-    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
   end
 end

--- a/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
+++ b/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankForbiddenComponent < Events::TableDetai
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/rubygem_event/version/yanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/yanked_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/table_details_component.rb
+++ b/app/views/components/events/table_details_component.rb
@@ -26,13 +26,16 @@ class Events::TableDetailsComponent < ApplicationComponent
     end
   end
 
-  def link_to_version_from_gid(gid, number, platform)
+  def link_to_version_from_gid(gid, number, platform, ruby_abi = nil)
     version = load_gid(gid, only: Version)
 
     if version
       view_context.link_to version.to_title, rubygem_version_path(version.rubygem.slug, version.slug)
     else
-      "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'})"
+      title = "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'}"
+      title << ", Ruby ABI #{ruby_abi}" if ruby_abi.present?
+      title << ")"
+      title
     end
   end
 

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -73,6 +73,9 @@
             <% if version.platformed? %>
               <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version.platform %></span>
             <% end %>
+            <% if version.ruby_abi.present? %>
+            <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
+            <% end %>
             <span class="text-b4 text-neutral-700 dark:text-neutral-400">(<%= number_to_human_size(version.size) %>)</span>
             <% if version.yanked? %>
               <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t "versions.version.yanked" %></span>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -5,6 +5,9 @@
   <% if version.platformed? %>
     <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version.platform %></span>
   <% end %>
+  <% if version.ruby_abi.present? %>
+    <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
+  <% end %>
   <span class="text-b4 text-neutral-700 dark:text-neutral-400">(<%= number_to_human_size(version.size) %>)</span>
   <% if version.yanked? %>
     <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t ".yanked" %></span>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -969,6 +969,7 @@ de:
       requirements_header: Anforderungen
       show_all_versions: Zeige alle Versionen (%{count} total)
       versions_header: Versionen
+      ruby_abi:
       yanked_notice:
     show_yanked:
       not_hosted_notice: Dieses Gem wird aktuell nicht auf RubyGems.org gehostet.
@@ -1069,6 +1070,7 @@ de:
       imported_gem_version_notice:
     version:
       yanked:
+      ruby_abi:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,6 +888,7 @@ en:
       requirements_header: Requirements
       show_all_versions: Show all versions (%{count} total)
       versions_header: Versions
+      ruby_abi: Ruby ABI
       yanked_notice: This version has been yanked, and it is not available for download directly or for other gems that may have depended on it.
     show_yanked:
       not_hosted_notice: This gem is not currently hosted on RubyGems.org. Yanked versions of this gem may already exist.
@@ -988,6 +989,7 @@ en:
       imported_gem_version_notice: "This gem version was imported to RubyGems.org on %{import_date}. The date displayed was specified by the author in the gemspec."
     version:
       yanked: yanked
+      ruby_abi: Ruby ABI
   webauthn_credentials:
     callback:
       success: You have successfully registered a security device.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -982,6 +982,7 @@ es:
       requirements_header: Requerimientos
       show_all_versions: Mostrar todas las versiones (%{count} total)
       versions_header: Versiones
+      ruby_abi:
       yanked_notice: Esta versión fue borrada, y no está disponible para su descarga
         directa ni por otras gemas que puedan haber dependido de la misma.
     show_yanked:
@@ -1098,6 +1099,7 @@ es:
         el archivo gemspec.
     version:
       yanked: borrada
+      ruby_abi:
   webauthn_credentials:
     callback:
       success: Has dado de alta con éxito un dispositivo de seguridad.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -911,6 +911,7 @@ fr:
       requirements_header: Dépendances
       show_all_versions: Voir toutes les versions (%{count})
       versions_header: Versions
+      ruby_abi:
       yanked_notice: 'Retrait de Gem : disponible ni directement, ni pour les gems
         qui en dépendraient.'
     show_yanked:
@@ -1024,6 +1025,7 @@ fr:
       imported_gem_version_notice:
     version:
       yanked: retiré
+      ruby_abi:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -897,6 +897,7 @@ ja:
       requirements_header: 必須要件
       show_all_versions: 全てのバージョンを表示（全%{count}件）
       versions_header: バージョン履歴
+      ruby_abi:
       yanked_notice: このバージョンはヤンクされ、直接のダウンロードや依存関係になっている可能性がある他のgemは利用できません。
     show_yanked:
       not_hosted_notice: このgemは現在RubyGems.org上ではホストされていません。このgemのヤンクされたバージョンはまだ存在する可能性があります。
@@ -1001,6 +1002,7 @@ ja:
       imported_gem_version_notice: このgemのバージョンは%{import_date}にRubyGems.orgにインポートされました。表示されている日付は作者によってgemspec中で指定されました。
     version:
       yanked: ヤンク済み
+      ruby_abi:
   webauthn_credentials:
     callback:
       success: セキュリティ機器が正常に登録されました。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -881,6 +881,7 @@ nl:
       requirements_header: Requirements
       show_all_versions: Toon alle versies (%{count} totaal)
       versions_header: Versies
+      ruby_abi:
       yanked_notice:
     show_yanked:
       not_hosted_notice: Deze gem wordt momenteel niet gehost op rubygems.org.
@@ -981,6 +982,7 @@ nl:
       imported_gem_version_notice:
     version:
       yanked: verwijderd
+      ruby_abi:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -894,6 +894,7 @@ pt-BR:
       requirements_header: Requisitos
       show_all_versions: Mostrar todas as versões (%{count})
       versions_header: Versões
+      ruby_abi:
       yanked_notice: Esta gem foi removida, e não está mais disponível para download.
     show_yanked:
       not_hosted_notice: Esta gem não está hospedada no Gemcutter.
@@ -1004,6 +1005,7 @@ pt-BR:
       imported_gem_version_notice:
     version:
       yanked: removida
+      ruby_abi:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -890,6 +890,7 @@ zh-CN:
       requirements_header: 要求
       show_all_versions: 显示所有版本 (共 %{count} 个)
       versions_header: 版本列表
+      ruby_abi:
       yanked_notice: 这个 Gem 版本已经撤回了，无法直接下载，也无法被其他 Gem 依赖。
     show_yanked:
       not_hosted_notice: 这个 Gem 目前没有被托管在 RubyGems.org 中。这个 Gem 撤回的版本可能已经存在了。
@@ -995,6 +996,7 @@ zh-CN:
         gemspec 中指定。
     version:
       yanked: 已撤回
+      ruby_abi:
   webauthn_credentials:
     callback:
       success: 您已成功注册一个安全设备。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -882,6 +882,7 @@ zh-TW:
       requirements_header: 必填
       show_all_versions: 顯示所有版本（共 %{count}）
       versions_header: 版本列表
+      ruby_abi:
       yanked_notice: 這個 Gem 版本已被移除，因此無法提供下載，也無法被其他的 Gem 相依。
     show_yanked:
       not_hosted_notice: 這個 Gem 目前沒有在 RubyGems.org 上
@@ -983,6 +984,7 @@ zh-TW:
         gemspec 指定。
     version:
       yanked: 已被移除
+      ruby_abi:
   webauthn_credentials:
     callback:
       success: 您已成功註冊安全裝置。

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -3,7 +3,7 @@
 module CompactIndex
   module GemVersionMethods
     def version_token
-      return "#{number}-#{content_address}" if ruby_abi.present? && content_address.present?
+      return "#{number}-#{content_address}" if content_address.present?
 
       if platform.nil? || platform == "ruby"
         number
@@ -27,7 +27,7 @@ module CompactIndex
       line = "#{version_token} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
-      line << ",platform:= #{platform}" if ruby_abi.present? && content_address.present?
+      line << ",platform:= #{platform}" if content_address.present?
       line
     end
 

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -2,7 +2,9 @@
 
 module CompactIndex
   module GemVersionMethods
-    def number_and_platform
+    def version_token
+      return "#{number}-#{content_address}" if ruby_abi.present? && content_address.present?
+
       if platform.nil? || platform == "ruby"
         number
       else
@@ -14,16 +16,18 @@ module CompactIndex
       number_comp = number <=> other.number
 
       if number_comp.zero?
-        [number, platform].compact <=> [other.number, other.platform].compact
+        [platform, ruby_abi, content_address].compact <=>
+          [other.platform, other.ruby_abi, other.content_address].compact
       else
         number_comp
       end
     end
 
     def to_line
-      line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
+      line = "#{version_token} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line << ",platform:= #{platform}" if ruby_abi.present? && content_address.present?
       line
     end
 
@@ -54,7 +58,7 @@ module CompactIndex
 
   GemVersionV2 = Struct.new(:number, :platform, :checksum, :info_checksum,
                             :dependencies, :ruby_version, :rubygems_version,
-                            :created_at) do
+                            :created_at, :ruby_abi, :content_address) do
     include GemVersionMethods
 
     def to_line

--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -46,7 +46,7 @@ module CompactIndex
 
     def write_gem_lines(io, gems)
       gems.each do |gem|
-        version_numbers = gem.versions.map(&:number_and_platform).join(",")
+        version_numbers = gem.versions.map(&:version_token).join(",")
         io << gem.name <<
           " " << version_numbers <<
           " #{gem.versions.last.info_checksum}\n"

--- a/lib/tasks/gemcutter.rake
+++ b/lib/tasks/gemcutter.rake
@@ -81,7 +81,8 @@ namespace :gemcutter do
         canonical_number = Gem::Version.new(version.number).canonical_segments.join(".")
 
         loop do
-          conflicting_version = Version.find_by(canonical_number: canonical_number, rubygem_id: version.rubygem_id, platform: version.platform)
+          conflicting_version = Version.find_by(canonical_number: canonical_number, rubygem_id: version.rubygem_id,
+                                                 platform: version.platform, ruby_abi: nil)
           break unless conflicting_version
 
           canonical_number += ".dedup"

--- a/script/restore_version
+++ b/script/restore_version
@@ -1,20 +1,24 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-gem_name, version_number, platform = *ARGV
+gem_name, version_number, platform, ruby_abi = *ARGV
 
-abort "Usage: script/restore_version GEM_NAME VESRION_NUMBER [PLATFORM]" if gem_name.nil? || version_number.nil?
+abort "Usage: script/restore_version GEM_NAME VERSION_NUMBER [PLATFORM] [RUBY_ABI]" if gem_name.nil? || version_number.nil?
 
 ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 rubygem = Rubygem.find_by_name!(gem_name)
-slug = version_number
+slug = version_number.dup
 slug << "-#{platform}" if platform.present?
-version = rubygem.find_version!(number: version_number, platform: platform)
-raise "Version #{slug} for #{gem_name} was not found" unless version
+slug << " (Ruby ABI #{ruby_abi})" if ruby_abi.present?
+begin
+  version = rubygem.find_version!(number: version_number, platform: platform, ruby_abi: ruby_abi.presence)
+rescue ActiveRecord::RecordNotFound
+  abort "Version #{slug} for #{gem_name} was not found"
+end
 
-deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform)
+deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform, ruby_abi: version.ruby_abi)
 raise "Deletion record for version: #{version.full_name} was not found" unless deletion
 
 deletion.version = version

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -32,6 +32,148 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
       end
     end
 
+    context "for a gem with content-addressable versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        create(:ownership, user: @user, rubygem: @rubygem)
+        RubygemFs.instance.store("gems/#{@abi32.full_name}.gem", "")
+        RubygemFs.instance.store("gems/#{@abi34.full_name}.gem", "")
+      end
+
+      context "ON DELETE with a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2" }
+        end
+
+        should respond_with :success
+
+        should "yank only the targeted Ruby ABI variant" do
+          refute_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond with the deleted variant including its content address and Ruby ABI" do
+          assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-724c5206, Platform: x86_64-linux-musl, Ruby ABI 3.2)"
+        end
+      end
+
+      context "ON DELETE without a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param that does not match any variant" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) (Ruby ABI 3.3) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param but no platform" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", ruby_abi: "3.2" }
+        end
+
+        should respond_with :bad_request
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the platform param is required" do
+          assert_includes @response.body, "The platform param is required when ruby_abi is specified."
+        end
+      end
+
+      context "ON DELETE with an invalid ruby_abi format" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "invalid" }
+        end
+
+        should respond_with :bad_request
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the ruby_abi format is invalid" do
+          assert_includes @response.body, "The ruby_abi param must be in the format X.Y (e.g., 3.2)."
+        end
+      end
+
+      context "when a version supporting multiple Ruby ABIs coexists" do
+        setup do
+          @multi_abi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                              required_ruby_version: ">= 3.2")
+          RubygemFs.instance.store("gems/#{@multi_abi.full_name}.gem", "")
+        end
+
+        context "ON DELETE with only a platform param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+          end
+
+          should respond_with :success
+
+          should "yank only the version supporting multiple Ruby ABIs and keep the single ABI variants" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+
+        context "ON DELETE with an empty ruby_abi param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "" }
+          end
+
+          should respond_with :success
+
+          should "treat the empty ruby_abi as absent and yank the version supporting multiple Ruby ABIs" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+      end
+    end
+
     context "for a gem SomeGem with a version 0.1.0" do
       setup do
         @rubygem   = create(:rubygem, name: "SomeGem")

--- a/test/functional/api/v2/contents_controller_test.rb
+++ b/test/functional/api/v2/contents_controller_test.rb
@@ -3,8 +3,8 @@
 require "test_helper"
 
 class Api::V2::ContentsControllerTest < ActionController::TestCase
-  def get_index(rubygem, version_number, platform = nil, format: :sha256)
-    get :index, params: { rubygem_name: rubygem.name, version_number:, platform:, format: }.compact
+  def get_index(rubygem, version_number, platform = nil, ruby_abi: nil, format: :sha256)
+    get :index, params: { rubygem_name: rubygem.name, version_number:, platform:, ruby_abi:, format: }.compact
   end
 
   def set_cache_header
@@ -198,6 +198,83 @@ class Api::V2::ContentsControllerTest < ActionController::TestCase
       get_index(@rubygem, "2.0.0")
 
       assert_response :not_found
+    end
+
+    should "return bad request when ruby_abi is given without a platform" do
+      get :index, params: { rubygem_name: @rubygem.name, version_number: "2.0.0", ruby_abi: "3.2", format: :sha256 }
+
+      assert_response :bad_request
+      assert_equal "The platform param is required when ruby_abi is specified.", @response.body
+    end
+
+    should "return bad request when ruby_abi has an invalid format" do
+      get :index, params: { rubygem_name: @rubygem.name, version_number: "2.0.0", platform: "x86_64-linux", ruby_abi: "invalid", format: :sha256 }
+
+      assert_response :bad_request
+      assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+    end
+
+    should "treat empty ruby_abi as absent" do
+      get_index(@rubygem, "2.0.0", nil, ruby_abi: "")
+
+      assert_response :success
+    end
+
+    should "reject boundary near-misses for ruby_abi format" do
+      %w[3 3.2.1 3.].each do |invalid|
+        get :index, params: { rubygem_name: @rubygem.name, version_number: "2.0.0", platform: "x86_64-linux", ruby_abi: invalid, format: :sha256 }
+
+        assert_response :bad_request
+        assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+      end
+    end
+
+    should "return format error when ruby_abi is invalid and platform is missing" do
+      get :index, params: { rubygem_name: @rubygem.name, version_number: "2.0.0", ruby_abi: "invalid", format: :sha256 }
+
+      assert_response :bad_request
+      assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+    end
+
+    should "return bad request for invalid ruby_abi even when version does not exist" do
+      get :index, params: { rubygem_name: @rubygem.name, version_number: "999.0.0", platform: "x86_64-linux", ruby_abi: "invalid", format: :sha256 }
+
+      assert_response :bad_request
+      assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+    end
+  end
+
+  context "on GET to index for content-addressable variants" do
+    setup do
+      @rubygem = create(:rubygem, name: "skinny-contents")
+      @skinny32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                          required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+                          sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.2"))
+      @skinny34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                          required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                          sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.4"))
+
+      @skinny32.manifest.store_checksums("lib/a.rb" => "aaa11111")
+      @skinny34.manifest.store_checksums("lib/a.rb" => "bbb22222")
+    end
+
+    should "serve each ABI variant its own checksums" do
+      get_index @rubygem, "1.0.0", "x86_64-linux", ruby_abi: "3.2"
+
+      assert_response :success
+      assert_equal "aaa11111  lib/a.rb\n", @response.body
+
+      get_index @rubygem, "1.0.0", "x86_64-linux", ruby_abi: "3.4"
+
+      assert_response :success
+      assert_equal "bbb22222  lib/a.rb\n", @response.body
+    end
+
+    should "return 404 for a non-matching Ruby ABI" do
+      get_index @rubygem, "1.0.0", "x86_64-linux", ruby_abi: "3.3"
+
+      assert_response :not_found
+      assert_equal "This version could not be found.", @response.body
     end
   end
 

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -219,7 +219,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       assert_equal(
         %w[
           name downloads version version_created_at version_downloads platform
-          authors info licenses metadata yanked sha spec_sha project_uri gem_uri
+          ruby_abi authors info licenses metadata yanked sha spec_sha project_uri gem_uri
           homepage_uri wiki_uri documentation_uri mailing_list_uri
           source_code_uri bug_tracker_uri changelog_uri funding_uri dependencies
           built_at created_at description downloads_count number summary

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -68,6 +68,92 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       create(:version, rubygem: @rubygem2, number: "1.0.0")
     end
 
+    context "with versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        @multi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: ">= 3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-multi"),
+                        spec_sha256: Digest::SHA2.base64digest("spec-multi"))
+      end
+
+      should "return the targeted Ruby ABI variant when ruby_abi is given" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_equal "3.2", payload["ruby_abi"]
+        assert_equal @abi32.sha256_hex, payload["sha"]
+      end
+
+      should "return the version supporting multiple Ruby ABIs without a ruby_abi param" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_nil payload["ruby_abi"]
+        assert_equal @multi.sha256_hex, payload["sha"]
+      end
+
+      should "return not found for a ruby_abi that does not match any variant" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3", format: "json" }
+
+        assert_response :not_found
+      end
+
+      should "return bad request when ruby_abi is given without a platform" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", ruby_abi: "3.2", format: "json" }
+
+        assert_response :bad_request
+        assert_equal "The platform param is required when ruby_abi is specified.", @response.body
+      end
+
+      should "return bad request when ruby_abi has an invalid format" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "invalid", format: "json" }
+
+        assert_response :bad_request
+        assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+      end
+
+      should "treat empty ruby_abi as absent" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_nil payload["ruby_abi"]
+        assert_equal @multi.sha256_hex, payload["sha"]
+      end
+
+      should "reject boundary near-misses for ruby_abi format" do
+        %w[3 3.2.1 3.].each do |invalid|
+          get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: invalid, format: "json" }
+
+          assert_response :bad_request
+          assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+        end
+      end
+
+      should "return format error when ruby_abi is invalid and platform is missing" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", ruby_abi: "invalid", format: "json" }
+
+        assert_response :bad_request
+        assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+      end
+
+      should "return bad request for invalid ruby_abi even when version does not exist" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "999.0.0", platform: "x86_64-linux-musl", ruby_abi: "invalid", format: "json" }
+
+        assert_response :bad_request
+        assert_equal "The ruby_abi param must be in the format X.Y (e.g., 3.2).", @response.body
+      end
+    end
+
     should_respond_to(:json) do |body|
       JSON.parse(body)
     end

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -13,7 +13,9 @@ module CompactIndexHelpers
       args[:dependencies],
       args[:ruby_version],
       args[:rubygems_version],
-      args[:created_at]
+      args[:created_at],
+      args[:ruby_abi],
+      args[:content_address]
     )
   end
 end

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -101,6 +101,28 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
   end
 
+  test "/versions includes content-addressable versions for gems which support single Ruby ABI" do
+    rubygem = create(:rubygem, name: "v2rubyabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: "~> 3.2.0",
+      required_rubygems_version: ">= 4.1.0.beta1",
+      sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    content_address = version.full_name.split("-").last
+
+    get versions_path
+
+    assert_response :success
+    assert_includes @response.body, "v2rubyabi 2.9.0-#{content_address} #{current_checksum(version)}"
+  end
+
   test "/versions partial response" do
     get versions_path
     full_response_body = @response.body
@@ -181,6 +203,70 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
     assert_equal "#{current_info_prefix}/* gem/v2gem #{current_info_prefix}/v2gem", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info serves correct format for gem which supports single Ruby ABI" do
+    rubygem = create(:rubygem, name: "v2rubyabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: "~> 3.2.0",
+      required_rubygems_version: ">= 4.1.0.beta1",
+      sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    content_address = version.full_name.split("-").last
+
+    expected = <<~VERSIONS_FILE
+      ---
+      2.9.0-#{content_address} |checksum:#{Version._sha256_hex(version.sha256)},ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:= x86_64-linux-musl,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+
+    expected_digest = digest(expected)
+
+    get info_path(gem_name: "v2rubyabi")
+
+    assert_response :success
+    assert_equal expected, @response.body
+    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
+    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "#{current_info_prefix}/* gem/v2rubyabi #{current_info_prefix}/v2rubyabi", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info serves correct format for gem which supports multiple Ruby ABIs" do
+    rubygem = create(:rubygem, name: "v2multiabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: ">= 3.2.0",
+      required_rubygems_version: ">= 4.1.0.beta1",
+      sha256: Digest::SHA2.base64digest("v2multiabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    expected = <<~VERSIONS_FILE
+      ---
+      2.9.0-x86_64-linux-musl |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 3.2.0,rubygems:>= 4.1.0.beta1,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+
+    expected_digest = digest(expected)
+
+    get info_path(gem_name: "v2multiabi")
+
+    assert_response :success
+    assert_equal expected, @response.body
+    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
+    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "#{current_info_prefix}/* gem/v2multiabi #{current_info_prefix}/v2multiabi", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -112,7 +112,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       required_ruby_version: "~> 3.2.0",
       required_rubygems_version: ">= 4.1.0.beta1",
       sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
-      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0),
+      ruby_abi: "3.2"
     )
 
     content_address = version.full_name.split("-").last
@@ -216,7 +217,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       required_ruby_version: "~> 3.2.0",
       required_rubygems_version: ">= 4.1.0.beta1",
       sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
-      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0),
+      ruby_abi: "3.2"
     )
 
     content_address = version.full_name.split("-").last

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -116,7 +116,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       ruby_abi: "3.2"
     )
 
-    content_address = version.full_name.split("-").last
+    content_address = version.content_address
 
     get versions_path
 
@@ -221,7 +221,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       ruby_abi: "3.2"
     )
 
-    content_address = version.full_name.split("-").last
+    content_address = version.content_address
 
     expected = <<~VERSIONS_FILE
       ---

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -491,10 +491,59 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       assert @cutter.save
     end
 
+    should "roll back version changes when normalize raises" do
+      original = @version.required_rubygems_version
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec) do |version, _spec|
+        version.update!(required_rubygems_version: "99.0.0")
+      end
+      @version.stubs(:normalize_content_addressable_gem_metadata!)
+        .raises(ActiveRecord::RecordInvalid.new(@version))
+
+      refute @cutter.save
+      assert_equal original, @version.reload.required_rubygems_version
+    end
+
     should "include platform and Ruby ABI in success message" do
       assert @cutter.save
 
       assert_equal "Successfully registered gem: #{@version.to_title}", @cutter.message
+    end
+
+    should "retry the persist on a content_address unique collision" do
+      sequence = sequence("content address collision retry")
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec)
+        .in_sequence(sequence)
+        .raises(ActiveRecord::RecordNotUnique.new(
+                  'duplicate key value violates unique constraint "index_versions_number_content_address"'
+                ))
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec)
+        .in_sequence(sequence)
+
+      assert @cutter.save
+    end
+
+    should "not retry on an unrelated unique violation" do
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec).once
+        .raises(ActiveRecord::RecordNotUnique.new(
+                  'duplicate key value violates unique constraint "index_versions_full_name"'
+                ))
+
+      refute @cutter.save
+    end
+
+    should "fail with an error after exhausting content_address retries" do
+      StatsD.stubs(:increment)
+      StatsD.expects(:increment).with("push.content_address_collision", tags: { rubygem: @rubygem.name }).times(3)
+      StatsD.expects(:increment).with("push.content_address_collision_exhausted", tags: { rubygem: @rubygem.name }).once
+
+      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec).times(4)
+        .raises(ActiveRecord::RecordNotUnique.new(
+                  'duplicate key value violates unique constraint "index_versions_number_content_address"'
+                ))
+
+      refute @cutter.save
+      assert_equal 409, @cutter.code
+      assert_includes @cutter.message, "could not generate a unique content address"
     end
   end
 

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -392,6 +392,10 @@ class PusherIntegrationTest < ActiveSupport::TestCase
           version_gid: @rubygem.versions.last.to_gid.to_s
         }, @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
       end
+
+      should "set success message" do
+        assert_equal "Successfully registered gem: #{@cutter.version.to_title}", @cutter.message
+      end
     end
 
     should "purge gem cache" do
@@ -430,6 +434,67 @@ class PusherIntegrationTest < ActiveSupport::TestCase
           end
         end
       end
+    end
+
+    should "preserve required rubygems version for gems supporting multiple Ruby ABIs" do
+      @cutter.version.update!(required_rubygems_version: ">= 3.0", ruby_abi: nil)
+
+      assert @cutter.save
+
+      assert_equal ">= 3.0", @cutter.version.reload.required_rubygems_version
+    end
+  end
+
+  context "successfully saving a gemcutter scoped to one Ruby ABI" do
+    setup do
+      @rubygem = create(:rubygem, name: "sandworm")
+      @version = create(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: ">= 0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4"),
+        pusher_api_key: @cutter.api_key
+      )
+
+      @cutter.stubs(:rubygem).returns @rubygem
+      @cutter.stubs(:version).returns @version
+      @cutter.stubs(:spec).returns(mock)
+      @rubygem.stubs(:update_attributes_from_gem_specification!)
+      GemCachePurger.stubs(:call)
+      @cutter.stubs(:write_gem)
+    end
+
+    should "set content addressable required rubygems version floor" do
+      assert @cutter.save
+
+      assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @version.reload.required_rubygems_version
+    end
+
+    should "normalize content addressable required rubygems version after applying gemspec metadata" do
+      sequence = sequence("content addressable metadata normalization")
+
+      @rubygem
+        .expects(:update_attributes_from_gem_specification!)
+        .with(@version, @cutter.spec)
+        .in_sequence(sequence)
+
+      @version
+        .expects(:normalize_content_addressable_gem_metadata!)
+        .in_sequence(sequence)
+
+      AfterVersionWriteJob.any_instance.stubs(:perform)
+
+      assert @cutter.save
+    end
+
+    should "include platform and Ruby ABI in success message" do
+      assert @cutter.save
+
+      assert_equal "Successfully registered gem: #{@version.to_title}", @cutter.message
     end
   end
 

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -29,9 +29,44 @@ class CompactIndex::GemVersionV2Test < ActiveSupport::TestCase
 
       assert_equal 0, v1 <=> v2
     end
+
+    should "sort by Ruby ABI and content address when numbers and platforms are equal" do
+      v1 = build_version(
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        ruby_abi: "3.2",
+        content_address: "ef716ba7"
+      )
+      v2 = build_version(
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        ruby_abi: "3.3",
+        content_address: "ab123456"
+      )
+
+      assert_equal(-1, v1 <=> v2)
+      assert_equal 1, v2 <=> v1
+    end
   end
 
   context "#to_line" do
+    should "use content address and platform metadata for Ruby ABI versions" do
+      version = build_version(
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        checksum: "ef716ba7abcdef",
+        ruby_version: "~> 3.2.0",
+        rubygems_version: ">= 4.1.0.beta1",
+        ruby_abi: "3.2",
+        content_address: "ef716ba7"
+      )
+
+      assert_equal(
+        "2.9.0-ef716ba7 |checksum:ef716ba7abcdef,ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:= x86_64-linux-musl",
+        version.to_line
+      )
+    end
+
     should "not include created_at when absent" do
       v = build_version(number: "1.0")
 

--- a/test/lib/compact_index/versions_file_test.rb
+++ b/test/lib/compact_index/versions_file_test.rb
@@ -135,6 +135,21 @@ class CompactIndex::VersionsFileTest < ActiveSupport::TestCase
   end
 
   context "#contents" do
+    should "use content address for Ruby ABI version tokens" do
+      versions = [
+        build_version(
+          name: "test",
+          number: "2.9.0",
+          platform: "x86_64-linux-musl",
+          ruby_abi: "3.2",
+          content_address: "ef716ba7"
+        )
+      ]
+      gems = [CompactIndex::Gem.new("test", versions)]
+
+      assert_includes @versions_file.contents(gems), "test 2.9.0-ef716ba7 info+test+2.9.0"
+    end
+
     should "raise when there are unknown options" do
       assert_raises(ArgumentError) { @versions_file.contents(nil, foo: :bar) }
     end

--- a/test/models/concerns/compact_index_versions_test.rb
+++ b/test/models/concerns/compact_index_versions_test.rb
@@ -8,6 +8,28 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
   end
 
   context ".compact_index_versions" do
+    should "include Ruby ABI and content address for created versions" do
+      rubygem = create(:rubygem, name: "skinny")
+      version = create(
+        :version,
+        rubygem:,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("skinny-2.9.0-x86_64-linux-musl"),
+        created_at: 2.days.ago,
+        info_checksum_v2: "skinny-info",
+        ruby_abi: "3.2"
+      )
+
+      versions = GemInfo.compact_index_versions(3.days.ago)
+      gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny" }
+
+      assert_equal "3.2", gem.versions.first.ruby_abi
+      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+    end
+
     should "return all versions created after given date" do
       create(:version, number: "0.0.1", created_at: 10.days.ago)
       rubygem = create(:rubygem, name: "foo")
@@ -37,6 +59,28 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
   end
 
   context ".compact_index_public_versions" do
+    should "include Ruby ABI and content address for public versions" do
+      rubygem = create(:rubygem, name: "skinny-public")
+      version = create(
+        :version,
+        rubygem:,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("skinny-public-2.9.0-x86_64-linux-musl"),
+        created_at: @ts,
+        info_checksum_v2: "skinny-public-info",
+        ruby_abi: "3.2"
+      )
+
+      versions = GemInfo.compact_index_public_versions(@ts)
+      gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny-public" }
+
+      assert_equal "3.2", gem.versions.first.ruby_abi
+      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+    end
+
     should "not return version updated after timestamp" do
       version = create(:version, number: "0.0.1", created_at: @ts, info_checksum_v2: "v2qw2dwe")
       _updated_after_ts = create(:version, number: "2.0.0", created_at: @ts + 1.second, info_checksum_v2: "v2qw2dwe")

--- a/test/models/concerns/compact_index_versions_test.rb
+++ b/test/models/concerns/compact_index_versions_test.rb
@@ -27,7 +27,26 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny" }
 
       assert_equal "3.2", gem.versions.first.ruby_abi
-      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+      assert_equal version.content_address, gem.versions.first.content_address
+    end
+
+    should "return no content address for unplatformed versions" do
+      rubygem = create(:rubygem, name: "datestamped")
+      create(
+        :version,
+        rubygem:,
+        number: "20260101",
+        platform: "ruby",
+        required_ruby_version: "~> 3.2.0",
+        created_at: 2.days.ago,
+        info_checksum_v2: "datestamped-info"
+      )
+
+      versions = GemInfo.compact_index_versions(3.days.ago)
+      gem = versions.find { |compact_index_gem| compact_index_gem.name == "datestamped" }
+
+      assert_nil gem.versions.first.content_address
+      assert_equal "20260101", gem.versions.first.version_token
     end
 
     should "return all versions created after given date" do
@@ -56,6 +75,19 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       assert_includes versions,
         CompactIndex::Gem.new("bar", [CompactIndex::GemVersionV2.new("-1.0.0", "ruby", nil, "v2yanked")])
     end
+
+    should "return yanked content-addressable versions with a content-addressed token" do
+      rubygem = create(:rubygem, name: "skinny-yanked")
+      version = create(:version, :yanked, rubygem: rubygem, number: "1.0.0", platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl", required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+        sha256: Digest::SHA2.base64digest("skinny-yanked-1.0.0"), created_at: 10.days.ago,
+        yanked_at: 1.day.ago, yanked_info_checksum_v2: "v2yanked")
+
+      versions = GemInfo.compact_index_versions(4.days.ago)
+      gem = versions.find { |candidate| candidate.name == "skinny-yanked" }
+
+      assert_equal "-1.0.0-#{version.content_address}", gem.versions.first.version_token
+    end
   end
 
   context ".compact_index_public_versions" do
@@ -78,7 +110,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny-public" }
 
       assert_equal "3.2", gem.versions.first.ruby_abi
-      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+      assert_equal version.content_address, gem.versions.first.content_address
     end
 
     should "not return version updated after timestamp" do

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -185,6 +185,16 @@ class DeletionTest < ActiveSupport::TestCase
 
     assert_equal deletion.rubygem, @version.rubygem.name
     assert_equal @version.id, deletion.version_id
+    assert_nil deletion.ruby_abi
+  end
+
+  should "record the Ruby ABI for versions targeting a single Ruby ABI" do
+    version = create(:version, rubygem: @version.rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("test-2.0.0-3.4"))
+    deletion = Deletion.new(version: version, user: @user)
+    deletion.valid?
+
+    assert_equal "3.4", deletion.ruby_abi
   end
 
   context "with restored gem" do

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -44,7 +44,8 @@ class GemInfoTest < ActiveSupport::TestCase
         gem_platform: "x86_64-linux-musl",
         required_ruby_version: "~> 3.2.0",
         sha256: Digest::SHA2.base64digest("single-abi-2.9.0-x86_64-linux-musl"),
-        info_checksum_v2: "single-abi-info-checksum"
+        info_checksum_v2: "single-abi-info-checksum",
+        ruby_abi: "3.2"
       )
 
       info = GemInfo.new("single-abi-info").compact_index_info

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -34,6 +34,83 @@ class GemInfoTest < ActiveSupport::TestCase
       @expected_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(@expected_info))
     end
 
+    should "include Ruby ABI and content address in info version targeting a single Ruby ABI" do
+      rubygem = create(:rubygem, name: "single-abi-info")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("single-abi-2.9.0-x86_64-linux-musl"),
+        info_checksum_v2: "single-abi-info-checksum"
+      )
+
+      info = GemInfo.new("single-abi-info").compact_index_info
+      compact_index_version = info.first
+
+      assert_equal "3.2", compact_index_version.ruby_abi
+      assert_equal version.full_name.split("-").last, compact_index_version.content_address
+    end
+
+    should "order info versions with the same number and platform by Ruby ABI" do
+      rubygem = create(:rubygem, name: "abi-ordering")
+      created_at = Time.utc(2026, 7, 1, 12, 0, 0)
+      create(
+        :version,
+        rubygem: rubygem,
+        number: "1.0.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: ">= 3.2",
+        sha256: Digest::SHA2.base64digest("abi-ordering-x86_64-linux-musl"),
+        info_checksum_v2: "abi-ordering-checksum",
+        ruby_abi: nil,
+        created_at: created_at
+      )
+      %w[3.4 3.2 3.3].each do |abi|
+        create(
+          :version,
+          rubygem: rubygem,
+          number: "1.0.0",
+          platform: "x86_64-linux-musl",
+          gem_platform: "x86_64-linux-musl",
+          required_ruby_version: "~> #{abi}.0",
+          sha256: Digest::SHA2.base64digest("abi-ordering-#{abi}-x86_64-linux-musl"),
+          info_checksum_v2: "abi-ordering-checksum",
+          ruby_abi: abi,
+          created_at: created_at
+        )
+      end
+
+      info = GemInfo.new("abi-ordering").compact_index_info
+
+      assert_equal ["3.2", "3.3", "3.4", nil], info.map(&:ruby_abi)
+    end
+
+    should "return platform identity without Ruby ABI or content address for versions targeting multiple Ruby ABIs" do
+      rubygem = create(:rubygem, name: "multi-abi")
+      create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: ">= 3.2.0",
+        sha256: Digest::SHA2.base64digest("multi-abi-2.9.0-x86_64-linux-musl"),
+        info_checksum_v2: "multi-abi-info-checksum"
+      )
+
+      info = GemInfo.new("multi-abi").compact_index_info
+      compact_index_version = info.first
+
+      assert_equal "2.9.0", compact_index_version.number
+      assert_equal "x86_64-linux-musl", compact_index_version.platform
+      assert_nil compact_index_version.ruby_abi
+      assert_nil compact_index_version.content_address
+    end
+
     should "return v2 gem version and dependency with created_at" do
       info = GemInfo.new("example").compact_index_info
 

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -52,7 +52,23 @@ class GemInfoTest < ActiveSupport::TestCase
       compact_index_version = info.first
 
       assert_equal "3.2", compact_index_version.ruby_abi
-      assert_equal version.full_name.split("-").last, compact_index_version.content_address
+      assert_equal version.content_address, compact_index_version.content_address
+    end
+
+    should "return no content address for unplatformed versions" do
+      rubygem = create(:rubygem, name: "datestamped")
+      create(
+        :version,
+        rubygem: rubygem,
+        number: "20260101",
+        platform: "ruby",
+        required_ruby_version: "~> 3.2.0",
+        info_checksum_v2: "datestamped-info"
+      )
+
+      info = GemInfo.new("datestamped").compact_index_info
+
+      assert_nil info.first.content_address
     end
 
     should "order info versions with the same number and platform by Ruby ABI" do

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -149,6 +149,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.stubs(:size).returns 5
@@ -193,6 +194,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "ruby"
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -214,6 +216,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:platform).returns "ruby"
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -233,6 +236,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "ruby"
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -255,6 +259,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "universal-darwin-6000"
       spec.stubs(:platform).returns Gem::Platform.new("universal-darwin-6000")
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -265,6 +270,60 @@ class PusherTest < ActiveSupport::TestCase
 
       assert_equal "universal-darwin-6000", @cutter.version.platform
       assert_equal "universal-darwin-6000", @cutter.version.gem_platform
+    end
+
+    should "initialize a new version when the existing version has a different Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+      required_ruby_version: "~> 3.3.0")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      assert @cutter.find
+
+      assert_equal rubygem, @cutter.rubygem
+      assert_not_predicate @cutter.version, :persisted?
+      assert_equal "1.0.0", @cutter.version.number
+      assert_equal "arm64-darwin-25", @cutter.version.platform
+      assert_equal "~> 3.4.0", @cutter.version.required_ruby_version
+      assert_equal "3.4", @cutter.version.ruby_abi
+    end
+
+    should "reject a new version when the existing version has the same Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+      required_ruby_version: "~> 3.4.0")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      refute @cutter.find
+
+      assert_equal 409, @cutter.code
+      assert_match(/Repushing of gem versions is not allowed/, @cutter.message)
     end
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -272,10 +272,38 @@ class PusherTest < ActiveSupport::TestCase
       assert_equal "universal-darwin-6000", @cutter.version.gem_platform
     end
 
-    should "initialize a new version when the existing version has a different Ruby ABI" do
+    should "initialize a new version but not set the Ruby ABI when the feature flag is off" do
+      rubygem = create(:rubygem, name: "sandworm")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      assert @cutter.find
+
+      assert_equal rubygem, @cutter.rubygem
+      assert_not_predicate @cutter.version, :persisted?
+      assert_equal "1.0.0", @cutter.version.number
+      assert_equal "arm64-darwin-25", @cutter.version.platform
+      assert_equal "~> 3.4.0", @cutter.version.required_ruby_version
+      assert_nil @cutter.version.ruby_abi
+    end
+
+    should "set Ruby ABI for a new version when the feature flag is on" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-      required_ruby_version: "~> 3.3.0")
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -302,9 +330,10 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "reject a new version when the existing version has the same Ruby ABI" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-      required_ruby_version: "~> 3.4.0")
+        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -324,6 +353,33 @@ class PusherTest < ActiveSupport::TestCase
 
       assert_equal 409, @cutter.code
       assert_match(/Repushing of gem versions is not allowed/, @cutter.message)
+    end
+  end
+
+  context "validating uploaded spec platform attributes" do
+    should "allow content-addressable versions whose uploaded spec keeps platform identity" do
+      rubygem = create(:rubygem, name: "sandworm")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4")
+      )
+      spec = mock
+      spec.stubs(:cert_chain).returns([])
+      spec.stubs(:original_platform).returns("arm64-darwin-25")
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+
+      @cutter.stubs(:rubygem).returns rubygem
+      @cutter.stubs(:version).returns version
+      @cutter.instance_variable_set(:@spec, spec)
+
+      assert_predicate version, :content_addressable?
+      assert @cutter.validate
     end
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -329,6 +329,31 @@ class PusherTest < ActiveSupport::TestCase
       assert_equal "3.4", @cutter.version.ruby_abi
     end
 
+    should "not set Ruby ABI for gems without a platform even when the feature flag is on" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
+      create(:rubygem, name: "sandworm")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "ruby"
+      spec.stubs(:platform).returns "ruby"
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      assert @cutter.find
+
+      assert_equal "ruby", @cutter.version.platform
+      assert_equal "~> 3.4.0", @cutter.version.required_ruby_version
+      assert_nil @cutter.version.ruby_abi
+    end
+
     should "reject a new version when the existing version has the same Ruby ABI" do
       FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -80,6 +80,25 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.most_recent_version
     end
 
+    should "mark the latest version for each Ruby ABI per platform" do
+      abi32_old = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                         required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-1.0.0"))
+      abi32_new = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                         required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-2.0.0"))
+      abi33_new = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                         required_ruby_version: "~> 3.3.0", ruby_abi: "3.3", sha256: Digest::SHA2.base64digest("abi33-2.0.0"))
+      plain_ruby = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "ruby")
+
+      @rubygem.reorder_versions
+
+      latest_versions = Version.latest
+
+      assert_includes latest_versions, abi32_new
+      assert_includes latest_versions, abi33_new
+      assert_includes latest_versions, plain_ruby
+      refute_includes latest_versions, abi32_old
+    end
+
     should "order latest platform gems with latest uniquely" do
       pre  = create(:version,
         rubygem: @rubygem,

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -537,6 +537,7 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal @rubygem.most_recent_version.created_at.as_json, hash["version_created_at"]
       assert_equal @rubygem.most_recent_version.downloads_count, hash["version_downloads"]
       assert_equal @rubygem.most_recent_version.platform, hash["platform"]
+      assert_nil hash.fetch("ruby_abi")
       assert_equal @rubygem.most_recent_version.authors, hash["authors"]
       assert_equal @rubygem.most_recent_version.info, hash["info"]
       assert_equal @rubygem.most_recent_version.metadata, hash["metadata"]

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -80,6 +80,19 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.most_recent_version
     end
 
+    should "find versions by number, platform and Ruby ABI" do
+      plain = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: ">= 3.2")
+      abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("abi34-1.0.0"))
+
+      assert_equal plain, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl")
+      assert_equal abi34, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.4")
+      assert_raises(ActiveRecord::RecordNotFound) do
+        @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2")
+      end
+    end
+
     should "mark the latest version for each Ruby ABI per platform" do
       abi32_old = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
                          required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-1.0.0"))
@@ -295,6 +308,23 @@ class RubygemTest < ActiveSupport::TestCase
 
       should "return nil if number is nil" do
         assert_nil @rubygem.find_public_version(nil)
+      end
+
+      should "not return a skinny ABI variant when no platform or ruby_abi is given" do
+        create(:version, rubygem: @rubygem, number: @version.number, platform: "x86_64-linux", gem_platform: "x86_64-linux",
+               required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+               sha256: Digest::SHA2.base64digest("find-pub-1.0.0-x86_64-linux-3.2"))
+
+        assert_equal @jruby_version, @rubygem.find_public_version(@version.number)
+      end
+
+      should "return nil when only skinny ABI variants exist and no ruby_abi is given" do
+        @rubygem.versions.update_all(indexed: false)
+        create(:version, rubygem: @rubygem, number: @version.number, platform: "x86_64-linux", gem_platform: "x86_64-linux",
+               required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+               sha256: Digest::SHA2.base64digest("find-pub-only-1.0.0-x86_64-linux-3.2"))
+
+        assert_nil @rubygem.find_public_version(@version.number)
       end
     end
 
@@ -1186,6 +1216,13 @@ class RubygemTest < ActiveSupport::TestCase
       rubygem = build(:rubygem)
 
       assert_equal VersionManifest.new(gem: rubygem.name, number: "0.1.0", platform: "jruby"), rubygem.version_manifest("0.1.0", "jruby")
+    end
+
+    should "return a content-addressed VersionManifest when content_address is given" do
+      rubygem = build(:rubygem)
+
+      assert_equal VersionManifest.new(gem: rubygem.name, number: "0.1.0", content_address: "1c616c4a"),
+                   rubygem.version_manifest("0.1.0", "x86_64-linux", content_address: "1c616c4a")
     end
   end
 

--- a/test/models/version_manifest_test.rb
+++ b/test/models/version_manifest_test.rb
@@ -12,6 +12,7 @@ class VersionsManifestTest < ActiveSupport::TestCase
     @manifest = VersionManifest.new(number: "0.1.0", gem: "gemname")
     @manifest2 = VersionManifest.new(number: "0.2.0", gem: "gemname")
     @manifest3 = VersionManifest.new(number: "0.2.0", platform: "platform", gem: "gemname")
+    @manifest4 = VersionManifest.new(number: "0.2.0", gem: "gemname", content_address: "1c616c4a")
 
     @files = [
       create_entry("path1", "hex1-A"),
@@ -41,6 +42,11 @@ class VersionsManifestTest < ActiveSupport::TestCase
     should "return a path with a platform" do
       assert_equal "gems/gemname/checksums/0.2.0-platform.sha256", @manifest3.checksums_key
     end
+
+    should "return a content-addressed path distinct from the platform path" do
+      assert_equal "gems/gemname/checksums/0.2.0-1c616c4a.sha256", @manifest4.checksums_key
+      refute_equal @manifest3.checksums_key, @manifest4.checksums_key
+    end
   end
 
   context "#path_root" do
@@ -51,6 +57,11 @@ class VersionsManifestTest < ActiveSupport::TestCase
 
     should "return a path with a platform" do
       assert_equal "gems/gemname/paths/0.2.0-platform/", @manifest3.path_root
+    end
+
+    should "return a content-addressed path distinct from the platform path" do
+      assert_equal "gems/gemname/paths/0.2.0-1c616c4a/", @manifest4.path_root
+      refute_equal @manifest3.path_root, @manifest4.path_root
     end
   end
 
@@ -63,6 +74,11 @@ class VersionsManifestTest < ActiveSupport::TestCase
     should "return a path with a platform" do
       assert_equal "gems/gemname/paths/0.2.0-platform/lib/to/path.rb", @manifest3.path_key("lib/to/path.rb")
     end
+
+    should "return a content-addressed path distinct from the platform path" do
+      assert_equal "gems/gemname/paths/0.2.0-1c616c4a/lib/to/path.rb", @manifest4.path_key("lib/to/path.rb")
+      refute_equal @manifest3.path_key("lib/to/path.rb"), @manifest4.path_key("lib/to/path.rb")
+    end
   end
 
   context "#spec_key" do
@@ -73,6 +89,11 @@ class VersionsManifestTest < ActiveSupport::TestCase
 
     should "return a path with a platform" do
       assert_equal "gems/gemname/specs/gemname-0.2.0-platform.gemspec", @manifest3.spec_key
+    end
+
+    should "return a content-addressed path distinct from the platform path" do
+      assert_equal "gems/gemname/specs/gemname-0.2.0-1c616c4a.gemspec", @manifest4.spec_key
+      refute_equal @manifest3.spec_key, @manifest4.spec_key
     end
   end
 
@@ -302,6 +323,15 @@ class VersionsManifestTest < ActiveSupport::TestCase
 
     should "return true for the same gem and number and platform" do
       assert_equal @manifest3, VersionManifest.new(gem: "gemname", number: "0.2.0", platform: "platform")
+    end
+
+    should "return true for the same gem and number and content address" do
+      assert_equal @manifest4, VersionManifest.new(gem: "gemname", number: "0.2.0", content_address: "1c616c4a")
+    end
+
+    should "return false for content-addressed vs platform manifest sharing number and platform" do
+      refute_equal @manifest3, @manifest4
+      refute_equal @manifest4, VersionManifest.new(gem: "gemname", number: "0.2.0", content_address: "f15c72ce")
     end
 
     should "return false for the same gem and number with different platform" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -15,7 +15,7 @@ class VersionTest < ActiveSupport::TestCase
       json = @version.as_json
 
       fields = %w[number built_at summary description authors platform
-                  ruby_version rubygems_version prerelease downloads_count licenses
+                  ruby_version rubygems_version prerelease ruby_abi downloads_count licenses
                   requirements sha spec_sha metadata created_at]
 
       assert_equal fields.sort, json.keys.sort
@@ -44,7 +44,7 @@ class VersionTest < ActiveSupport::TestCase
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w[number built-at summary description authors platform
-                  ruby-version rubygems-version prerelease downloads-count licenses
+                  ruby-version rubygems-version prerelease ruby-abi downloads-count licenses
                   requirements sha spec-sha metadata created-at]
 
       assert_equal fields.map(&:to_s).sort,

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -165,6 +165,74 @@ class VersionTest < ActiveSupport::TestCase
 
       assert_includes version.errors[:ruby_abi], "is invalid"
     end
+
+    should "allow duplicate versions with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow duplicate versions with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+
+      assert_raises ActiveRecord::RecordNotUnique do
+        version.save!(validate: false)
+      end
+    end
+
+    should "not allow duplicate versions with nil Ruby ABIs" do
+      create(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: ">= 3.2"
+      )
+
+      duplicate = build(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: ">= 3.0"
+      )
+
+      refute_predicate duplicate, :valid?
+      assert_nil duplicate.ruby_abi
+
+      assert_raises ActiveRecord::RecordNotUnique do
+        duplicate.save!(validate: false)
+      end
+    end
+
+    should "allow canonical number duplicates with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow canonical number duplicates with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+    end
+
     should "be able to find dependencies" do
       @dependency = create(:rubygem)
       @version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "ruby")

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -584,7 +584,7 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
     end
 
-    context "#derive_ruby_abi" do
+    context ".ruby_abi_for" do
       should "return the Ruby ABI when required_ruby_version targets a single Ruby minor version" do
         assert_equal "3.2", derived_abi("~> 3.2.0")
       end
@@ -1608,7 +1608,7 @@ class VersionTest < ActiveSupport::TestCase
   private
 
   def derived_abi(required_ruby_version, platform: "x86_64-linux")
-    Version.new(platform:, required_ruby_version:).derive_ruby_abi
+    Version.ruby_abi_for(platform, required_ruby_version)
   end
 
   def encoded_sha256_with_hex_prefix(hex_sha256)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1394,6 +1394,14 @@ class VersionTest < ActiveSupport::TestCase
         number: "0.0.2.pre",
         platform: "java",
         prerelease: true)
+      @content_addressable_version = create(:version,
+        rubygem: @second_rubygem,
+        number: "0.0.2",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("second-0.0.2-x86_64-linux-musl"))
     end
 
     should "select only name, version, and platform for all gems" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -168,6 +168,14 @@ class VersionTest < ActiveSupport::TestCase
       assert_includes version.errors[:ruby_abi], "is invalid"
     end
 
+    should "not allow a ruby_abi on an unplatformed version" do
+      version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "ruby", gem_platform: "ruby",
+                      required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
+
+      refute_predicate version, :valid?
+      assert_includes version.errors[:ruby_abi], "must be blank"
+    end
+
     should "allow duplicate versions with different Ruby ABIs" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
         required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
@@ -565,37 +573,97 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
     end
 
-    context ".ruby_abi_for" do
-      should "returns Ruby ABI when required_ruby_version targets a single Ruby minor version" do
-        assert_equal "3.2", Version.ruby_abi_for("~> 3.2.0")
+    context "#derive_ruby_abi" do
+      should "return the Ruby ABI when required_ruby_version targets a single Ruby minor version" do
+        assert_equal "3.2", derived_abi("~> 3.2.0")
+      end
+
+      should "return nil for versions without a platform" do
+        assert_nil derived_abi("~> 3.2.0", platform: "ruby")
+        assert_nil derived_abi("~> 3.2.0", platform: nil)
       end
 
       should "return nil when required_ruby_version is broad" do
-        assert_nil Version.ruby_abi_for(">= 3.2")
+        assert_nil derived_abi(">= 3.2")
       end
 
       should "return nil for clean requirements with more than three segments" do
-        assert_nil Version.ruby_abi_for("~> 3.2.0.0")
+        assert_nil derived_abi("~> 3.2.0.0")
       end
 
       should "return nil when required_ruby_version has multiple requirements" do
-        assert_nil Version.ruby_abi_for(">= 3.2, < 3.4")
+        assert_nil derived_abi(">= 3.2, < 3.4")
       end
 
       should "return nil when required_ruby_version is malformed" do
-        assert_nil Version.ruby_abi_for("not a requirement")
+        assert_nil derived_abi("not a requirement")
       end
 
       should "return nil when required_ruby_version indicates multiple Ruby ABIs" do
-        assert_nil Version.ruby_abi_for("~> 3.2")
+        assert_nil derived_abi("~> 3.2")
       end
 
       should "return nil when required_ruby_version is blank" do
-        assert_nil Version.ruby_abi_for("")
+        assert_nil derived_abi("")
       end
 
       should "return nil for patch-specific pessimistic requirements" do
-        assert_nil Version.ruby_abi_for("~> 3.2.1")
+        assert_nil derived_abi("~> 3.2.1")
+      end
+    end
+
+    context "#content_addressify!" do
+      should "store the content address for versions targeting a single Ruby ABI" do
+        version = create(:version, rubygem: create(:rubygem, name: "addressed"), number: "1.0.0",
+                         platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                         required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                         sha256: Digest::SHA2.base64digest("addressed-1.0.0"))
+
+        assert_equal version.sha256_hex.first(Version::DEFAULT_CONTENT_ADDRESS_LENGTH), version.content_address
+      end
+
+      should "not store a content address for versions supporting multiple Ruby ABIs" do
+        version = create(:version, rubygem: create(:rubygem, name: "plain"), number: "1.0.0",
+                         platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                         required_ruby_version: ">= 3.2")
+
+        assert_nil version.content_address
+      end
+
+      should "not store a content address for unplatformed versions" do
+        version = create(:version, rubygem: create(:rubygem, name: "unplat"), number: "20260101",
+                         platform: "ruby", gem_platform: "ruby",
+                         required_ruby_version: "~> 3.2.0")
+
+        assert_nil version.content_address
+      end
+
+      should "not attempt to derive a content address without a rubygem" do
+        version = Version.new(number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                              ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("orphan-1.0.0"))
+
+        refute_predicate version, :valid?
+        assert_nil version.content_address
+      end
+
+      should "be invalid when a platformed version with no ruby_abi has a content address" do
+        version = build(:version, rubygem: create(:rubygem, name: "inconsistent"), number: "1.0.0",
+                        platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                        ruby_abi: nil, content_address: "abcdef12")
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:content_address], "must be blank"
+      end
+
+      should "reject content addresses that do not match the address format" do
+        version = build(:version, rubygem: create(:rubygem, name: "badaddr"), number: "1.0.0",
+                        platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                        sha256: Digest::SHA2.base64digest("badaddr-1.0.0"))
+        version.content_address = "not hex!"
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:content_address], "is invalid"
       end
     end
 
@@ -688,6 +756,25 @@ class VersionTest < ActiveSupport::TestCase
         assert_equal(expected_identity, version.full_name)
         assert_equal(expected_identity, version.gem_full_name)
         assert_not_equal(existing_version.full_name, version.full_name)
+        assert_includes version.reload.to_title, "1.18.9-#{version.sha256_hex.first(9)}"
+      end
+
+      should "derive the content address from full_name without a uniqueness query once computed" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          ruby_abi: "3.4",
+          sha256: Digest::SHA2.base64digest("content addressable gem")
+        )
+        version.reload
+
+        Version.expects(:where).never
+
+        assert_includes version.to_title, "1.18.9-#{version.sha256_hex.first(8)}"
       end
 
       should "be invalid when content-addressable version has no sha256" do
@@ -946,7 +1033,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "give content address, platform and Ruby ABI for #to_title" do
       rubygem = create(:rubygem, name: "nokogiri")
-      version = build(
+      version = create(
         :version,
         rubygem: rubygem,
         number: "1.18.9",
@@ -1458,6 +1545,10 @@ class VersionTest < ActiveSupport::TestCase
   end
 
   private
+
+  def derived_abi(required_ruby_version, platform: "x86_64-linux")
+    Version.new(platform:, required_ruby_version:).derive_ruby_abi
+  end
 
   def encoded_sha256_with_hex_prefix(hex_sha256)
     [[hex_sha256].pack("H*")].pack("m0")

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -160,26 +160,30 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "not allow a ruby_abi that is not a Ruby minor version" do
-      version = Version.new(ruby_abi: "banana")
-      version.validate
+      version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                      required_ruby_version: "~> 3.4.0", ruby_abi: "banana",
+                      sha256: Digest::SHA2.base64digest("abi-format-1.0.0"))
 
+      refute_predicate version, :valid?
       assert_includes version.errors[:ruby_abi], "is invalid"
     end
 
     should "allow duplicate versions with different Ruby ABIs" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow duplicate versions with the same Ruby ABI" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       refute_predicate version, :valid?
 
@@ -216,19 +220,21 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "allow canonical number duplicates with different Ruby ABIs" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow canonical number duplicates with the same Ruby ABI" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       refute_predicate version, :valid?
     end
@@ -559,74 +565,37 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
     end
 
-    context "deriving ruby ABI" do
-      should "set ruby_abi when required_ruby_version targets a single Ruby minor version" do
-        version = create(:version, required_ruby_version: "~> 3.2.0")
-
-        assert_equal("3.2", version.ruby_abi)
+    context ".ruby_abi_for" do
+      should "returns Ruby ABI when required_ruby_version targets a single Ruby minor version" do
+        assert_equal "3.2", Version.ruby_abi_for("~> 3.2.0")
       end
 
-      should "not set ruby_abi when required_ruby_version is broad" do
-        version = create(:version, required_ruby_version: ">= 3.2")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version is broad" do
+        assert_nil Version.ruby_abi_for(">= 3.2")
       end
 
-      should "only set ruby_abi for clean three-segment requirements" do
-        version = create(:version, required_ruby_version: "~> 3.2.0.0")
-
-        assert_nil(version.ruby_abi)
+      should "return nil for clean requirements with more than three segments" do
+        assert_nil Version.ruby_abi_for("~> 3.2.0.0")
       end
 
-      should "not set ruby_abi when required_ruby_version has multiple requirements" do
-        version = create(:version, required_ruby_version: ">= 3.2, < 3.4")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version has multiple requirements" do
+        assert_nil Version.ruby_abi_for(">= 3.2, < 3.4")
       end
 
-      should "not set ruby_abi when required_ruby_version is malformed" do
-        version = build(:version, required_ruby_version: "not a requirement")
-
-        assert_nothing_raised { version.valid? }
-        assert_nil(version.ruby_abi)
-        assert_includes(version.errors[:required_ruby_version], "must be list of valid requirements")
+      should "return nil when required_ruby_version is malformed" do
+        assert_nil Version.ruby_abi_for("not a requirement")
       end
 
-      should "not set ruby_abi when required_ruby_version indicates multiple Ruby ABIs" do
-        version = create(:version, required_ruby_version: "~> 3.2")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version indicates multiple Ruby ABIs" do
+        assert_nil Version.ruby_abi_for("~> 3.2")
       end
 
-      should "not set ruby_abi when required_ruby_version is blank" do
-        version = create(:version, required_ruby_version: "")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version is blank" do
+        assert_nil Version.ruby_abi_for("")
       end
 
-      should "not set ruby_abi for patch-specific pessimistic requirements" do
-        version = create(:version, required_ruby_version: "~> 3.2.1")
-
-        assert_nil(version.ruby_abi)
-      end
-
-      should "recalculate ruby_abi when required_ruby_version is updated" do
-        version = create(:version, required_ruby_version: ">= 3.2.0")
-
-        assert_nil(version.ruby_abi)
-
-        version.update!(required_ruby_version: "~> 3.2.0")
-
-        assert_equal("3.2", version.reload.ruby_abi)
-      end
-
-      should "not recalculate ruby_abi when required_ruby_version is unchanged" do
-        version = create(:version, required_ruby_version: "~> 3.2.0")
-        version.update_column(:ruby_abi, "9.9")
-
-        version.update!(summary: "Updated summary")
-
-        assert_equal("9.9", version.reload.ruby_abi)
+      should "return nil for patch-specific pessimistic requirements" do
+        assert_nil Version.ruby_abi_for("~> 3.2.1")
       end
     end
 
@@ -665,15 +634,18 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "use sha256 identity for versions targeting a single Ruby ABI" do
-        version = create(
+        version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: Digest::SHA2.base64digest("skinny gem")
+          ruby_abi: "3.4",
+          sha256: Digest::SHA2.base64digest("content addressable gem")
         )
+
+        version.save!
 
         expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(8)}"
 
@@ -687,25 +659,29 @@ class VersionTest < ActiveSupport::TestCase
         existing_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("0" * 56))
         colliding_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("1" * 56))
 
-        existing_version = create(
+        existing_version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.3.0",
-          sha256: existing_sha256
+          sha256: existing_sha256,
+          ruby_abi: "3.3"
         )
+        existing_version.save!
 
-        version = create(
+        version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: colliding_sha256
+          sha256: colliding_sha256,
+          ruby_abi: "3.4"
         )
+        version.save!
 
         expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(9)}"
 
@@ -722,11 +698,126 @@ class VersionTest < ActiveSupport::TestCase
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: nil
+          sha256: nil,
+          ruby_abi: "3.4"
         )
 
         refute_predicate version, :valid?
         assert_includes version.errors[:sha256], "can't be blank"
+      end
+    end
+
+    context "#normalize_content_addressable_gem_metadata!" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @content_addressable_version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.0.0",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          required_rubygems_version: ">= 0",
+          ruby_abi: "3.4",
+          sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4")
+        )
+      end
+
+      should "set the content addressable required rubygems version floor" do
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "set the floor when required rubygems version is blank" do
+        @content_addressable_version.update!(required_rubygems_version: nil)
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "set the floor and preserve an explicit upper bound when only an upper bound is present" do
+        @content_addressable_version.update!(required_rubygems_version: "< 5")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "raise the lower bound to the floor while preserving an existing upper bound" do
+        @content_addressable_version.update!(required_rubygems_version: ">= 3.0, < 5")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve required rubygems version when it is higher than the content addressable floor" do
+        @content_addressable_version.update!(required_rubygems_version: ">= 5.0.0")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal ">= 5.0.0", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve compound required rubygems version when its lower bound satisfies the content addressable floor" do
+        @content_addressable_version.update!(required_rubygems_version: ">= 4.2, < 5")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal ">= 4.2, < 5", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve required rubygems version when requirement only has an = operator and value is greater" do
+        @content_addressable_version.update!(required_rubygems_version: "= 4.2")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "= 4.2", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve required rubygems version when requirement only has a ~> operator and value is greater" do
+        @content_addressable_version.update!(required_rubygems_version: "~> 4.2")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "~> 4.2", @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve the implied upper bound from a ~> requirement whose lower bound is below the floor" do
+        @content_addressable_version.update!(required_rubygems_version: "~> 4.0")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5",
+                     @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve the implied upper bound from a three-segment ~> requirement" do
+        @content_addressable_version.update!(required_rubygems_version: "~> 4.0.1")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 4.1",
+                     @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve exclusions alongside the implied upper bound" do
+        @content_addressable_version.update!(required_rubygems_version: "~> 4.0, != 4.1.1")
+
+        @content_addressable_version.normalize_content_addressable_gem_metadata!
+
+        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5, != 4.1.1",
+                     @content_addressable_version.reload.required_rubygems_version
+      end
+
+      should "preserve required rubygems version for versions supporting multiple Ruby ABIs" do
+        version = create(:version, rubygem: @rubygem, number: "2.0.0", required_rubygems_version: ">= 3.0", ruby_abi: nil)
+
+        version.normalize_content_addressable_gem_metadata!
+
+        assert_equal ">= 3.0", version.reload.required_rubygems_version
       end
     end
 
@@ -851,6 +942,23 @@ class VersionTest < ActiveSupport::TestCase
       @version.platform = "zomg"
 
       assert_equal "#{@version.rubygem.name} (#{@version.number}-zomg)", @version.to_title
+    end
+
+    should "give content address, platform and Ruby ABI for #to_title" do
+      rubygem = create(:rubygem, name: "nokogiri")
+      version = build(
+        :version,
+        rubygem: rubygem,
+        number: "1.18.9",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("content addressable gem")
+      )
+      expected_content_address = version.sha256_hex.first(Version::DEFAULT_CONTENT_ADDRESS_LENGTH).to_s
+
+      assert_equal "nokogiri (1.18.9-#{expected_content_address}, Platform: arm64-darwin-25, Ruby ABI 3.4)", version.to_title
     end
 
     should "have description for info" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -667,6 +667,48 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
+    context "#manifest" do
+      setup do
+        @rubygem = create(:rubygem, name: "manifest-iso")
+        @skinny32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                            required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+                            sha256: Digest::SHA2.base64digest("manifest-iso-1.0.0-x86_64-linux-3.2"))
+        @skinny34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                            required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                            sha256: Digest::SHA2.base64digest("manifest-iso-1.0.0-x86_64-linux-3.4"))
+      end
+
+      should "key the manifest by the content address, not the platform" do
+        assert_equal "1.0.0-#{@skinny32.content_address}", @skinny32.manifest.version
+        assert_equal "1.0.0-#{@skinny34.content_address}", @skinny34.manifest.version
+        refute_equal @skinny32.manifest.version, @skinny34.manifest.version
+      end
+
+      should "give each ABI variant an isolated checksums namespace" do
+        @skinny32.manifest.store_checksums("lib/a.rb" => "aaa11111")
+        @skinny34.manifest.store_checksums("lib/a.rb" => "bbb22222")
+
+        assert_equal "aaa11111", @skinny32.manifest.checksums["lib/a.rb"]
+        assert_equal "bbb22222", @skinny34.manifest.checksums["lib/a.rb"]
+      end
+
+      should "yank one ABI variant without removing the other's checksums" do
+        @skinny32.manifest.store_checksums("lib/a.rb" => "aaa11111")
+        @skinny34.manifest.store_checksums("lib/a.rb" => "bbb22222")
+
+        @skinny32.manifest.yank
+
+        assert_empty @skinny32.manifest.checksums
+        assert_equal "bbb22222", @skinny34.manifest.checksums["lib/a.rb"]
+      end
+
+      should "use the platform-keyed manifest for non-content-addressable versions" do
+        fat = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux")
+
+        assert_equal "1.0.0-x86_64-linux", fat.manifest.version
+      end
+    end
+
     should "raise an ActiveRecord::RecordNotFound if an invalid slug is given" do
       assert_raise ActiveRecord::RecordNotFound do
         @version.rubygem.find_version!(number: "some stupid version 399", platform: @version.platform)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,12 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "not allow a ruby_abi that is not a Ruby minor version" do
+      version = Version.new(ruby_abi: "banana")
+      version.validate
+
+      assert_includes version.errors[:ruby_abi], "is invalid"
+    end
     should "be able to find dependencies" do
       @dependency = create(:rubygem)
       @version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "ruby")
@@ -483,6 +489,77 @@ class VersionTest < ActiveSupport::TestCase
       @version.full_name = "abc-1.1.1"
 
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
+    end
+
+    context "deriving ruby ABI" do
+      should "set ruby_abi when required_ruby_version targets a single Ruby minor version" do
+        version = create(:version, required_ruby_version: "~> 3.2.0")
+
+        assert_equal("3.2", version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is broad" do
+        version = create(:version, required_ruby_version: ">= 3.2")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "only set ruby_abi for clean three-segment requirements" do
+        version = create(:version, required_ruby_version: "~> 3.2.0.0")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version has multiple requirements" do
+        version = create(:version, required_ruby_version: ">= 3.2, < 3.4")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is malformed" do
+        version = build(:version, required_ruby_version: "not a requirement")
+
+        assert_nothing_raised { version.valid? }
+        assert_nil(version.ruby_abi)
+        assert_includes(version.errors[:required_ruby_version], "must be list of valid requirements")
+      end
+
+      should "not set ruby_abi when required_ruby_version indicates multiple Ruby ABIs" do
+        version = create(:version, required_ruby_version: "~> 3.2")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi when required_ruby_version is blank" do
+        version = create(:version, required_ruby_version: "")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "not set ruby_abi for patch-specific pessimistic requirements" do
+        version = create(:version, required_ruby_version: "~> 3.2.1")
+
+        assert_nil(version.ruby_abi)
+      end
+
+      should "recalculate ruby_abi when required_ruby_version is updated" do
+        version = create(:version, required_ruby_version: ">= 3.2.0")
+
+        assert_nil(version.ruby_abi)
+
+        version.update!(required_ruby_version: "~> 3.2.0")
+
+        assert_equal("3.2", version.reload.ruby_abi)
+      end
+
+      should "not recalculate ruby_abi when required_ruby_version is unchanged" do
+        version = create(:version, required_ruby_version: "~> 3.2.0")
+        version.update_column(:ruby_abi, "9.9")
+
+        version.update!(summary: "Updated summary")
+
+        assert_equal("9.9", version.reload.ruby_abi)
+      end
     end
 
     should "raise an ActiveRecord::RecordNotFound if an invalid slug is given" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,17 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "record the Ruby ABI on the pushed version event" do
+      version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                       required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                       sha256: Digest::SHA2.base64digest("abi-event-1.0.0"))
+
+      pushed = @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
+
+      assert_equal "3.4", pushed.additional.ruby_abi
+      assert_equal version.sha256_hex, pushed.additional.sha256
+    end
+
     should "not allow a ruby_abi that is not a Ruby minor version" do
       version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
                       required_ruby_version: "~> 3.4.0", ruby_abi: "banana",

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -576,6 +576,92 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
+    context "with content-addressable naming" do
+      setup do
+        @rubygem = create(:rubygem, name: "nokogiri")
+      end
+
+      should "use platform identity for versions targeting multiple Ruby ABIs" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: ">= 3.2"
+        )
+
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.full_name)
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "use sha256 identity for versions targeting a single Ruby ABI" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: Digest::SHA2.base64digest("skinny gem")
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(8)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "extend sha256 identity when another version already uses the first eight characters" do
+        shared_hex_prefix = "abc12345"
+        existing_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("0" * 56))
+        colliding_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("1" * 56))
+
+        existing_version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.3.0",
+          sha256: existing_sha256
+        )
+
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: colliding_sha256
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(9)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_not_equal(existing_version.full_name, version.full_name)
+      end
+
+      should "be invalid when content-addressable version has no sha256" do
+        version = build(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: nil
+        )
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:sha256], "can't be blank"
+      end
+    end
+
     %w[x86_64-linux java mswin x86-mswin32-60].each do |platform|
       should "be able to find with platform of #{platform}" do
         version = create(:version, platform: platform)
@@ -1193,5 +1279,11 @@ class VersionTest < ActiveSupport::TestCase
         end
       end
     end
+  end
+
+  private
+
+  def encoded_sha256_with_hex_prefix(hex_sha256)
+    [[hex_sha256].pack("H*")].pack("m0")
   end
 end


### PR DESCRIPTION
## Summary

Re-applies the content-addressable application code from #6674 (reverted after the August incident), on top of the index branches (#6785 + #6788 + #6790) so ABI variants can coexist at the database level. Feature-gated behind `CONTENT_ADDRESSABLE_GEM_PUSHES` (off by default).

- **Ruby ABI derivation** from `required_ruby_version` (`~> X.Y.0` → `X.Y`).
- **ABI-scoped version lookups**: every `(rubygem_id, number, platform)` and `(canonical_number, rubygem_id, platform)` lookup emits a `ruby_abi` predicate (`nil` for fat/default variants, the derived ABI for skinny variants) so the planner can serve them from the `…_no_abi` / `…_abi` partial unique indexes instead of the non-unique serving indexes. With the flag off, `ruby_abi` is nil for all pushes so these return identical results to today.
- **Content-addressable identity** (`full_name = name-number-<sha256prefix>`) for skinny variants; fat/source gems unchanged.
- **ABI-aware uniqueness checks and duplicate detection.**
- **Compact-index data** (`ruby_abi`, `content_address`, `platform:=` metadata) and deterministic ordering; skinny variants excluded from the legacy Marshal index.
- **ABI-targeted yank** (`ruby_abi` param on the deletions API + `Deletion` metadata).
- `ruby_abi` / `content_address` surfaced in events, v1/v2 APIs, UI, and Avo.

## What reviewers should focus on
Checking if the code is the same to the original PR (excluding the migrations)

## Stack

Fourth (final) PR of a 4-PR stacked rollout for #6674:

1. #6785 — add `content_address` + `deletions.ruby_abi` columns
2. #6788 — add non-unique serving indexes
3. #6790 — remove the old full unique indexes (base of this PR)
4. **#6789 (this)** — content-addressable gem server feature (flag off) + critical Flipper/trusted-publisher fix

## DB Testing
### 1. Compact-index full streaming query (`each_compact_index_public_version`)

The full compact-index regeneration: all versions joined to rubygems, ordered by
`r.name COLLATE "C", stamp, number, platform, ruby_abi, content_address`. Scans all 1.96M rows,
parallel (2 workers), external merge sort.

| variant | Execution time | sort tuple width | sort disk/worker | temp blocks |
|---|---|---|---|---|
| **POST-#6789** (…ruby_abi, content_address) | **1643 ms** | 692 B/row | ~77 MB | read=58316 written=58389 |
| PRE-#6789 (…platform only) | 1482 ms | 628 B/row | ~73 MB | read=54472 written=54542 |

```
POST-#6789:
 Gather Merge  (actual time=1127..1519 rows=1963655)
   ->  Sort  Sort Key: r.name COLLATE "C", stamp, number, platform, ruby_abi, content_address
         Sort Method: external merge  Disk: 77544kB
         ->  Parallel Hash Join  Hash Cond: (v.rubygem_id = r.id)
               ->  Parallel Seq Scan on versions  (rows=654551/worker)
```

**Delta: +161 ms (+11%), +64 B/row.** Plan shape identical (parallel seq scan → hash join →
external merge sort). The added columns only widen the sort tuples; no new index is needed or used
(the sort is on `name`, which has no covering index in either variant). This is the infrequent
full-reindex path — ~1.6 s for 1.96M rows is acceptable, and the +11% is tuple-width cost, not a
plan regression.

---

## 2. Compact-index incremental query (`compact_index_versions`)

The incremental endpoint (client fetches changes since a timestamp): UNION of `created_at > date`
and yanked `yanked_at > date`, ordered by `date, number, platform, ruby_abi, content_address, name`.
Tested with a 7-day window (8,260 new + 5,496 yanked = 13,756 rows). Warm cache, fair comparison.

| variant | Execution time | tuple width | HashAggregate disk |
|---|---|---|---|
| **POST-#6789** (…ruby_abi, content_address) | **45.8 ms** | 1168 B | 720 kB |
| PRE-#6789 (…platform only) | 37.9 ms | 1104 B | 712 kB |

```
POST-#6789:
 Sort  (actual time=44.0..44.7 rows=13756)  Sort Method: quicksort  Memory: 1545kB
   Sort Key: created_at, number, platform, ruby_abi, content_address, name
   ->  HashAggregate  Group Key: ..., ruby_abi, content_address  Disk Usage: 720kB
         ->  Append
               ->  Gather -> Nested Loop -> Bitmap Index Scan on index_versions_on_created_at
               ->  Nested Loop -> Index Scan on index_versions_on_indexed_and_yanked_at
```

**Delta: +7.9 ms (+21%), +64 B/row.** Plan identical; the indexes used
(`index_versions_on_created_at`, `index_versions_on_indexed_and_yanked_at`) are unchanged by #6789.
The overhead is the wider HashAggregate + sort tuples. Absolute cost is small (~8 ms on a 14k-row
incremental window); the +21% relative is the wider aggregate pushing slightly more to disk.

---

## 3. Hot lookups (ABI-scoped)

#6789's scoping adds `ruby_abi IS NULL` (fat/default) or `ruby_abi = 'X.Y'` (skinny) to every model
lookup. Run against the worst case — `sass-embedded 1.76.0` (`rubygem_id = 200950`,
`canonical_number = '1.76'`, 27 platform variants), sample platform `aarch64-linux-gnu` — in the
stack state #6789 ships in (old uniques dropped, #6788 non-unique + partials present). Every lookup
is a single index descent, sub-millisecond, ~4 buffers.

**`find_version!` (platform path)** — `Rubygem#find_version!`, `Pusher#find` republish check is the same shape
```
 Limit  (actual time=0.032..0.033 rows=1)   Buffers: shared hit=2 read=2
   ->  Index Scan using index_versions_number_platform on versions  (actual time=0.030..0.031 rows=1)
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.060 ms   (4 buffers)
```

**`find_public_version` (platform path)** — `public_versions` = `order(:position, created_at: :desc).where(indexed: true)`
```
 Limit  (actual time=0.017..0.018 rows=1)   Buffers: shared hit=4
   ->  Sort  Sort Key: position, created_at DESC  Sort Method: quicksort  Memory: 26kB
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.008..0.008 rows=1)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.030 ms   (4 buffers)
```

**`find_public_version` (no platform — 27-platform worst case)**
```
 Limit  (actual time=0.138..0.139 rows=1)   Buffers: shared hit=9 read=21
   ->  Sort  Sort Key: position, created_at DESC  Sort Method: top-N heapsort  Memory: 26kB
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.014..0.131 rows=27)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.151 ms   (30 buffers)
```
The non-unique index serves this via its `(rubygem_id, number)` prefix; the unconstrained `platform`
is a trailing column that doesn't block btree use. It scans the 27 platform rows, top-N heapsorts,
limits to 1.

**`Pusher#find` republish check** (`find_by number:, platform:, ruby_abi:`)
```
 Limit  (actual time=0.006..0.006 rows=1)   Buffers: shared hit=4
   ->  Index Scan using index_versions_number_platform on versions  (actual time=0.006..0.006 rows=1)
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.012 ms   (4 buffers)
```

**uniqueness `exists?`** (`Version#platform_and_number_are_unique`) — Index-Only Scan on the `_no_abi` partial
```
 Limit  (actual time=0.063..0.063 rows=1)   Buffers: shared hit=1 read=3
   ->  Index Only Scan using index_versions_number_platform_no_abi on versions
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Heap Fetches: 0
 Execution Time: 0.067 ms   (4 buffers)
```
The partial wins here because it's smaller and all-visible → Index-Only Scan with zero heap fetches,
a win the non-unique can't give.

**`unique_canonical_number`** (`Version.find_by canonical_number:, rubygem_id:, platform:, ruby_abi:`)
```
 Limit  (actual time=0.014..0.015 rows=1)   Buffers: shared hit=4
   ->  Index Scan using index_versions_canonical_platform on versions  (actual time=0.014..0.014 rows=1)
         Index Cond: (canonical_number = '1.76') AND (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.020 ms   (4 buffers)
```

**Skinny variant** (`ruby_abi = '1.8'`) — uses the `_abi` partial directly
```
 Limit  (actual time=0.016..0.016 rows=1)   Buffers: shared read=2
   ->  Index Scan using index_versions_number_platform_abi on versions  (actual time=0.015..0.016 rows=1)
         Index Cond: (rubygem_id = 16547) AND (number = '1.0.2') AND (platform = 'i386-mswin32') AND (ruby_abi = '1.8')
 Execution Time: 0.021 ms   (2 buffers)
```
The `= 'X.Y'` predicate lands on `ruby_abi` as a leading key of the `_abi` partial, so it's an index
condition, not a filter — cost 0.12..8.14 (cheaper than the fat path's 0.43..8.45).

### Broad sample (20 random indexed gems, LATERAL lookup)

```
SCOPED (ruby_abi IS NULL), 20 lookups:
 Nested Loop Left Join  (actual time=0.034..0.334 rows=20)
   ->  Limit  (actual time=0.016..0.016 rows=1 loops=20)
         Index Scan using index_versions_number_platform
 Execution Time: 0.356 ms   (≈ 0.018 ms/lookup, 4 buffers/lookup)
```
No outliers across the 20-gem sample; every lookup is a single index descent.