### PR TITLE
Remove old version unique indexes

### DIFF
--- a/db/migrate/20260819160003_remove_old_version_unique_indexes.rb
+++ b/db/migrate/20260819160003_remove_old_version_unique_indexes.rb
@@ -15,6 +15,10 @@ class RemoveOldVersionUniqueIndexes < ActiveRecord::Migration[8.1]
       if_exists: true
   end
 
+  # To revert: remove all content-addressable (ruby_abi) variants first —
+  # recreating these full uniques fails with PG::UniqueViolation once fat and
+  # skinny rows coexist at the same (gem, number, platform). Irreversible
+  # after any content-addressable push has landed.
   def down
     add_index :versions,
       %i[canonical_number rubygem_id platform],

--- a/db/migrate/20260819160003_remove_old_version_unique_indexes.rb
+++ b/db/migrate/20260819160003_remove_old_version_unique_indexes.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class RemoveOldVersionUniqueIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently,
+      if_exists: true
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently,
+      if_exists: true
+  end
+
+  def down
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_160002) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -738,7 +738,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160002) do
     t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_canonical_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
-    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
+
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -751,7 +751,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160002) do
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
-    t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
+
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -738,7 +738,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
     t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_canonical_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
-
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -751,7 +750,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_160003) do
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
-
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 


### PR DESCRIPTION
## Summary

Drops the two superseded full unique indexes on `versions`:

- `index_versions_on_canonical_number_and_rubygem_id_and_platform`
- `index_versions_on_rubygem_id_and_number_and_platform`

Both removed `CONCURRENTLY` + `if_exists` (partial-failure retry safe). Migration-only — no application code.

## Why

The uniqueness constraint on these indexes blocks ABI-variant coexistence: a skinny `ruby_abi=3.4`
variant and a fat `ruby_abi=nil` version at the same `(gem, number, platform)` could not both
exist. The ABI-partitioned partial unique indexes (`…_no_abi` for `ruby_abi IS NULL`, `…_abi` for
`ruby_abi IS NOT NULL`) already enforce uniqueness **within** each partition, so the full unique
constraint is redundant and incompatible with coexistence.

The partials catch every case that should still be caught:

| case | caught by |
|---|---|
| two fat rows (both `ruby_abi IS NULL`) | `…_no_abi` |
| two skinny rows, same ABI | `…_abi` (key includes `ruby_abi`) |
| two skinny rows, different ABI | **allowed** — distinct ABI variants |
| fat + skinny | **allowed** — coexistence |

## Safety

This is safe because the base branch (#6788) already added non-unique serving indexes
(`index_versions_number_platform`, `index_versions_canonical_platform`) on the same keys.

**Empirically verified** against the latest prod dump (2026-08-17, 1,963,655 versions): with both
present, the planner **already uses the non-unique indexes** for the hot lookups (PG 18 tie-breaks
to the non-unique at equal cost), so dropping the uniques is **plan-neutral** — the post-drop
`EXPLAIN` is identical (0.04–0.07 ms).

## Alternatives considered

- **Drop-only, relying on the lookup soak + partial indexes** (original plan): safe only if every
  hot lookup is scoped to `ruby_abi IS NULL`. Rejected as the sole safety path.
- **Non-unique safety net in the base (chosen)**: #6788 adds non-unique indexes first, so this drop
  can never cause a regression even if the soak missed something. The EXPLAIN ship gate moves to
  the *follow-up* that drops the non-unique indexes, not this PR.
- **Replace unique with non-unique in a single migration**: rejected — create-then-drop as two
  CONCURRENTLY operations across two PRs gives a no-gap cutover and lets the create be validated
  (`indisvalid`) before the drop.

## Stack

Third PR of a 4-PR stacked rollout for #6674:

1. #6785 — add `content_address` + `deletions.ruby_abi` columns
2. #6788 — add non-unique serving indexes (base of this PR)
3. **#6790 (this)** — remove the old full unique indexes
4. #6789 — content-addressable gem server feature (flag off); includes a **critical fix** for trusted-publishing pushes (Flipper actor — see that PR's description)

## Testing
Dropped the two old full uniques (`DROP INDEX CONCURRENTLY`) and re-ran the same six lookups. The
plans are using #6788 non-unique indexes, same costs, same buffers —
confirming #6790 is plan-neutral.

**`find_version!` (platform path)**
```
 Limit  (actual time=0.086..0.086 rows=1)   Buffers: shared hit=3 read=1
   ->  Index Scan using index_versions_number_platform on versions  (actual time=0.084..0.084 rows=1)
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.151 ms
```

**`find_public_version` (platform path)**
```
 Limit  (actual time=0.070..0.071 rows=1)   Buffers: shared hit=10
   ->  Sort  Sort Key: position, created_at DESC
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.027..0.028 rows=1)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.115 ms
```

**`find_public_version` (no platform — 27-platform worst case)**
```
 Limit  (actual time=0.132..0.133 rows=1)   Buffers: shared hit=30
   ->  Sort  Sort Key: position, created_at DESC
         ->  Index Scan using index_versions_number_platform on versions  (actual time=0.029..0.111 rows=27)
               Index Cond: (rubygem_id = 200950) AND (number = '1.76.0')
               Filter: indexed AND (ruby_abi IS NULL)
 Execution Time: 0.164 ms
```
The non-unique index serves this via its `(rubygem_id, number)` prefix; the unconstrained `platform`
is a trailing column that doesn't block btree use. It scans the 27 platform rows and limits to 1.

**uniqueness `exists?`**
```
 Limit  (actual time=0.010..0.010 rows=1)   Buffers: shared hit=4
   ->  Index Scan using index_versions_number_platform on versions
         Index Cond: (rubygem_id = 200950) AND (number = '1.76.0') AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.015 ms
```

**`unique_canonical_number`**
```
 Limit  (actual time=0.041..0.041 rows=1)   Buffers: shared hit=3 read=1
   ->  Index Scan using index_versions_canonical_platform on versions
         Index Cond: (canonical_number = '1.76') AND (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Filter: (ruby_abi IS NULL)
 Execution Time: 0.050 ms
```

### Without the 6788 indexes

**`find_version!` unscoped**
```
 Limit  (actual time=2.367..2.369 rows=1)   Buffers: shared hit=25 read=248
   ->  Bitmap Heap Scan on versions
         Recheck Cond: (number = '1.76.0')
         Filter: (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Rows Removed by Filter: 263   Heap Blocks: exact=264
         ->  Bitmap Index Scan on index_versions_on_number  (rows=272)
 Execution Time: 2.419 ms   (273 buffers vs 4 scoped; 0.045 → 2.4 ms, ~54×)
```

**`find_public_version` (platform path) unscoped**
```
 Limit  (actual time=1.051..1.052 rows=1)   Buffers: shared hit=34 read=59
   ->  Sort  Sort Key: position, created_at DESC
         ->  Bitmap Heap Scan on versions  (rows=1, removed by filter: 26)
               ->  BitmapAnd
                     ->  Bitmap Index Scan on index_versions_on_number  (rows=272)
                     ->  Bitmap Index Scan on index_versions_on_rubygem_id_and_position_and_created_at  (rows=2311)
 Execution Time: 1.082 ms   (93 buffers vs 10 scoped)
```

**`find_public_version` (no platform, 27-variant) unscoped**
```
 Limit  (actual time=0.443..0.444 rows=1)   Buffers: shared hit=87
   ->  Sort  Sort Key: position, created_at DESC
         ->  Bitmap Heap Scan on versions  (rows=27)
               ->  BitmapAnd  (index_versions_on_number  rows=272  ∩  …rubygem_id_and_position_and_created_at  rows=2311)
 Execution Time: 0.488 ms   (87 buffers vs 30 scoped)
```

**`Pusher#find` republish unscoped**
```
 Limit  (actual time=0.561..0.562 rows=1)   Buffers: shared hit=268
   ->  Bitmap Heap Scan on versions
         Recheck Cond: (number = '1.76.0')   Filter: (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Rows Removed by Filter: 263   Heap Blocks: exact=264
 Execution Time: 0.592 ms   (268 buffers vs 4 scoped)
```

**uniqueness `exists?` unscoped**
```
 Limit  (actual time=0.311..0.311 rows=1)   Buffers: shared hit=268
   ->  Bitmap Heap Scan on versions
         Recheck Cond: (number = '1.76.0')   Filter: (rubygem_id = 200950) AND (platform = 'aarch64-linux-gnu')
         Rows Removed by Filter: 263   Heap Blocks: exact=264
 Execution Time: 0.324 ms   (268 buffers vs 4 scoped; loses the Index-Only Scan)
```

**`unique_canonical_number` unscoped — the worst**
```
 Limit  (actual time=18.607..18.608 rows=1)   Buffers: shared hit=1186 read=1290
   ->  Bitmap Heap Scan on versions
         Recheck Cond: (rubygem_id = 200950)
         Filter: (canonical_number = '1.76') AND (platform = 'aarch64-linux-gnu')
         Rows Removed by Filter: 2031   Heap Blocks: exact=422
         ->  Bitmap Index Scan on index_versions_on_position_and_rubygem_id  (rows=2314)
 Execution Time: 18.642 ms   (2476 buffers vs 4 scoped; 0.036 → 18.6 ms, ~517×)
```
The canonical lookup bitmap-scans the gem's entire version set (2314 rows, 422 heap blocks) because
the `(canonical_number, rubygem_id, platform)` partial is unreachable without the `ruby_abi IS NULL`
predicate — there is no full covering index to fall back on.