### PR TITLE
Fix password reset links with strict SameSite cookies

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,29 +7,25 @@ class PasswordsController < ApplicationController
 
   before_action :ensure_email_present, only: %i[create]
 
-  before_action :no_referrer, only: :edit
+  prepend_before_action :protect_password_reset_response, only: %i[edit reset otp_edit webauthn_edit update]
   before_action :begin_password_reset, only: :edit
   before_action :load_password_reset, only: %i[reset otp_edit webauthn_edit update]
   before_action :validate_otp, only: %i[otp_edit]
   before_action :validate_webauthn, only: %i[webauthn_edit]
   after_action :delete_mfa_expiry_session, only: %i[otp_edit webauthn_edit]
 
-  before_action :validate_password_reset_session, only: :update
+  before_action :validate_password_reset_verification, only: :update
 
   def new
     render :new
   end
 
   def edit
-    redirect_to reset_password_path
+    render_password_reset
   end
 
   def reset
-    return require_mfa if password_reset_requires_mfa?
-
-    verify_password_reset_session unless password_reset_session_verified?
-    set_compromised_flag
-    render :edit
+    render_password_reset
   end
 
   def create
@@ -71,6 +67,21 @@ class PasswordsController < ApplicationController
 
   private
 
+  def render_password_reset
+    return require_mfa if password_reset_requires_mfa?
+
+    mark_password_reset_verified unless password_reset_verification_active?
+    set_compromised_flag
+    render :edit
+  end
+
+  def protect_password_reset_response
+    disable_cache
+    no_referrer
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Surrogate-Control"] = "no-store"
+  end
+
   def set_compromised_flag
     @compromised = session[:password_reset_reason] == "compromised"
   end
@@ -105,24 +116,24 @@ class PasswordsController < ApplicationController
   end
 
   def password_reset_requires_mfa?
-    @user.mfa_enabled? && session[:password_reset_reason] != "compromised" && !password_reset_session_verified?
+    @user.mfa_enabled? && session[:password_reset_reason] != "compromised" && !password_reset_verification_active?
   end
 
-  def verify_password_reset_session
+  def mark_password_reset_verified
     session[:password_reset_verified] = Gemcutter::PASSWORD_VERIFICATION_EXPIRY.from_now
   end
 
   def complete_password_reset_verification
     delete_mfa_session
-    verify_password_reset_session
+    mark_password_reset_verified
     redirect_to reset_password_path
   end
 
-  def password_reset_session_verified?
+  def password_reset_verification_active?
     session[:password_reset_verified].present? && Time.current.before?(session[:password_reset_verified])
   end
 
-  def validate_password_reset_session
+  def validate_password_reset_verification
     return login_failure(t("passwords.edit.token_failure")) if session[:password_reset_verified].nil?
     login_failure(t("verification_expired")) if Time.current.after?(session[:password_reset_verified])
   end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -79,6 +79,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "with a valid password reset token" do
       context "when not signed in" do
+        should "present the password edit form directly without relying on JavaScript" do
+          get edit_password_path, params: { token: @token }
+
+          assert_response :success
+          assert_new_password_form
+          assert_password_reset_response_headers
+        end
+
         should "presents the password edit form" do
           begin_password_reset
 
@@ -87,7 +95,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
           assert @user.reload.valid_password_reset_token?(@token)
           refute_signed_in
-          assert_equal reset_password_path, request.path
+          assert_equal edit_password_path, request.path
         end
       end
 
@@ -403,6 +411,24 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "with an invalid authenticity token" do
+      should "reject the update with password reset security headers" do
+        original_allow_forgery_protection = ActionController::Base.allow_forgery_protection
+        begin_password_reset
+        ActionController::Base.allow_forgery_protection = true
+
+        put password_path, params: {
+          password_reset: { password: PasswordHelpers::SECURE_TEST_PASSWORD }
+        }
+
+        assert_response :forbidden
+        assert_password_reset_response_headers
+        assert_equal @old_encrypted_password, @user.reload.encrypted_password
+      ensure
+        ActionController::Base.allow_forgery_protection = original_allow_forgery_protection
+      end
+    end
+
     context "when verification has expired" do
       should "redirect to the sign in page" do
         begin_password_reset
@@ -546,9 +572,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     get path, params: reset_params
 
+    assert_response :success
+    assert_password_reset_response_headers
+  end
+
+  def assert_password_reset_response_headers
+    assert_equal "private, no-store", response.headers["Cache-Control"]
+    assert_includes %w[no-store max-age=0], response.headers["Surrogate-Control"]
     assert_equal "no-referrer", response.headers["Referrer-Policy"]
-    assert_redirected_to reset_password_path
-    follow_redirect!
   end
 
   def webauthn_result(challenge = nil)

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -210,7 +210,8 @@ class RackAttackTest < ActionDispatch::IntegrationTest
           token = @user.issue_password_reset!
           get "/password/edit",
             params: { token:, user_id: @user.id }
-          follow_redirect!
+
+          assert_response :success
           post "/password/otp_edit",
             params: { otp: ROTP::TOTP.new(@user.totp_seed).now },
             headers: { REMOTE_ADDR: @ip_address }

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -38,7 +38,7 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     visit password_reset_link
 
-    assert_current_path reset_password_path
+    assert_current_path edit_password_path, ignore_query: true
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
     click_button "Save this password"
@@ -53,18 +53,35 @@ class PasswordResetTest < ApplicationSystemTestCase
     assert_text "Dashboard"
   end
 
+  test "resetting password from a cross-site email link" do
+    assert_equal :strict, Rails.application.config.session_options[:same_site]
+    forgot_password_with @user.email
+
+    visit_from_cross_site password_reset_link
+
+    assert_current_path edit_password_path, ignore_query: true
+    assert_text "Reset password"
+
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Save this password"
+
+    assert_text "Your password has been changed."
+    assert_current_path sign_in_path
+    assert @user.reload.authenticated?(PasswordHelpers::SECURE_TEST_PASSWORD)
+  end
+
   test "opening the reset link more than once does not consume it" do
     forgot_password_with @user.email
     link = password_reset_link
 
     visit link
 
-    assert_current_path reset_password_path
+    assert_current_path edit_password_path, ignore_query: true
     assert_text "Reset password"
 
     visit link
 
-    assert_current_path reset_password_path
+    assert_current_path edit_password_path, ignore_query: true
     assert_text "Reset password"
 
     fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
@@ -154,7 +171,7 @@ class PasswordResetTest < ApplicationSystemTestCase
     @user.enable_totp!(ROTP::Base32.random_base32, :ui_only)
     forgot_password_with @user.email
 
-    visit password_reset_link
+    visit_from_cross_site password_reset_link
 
     assert_no_text("Sign out")
 
@@ -287,7 +304,7 @@ class PasswordResetTest < ApplicationSystemTestCase
       assert_current_path compromised_password_path
     end
 
-    visit password_reset_link
+    visit_from_cross_site password_reset_link
 
     assert_text "Reset password"
 
@@ -325,7 +342,7 @@ class PasswordResetTest < ApplicationSystemTestCase
       assert_current_path compromised_password_path
     end
 
-    visit password_reset_link
+    visit_from_cross_site password_reset_link
 
     assert_text "Reset password"
 
@@ -346,6 +363,20 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     assert_empty ActionMailer::Base.deliveries
     page.assert_text "instructions for changing your password"
+  end
+
+  def visit_from_cross_site(url)
+    server = Capybara.current_session.server
+    target = URI(url)
+    target_url = "http://localhost:#{server.port}#{target.request_uri}"
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.goto("http://127.0.0.1:#{server.port}")
+      pw_page.set_content <<~HTML
+        <a href="#{ERB::Util.html_escape(target_url)}">Open password reset</a>
+      HTML
+      pw_page.get_by_role("link", name: "Open password reset").click
+    end
   end
 
   teardown do


### PR DESCRIPTION
## What was the end-user or developer problem?

Password reset links opened from cross-site email clients could redirect users to sign in instead of showing the reset form. The reset entry action rotated the session and redirected immediately, but browsers can withhold the newly set `SameSite=Strict` cookie throughout that redirect chain.

## What is your fix for the problem, implemented in this PR?

Render the password reset form or MFA prompt directly from the validated reset-link request, sharing the same rendering path with `/password/reset`. Keep the global Strict session policy, session rotation, token validation, MFA behavior, and consume-on-success semantics unchanged. Reset and MFA responses also receive private no-store and no-referrer headers before CSRF processing.

Add real-browser coverage that begins on a cross-site origin for ordinary and compromised password resets, with and without MFA.

## What are the testing steps?

- `bin/rails test test/functional/passwords_controller_test.rb`
- `bin/rails test test/system/password_reset_test.rb`
- Google Chrome: full password-reset system suite, 15 tests / 113 assertions
- Firefox: non-WebAuthn password-reset suite, 13 tests / 90 assertions (WebAuthn helpers require Chromium CDP)
- `bundle exec rubocop app/controllers/passwords_controller.rb test/functional/passwords_controller_test.rb test/system/password_reset_test.rb`
- `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error`
- `git diff --check`