### PR TITLE
organizations: Use `find_by_handle!` consistently

### DIFF
--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -11,6 +11,6 @@ class Organizations::BaseController < ApplicationController
   private
 
   def find_organization
-    @organization = Organization.find_by(handle: params[:organization_id])
+    @organization = Organization.find_by_handle!(params[:organization_id])
   end
 end

--- a/app/controllers/organizations/gems_controller.rb
+++ b/app/controllers/organizations/gems_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Organizations::GemsController < Organizations::BaseController
-  before_action :find_organization, only: %i[index]
-
   skip_before_action :redirect_to_signin, only: %i[index]
 
   layout "subject"
@@ -10,11 +8,5 @@ class Organizations::GemsController < Organizations::BaseController
   def index
     @gems = @organization.rubygems.with_versions.by_downloads.preload(:most_recent_version, :gem_download).load_async
     @gems_count = @organization.rubygems.with_versions.count
-  end
-
-  private
-
-  def find_organization
-    @organization = Organization.find_by_handle!(params[:organization_id])
   end
 end

--- a/test/functional/organizations/members_controller_test.rb
+++ b/test/functional/organizations/members_controller_test.rb
@@ -34,6 +34,20 @@ class Organizations::MembersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "GET /organizations/:organization_handle/members with a differently cased handle" do
+    get organization_memberships_path(@organization.handle.upcase)
+
+    assert_response :success
+  end
+
+  test "GET /organizations/:organization_handle/members with an unknown handle when signed out" do
+    delete sign_out_path
+
+    get organization_memberships_path("does-not-exist")
+
+    assert_response :not_found
+  end
+
   test "GET /organizations/:organization_handle/members/new" do
     get new_organization_membership_path(@organization)
 

--- a/test/integration/organizations_test.rb
+++ b/test/integration/organizations_test.rb
@@ -18,6 +18,15 @@ class OrganizationsTest < ActionDispatch::IntegrationTest
     assert page.has_content? "arrakis"
   end
 
+  test "should show an organization when signed out" do
+    organization = create(:organization, owners: [@user], handle: "arrakis", name: "Arrakis")
+    delete sign_out_path
+
+    get organization_path(organization)
+
+    assert_response :success
+  end
+
   test "should render not found when an organization doesn't exist" do
     get organization_path("nonexistent")
 


### PR DESCRIPTION
- I looked into these four errors occurring this week:

```
NoMethodError: undefined method 'memberships' for nil
    app/controllers/organizations/members_controller.rb:15:in 'Organizations::MembersController#index'
```

- `find_by(handle:)` returns nil for an unknown handle whereas the bang version raises RecordNotFound which becomes a 404 HTTP response.
- The `by_handle!` method is already used in multiple places and comes with the benefit of doing a lowercase match so RubyGems and rubygems are the same.