### PR TITLE
Fully silence MultiJSON's deprecation warnings

### DIFF
--- a/config/initializers/opensearch_multi_json_serializer_patch.rb
+++ b/config/initializers/opensearch_multi_json_serializer_patch.rb
@@ -16,3 +16,5 @@ module OpenSearchMultiJsonSerializerPatch
 end
 
 OpenSearch::Transport::Transport::Serializer::MultiJson.prepend(OpenSearchMultiJsonSerializerPatch)
+
+OpenSearch::API.settings[:serializer] = OpenSearch::Transport::Transport::Serializer::MultiJson.new


### PR DESCRIPTION
- The existing patch didn't go far enough because the bulk gem download updates were using another JSON serializer path than regular OpenSearch requests, thus continuing to trigger deprecation warnings.