### PR TITLE
Fix reusable workflow attestation verification

### DIFF
--- a/app/models/oidc/trusted_publisher/github_action.rb
+++ b/app/models/oidc/trusted_publisher/github_action.rb
@@ -149,9 +149,16 @@ class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
     end
 
     def verify(cert)
-      ref = cert.openssl.find_extension("1.3.6.1.4.1.57264.1.14")&.value_der&.then { OpenSSL::ASN1.decode(it).value }
+      build_signer_uri = cert.openssl.find_extension("1.3.6.1.4.1.57264.1.9")&.value_der&.then { OpenSSL::ASN1.decode(it).value }
+      expected_prefix = "https://github.com/#{@trusted_publisher.workflow_repository}/#{@trusted_publisher.workflow_slug}@"
+      unless build_signer_uri&.start_with?(expected_prefix) && build_signer_uri != expected_prefix
+        return Sigstore::VerificationFailure.new(
+          "Certificate's Build Signer URI does not match #{expected_prefix}"
+        )
+      end
+
       Sigstore::Policy::Identity.new(
-        identity: "https://github.com/#{@trusted_publisher.workflow_repository}/#{@trusted_publisher.workflow_slug}@#{ref}",
+        identity: build_signer_uri,
         issuer: OIDC::Provider::GITHUB_ACTIONS_ISSUER
       ).verify(cert)
     end

--- a/test/factories/x509.rb
+++ b/test/factories/x509.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     public_key { OpenSSL::PKey::EC.generate("prime256v1") }
     transient do
       extension_factory { OpenSSL::X509::ExtensionFactory.new }
+      github_actions_job_workflow_ref { "sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1" }
+      github_actions_source_repository_ref { "refs/tags/v0.1.1" }
     end
 
     trait :key_usage do
@@ -25,7 +27,7 @@ FactoryBot.define do
         # Add subjectAltName with the workflow URI (required for policy extraction)
         cert.add_extension(ctx.extension_factory.create_ext(
                              "subjectAltName",
-          "URI:https://github.com/sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1",
+          "URI:https://github.com/#{ctx.github_actions_job_workflow_ref}",
           false
                            ))
 
@@ -45,7 +47,7 @@ FactoryBot.define do
             "1.3.6.1.4.1.57264.1.8" =>
                 "https://token.actions.githubusercontent.com",
             "1.3.6.1.4.1.57264.1.9" =>
-                ".Xhttps://github.com/sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1",
+                "https://github.com/#{ctx.github_actions_job_workflow_ref}",
             "1.3.6.1.4.1.57264.1.10" =>
                 ".(f106999a2210a9a17b32b172f95518859a85ffed",
             "1.3.6.1.4.1.57264.1.11" =>
@@ -55,7 +57,7 @@ FactoryBot.define do
             "1.3.6.1.4.1.57264.1.13" =>
                 ".(f106999a2210a9a17b32b172f95518859a85ffed",
             "1.3.6.1.4.1.57264.1.14" =>
-                "..refs/tags/v0.1.1",
+                ctx.github_actions_source_repository_ref,
             "1.3.6.1.4.1.57264.1.15" =>
                 "..766398650",
             "1.3.6.1.4.1.57264.1.16" =>

--- a/test/models/oidc/trusted_publisher/github_action_test.rb
+++ b/test/models/oidc/trusted_publisher/github_action_test.rb
@@ -451,4 +451,47 @@ class OIDC::TrustedPublisher::GitHubActionTest < ActiveSupport::TestCase
       )
     end
   end
+
+  test "#to_sigstore_identity_policy verifies a reusable workflow pinned by SHA when the caller has a different ref" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "caller-org",
+      repository_name: "caller-repo",
+      workflow_filename: "release.yml",
+      workflow_repository_owner: "shared-org",
+      workflow_repository_name: "shared-workflows")
+    workflow_ref = "shared-org/shared-workflows/.github/workflows/release.yml@cdefa43486604b3aae79e9d1db24b670475f2c92"
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+      github_actions_job_workflow_ref: workflow_ref,
+      github_actions_source_repository_ref: "refs/heads/master")
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    assert_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
+
+  test "#to_sigstore_identity_policy verifies a same-repository workflow" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "sigstore",
+      repository_name: "sigstore-ruby",
+      workflow_filename: "release.yml")
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio)
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    assert_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
+
+  test "#to_sigstore_identity_policy rejects a different reusable workflow" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "caller-org",
+      repository_name: "caller-repo",
+      workflow_filename: "release.yml",
+      workflow_repository_owner: "shared-org",
+      workflow_repository_name: "shared-workflows")
+    workflow_ref = "attacker-org/shared-workflows/.github/workflows/release.yml@cdefa43486604b3aae79e9d1db24b670475f2c92"
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+      github_actions_job_workflow_ref: workflow_ref,
+      github_actions_source_repository_ref: "refs/heads/main")
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    refute_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
 end


### PR DESCRIPTION
## Summary

- verify GitHub Actions attestations against Fulcio's Build Signer URI
- support cross-repository reusable workflows pinned by SHA when the caller ref differs
- retain same-repository verification and reject mismatched workflow identities

## Testing

- `bin/rails test test/models/oidc/trusted_publisher/github_action_test.rb`
- `bundle exec rubocop app/models/oidc/trusted_publisher/github_action.rb test/factories/x509.rb test/models/oidc/trusted_publisher/github_action_test.rb`

Fixes #6797