### PR TITLE
Improve trusted publishing attestation diagnostics

### DIFF
--- a/app/models/oidc/trusted_publisher/github_action.rb
+++ b/app/models/oidc/trusted_publisher/github_action.rb
@@ -144,6 +144,18 @@ class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
   end
 
   class SigstorePolicy
+    class DiagnosticFailure < Sigstore::VerificationFailure
+      attr_reader :code, :internal_context
+
+      alias public_message reason
+
+      def initialize(code:, public_message:, internal_context:)
+        @code = code
+        @internal_context = internal_context
+        super(public_message)
+      end
+    end
+
     def initialize(trusted_publisher)
       @trusted_publisher = trusted_publisher
     end
@@ -151,16 +163,48 @@ class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
     def verify(cert)
       build_signer_uri = cert.openssl.find_extension("1.3.6.1.4.1.57264.1.9")&.value_der&.then { OpenSSL::ASN1.decode(it).value }
       expected_prefix = "https://github.com/#{@trusted_publisher.workflow_repository}/#{@trusted_publisher.workflow_slug}@"
-      unless build_signer_uri&.start_with?(expected_prefix) && build_signer_uri != expected_prefix
-        return Sigstore::VerificationFailure.new(
-          "Certificate's Build Signer URI does not match #{expected_prefix}"
-        )
+
+      return missing_build_signer_uri_failure(expected_prefix, build_signer_uri) if build_signer_uri.blank?
+
+      unless build_signer_uri.start_with?(expected_prefix) && build_signer_uri != expected_prefix
+        return build_signer_uri_mismatch_failure(expected_prefix, build_signer_uri)
       end
 
       Sigstore::Policy::Identity.new(
         identity: build_signer_uri,
         issuer: OIDC::Provider::GITHUB_ACTIONS_ISSUER
       ).verify(cert)
+    end
+
+    private
+
+    def missing_build_signer_uri_failure(expected_prefix, build_signer_uri)
+      DiagnosticFailure.new(
+        code: "attestation.build_signer_uri_missing",
+        public_message: "The certificate is missing the GitHub Actions Build Signer URI. " \
+                        "Generate a new attestation in the configured publishing workflow and retry.",
+        internal_context: {
+          expected_build_signer_uri_prefix: expected_prefix,
+          actual_build_signer_uri: build_signer_uri
+        }
+      )
+    end
+
+    def build_signer_uri_mismatch_failure(expected_prefix, build_signer_uri)
+      safe_build_signer_uri = build_signer_uri.scrub.first(512)
+      DiagnosticFailure.new(
+        code: "attestation.build_signer_uri_mismatch",
+        public_message: <<~MSG.chomp,
+          The attestation was created by a different GitHub Actions workflow.
+          Expected workflow: #{expected_prefix}<ref>
+          Actual workflow: #{safe_build_signer_uri.inspect}
+          Check the workflow repository and filename in the trusted publisher configuration.
+        MSG
+        internal_context: {
+          expected_build_signer_uri_prefix: expected_prefix,
+          actual_build_signer_uri: safe_build_signer_uri
+        }
+      )
     end
   end
 

--- a/app/models/oidc/trusted_publisher/github_action.rb
+++ b/app/models/oidc/trusted_publisher/github_action.rb
@@ -149,9 +149,16 @@ class OIDC::TrustedPublisher::GitHubAction < ApplicationRecord
     end
 
     def verify(cert)
-      ref = cert.openssl.find_extension("1.3.6.1.4.1.57264.1.14")&.value_der&.then { OpenSSL::ASN1.decode(it).value }
+      build_signer_uri = cert.openssl.find_extension("1.3.6.1.4.1.57264.1.9")&.value_der&.then { OpenSSL::ASN1.decode(it).value }
+      expected_prefix = "https://github.com/#{@trusted_publisher.workflow_repository}/#{@trusted_publisher.workflow_slug}@"
+      unless build_signer_uri&.start_with?(expected_prefix) && build_signer_uri != expected_prefix
+        return Sigstore::VerificationFailure.new(
+          "Certificate's Build Signer URI does not match #{expected_prefix}"
+        )
+      end
+
       Sigstore::Policy::Identity.new(
-        identity: "https://github.com/#{@trusted_publisher.workflow_repository}/#{@trusted_publisher.workflow_slug}@#{ref}",
+        identity: build_signer_uri,
         issuer: OIDC::Provider::GITHUB_ACTIONS_ISSUER
       ).verify(cert)
     end

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -181,9 +181,7 @@ class Pusher
       verification_input.bundle = bundle
       input = Sigstore::VerificationInput.new(verification_input)
       sigstore_verification = sigstore_verifier.verify(input:, policy:, offline: true)
-      logger.info do
-        { message: "verifying sigstore bundles", sigstore_verification: sigstore_verification, policy: policy }
-      end
+      logger.info { sigstore_verification_log(sigstore_verification, policy) }
 
       return notify("Attestation verification failed:\n#{sigstore_verification.reason}", 422) unless sigstore_verification.verified?
       return notify("Must provide at least v0.3 bundles", 422) unless input.sbundle.bundle_type >= Sigstore::BundleType::BUNDLE_0_3
@@ -201,6 +199,14 @@ class Pusher
   end
 
   private
+
+  def sigstore_verification_log(verification, policy)
+    log = { message: "verifying sigstore bundles", sigstore_verification: verification, policy: policy }
+    if verification.respond_to?(:code) && verification.respond_to?(:internal_context)
+      log[:diagnostic] = verification.internal_context.merge(code: verification.code)
+    end
+    log
+  end
 
   def after_write
     GemCachePurger.call(rubygem.name)

--- a/test/factories/x509.rb
+++ b/test/factories/x509.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     public_key { OpenSSL::PKey::EC.generate("prime256v1") }
     transient do
       extension_factory { OpenSSL::X509::ExtensionFactory.new }
+      github_actions_job_workflow_ref { "sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1" }
+      github_actions_source_repository_ref { "refs/tags/v0.1.1" }
     end
 
     trait :key_usage do
@@ -25,7 +27,7 @@ FactoryBot.define do
         # Add subjectAltName with the workflow URI (required for policy extraction)
         cert.add_extension(ctx.extension_factory.create_ext(
                              "subjectAltName",
-          "URI:https://github.com/sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1",
+          "URI:https://github.com/#{ctx.github_actions_job_workflow_ref}",
           false
                            ))
 
@@ -45,7 +47,7 @@ FactoryBot.define do
             "1.3.6.1.4.1.57264.1.8" =>
                 "https://token.actions.githubusercontent.com",
             "1.3.6.1.4.1.57264.1.9" =>
-                ".Xhttps://github.com/sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1",
+                "https://github.com/#{ctx.github_actions_job_workflow_ref}",
             "1.3.6.1.4.1.57264.1.10" =>
                 ".(f106999a2210a9a17b32b172f95518859a85ffed",
             "1.3.6.1.4.1.57264.1.11" =>
@@ -55,7 +57,7 @@ FactoryBot.define do
             "1.3.6.1.4.1.57264.1.13" =>
                 ".(f106999a2210a9a17b32b172f95518859a85ffed",
             "1.3.6.1.4.1.57264.1.14" =>
-                "..refs/tags/v0.1.1",
+                ctx.github_actions_source_repository_ref,
             "1.3.6.1.4.1.57264.1.15" =>
                 "..766398650",
             "1.3.6.1.4.1.57264.1.16" =>

--- a/test/factories/x509.rb
+++ b/test/factories/x509.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
       extension_factory { OpenSSL::X509::ExtensionFactory.new }
       github_actions_job_workflow_ref { "sigstore/sigstore-ruby/.github/workflows/release.yml@refs/tags/v0.1.1" }
       github_actions_source_repository_ref { "refs/tags/v0.1.1" }
+      github_actions_build_signer_uri { "https://github.com/#{github_actions_job_workflow_ref}" }
     end
 
     trait :key_usage do
@@ -47,7 +48,7 @@ FactoryBot.define do
             "1.3.6.1.4.1.57264.1.8" =>
                 "https://token.actions.githubusercontent.com",
             "1.3.6.1.4.1.57264.1.9" =>
-                "https://github.com/#{ctx.github_actions_job_workflow_ref}",
+                ctx.github_actions_build_signer_uri,
             "1.3.6.1.4.1.57264.1.10" =>
                 ".(f106999a2210a9a17b32b172f95518859a85ffed",
             "1.3.6.1.4.1.57264.1.11" =>
@@ -74,7 +75,7 @@ FactoryBot.define do
                 ".Mhttps://github.com/sigstore/sigstore-ruby/actions/runs/11446323187/attempts/1",
             "1.3.6.1.4.1.57264.1.22" =>
                 "..public"
-        }.each do |oid, value|
+        }.compact.each do |oid, value|
           cert.add_extension(ctx.extension_factory.create_ext(oid, "ASN1:UTF8String:#{value}", false))
         end
       end

--- a/test/models/oidc/trusted_publisher/github_action_test.rb
+++ b/test/models/oidc/trusted_publisher/github_action_test.rb
@@ -492,6 +492,68 @@ class OIDC::TrustedPublisher::GitHubActionTest < ActiveSupport::TestCase
       github_actions_source_repository_ref: "refs/heads/main")
     cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
 
-    refute_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+    result = publisher.to_sigstore_identity_policy.verify(cert)
+
+    refute_predicate result, :verified?
+    assert_equal "attestation.build_signer_uri_mismatch", result.code
+    assert_equal(
+      {
+        expected_build_signer_uri_prefix: "https://github.com/shared-org/shared-workflows/.github/workflows/release.yml@",
+        actual_build_signer_uri: "https://github.com/#{workflow_ref}"
+      },
+      result.internal_context
+    )
+    assert_equal <<~MSG.chomp, result.public_message
+      The attestation was created by a different GitHub Actions workflow.
+      Expected workflow: https://github.com/shared-org/shared-workflows/.github/workflows/release.yml@<ref>
+      Actual workflow: "https://github.com/#{workflow_ref}"
+      Check the workflow repository and filename in the trusted publisher configuration.
+    MSG
+  end
+
+  test "#to_sigstore_identity_policy diagnoses a missing Build Signer URI" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "sigstore",
+      repository_name: "sigstore-ruby",
+      workflow_filename: "release.yml")
+
+    [nil, ""].each do |build_signer_uri|
+      openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+        github_actions_build_signer_uri: build_signer_uri)
+      cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+      result = publisher.to_sigstore_identity_policy.verify(cert)
+
+      refute_predicate result, :verified?
+      assert_equal "attestation.build_signer_uri_missing", result.code
+      assert_equal(
+        {
+          expected_build_signer_uri_prefix: "https://github.com/sigstore/sigstore-ruby/.github/workflows/release.yml@",
+          actual_build_signer_uri: build_signer_uri
+        },
+        result.internal_context
+      )
+      assert_equal(
+        "The certificate is missing the GitHub Actions Build Signer URI. " \
+        "Generate a new attestation in the configured publishing workflow and retry.",
+        result.public_message
+      )
+    end
+  end
+
+  test "#to_sigstore_identity_policy safely displays an invalid Build Signer URI" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "sigstore",
+      repository_name: "sigstore-ruby",
+      workflow_filename: "release.yml")
+    build_signer_uri = "https://github.com/attacker/workflow\n#{'a' * 600}"
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+      github_actions_build_signer_uri: build_signer_uri)
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    result = publisher.to_sigstore_identity_policy.verify(cert)
+
+    assert_equal 512, result.internal_context.fetch(:actual_build_signer_uri).length
+    assert_includes result.public_message, '"https://github.com/attacker/workflow\\n'
+    refute_includes result.public_message, "Actual workflow: \"https://github.com/attacker/workflow\n"
   end
 end

--- a/test/models/oidc/trusted_publisher/github_action_test.rb
+++ b/test/models/oidc/trusted_publisher/github_action_test.rb
@@ -451,4 +451,47 @@ class OIDC::TrustedPublisher::GitHubActionTest < ActiveSupport::TestCase
       )
     end
   end
+
+  test "#to_sigstore_identity_policy verifies a reusable workflow pinned by SHA when the caller has a different ref" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "caller-org",
+      repository_name: "caller-repo",
+      workflow_filename: "release.yml",
+      workflow_repository_owner: "shared-org",
+      workflow_repository_name: "shared-workflows")
+    workflow_ref = "shared-org/shared-workflows/.github/workflows/release.yml@cdefa43486604b3aae79e9d1db24b670475f2c92"
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+      github_actions_job_workflow_ref: workflow_ref,
+      github_actions_source_repository_ref: "refs/heads/master")
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    assert_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
+
+  test "#to_sigstore_identity_policy verifies a same-repository workflow" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "sigstore",
+      repository_name: "sigstore-ruby",
+      workflow_filename: "release.yml")
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio)
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    assert_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
+
+  test "#to_sigstore_identity_policy rejects a different reusable workflow" do
+    publisher = create(:oidc_trusted_publisher_github_action,
+      repository_owner: "caller-org",
+      repository_name: "caller-repo",
+      workflow_filename: "release.yml",
+      workflow_repository_owner: "shared-org",
+      workflow_repository_name: "shared-workflows")
+    workflow_ref = "attacker-org/shared-workflows/.github/workflows/release.yml@cdefa43486604b3aae79e9d1db24b670475f2c92"
+    openssl_cert = build(:x509_certificate, :key_usage, :github_actions_fulcio,
+      github_actions_job_workflow_ref: workflow_ref,
+      github_actions_source_repository_ref: "refs/heads/main")
+    cert = Sigstore::Internal::X509::Certificate.new(openssl_cert)
+
+    refute_predicate publisher.to_sigstore_identity_policy.verify(cert), :verified?
+  end
 end

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -464,11 +464,38 @@ class PusherTest < ActiveSupport::TestCase
       @api_key.owner = create(:oidc_trusted_publisher_github_action)
       @api_key.oidc_id_token = create(:oidc_id_token)
 
+      diagnostic = OIDC::TrustedPublisher::GitHubAction::SigstorePolicy::DiagnosticFailure.new(
+        code: "attestation.build_signer_uri_mismatch",
+        public_message: "The attestation was created by a different GitHub Actions workflow.",
+        internal_context: {
+          expected_build_signer_uri_prefix: "https://github.com/example/gem/.github/workflows/release.yml@",
+          actual_build_signer_uri: "https://github.com/example/gem/.github/workflows/other.yml@refs/heads/main"
+        }
+      )
+      captured_logger = Class.new do
+        attr_reader :payloads
+
+        def initialize
+          @payloads = []
+        end
+
+        def info
+          @payloads << yield
+        end
+      end.new
+      @cutter.stubs(:logger).returns(captured_logger)
       @cutter.send(:sigstore_verifier).expects(:verify).with(input: anything, policy: anything, offline: true)
-        .returns Sigstore::VerificationFailure.new("Attestation failed to validate")
+        .returns diagnostic
 
       refute @cutter.verify_sigstore
-      assert_equal "Attestation verification failed:\nAttestation failed to validate", @cutter.message
+      assert_equal(
+        "Attestation verification failed:\nThe attestation was created by a different GitHub Actions workflow.",
+        @cutter.message
+      )
+      assert_equal(
+        diagnostic.internal_context.merge(code: diagnostic.code),
+        captured_logger.payloads.first[:diagnostic]
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

- distinguish missing Build Signer URIs from workflow identity mismatches
- give gem authors actionable expected and actual workflow details while escaping and limiting certificate input
- attach stable diagnostic codes and allowlisted context to structured verification logs

## Testing

- `bin/rails test test/models/oidc/trusted_publisher/github_action_test.rb`
- `bin/rails test test/models/pusher_test.rb -n /attestation/`
- `bundle exec rubocop app/models/oidc/trusted_publisher/github_action.rb app/models/pusher.rb test/factories/x509.rb test/models/oidc/trusted_publisher/github_action_test.rb test/models/pusher_test.rb`

## Stack

Depends on #6811.