### PR TITLE
Gem page security advisories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
     - db/**/*.rb
 
 Metrics/ClassLength:
-  Max: 357 # TODO: Lower to 100
+  Max: 360 # TODO: Lower to 100
   Exclude:
     - test/**/*
     - db/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem "faraday-multipart", "~> 1.2"
 gem "sigstore", "~> 0.2.3"
 gem "kramdown", "~> 2.5"
 gem "zlib", "~> 3.2"
+gem "rubyzip", "~> 3.5"
 gem "yaml-schema", "~> 1.2"
 
 # Admin dashboard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -785,6 +785,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-statistics (4.1.1)
     ruby2_keywords (0.0.5)
+    rubyzip (3.5.0)
     safely_block (1.0.0)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
@@ -1012,6 +1013,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.27)
   rubocop-rails (~> 2.37)
   ruby-magic (~> 0.6)
+  rubyzip (~> 3.5)
   searchkick (~> 6.1)
   shoryuken (~> 7.0)
   shoulda-context (~> 3.0.0.rc1)
@@ -1321,6 +1323,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-statistics (4.1.1) sha256=a9923db9bc4b1bda685fac2c47a9fadcc9a93cfd36465f5782a68dfbdf43c171
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  rubyzip (3.5.0) sha256=f77c49d737a849b662f6ca4de473f31b4ecd8288f1c9f901a5c820641f0f8d7c
   safely_block (1.0.0) sha256=bea80e084e620adeada62fd98cf461bbb9888d40dc0f06d337df9d01e1a658e5
   safety_net_attestation (0.5.0) sha256=c8cd01dd550dbe8553862918af6355a04672db11d218ec96104ce3955293f2aa
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984

--- a/app/avo/actions/sync_advisories.rb
+++ b/app/avo/actions/sync_advisories.rb
@@ -11,7 +11,7 @@ class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
 
   def fields
     field :source, as: :select,
-      options: -> { Advisory.sources.to_h { |klass| [klass.name.demodulize, klass.sti_name] } },
+      options: -> { Advisory::SOURCES.to_h { |klass| [klass.name.demodulize, klass.sti_name] } },
       required: true,
       help: "Which advisory source to fetch."
     super
@@ -19,7 +19,7 @@ class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
 
   class ActionHandler < Avo::Actions::ActionHandler
     set_callback :handle, :before do
-      error "Unknown advisory source" unless Advisory.sources.map(&:sti_name).include?(fields[:source])
+      error "Unknown advisory source" unless Advisory::SOURCES.map(&:sti_name).include?(fields[:source])
     end
 
     def handle_standalone

--- a/app/avo/actions/sync_advisories.rb
+++ b/app/avo/actions/sync_advisories.rb
@@ -2,16 +2,28 @@
 
 class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
   self.name = "Sync Advisories"
-  self.message = "Fetch and upsert security advisories from all sources. This runs even when public source flags are off."
+  self.message = "Fetch and upsert security advisories from the selected source. This runs even when the public source flag is off."
   self.visible = lambda {
     current_user.team_member?("rubygems-org") && view == :index
   }
   self.standalone = true
   self.confirm_button_label = "Sync"
 
+  def fields
+    field :source, as: :select,
+      options: -> { Advisory.sources.to_h { |klass| [klass.name.demodulize, klass.sti_name] } },
+      required: true,
+      help: "Which advisory source to fetch."
+    super
+  end
+
   class ActionHandler < Avo::Actions::ActionHandler
+    set_callback :handle, :before do
+      error "Unknown advisory source" unless Advisory.sources.map(&:sti_name).include?(fields[:source])
+    end
+
     def handle_standalone
-      SyncAdvisoriesJob.perform_later(force: true)
+      SyncAdvisoriesJob.perform_later(source: fields[:source], force: true)
 
       succeed("Advisory sync job scheduled")
 

--- a/app/avo/actions/sync_advisories.rb
+++ b/app/avo/actions/sync_advisories.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
+  self.name = "Sync Advisories"
+  self.message = "Fetch and upsert security advisories from all sources. This runs even when public source flags are off."
+  self.visible = lambda {
+    current_user.team_member?("rubygems-org") && view == :index
+  }
+  self.standalone = true
+  self.confirm_button_label = "Sync"
+
+  class ActionHandler < Avo::Actions::ActionHandler
+    def handle_standalone
+      SyncAdvisoriesJob.perform_later(force: true)
+
+      succeed("Advisory sync job scheduled")
+
+      current_user
+    end
+  end
+end

--- a/app/avo/actions/sync_advisories.rb
+++ b/app/avo/actions/sync_advisories.rb
@@ -23,9 +23,11 @@ class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
     end
 
     def handle_standalone
-      SyncAdvisoriesJob.perform_later(source: fields[:source], force: true)
-
-      succeed("Advisory sync job scheduled")
+      if SyncAdvisoriesJob.perform_later(source: fields[:source], force: true)
+        succeed("Advisory sync job scheduled")
+      else
+        error "Failed to enqueue advisory sync job. Another may already be queued"
+      end
 
       current_user
     end

--- a/app/avo/actions/sync_advisories.rb
+++ b/app/avo/actions/sync_advisories.rb
@@ -2,7 +2,7 @@
 
 class Avo::Actions::SyncAdvisories < Avo::Actions::ApplicationAction
   self.name = "Sync Advisories"
-  self.message = "Fetch and upsert security advisories from the selected source. This runs even when the public source flag is off."
+  self.message = "Fetch and replace security advisories from the selected source. This runs even when the public source flag is off."
   self.visible = lambda {
     current_user.team_member?("rubygems-org") && view == :index
   }

--- a/app/avo/resources/advisory.rb
+++ b/app/avo/resources/advisory.rb
@@ -11,6 +11,10 @@ class Avo::Resources::Advisory < Avo::BaseResource
     }
   }
 
+  def actions
+    action Avo::Actions::SyncAdvisories
+  end
+
   def fields
     field :id, as: :id, hide_on: :index
     field :identifier, as: :text, link_to_resource: true

--- a/app/avo/resources/advisory.rb
+++ b/app/avo/resources/advisory.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Avo::Resources::Advisory < Avo::BaseResource
+  self.model_class = ::Advisory
+  self.title = :identifier
+  self.includes = []
+  self.search = {
+    query: lambda {
+      search_term = ActiveRecord::Base.sanitize_sql_like(params[:q])
+      query.where("identifier LIKE :q OR rubygem_name LIKE :q", q: "#{search_term}%")
+    }
+  }
+
+  def fields
+    field :id, as: :id, hide_on: :index
+    field :identifier, as: :text, link_to_resource: true
+    field :type, as: :text
+    field :rubygem_name, as: :text
+    field :rubygem, as: :belongs_to
+    field :aliases, as: :tags
+    field :summary, as: :textarea
+    field :severity, as: :text
+    field :url, as: :text
+    field :published_at, as: :date_time, sortable: true
+    field :modified_at, as: :date_time, sortable: true
+    field :withdrawn_at, as: :date_time, sortable: true
+    field :ranges, as: :json_viewer, only_on: :show
+    field :payload, as: :json_viewer, only_on: :show
+  end
+end

--- a/app/avo/resources/advisory.rb
+++ b/app/avo/resources/advisory.rb
@@ -3,7 +3,7 @@
 class Avo::Resources::Advisory < Avo::BaseResource
   self.model_class = ::Advisory
   self.title = :identifier
-  self.includes = []
+  self.includes = [:rubygem]
   self.search = {
     query: lambda {
       search_term = ActiveRecord::Base.sanitize_sql_like(params[:q])

--- a/app/avo/resources/advisory.rb
+++ b/app/avo/resources/advisory.rb
@@ -29,6 +29,5 @@ class Avo::Resources::Advisory < Avo::BaseResource
     field :modified_at, as: :date_time, sortable: true
     field :withdrawn_at, as: :date_time, sortable: true
     field :ranges, as: :json_viewer, only_on: :show
-    field :payload, as: :json_viewer, only_on: :show
   end
 end

--- a/app/avo/resources/rubygem.rb
+++ b/app/avo/resources/rubygem.rb
@@ -50,6 +50,7 @@ class Avo::Resources::Rubygem < Avo::BaseResource
 
       field :link_verifications, as: :has_many
       field :oidc_rubygem_trusted_publishers, as: :has_many
+      field :advisories, as: :has_many
 
       field :audits, as: :has_many
       field :events, as: :has_many

--- a/app/controllers/avo/advisories_controller.rb
+++ b/app/controllers/avo/advisories_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::AdvisoriesController < Avo::ResourcesController
+end

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -30,7 +30,7 @@ class RubygemsController < ApplicationController
 
   def show
     @versions = @rubygem.public_versions.limit(5)
-    @advisories = find_advisories
+    @advisories = @rubygem.advisories.visible.to_a
     if @versions.to_a.any?
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
       add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.slug)
@@ -51,10 +51,6 @@ class RubygemsController < ApplicationController
   end
 
   private
-
-  def find_advisories
-    @rubygem.advisories.current.merge(Advisory.enabled_sources).to_a
-  end
 
   def show_reserved_gem
     return unless GemNameReservation.reserved?(params[:id])

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -30,6 +30,7 @@ class RubygemsController < ApplicationController
 
   def show
     @versions = @rubygem.public_versions.limit(5)
+    @advisories = find_advisories
     if @versions.to_a.any?
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
       add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.slug)
@@ -50,6 +51,10 @@ class RubygemsController < ApplicationController
   end
 
   private
+
+  def find_advisories
+    @rubygem.advisories.current.merge(Advisory.enabled_sources).to_a
+  end
 
   def show_reserved_gem
     return unless GemNameReservation.reserved?(params[:id])

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -11,7 +11,7 @@ class VersionsController < ApplicationController
     @versioned_links     = @rubygem.links(@latest_version) if @latest_version
     @oldest_version_date = @rubygem.versions.oldest_authored_at
     @versions = @rubygem.versions.by_position.page(@page).per(Gemcutter::VERSIONS_PER_PAGE)
-    @advisories = find_advisories
+    @advisories = @rubygem.advisories.visible.to_a
     if @latest_version
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
       add_breadcrumb t("breadcrumbs.versions")
@@ -24,7 +24,7 @@ class VersionsController < ApplicationController
     @latest_version  = @rubygem.find_version_by_slug!(params[:id])
     @versions        = @rubygem.public_versions_with_extra_version(@latest_version)
     @versioned_links = @rubygem.links(@latest_version)
-    @advisories = find_advisories
+    @advisories = @rubygem.advisories.visible.to_a
     @on_version_page = true
     add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
     if @latest_version == @rubygem.most_recent_version
@@ -35,11 +35,5 @@ class VersionsController < ApplicationController
     render "rubygems/show"
     set_surrogate_key "gem/#{@rubygem.name}"
     cache_expiry_headers(expiry: 60, fastly_expiry: 60) if cacheable_request?
-  end
-
-  private
-
-  def find_advisories
-    @rubygem.advisories.current.merge(Advisory.enabled_sources).to_a
   end
 end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -11,6 +11,7 @@ class VersionsController < ApplicationController
     @versioned_links     = @rubygem.links(@latest_version) if @latest_version
     @oldest_version_date = @rubygem.versions.oldest_authored_at
     @versions = @rubygem.versions.by_position.page(@page).per(Gemcutter::VERSIONS_PER_PAGE)
+    @advisories = find_advisories
     if @latest_version
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
       add_breadcrumb t("breadcrumbs.versions")
@@ -23,6 +24,7 @@ class VersionsController < ApplicationController
     @latest_version  = @rubygem.find_version_by_slug!(params[:id])
     @versions        = @rubygem.public_versions_with_extra_version(@latest_version)
     @versioned_links = @rubygem.links(@latest_version)
+    @advisories = find_advisories
     @on_version_page = true
     add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
     if @latest_version == @rubygem.most_recent_version
@@ -33,5 +35,11 @@ class VersionsController < ApplicationController
     render "rubygems/show"
     set_surrogate_key "gem/#{@rubygem.name}"
     cache_expiry_headers(expiry: 60, fastly_expiry: 60) if cacheable_request?
+  end
+
+  private
+
+  def find_advisories
+    @rubygem.advisories.current.merge(Advisory.enabled_sources).to_a
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -28,6 +28,10 @@ module VersionsHelper
     end
   end
 
+  def version_advisory?(advisories, version)
+    Array(advisories).any? { |advisory| advisory.affects?(version) }
+  end
+
   def download_count_component(rubygem, **options)
     downloads = number_with_delimiter(rubygem.downloads)
     options[:class] = "flex text-neutral-600 dark:text-neutral-400 text-nowrap text-b3 space-x-1 items-center #{options[:class]}"

--- a/app/jobs/sync_advisories_job.rb
+++ b/app/jobs/sync_advisories_job.rb
@@ -11,7 +11,7 @@ class SyncAdvisoriesJob < ApplicationJob
     key: name
   )
 
-  def perform
-    Advisory::Fetcher.sync_all
+  def perform(force: false)
+    Advisory::Fetcher.sync_all(force:)
   end
 end

--- a/app/jobs/sync_advisories_job.rb
+++ b/app/jobs/sync_advisories_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SyncAdvisoriesJob < ApplicationJob
+  queue_as "stats"
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    perform_limit: 1,
+    key: name
+  )
+
+  def perform
+    Advisory::Fetcher.sync_all
+  end
+end

--- a/app/jobs/sync_advisories_job.rb
+++ b/app/jobs/sync_advisories_job.rb
@@ -11,7 +11,11 @@ class SyncAdvisoriesJob < ApplicationJob
     key: name
   )
 
-  def perform(force: false)
-    Advisory::Fetcher.sync_all(force:)
+  def perform(source: nil, force: false)
+    if source
+      Advisory::Fetcher.sync(source, force:)
+    else
+      Advisory::Fetcher.sync_all
+    end
   end
 end

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Advisory < ApplicationRecord
+  belongs_to :rubygem, primary_key: :name, foreign_key: :rubygem_name, optional: true, inverse_of: :advisories
+
+  enum :severity, { low: "low", moderate: "moderate", high: "high", critical: "critical" }, validate: { allow_nil: true }
+
+  attribute :payload, :jsonb
+  attribute :ranges, :jsonb
+
+  validates :type, :identifier, :rubygem_name, :summary, :url, :modified_at, presence: true
+  validates :identifier, uniqueness: { scope: %i[type rubygem_name] }
+
+  scope :current, -> { where(withdrawn_at: nil) }
+end

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Advisory < ApplicationRecord
+  SOURCES = [OSV].freeze
+
   belongs_to :rubygem, primary_key: :name, foreign_key: :rubygem_name, optional: true, inverse_of: :advisories
 
   attribute :payload, :jsonb
@@ -10,12 +12,12 @@ class Advisory < ApplicationRecord
   validates :identifier, uniqueness: { scope: %i[type rubygem_name] }
 
   scope :current, -> { where(withdrawn_at: nil) }
+  scope :visible, lambda {
+    types = enabled_sources.map(&:sti_name)
+    types.empty? ? none : current.where(type: types)
+  }
 
   class << self
-    def sources
-      [OSV]
-    end
-
     def feature_flag
       raise NotImplementedError, "#{name} must define .feature_flag"
     end
@@ -25,10 +27,7 @@ class Advisory < ApplicationRecord
     end
 
     def enabled_sources
-      types = sources.select(&:enabled?).map(&:sti_name)
-      return none if types.empty?
-
-      where(type: types)
+      SOURCES.select(&:enabled?)
     end
   end
 

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -3,8 +3,6 @@
 class Advisory < ApplicationRecord
   belongs_to :rubygem, primary_key: :name, foreign_key: :rubygem_name, optional: true, inverse_of: :advisories
 
-  enum :severity, { low: "low", moderate: "moderate", high: "high", critical: "critical" }, validate: { allow_nil: true }
-
   attribute :payload, :jsonb
   attribute :ranges, :jsonb
 

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -10,4 +10,45 @@ class Advisory < ApplicationRecord
   validates :identifier, uniqueness: { scope: %i[type rubygem_name] }
 
   scope :current, -> { where(withdrawn_at: nil) }
+
+  class << self
+    def sources
+      [OSV]
+    end
+
+    def feature_flag
+      raise NotImplementedError, "#{name} must define .feature_flag"
+    end
+
+    def enabled?
+      FeatureFlag.enabled?(feature_flag)
+    end
+
+    def enabled_sources
+      types = sources.select(&:enabled?).map(&:sti_name)
+      return none if types.empty?
+
+      where(type: types)
+    end
+  end
+
+  def affects?(version)
+    gem_version = to_gem_version(version)
+    return false if gem_version.nil? || ranges.blank?
+
+    ranges.any? { |range| range_includes?(range, gem_version) }
+  end
+
+  private
+
+  def to_gem_version(version)
+    number = version.respond_to?(:number) ? version.number : version
+    Gem::Version.new(number.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def range_includes?(_range, _gem_version)
+    raise NotImplementedError, "#{self.class} must implement #range_includes?"
+  end
 end

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Advisory < ApplicationRecord
-  SOURCES = [OSV].freeze
-
   belongs_to :rubygem, primary_key: :name, foreign_key: :rubygem_name, optional: true, inverse_of: :advisories
 
   attribute :payload, :jsonb
@@ -16,6 +14,8 @@ class Advisory < ApplicationRecord
     types = enabled_sources.map(&:sti_name)
     types.empty? ? none : current.where(type: types)
   }
+
+  SOURCES = [OSV].freeze
 
   class << self
     def feature_flag

--- a/app/models/advisory.rb
+++ b/app/models/advisory.rb
@@ -3,7 +3,6 @@
 class Advisory < ApplicationRecord
   belongs_to :rubygem, primary_key: :name, foreign_key: :rubygem_name, optional: true, inverse_of: :advisories
 
-  attribute :payload, :jsonb
   attribute :ranges, :jsonb
 
   validates :type, :identifier, :rubygem_name, :summary, :url, :modified_at, presence: true

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -39,9 +39,13 @@ class Advisory::Fetcher
       all.select(&:enabled?)
     end
 
-    def sync_all(force: false)
-      fetchers = force ? all : enabled
-      fetchers.each { |fetcher| fetcher.new.sync(force:) }
+    def sync_all
+      enabled.each { |fetcher| fetcher.new.sync }
+    end
+
+    def sync(source, force: false)
+      klass = source.is_a?(Class) ? source : source.constantize
+      all.find { |fetcher| fetcher.advisory_class == klass }.new.sync(force:)
     end
   end
 

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -2,9 +2,21 @@
 
 class Advisory::Fetcher
   BATCH_SIZE = 500
-  UPDATE_COLUMNS = %i[
-    aliases summary severity url published_at modified_at withdrawn_at ranges payload updated_at
+  OPEN_TIMEOUT = 10
+  READ_TIMEOUT = 60
+
+  RETRY_EXCEPTIONS = [
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError,
+    Faraday::ServerError,
+    Faraday::TooManyRequestsError
   ].freeze
+
+  UPDATE_COLUMNS = %i[
+    aliases summary severity url published_at modified_at withdrawn_at ranges payload
+  ].freeze
+
+  class Error < StandardError; end
 
   class << self
     def feature_flag
@@ -46,6 +58,10 @@ class Advisory::Fetcher
     raise NotImplementedError, "#{self.class}#map must be implemented"
   end
 
+  def download(url)
+    connection.get(url).body.to_s
+  end
+
   def import(records)
     return 0 if records.empty?
 
@@ -61,5 +77,16 @@ class Advisory::Fetcher
 
     records.size
   end
+
+  private
+
+  def connection
+    @connection ||= Faraday.new(
+      request: { open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT },
+      headers: { "User-Agent" => "RubyGems.org Advisory Fetcher/#{AppRevision.version}" }
+    ) do |f|
+      f.request :retry, max: 2, interval: 0.05, backoff_factor: 2, methods: %i[get], exceptions: RETRY_EXCEPTIONS
+      f.response :raise_error
+    end
   end
 end

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class Advisory::Fetcher
+  BATCH_SIZE = 500
+  UPDATE_COLUMNS = %i[
+    aliases summary severity url published_at modified_at withdrawn_at ranges payload updated_at
+  ].freeze
+
+  class << self
+    def feature_flag
+      raise NotImplementedError, "#{name} must define .feature_flag"
+    end
+
+    def advisory_class
+      raise NotImplementedError, "#{name} must define .advisory_class"
+    end
+
+    def enabled?
+      FeatureFlag.enabled?(feature_flag)
+    end
+
+    def all
+      [Advisory::OSV::Fetcher]
+    end
+
+    def enabled
+      all.select(&:enabled?)
+    end
+
+    def sync_all
+      enabled.each { |fetcher| fetcher.new.sync }
+    end
+  end
+
+  def sync
+    return unless self.class.enabled?
+
+    import(fetch.flat_map { |document| map(document) })
+  end
+
+  def fetch
+    raise NotImplementedError, "#{self.class}#fetch must be implemented"
+  end
+
+  def map(_document)
+    raise NotImplementedError, "#{self.class}#map must be implemented"
+  end
+
+  def import(records)
+    return 0 if records.empty?
+
+    self.class.advisory_class.transaction do
+      records.each_slice(BATCH_SIZE) do |slice|
+        self.class.advisory_class.upsert_all(
+          slice,
+          unique_by: %i[type identifier rubygem_name],
+          update_only: UPDATE_COLUMNS
+        )
+      end
+    end
+
+    records.size
+  end
+  end
+end

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -19,33 +19,25 @@ class Advisory::Fetcher
   class Error < StandardError; end
 
   class << self
-    def feature_flag
-      raise NotImplementedError, "#{name} must define .feature_flag"
-    end
-
     def advisory_class
       raise NotImplementedError, "#{name} must define .advisory_class"
     end
 
-    def enabled?
-      FeatureFlag.enabled?(feature_flag)
-    end
+    delegate :enabled?, to: :advisory_class
 
-    def all
-      [Advisory::OSV::Fetcher]
-    end
-
-    def enabled
-      all.select(&:enabled?)
+    def sources
+      Advisory::SOURCES.map { |klass| klass::Fetcher }
     end
 
     def sync_all
-      enabled.each { |fetcher| fetcher.new.sync }
+      Advisory.enabled_sources.each { |klass| klass::Fetcher.new.sync }
     end
 
     def sync(source, force: false)
       klass = source.is_a?(Class) ? source : source.constantize
-      all.find { |fetcher| fetcher.advisory_class == klass }.new.sync(force:)
+      raise ArgumentError, "Unknown advisory source: #{source.inspect}" unless Advisory::SOURCES.include?(klass)
+
+      klass::Fetcher.new.sync(force:)
     end
   end
 

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -39,13 +39,14 @@ class Advisory::Fetcher
       all.select(&:enabled?)
     end
 
-    def sync_all
-      enabled.each { |fetcher| fetcher.new.sync }
+    def sync_all(force: false)
+      fetchers = force ? all : enabled
+      fetchers.each { |fetcher| fetcher.new.sync(force:) }
     end
   end
 
-  def sync
-    return unless self.class.enabled?
+  def sync(force: false)
+    return unless force || self.class.enabled?
 
     import(fetch.flat_map { |document| map(document) })
   end

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -25,10 +25,6 @@ class Advisory::Fetcher
 
     delegate :enabled?, to: :advisory_class
 
-    def sources
-      Advisory::SOURCES.map { |klass| klass::Fetcher }
-    end
-
     def sync_all
       Advisory.enabled_sources.each { |klass| klass::Fetcher.new.sync }
     end

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -13,7 +13,7 @@ class Advisory::Fetcher
   ].freeze
 
   UPDATE_COLUMNS = %i[
-    aliases summary severity url published_at modified_at withdrawn_at ranges payload
+    aliases summary severity url published_at modified_at withdrawn_at ranges
   ].freeze
 
   class Error < StandardError; end

--- a/app/models/advisory/fetcher.rb
+++ b/app/models/advisory/fetcher.rb
@@ -12,10 +12,6 @@ class Advisory::Fetcher
     Faraday::TooManyRequestsError
   ].freeze
 
-  UPDATE_COLUMNS = %i[
-    aliases summary severity url published_at modified_at withdrawn_at ranges
-  ].freeze
-
   class Error < StandardError; end
 
   class << self
@@ -56,15 +52,11 @@ class Advisory::Fetcher
   end
 
   def import(records)
-    return 0 if records.empty?
-
     self.class.advisory_class.transaction do
+      self.class.advisory_class.delete_all
+
       records.each_slice(BATCH_SIZE) do |slice|
-        self.class.advisory_class.upsert_all(
-          slice,
-          unique_by: %i[type identifier rubygem_name],
-          update_only: UPDATE_COLUMNS
-        )
+        self.class.advisory_class.insert_all!(slice)
       end
     end
 

--- a/app/models/advisory/osv.rb
+++ b/app/models/advisory/osv.rb
@@ -1,5 +1,41 @@
 # frozen_string_literal: true
 
 class Advisory::OSV < Advisory
+  def self.feature_flag = FeatureFlag::OSV_ADVISORIES
+
   enum :severity, { low: "low", moderate: "moderate", high: "high", critical: "critical" }, validate: { allow_nil: true }
+
+  private
+
+  def range_includes?(range, gem_version)
+    return false unless range.is_a?(Hash)
+
+    unless range["introduced"] == "0"
+      introduced = parse_bound(range["introduced"])
+      return false if introduced.nil?
+      return false if gem_version < introduced
+    end
+
+    if range.key?("fixed")
+      fixed = parse_bound(range["fixed"])
+      return false if fixed.nil?
+      return gem_version < fixed
+    end
+
+    if range.key?("last_affected")
+      last_affected = parse_bound(range["last_affected"])
+      return false if last_affected.nil?
+      return gem_version <= last_affected
+    end
+
+    true
+  end
+
+  def parse_bound(value)
+    return nil if value.blank?
+
+    Gem::Version.new(value.to_s)
+  rescue ArgumentError
+    nil
+  end
 end

--- a/app/models/advisory/osv.rb
+++ b/app/models/advisory/osv.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Advisory::OSV < Advisory
+end

--- a/app/models/advisory/osv.rb
+++ b/app/models/advisory/osv.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Advisory::OSV < Advisory
+  enum :severity, { low: "low", moderate: "moderate", high: "high", critical: "critical" }, validate: { allow_nil: true }
 end

--- a/app/models/advisory/osv.rb
+++ b/app/models/advisory/osv.rb
@@ -5,6 +5,10 @@ class Advisory::OSV < Advisory
 
   enum :severity, { low: "low", moderate: "moderate", high: "high", critical: "critical" }, validate: { allow_nil: true }
 
+  def malware?
+    identifier.to_s.start_with?("MAL-")
+  end
+
   private
 
   def range_includes?(range, gem_version)

--- a/app/models/advisory/osv/fetcher.rb
+++ b/app/models/advisory/osv/fetcher.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Advisory::OSV::Fetcher < Advisory::Fetcher
+  def self.feature_flag = FeatureFlag::OSV_ADVISORIES
+  def self.advisory_class = Advisory::OSV
+
+  def map(document)
+    Advisory::OSV::Mapper.call(document)
+  end
+end

--- a/app/models/advisory/osv/fetcher.rb
+++ b/app/models/advisory/osv/fetcher.rb
@@ -7,7 +7,6 @@ class Advisory::OSV::Fetcher < Advisory::Fetcher
   MAX_INCREMENTAL_IDS = 25
   MAX_ENTRY_BYTES = 1.megabyte
 
-  def self.feature_flag = FeatureFlag::OSV_ADVISORIES
   def self.advisory_class = Advisory::OSV
 
   def fetch

--- a/app/models/advisory/osv/fetcher.rb
+++ b/app/models/advisory/osv/fetcher.rb
@@ -1,10 +1,103 @@
 # frozen_string_literal: true
 
 class Advisory::OSV::Fetcher < Advisory::Fetcher
+  BASE_URL = "https://osv-vulnerabilities.storage.googleapis.com/RubyGems"
+  DUMP_URL = "#{BASE_URL}/all.zip".freeze
+  INDEX_URL = "#{BASE_URL}/modified_id.csv".freeze
+  MAX_INCREMENTAL_IDS = 25
+  MAX_ENTRY_BYTES = 1.megabyte
+
   def self.feature_flag = FeatureFlag::OSV_ADVISORIES
   def self.advisory_class = Advisory::OSV
 
+  def fetch
+    since = self.class.advisory_class.maximum(:modified_at)
+    since ? fetch_updates(since) : fetch_all
+  end
+
   def map(document)
     Advisory::OSV::Mapper.call(document)
+  end
+
+  private
+
+  def fetch_all
+    documents_from_zip(download(DUMP_URL))
+  end
+
+  def fetch_updates(since)
+    ids = updated_ids(since)
+    return fetch_all if ids.nil? || ids.size > MAX_INCREMENTAL_IDS
+
+    incremental_documents(ids) || fetch_all
+  end
+
+  def updated_ids(since)
+    ids = []
+    CSV.parse(download(INDEX_URL)) do |modified, id, *|
+      time = parse_modified(modified)
+      next if time.blank? || id.blank?
+      break if time < since
+      next if ids.include?(id)
+
+      ids << id
+      break if ids.size > MAX_INCREMENTAL_IDS
+    end
+    ids
+  rescue Faraday::Error => e
+    log_incremental_fallback(e)
+    nil
+  end
+
+  def incremental_documents(ids)
+    ids.map { |id| JSON.parse(download(document_url(id))) }
+  rescue Faraday::Error, JSON::ParserError => e
+    log_incremental_fallback(e)
+    nil
+  end
+
+  def document_url(id)
+    "#{BASE_URL}/#{CGI.escapeURIComponent(id)}.json"
+  end
+
+  def documents_from_zip(bytes)
+    documents = []
+    Zip::File.open_buffer(bytes.b) do |zip|
+      zip.each do |entry|
+        next unless json_entry?(entry)
+
+        documents << parse_entry(entry)
+      end
+    end
+    documents.compact
+  rescue Zip::Error => e
+    raise Error, "Invalid OSV dump archive: #{e.message}"
+  end
+
+  def json_entry?(entry)
+    entry.file? && entry.name.end_with?(".json") && entry.name.exclude?("/")
+  end
+
+  def parse_entry(entry)
+    raise Error, "OSV dump entry too large: #{entry.name}" if entry.size > MAX_ENTRY_BYTES
+
+    parse_json(entry.get_input_stream.read, entry.name)
+  end
+
+  def parse_json(raw, name)
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    Rails.logger.warn("Skipping invalid OSV document #{name}")
+    nil
+  end
+
+  def parse_modified(value)
+    Time.iso8601(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def log_incremental_fallback(error)
+    Rails.logger.warn("OSV incremental fetch failed (#{error.class}: #{error.message}); falling back to dump")
   end
 end

--- a/app/models/advisory/osv/fetcher.rb
+++ b/app/models/advisory/osv/fetcher.rb
@@ -43,7 +43,7 @@ class Advisory::OSV::Fetcher < Advisory::Fetcher
       break if ids.size > MAX_INCREMENTAL_IDS
     end
     ids
-  rescue Faraday::Error => e
+  rescue Faraday::Error, CSV::MalformedCSVError => e
     log_incremental_fallback(e)
     nil
   end

--- a/app/models/advisory/osv/fetcher.rb
+++ b/app/models/advisory/osv/fetcher.rb
@@ -3,15 +3,12 @@
 class Advisory::OSV::Fetcher < Advisory::Fetcher
   BASE_URL = "https://osv-vulnerabilities.storage.googleapis.com/RubyGems"
   DUMP_URL = "#{BASE_URL}/all.zip".freeze
-  INDEX_URL = "#{BASE_URL}/modified_id.csv".freeze
-  MAX_INCREMENTAL_IDS = 25
   MAX_ENTRY_BYTES = 1.megabyte
 
   def self.advisory_class = Advisory::OSV
 
   def fetch
-    since = self.class.advisory_class.maximum(:modified_at)
-    since ? fetch_updates(since) : fetch_all
+    documents_from_zip(download(DUMP_URL))
   end
 
   def map(document)
@@ -19,45 +16,6 @@ class Advisory::OSV::Fetcher < Advisory::Fetcher
   end
 
   private
-
-  def fetch_all
-    documents_from_zip(download(DUMP_URL))
-  end
-
-  def fetch_updates(since)
-    ids = updated_ids(since)
-    return fetch_all if ids.nil? || ids.size > MAX_INCREMENTAL_IDS
-
-    incremental_documents(ids) || fetch_all
-  end
-
-  def updated_ids(since)
-    ids = []
-    CSV.parse(download(INDEX_URL)) do |modified, id, *|
-      time = parse_modified(modified)
-      next if time.blank? || id.blank?
-      break if time < since
-      next if ids.include?(id)
-
-      ids << id
-      break if ids.size > MAX_INCREMENTAL_IDS
-    end
-    ids
-  rescue Faraday::Error, CSV::MalformedCSVError => e
-    log_incremental_fallback(e)
-    nil
-  end
-
-  def incremental_documents(ids)
-    ids.map { |id| JSON.parse(download(document_url(id))) }
-  rescue Faraday::Error, JSON::ParserError => e
-    log_incremental_fallback(e)
-    nil
-  end
-
-  def document_url(id)
-    "#{BASE_URL}/#{CGI.escapeURIComponent(id)}.json"
-  end
 
   def documents_from_zip(bytes)
     documents = []
@@ -68,7 +26,7 @@ class Advisory::OSV::Fetcher < Advisory::Fetcher
         documents << parse_entry(entry)
       end
     end
-    documents.compact
+    documents
   rescue Zip::Error => e
     raise Error, "Invalid OSV dump archive: #{e.message}"
   end
@@ -85,18 +43,7 @@ class Advisory::OSV::Fetcher < Advisory::Fetcher
 
   def parse_json(raw, name)
     JSON.parse(raw)
-  rescue JSON::ParserError
-    Rails.logger.warn("Skipping invalid OSV document #{name}")
-    nil
-  end
-
-  def parse_modified(value)
-    Time.iso8601(value.to_s)
-  rescue ArgumentError
-    nil
-  end
-
-  def log_incremental_fallback(error)
-    Rails.logger.warn("OSV incremental fetch failed (#{error.class}: #{error.message}); falling back to dump")
+  rescue JSON::ParserError => e
+    raise Error, "Invalid OSV document #{name}: #{e.message}"
   end
 end

--- a/app/models/advisory/osv/mapper.rb
+++ b/app/models/advisory/osv/mapper.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class Advisory::OSV::Mapper
+  ECOSYSTEM = "RubyGems"
+  URL_PREFIX = "https://osv.dev/vulnerability/"
+  RANGE_TYPES = %w[ECOSYSTEM SEMVER].freeze
+  RANGE_EVENTS = %w[introduced fixed last_affected].freeze
+
+  def self.call(document)
+    new(document).records
+  end
+
+  def initialize(document)
+    @document = document.to_h.deep_stringify_keys
+  end
+
+  def records
+    return [] if identifier.blank? || modified_at.blank?
+
+    packages.map do |name, ranges|
+      {
+        identifier:,
+        rubygem_name: name,
+        aliases:,
+        summary:,
+        severity:,
+        url:,
+        published_at:,
+        modified_at:,
+        withdrawn_at:,
+        ranges:,
+        payload: @document
+      }
+    end
+  end
+
+  private
+
+  def identifier
+    @document["id"].presence
+  end
+
+  def aliases
+    Array(@document["aliases"]).map(&:to_s)
+  end
+
+  def summary
+    @document["summary"].presence || identifier
+  end
+
+  def severity
+    raw = @document.dig("database_specific", "severity")&.to_s&.downcase
+    raw if Advisory::OSV.severities.key?(raw)
+  end
+
+  def url
+    "#{URL_PREFIX}#{identifier}"
+  end
+
+  def published_at
+    parse_time(@document["published"])
+  end
+
+  def modified_at
+    parse_time(@document["modified"])
+  end
+
+  def withdrawn_at
+    parse_time(@document["withdrawn"])
+  end
+
+  def packages
+    Array(@document["affected"]).each_with_object({}) do |entry, grouped|
+      package = entry["package"] || {}
+      next unless package["ecosystem"] == ECOSYSTEM
+
+      name = package["name"].presence
+      next unless name
+
+      grouped[name] ||= []
+      grouped[name].concat(normalized_ranges(entry).presence || normalized_versions(entry))
+    end
+  end
+
+  def normalized_ranges(entry)
+    Array(entry["ranges"]).filter_map do |range|
+      next unless RANGE_TYPES.include?(range["type"])
+
+      events = Array(range["events"]).each_with_object({}) { |event, hash| hash.merge!(event) }
+      events.slice(*RANGE_EVENTS).presence
+    end
+  end
+
+  def normalized_versions(entry)
+    Array(entry["versions"]).filter_map do |version|
+      { "introduced" => version.to_s, "last_affected" => version.to_s } if version.present?
+    end
+  end
+
+  def parse_time(value)
+    Time.iso8601(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/models/advisory/osv/mapper.rb
+++ b/app/models/advisory/osv/mapper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# OSV schema: https://ossf.github.io/osv-schema
 class Advisory::OSV::Mapper
   ECOSYSTEM = "RubyGems"
   URL_PREFIX = "https://osv.dev/vulnerability/"
@@ -69,6 +70,9 @@ class Advisory::OSV::Mapper
     parse_time(@document["withdrawn"])
   end
 
+  # One record per gem: several affected entries for the same name are merged.
+  # Prefer ECOSYSTEM/SEMVER ranges; fall back to enumerated versions when those
+  # are missing or only GIT ranges are present.
   def packages
     Array(@document["affected"]).each_with_object({}) do |entry, grouped|
       package = entry["package"] || {}
@@ -82,15 +86,20 @@ class Advisory::OSV::Mapper
     end
   end
 
+  # Split OSV events into {introduced, fixed|last_affected} hashes. GIT ranges
+  # and limit events are dropped. Each introduced starts a new interval. See tests for examples.
   def normalized_ranges(entry)
-    Array(entry["ranges"]).filter_map do |range|
-      next unless RANGE_TYPES.include?(range["type"])
+    Array(entry["ranges"]).flat_map do |range|
+      next [] unless RANGE_TYPES.include?(range["type"])
 
-      events = Array(range["events"]).each_with_object({}) { |event, hash| hash.merge!(event) }
-      events.slice(*RANGE_EVENTS).presence
+      Array(range["events"])
+        .filter_map { |event| event.slice(*RANGE_EVENTS).presence }
+        .slice_when { |_, event| event.key?("introduced") }
+        .map { |events| events.reduce({}, :merge) }
     end
   end
 
+  # Enumerated versions become exact ranges so they share the same matching path.
   def normalized_versions(entry)
     Array(entry["versions"]).filter_map do |version|
       { "introduced" => version.to_s, "last_affected" => version.to_s } if version.present?

--- a/app/models/advisory/osv/mapper.rb
+++ b/app/models/advisory/osv/mapper.rb
@@ -29,8 +29,7 @@ class Advisory::OSV::Mapper
         published_at:,
         modified_at:,
         withdrawn_at:,
-        ranges:,
-        payload: @document
+        ranges:
       }
     end
   end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -3,6 +3,7 @@
 class FeatureFlag
   ORGANIZATIONS = :organizations
   CONTENT_ADDRESSABLE_GEM_PUSHES = :content_addressable_gem_pushes
+  OSV_ADVISORIES = :osv_advisories
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -18,6 +18,7 @@ class Rubygem < ApplicationRecord
   has_many :subscribers, through: :subscriptions, source: :user
   has_many :versions, dependent: :destroy, validate: false
   has_one :latest_version, -> { latest.order(:position) }, class_name: "Version", inverse_of: :rubygem
+  has_many :advisories, primary_key: :name, foreign_key: :rubygem_name, inverse_of: :rubygem
   has_many :web_hooks, dependent: :destroy
   has_one :linkset, dependent: :destroy, inverse_of: :rubygem
   has_one :gem_download, -> { where(version_id: 0) }, inverse_of: :rubygem

--- a/app/policies/admin/advisory/osv_policy.rb
+++ b/app/policies/admin/advisory/osv_policy.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Admin::Advisory::OSVPolicy < Admin::AdvisoryPolicy
+end

--- a/app/policies/admin/advisory_policy.rb
+++ b/app/policies/admin/advisory_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Admin::AdvisoryPolicy < Admin::ApplicationPolicy
+  class Scope < Admin::ApplicationPolicy::Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  has_association :rubygem
+
+  def avo_index? = rubygems_org_admin?
+  def avo_show? = rubygems_org_admin?
+end

--- a/app/policies/admin/advisory_policy.rb
+++ b/app/policies/admin/advisory_policy.rb
@@ -11,4 +11,5 @@ class Admin::AdvisoryPolicy < Admin::ApplicationPolicy
 
   def avo_index? = rubygems_org_admin?
   def avo_show? = rubygems_org_admin?
+  def act_on? = rubygems_org_admin?
 end

--- a/app/policies/admin/rubygem_policy.rb
+++ b/app/policies/admin/rubygem_policy.rb
@@ -24,6 +24,7 @@ class Admin::RubygemPolicy < Admin::ApplicationPolicy
   has_association :audits
   has_association :link_verifications
   has_association :oidc_rubygem_trusted_publishers
+  has_association :advisories
 
   def avo_index?
     rubygems_org_admin?

--- a/app/views/components/rubygem/advisories_component.rb
+++ b/app/views/components/rubygem/advisories_component.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Rubygem::AdvisoriesComponent < ApplicationComponent
+  include Phlex::Rails::Helpers::LinkTo
+
+  SEVERITY_RANK = { "critical" => 0, "high" => 1, "moderate" => 2, "low" => 3 }.freeze
+  HIGH_SEVERITIES = %w[critical high].freeze
+  LINK = "text-orange-500 underline hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300"
+
+  def initialize(advisories:, version:)
+    super()
+    @advisories = advisories
+    @version = version
+  end
+
+  def view_template
+    list = affected_advisories
+    return if list.empty?
+
+    color, icon_color, icon = AlertComponent::STYLES.fetch(style_for(list))
+
+    div(
+      class: "flex flex-row items-start gap-3 p-4 rounded border text-b2 #{color}",
+      data: { testid: "gem-advisories" }
+    ) do
+      icon_tag(icon, size: 8, class: "#{icon_color} shrink-0 h-8 w-8")
+      div(class: "flex flex-col gap-3 min-w-0") do
+        p(class: "font-semibold") { t("rubygems.advisories.title", count: list.size) }
+        ul(class: "flex flex-col gap-3") do
+          list.each { |advisory| advisory_item(advisory) }
+        end
+      end
+    end
+  end
+
+  private
+
+  def affected_advisories
+    Array(@advisories)
+      .select { |advisory| advisory.affects?(@version) }
+      .sort_by { |advisory| [SEVERITY_RANK.fetch(advisory.severity, 4), advisory.identifier] }
+  end
+
+  def style_for(list)
+    list.any? { |advisory| HIGH_SEVERITIES.include?(advisory.severity) } ? :error : :alert
+  end
+
+  def advisory_item(advisory)
+    li(class: "flex flex-col gap-1") do
+      div(class: "flex flex-wrap items-baseline gap-x-2 gap-y-1") do
+        span(class: "font-semibold uppercase text-b4") { advisory.severity } if advisory.severity.present?
+        span(class: "font-mono text-c4") { advisory.identifier }
+        span(class: "text-b4") { "(#{advisory.aliases.join(', ')})" } if advisory.aliases.present?
+      end
+      p { advisory.summary }
+      p do
+        link_to t("rubygems.advisories.view_advisory"), advisory.url, class: LINK, target: "_blank", rel: "noopener"
+      end
+    end
+  end
+end

--- a/app/views/components/rubygem/advisories_component.rb
+++ b/app/views/components/rubygem/advisories_component.rb
@@ -38,17 +38,24 @@ class Rubygem::AdvisoriesComponent < ApplicationComponent
   def affected_advisories
     Array(@advisories)
       .select { |advisory| advisory.affects?(@version) }
-      .sort_by { |advisory| [SEVERITY_RANK.fetch(advisory.severity, 4), advisory.identifier] }
+      .sort_by { |advisory| [sort_rank(advisory), advisory.identifier] }
+  end
+
+  def sort_rank(advisory)
+    return 0 if advisory.malware?
+
+    SEVERITY_RANK.fetch(advisory.severity, 4)
   end
 
   def style_for(list)
-    list.any? { |advisory| HIGH_SEVERITIES.include?(advisory.severity) } ? :error : :alert
+    list.any? { |advisory| advisory.malware? || HIGH_SEVERITIES.include?(advisory.severity) } ? :error : :alert
   end
 
   def advisory_item(advisory)
+    label = advisory_label(advisory)
     li(class: "flex flex-col gap-1") do
       div(class: "flex flex-wrap items-baseline gap-x-2 gap-y-1") do
-        span(class: "font-semibold uppercase text-b4") { advisory.severity } if advisory.severity.present?
+        span(class: "font-semibold uppercase text-b4") { label } if label
         span(class: "font-mono text-c4") { advisory.identifier }
         span(class: "text-b4") { "(#{advisory.aliases.join(', ')})" } if advisory.aliases.present?
       end
@@ -57,5 +64,11 @@ class Rubygem::AdvisoriesComponent < ApplicationComponent
         link_to t("rubygems.advisories.view_advisory"), advisory.url, class: LINK, target: "_blank", rel: "noopener"
       end
     end
+  end
+
+  def advisory_label(advisory)
+    return t("rubygems.advisories.malware") if advisory.malware?
+
+    advisory.severity.presence
   end
 end

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -26,6 +26,8 @@
 <div class="flex flex-col gap-8 pb-16 lg:pt-10 text-neutral-800 dark:text-neutral-200">
   <%= render "rubygems/tabs", rubygem: @rubygem, version: @latest_version, current: :gem_info %>
 
+  <%= render Rubygem::AdvisoriesComponent.new(advisories: @advisories, version: @latest_version) %>
+
   <% if @latest_version.indexed %>
     <div class="flex flex-col gap-3">
       <%= render CopyFieldComponent.new(value: @latest_version.to_bundler(locked_version: @on_version_page), name: "gemfile_text", label: t(".bundler_header")) %>
@@ -65,23 +67,7 @@
     <div class="versions">
       <h3 class="<%= section_heading_class %> mb-2"><%= t ".versions_header" %></h3>
       <ol data-testid="gem-versions" class="flex flex-col gap-1.5">
-        <% @versions.each do |version| %>
-          <li class="flex flex-wrap items-center gap-x-2">
-            <%= link_to version.number, rubygem_version_path(version.rubygem.slug, version.slug),
-                  class: "font-mono text-c4 px-2 py-0.5 rounded-sm bg-green-200 dark:bg-green-800 text-neutral-900 dark:text-white hover:bg-green-300 dark:hover:bg-green-700" %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version_date_tag(version) %></span>
-            <% if version.platformed? %>
-              <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version.platform %></span>
-            <% end %>
-            <% if version.ruby_abi.present? %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
-            <% end %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400">(<%= number_to_human_size(version.size) %>)</span>
-            <% if version.yanked? %>
-              <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t "versions.version.yanked" %></span>
-            <% end %>
-          </li>
-        <% end %>
+        <%= render @versions %>
       </ol>
       <% if show_all_versions_link?(@rubygem) %>
         <%= link_to t(".show_all_versions", count: @rubygem.versions.count), rubygem_versions_url(@rubygem.slug),

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -12,4 +12,7 @@
   <% if version.yanked? %>
     <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t ".yanked" %></span>
   <% end %>
+  <% if version_advisory?(@advisories, version) %>
+    <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t ".vulnerable" %></span>
+  <% end %>
 </li>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.configure do
+Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.good_job.preserve_job_records = true
   config.good_job.retry_on_unhandled_error = false
   config.good_job.on_thread_error = ->(exception) { Rails.error.report(exception, handled: false) }

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -33,6 +33,12 @@ Rails.application.configure do
       class: "SyncDisposableEmailDomainsJob",
       set: { priority: 10 },
       description: "Syncing disposable email domain blocklist daily at 04:00 UTC"
+    },
+    sync_advisories: {
+      cron: "every hour",
+      class: "SyncAdvisoriesJob",
+      set: { priority: 10 },
+      description: "Syncing security advisories every hour"
     }
   }
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -23,4 +23,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "GitHub"
   inflect.acronym "StatsD"
   inflect.acronym "OIDC"
+  inflect.acronym "OSV"
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -953,6 +953,11 @@ de:
     index:
       downloads: Downloads
       title: Gems
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: installieren
@@ -1071,6 +1076,7 @@ de:
     version:
       yanked:
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -957,6 +957,7 @@ de:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -872,6 +872,11 @@ en:
     index:
       downloads: Downloads
       title: Gems
+    advisories:
+      title:
+        one: "1 known security vulnerability"
+        other: "%{count} known security vulnerabilities"
+      view_advisory: View advisory
     show:
       bundler_header: Gemfile
       install: install
@@ -990,6 +995,7 @@ en:
     version:
       yanked: yanked
       ruby_abi: Ruby ABI
+      vulnerable: vulnerable
   webauthn_credentials:
     callback:
       success: You have successfully registered a security device.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,6 +876,7 @@ en:
       title:
         one: "1 known security vulnerability"
         other: "%{count} known security vulnerabilities"
+      malware: Malware
       view_advisory: View advisory
     show:
       bundler_header: Gemfile

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -966,6 +966,11 @@ es:
     index:
       downloads: Descargas
       title: Gemas
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: instalar
@@ -1100,6 +1105,7 @@ es:
     version:
       yanked: borrada
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success: Has dado de alta con éxito un dispositivo de seguridad.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -970,6 +970,7 @@ es:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -895,6 +895,11 @@ fr:
     index:
       downloads: Téléchargements
       title: Gems
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: installation
@@ -1026,6 +1031,7 @@ fr:
     version:
       yanked: retiré
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -899,6 +899,7 @@ fr:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -881,6 +881,11 @@ ja:
     index:
       downloads: ダウンロード数
       title: gem
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: インストール
@@ -1003,6 +1008,7 @@ ja:
     version:
       yanked: ヤンク済み
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success: セキュリティ機器が正常に登録されました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -885,6 +885,7 @@ ja:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -865,6 +865,11 @@ nl:
     index:
       downloads: Downloads
       title: alle gems
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: Installeer
@@ -983,6 +988,7 @@ nl:
     version:
       yanked: verwijderd
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -869,6 +869,7 @@ nl:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -878,6 +878,11 @@ pt-BR:
     index:
       downloads: Downloads
       title: Gems
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: instalar
@@ -1006,6 +1011,7 @@ pt-BR:
     version:
       yanked: removida
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -882,6 +882,7 @@ pt-BR:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -874,6 +874,11 @@ zh-CN:
     index:
       downloads: 下载
       title: Gem
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: 安装
@@ -997,6 +1002,7 @@ zh-CN:
     version:
       yanked: 已撤回
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success: 您已成功注册一个安全设备。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -878,6 +878,7 @@ zh-CN:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -866,6 +866,11 @@ zh-TW:
     index:
       downloads: 下載
       title: Gems
+    advisories:
+      title:
+        one:
+        other:
+      view_advisory:
     show:
       bundler_header: Gemfile
       install: 安裝
@@ -985,6 +990,7 @@ zh-TW:
     version:
       yanked: 已被移除
       ruby_abi:
+      vulnerable:
   webauthn_credentials:
     callback:
       success: 您已成功註冊安全裝置。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -870,6 +870,7 @@ zh-TW:
       title:
         one:
         other:
+      malware:
       view_advisory:
     show:
       bundler_header: Gemfile

--- a/db/migrate/20260825080543_create_advisories.rb
+++ b/db/migrate/20260825080543_create_advisories.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateAdvisories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :advisories do |t|
+      t.string :type, null: false
+      t.string :identifier, null: false
+      t.string :rubygem_name, null: false
+      t.string :aliases, null: false, array: true, default: []
+      t.text :summary, null: false
+      t.string :severity
+      t.string :url, null: false
+      t.datetime :published_at
+      t.datetime :modified_at, null: false
+      t.datetime :withdrawn_at
+      t.jsonb :ranges, null: false, default: []
+      t.jsonb :payload, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :advisories, %i[type identifier rubygem_name], unique: true
+    add_index :advisories, :rubygem_name
+  end
+end

--- a/db/migrate/20260825080543_create_advisories.rb
+++ b/db/migrate/20260825080543_create_advisories.rb
@@ -14,7 +14,6 @@ class CreateAdvisories < ActiveRecord::Migration[8.1]
       t.datetime :modified_at, null: false
       t.datetime :withdrawn_at
       t.jsonb :ranges, null: false, default: []
-      t.jsonb :payload, null: false, default: {}
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_080543) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -27,6 +27,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
     t.string "oauth_token"
     t.datetime "updated_at", null: false
     t.index ["github_id"], name: "index_admin_github_users_on_github_id", unique: true
+  end
+
+  create_table "advisories", force: :cascade do |t|
+    t.string "aliases", default: [], null: false, array: true
+    t.datetime "created_at", null: false
+    t.string "identifier", null: false
+    t.datetime "modified_at", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "published_at"
+    t.jsonb "ranges", default: [], null: false
+    t.string "rubygem_name", null: false
+    t.string "severity"
+    t.text "summary", null: false
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.datetime "withdrawn_at"
+    t.index ["rubygem_name"], name: "index_advisories_on_rubygem_name"
+    t.index ["type", "identifier", "rubygem_name"], name: "index_advisories_on_type_and_identifier_and_rubygem_name", unique: true
   end
 
   create_table "api_key_rubygem_scopes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
     t.datetime "created_at", null: false
     t.string "identifier", null: false
     t.datetime "modified_at", null: false
-    t.jsonb "payload", default: {}, null: false
     t.datetime "published_at"
     t.jsonb "ranges", default: [], null: false
     t.string "rubygem_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_080543) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/test/components/previews/rubygem/advisories_component_preview.rb
+++ b/test/components/previews/rubygem/advisories_component_preview.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Rubygem::AdvisoriesComponentPreview < Lookbook::Preview
+  layout "hammy_component_preview"
+
+  def moderate
+    render Rubygem::AdvisoriesComponent.new(
+      advisories: [
+        Advisory::OSV.new(
+          identifier: "GHSA-mm33-5vfq-3mm3",
+          aliases: ["CVE-2022-22577"],
+          summary: "Cross-site Scripting Vulnerability in Action Pack",
+          severity: "moderate",
+          url: "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3",
+          ranges: ["introduced" => "0"]
+        )
+      ],
+      version: Version.new(number: "1.0.0")
+    )
+  end
+
+  def critical
+    render Rubygem::AdvisoriesComponent.new(
+      advisories: [
+        Advisory::OSV.new(
+          identifier: "GHSA-crit-ical-0001",
+          aliases: ["CVE-2024-0001"],
+          summary: "Remote code execution in example gem",
+          severity: "critical",
+          url: "https://osv.dev/vulnerability/GHSA-crit-ical-0001",
+          ranges: ["introduced" => "0"]
+        ),
+        Advisory::OSV.new(
+          identifier: "GHSA-mode-rate-0002",
+          summary: "Information disclosure",
+          severity: "moderate",
+          url: "https://osv.dev/vulnerability/GHSA-mode-rate-0002",
+          ranges: ["introduced" => "0"]
+        )
+      ],
+      version: Version.new(number: "1.0.0")
+    )
+  end
+end

--- a/test/factories/advisory.rb
+++ b/test/factories/advisory.rb
@@ -20,5 +20,17 @@ FactoryBot.define do
       rubygem
       rubygem_name { rubygem.name }
     end
+
+    trait :unfixed do
+      ranges { ["introduced" => "0"] }
+    end
+
+    trait :range do
+      ranges { ["introduced" => "1.0.0", "fixed" => "1.2.0"] }
+    end
+
+    trait :exact do
+      ranges { ["introduced" => "1.0.0", "last_affected" => "1.0.0"] }
+    end
   end
 end

--- a/test/factories/advisory.rb
+++ b/test/factories/advisory.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :advisory, class: "Advisory::OSV" do
+    sequence(:identifier) { |n| format("GHSA-%04x-%04x-%04x", n, n, n) }
+    rubygem_name { "example" }
+    summary { "Example advisory summary" }
+    url { "https://osv.dev/vulnerability/#{identifier}" }
+    severity { :moderate }
+    modified_at { Time.current }
+    aliases { [] }
+    ranges { [] }
+    payload { {} }
+
+    trait :withdrawn do
+      withdrawn_at { Time.current }
+    end
+
+    trait :with_rubygem do
+      rubygem
+      rubygem_name { rubygem.name }
+    end
+  end
+end

--- a/test/factories/advisory.rb
+++ b/test/factories/advisory.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     modified_at { Time.current }
     aliases { [] }
     ranges { [] }
-    payload { {} }
 
     trait :withdrawn do
       withdrawn_at { Time.current }

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -421,4 +421,60 @@ class RubygemsControllerTest < ActionController::TestCase
       assert page.has_selector?("a[href='#{profile_path(@outside_contributor.display_id)}']")
     end
   end
+
+  context "On GET to show with advisories" do
+    setup do
+      @rubygem = create(:rubygem, name: "actionpack")
+      create(:version, rubygem: @rubygem, number: "1.0.0")
+      create(:version, rubygem: @rubygem, number: "2.0.0")
+      create(:advisory, :with_rubygem, rubygem: @rubygem,
+             ranges: ["introduced" => "1.0.0", "fixed" => "2.0.0"],
+             summary: "XSS in Action Pack",
+             identifier: "GHSA-test-show-0001")
+    end
+
+    should "not show advisories when the source flag is off" do
+      get :show, params: { id: @rubygem.slug }
+
+      refute page.has_css?("[data-testid='gem-advisories']")
+      refute page.has_content?("vulnerable")
+    end
+
+    should "show advisories affecting the latest version when the source is enabled" do
+      create(:advisory, :with_rubygem, :unfixed, rubygem: @rubygem,
+             summary: "RCE in Action Pack",
+             identifier: "GHSA-test-show-0002",
+             severity: :high)
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :show, params: { id: @rubygem.slug }
+      end
+
+      assert page.has_css?("[data-testid='gem-advisories']")
+      assert page.has_content?("RCE in Action Pack")
+      assert page.has_link?("View advisory")
+      assert page.has_content?("vulnerable")
+    end
+
+    should "not show a patched latest version as vulnerable for older ranges" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :show, params: { id: @rubygem.slug }
+      end
+
+      refute page.has_css?("[data-testid='gem-advisories']")
+      assert page.has_content?("vulnerable")
+    end
+
+    should "hide withdrawn advisories" do
+      create(:advisory, :with_rubygem, :withdrawn, :unfixed, rubygem: @rubygem,
+             summary: "Withdrawn advisory",
+             identifier: "GHSA-test-show-0003")
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :show, params: { id: @rubygem.slug }
+      end
+
+      refute page.has_content?("Withdrawn advisory")
+    end
+  end
 end

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -239,4 +239,64 @@ class VersionsControllerTest < ActionController::TestCase
       assert page.has_selector?("a[href='#{profile_path('johndoe')}']")
     end
   end
+
+  context "On GET to show with advisories" do
+    setup do
+      @rubygem = create(:rubygem, name: "actionpack")
+      create(:version, rubygem: @rubygem, number: "1.0.0")
+      create(:version, rubygem: @rubygem, number: "2.0.0")
+      create(:advisory, :with_rubygem, rubygem: @rubygem,
+             ranges: ["introduced" => "1.0.0", "fixed" => "2.0.0"],
+             summary: "XSS in Action Pack",
+             identifier: "GHSA-test-vers-0001")
+    end
+
+    should "show the advisory on an affected version page" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :show, params: { rubygem_id: @rubygem.name, id: "1.0.0" }
+      end
+
+      assert page.has_css?("[data-testid='gem-advisories']")
+      assert page.has_content?("XSS in Action Pack")
+    end
+
+    should "not show the advisory on a patched version page" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :show, params: { rubygem_id: @rubygem.name, id: "2.0.0" }
+      end
+
+      refute page.has_css?("[data-testid='gem-advisories']")
+    end
+
+    should "not show advisories when the source flag is off" do
+      get :show, params: { rubygem_id: @rubygem.name, id: "1.0.0" }
+
+      refute page.has_css?("[data-testid='gem-advisories']")
+    end
+  end
+
+  context "On GET to index with advisories" do
+    setup do
+      @rubygem = create(:rubygem, name: "actionpack")
+      create(:version, rubygem: @rubygem, number: "1.0.0")
+      create(:version, rubygem: @rubygem, number: "2.0.0")
+      create(:advisory, :with_rubygem, rubygem: @rubygem,
+             ranges: ["introduced" => "1.0.0", "fixed" => "2.0.0"],
+             identifier: "GHSA-test-idx-0001")
+    end
+
+    should "badge affected versions when the source is enabled" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        get :index, params: { rubygem_id: @rubygem.name }
+      end
+
+      assert page.has_content?("vulnerable")
+    end
+
+    should "not badge versions when the source flag is off" do
+      get :index, params: { rubygem_id: @rubygem.name }
+
+      refute page.has_content?("vulnerable")
+    end
+  end
 end

--- a/test/integration/avo/advisories_test.rb
+++ b/test/integration/avo/advisories_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Avo::AdvisoriesTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
+  test "getting advisories as admin" do
+    admin_sign_in_as create(:admin_github_user, :is_admin)
+
+    get avo.resources_advisories_path
+
+    assert_response :success
+
+    advisory = create(:advisory)
+
+    get avo.resources_advisories_path
+
+    assert_response :success
+    assert page.has_content? advisory.identifier
+
+    get avo.resources_advisory_path(advisory)
+
+    assert_response :success
+    assert page.has_content? advisory.identifier
+    assert page.has_content? advisory.rubygem_name
+  end
+end

--- a/test/jobs/sync_advisories_job_test.rb
+++ b/test/jobs/sync_advisories_job_test.rb
@@ -36,5 +36,13 @@ class SyncAdvisoriesJobTest < ActiveJob::TestCase
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
+
+    should "sync when forced even if flags are off" do
+      Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
+
+      SyncAdvisoriesJob.perform_now(force: true)
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+    end
   end
 end

--- a/test/jobs/sync_advisories_job_test.rb
+++ b/test/jobs/sync_advisories_job_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SyncAdvisoriesJobTest < ActiveJob::TestCase
+  setup do
+    @document = {
+      "id" => "GHSA-test-0001-0001",
+      "summary" => "Example",
+      "modified" => "2024-01-02T00:00:00Z",
+      "published" => "2024-01-01T00:00:00Z",
+      "aliases" => ["CVE-2024-0001"],
+      "database_specific" => { "severity" => "HIGH" },
+      "affected" => [
+        "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+        "ranges" => [
+          "type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.2.4"]
+        ]
+      ]
+    }
+  end
+
+  context "#perform" do
+    should "not sync when fetcher flags are off" do
+      Advisory::OSV::Fetcher.any_instance.expects(:sync).never
+
+      SyncAdvisoriesJob.perform_now
+    end
+
+    should "sync enabled fetchers" do
+      Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        SyncAdvisoriesJob.perform_now
+      end
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+    end
+  end
+end

--- a/test/jobs/sync_advisories_job_test.rb
+++ b/test/jobs/sync_advisories_job_test.rb
@@ -37,10 +37,16 @@ class SyncAdvisoriesJobTest < ActiveJob::TestCase
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
 
-    should "sync when forced even if flags are off" do
+    should "not sync a given source when flags are off" do
+      Advisory::OSV::Fetcher.any_instance.expects(:fetch).never
+
+      SyncAdvisoriesJob.perform_now(source: "Advisory::OSV")
+    end
+
+    should "sync the given source when forced even if flags are off" do
       Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
 
-      SyncAdvisoriesJob.perform_now(force: true)
+      SyncAdvisoriesJob.perform_now(source: "Advisory::OSV", force: true)
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -69,11 +69,19 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
+  end
 
-    should "sync all fetchers when forced even if flags are off" do
+  context ".sync" do
+    should "not sync when the source flag is off" do
+      Advisory::OSV::Fetcher.any_instance.expects(:fetch).never
+
+      Advisory::Fetcher.sync("Advisory::OSV")
+    end
+
+    should "sync the given source when forced even if its flag is off" do
       Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
 
-      Advisory::Fetcher.sync_all(force: true)
+      Advisory::Fetcher.sync("Advisory::OSV", force: true)
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -98,6 +98,25 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
     end
   end
 
+  context "#download" do
+    setup do
+      @url = "https://example.test/advisories"
+    end
+
+    should "return the response body" do
+      stub_request(:get, @url).to_return(status: 200, body: "ok")
+
+      assert_equal "ok", FakeFetcher.new.download(@url)
+    end
+
+    should "retry a failed GET and succeed" do
+      stub_request(:get, @url).to_return(status: 500, body: "nope").then.to_return(status: 200, body: "ok")
+
+      assert_equal "ok", FakeFetcher.new.download(@url)
+      assert_requested :get, @url, times: 2
+    end
+  end
+
   context "abstract interface" do
     should "require subclasses to define feature_flag" do
       assert_raises(NotImplementedError) { Advisory::Fetcher.feature_flag }

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Advisory::FetcherTest < ActiveSupport::TestCase
+  class FakeFetcher < Advisory::Fetcher
+    attr_writer :documents
+
+    def self.feature_flag = :fake_advisories
+    def self.advisory_class = Advisory::OSV
+
+    def fetch
+      @documents
+    end
+
+    def map(document)
+      Advisory::OSV::Mapper.call(document)
+    end
+  end
+
+  setup do
+    @document = {
+      "id" => "GHSA-test-0001-0001",
+      "summary" => "Example",
+      "modified" => "2024-01-02T00:00:00Z",
+      "published" => "2024-01-01T00:00:00Z",
+      "aliases" => ["CVE-2024-0001"],
+      "database_specific" => { "severity" => "HIGH" },
+      "affected" => [
+        "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+        "ranges" => [
+          "type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.2.4"]
+        ]
+      ]
+    }
+  end
+
+  context ".all" do
+    should "include the OSV fetcher" do
+      assert_includes Advisory::Fetcher.all, Advisory::OSV::Fetcher
+    end
+  end
+
+  context ".enabled" do
+    should "exclude fetchers whose flag is off" do
+      refute_includes Advisory::Fetcher.enabled, Advisory::OSV::Fetcher
+    end
+
+    should "include fetchers whose flag is on" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_includes Advisory::Fetcher.enabled, Advisory::OSV::Fetcher
+      end
+    end
+  end
+
+  context ".sync_all" do
+    should "not sync when the fetcher flag is off" do
+      Advisory::OSV::Fetcher.any_instance.expects(:sync).never
+
+      Advisory::Fetcher.sync_all
+    end
+
+    should "sync enabled fetchers" do
+      Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        Advisory::Fetcher.sync_all
+      end
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+    end
+  end
+
+  context "#sync" do
+    should "not fetch or import when the flag is off" do
+      fetcher = FakeFetcher.new
+      fetcher.documents = [@document]
+      fetcher.expects(:fetch).never
+
+      fetcher.sync
+
+      assert_empty Advisory::OSV.where(identifier: "GHSA-test-0001-0001")
+    end
+
+    should "import mapped documents when the flag is on" do
+      fetcher = FakeFetcher.new
+      fetcher.documents = [@document]
+
+      with_feature :fake_advisories do
+        fetcher.sync
+      end
+
+      advisory = Advisory::OSV.find_by!(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+
+      assert_equal "Example", advisory.summary
+      assert_equal "high", advisory.severity
+      assert_equal ["introduced" => "7.0.0", "fixed" => "7.0.2.4"], advisory.ranges
+    end
+  end
+
+  context "abstract interface" do
+    should "require subclasses to define feature_flag" do
+      assert_raises(NotImplementedError) { Advisory::Fetcher.feature_flag }
+    end
+
+    should "require subclasses to define advisory_class" do
+      assert_raises(NotImplementedError) { Advisory::Fetcher.advisory_class }
+    end
+
+    should "require subclasses to implement fetch" do
+      assert_raises(NotImplementedError) { Advisory::Fetcher.new.fetch }
+    end
+
+    should "require subclasses to implement map" do
+      assert_raises(NotImplementedError) { Advisory::Fetcher.new.map({}) }
+    end
+  end
+end

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -69,6 +69,14 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
+
+    should "sync all fetchers when forced even if flags are off" do
+      Advisory::OSV::Fetcher.any_instance.stubs(:fetch).returns([@document])
+
+      Advisory::Fetcher.sync_all(force: true)
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+    end
   end
 
   context "#sync" do
@@ -80,6 +88,15 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
       fetcher.sync
 
       assert_empty Advisory::OSV.where(identifier: "GHSA-test-0001-0001")
+    end
+
+    should "import when forced even if the flag is off" do
+      fetcher = FakeFetcher.new
+      fetcher.documents = [@document]
+
+      fetcher.sync(force: true)
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
 
     should "import mapped documents when the flag is on" do

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -6,7 +6,6 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
   class FakeFetcher < Advisory::Fetcher
     attr_writer :documents
 
-    def self.feature_flag = :fake_advisories
     def self.advisory_class = Advisory::OSV
 
     def fetch
@@ -35,20 +34,18 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
     }
   end
 
-  context ".all" do
+  context ".sources" do
     should "include the OSV fetcher" do
-      assert_includes Advisory::Fetcher.all, Advisory::OSV::Fetcher
+      assert_includes Advisory::Fetcher.sources, Advisory::OSV::Fetcher
     end
   end
 
-  context ".enabled" do
-    should "exclude fetchers whose flag is off" do
-      refute_includes Advisory::Fetcher.enabled, Advisory::OSV::Fetcher
-    end
+  context ".enabled?" do
+    should "follow the advisory class flag" do
+      refute_predicate Advisory::OSV::Fetcher, :enabled?
 
-    should "include fetchers whose flag is on" do
       with_feature FeatureFlag::OSV_ADVISORIES do
-        assert_includes Advisory::Fetcher.enabled, Advisory::OSV::Fetcher
+        assert_predicate Advisory::OSV::Fetcher, :enabled?
       end
     end
   end
@@ -85,6 +82,12 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
 
       assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
     end
+
+    should "raise for an unknown source" do
+      error = assert_raises(ArgumentError) { Advisory::Fetcher.sync("Advisory") }
+
+      assert_match(/Unknown advisory source: "Advisory"/, error.message)
+    end
   end
 
   context "#sync" do
@@ -111,7 +114,7 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
       fetcher = FakeFetcher.new
       fetcher.documents = [@document]
 
-      with_feature :fake_advisories do
+      with_feature FeatureFlag::OSV_ADVISORIES do
         fetcher.sync
       end
 
@@ -143,10 +146,6 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
   end
 
   context "abstract interface" do
-    should "require subclasses to define feature_flag" do
-      assert_raises(NotImplementedError) { Advisory::Fetcher.feature_flag }
-    end
-
     should "require subclasses to define advisory_class" do
       assert_raises(NotImplementedError) { Advisory::Fetcher.advisory_class }
     end

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -34,12 +34,6 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
     }
   end
 
-  context ".sources" do
-    should "include the OSV fetcher" do
-      assert_includes Advisory::Fetcher.sources, Advisory::OSV::Fetcher
-    end
-  end
-
   context ".enabled?" do
     should "follow the advisory class flag" do
       refute_predicate Advisory::OSV::Fetcher, :enabled?

--- a/test/models/advisory/fetcher_test.rb
+++ b/test/models/advisory/fetcher_test.rb
@@ -120,6 +120,48 @@ class Advisory::FetcherTest < ActiveSupport::TestCase
     end
   end
 
+  context "#import" do
+    should "roll back the previous snapshot when a later insert batch fails" do
+      create(:advisory, identifier: "GHSA-keep-0000-0000", rubygem_name: "actionpack", summary: "Keep me")
+      records = Advisory::OSV::Mapper.call(@document.merge(
+                                             "affected" => [
+                                               {
+                                                 "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+                                                 "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.2.4"]]
+                                               },
+                                               {
+                                                 "package" => { "name" => "rails", "ecosystem" => "RubyGems" },
+                                                 "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.2.4"]]
+                                               }
+                                             ]
+                                           ))
+
+      stub_const(Advisory::Fetcher, :BATCH_SIZE, 1) do
+        Advisory::OSV.stubs(:insert_all!).returns(nil).then.raises(StandardError, "insert failed")
+
+        assert_raises(StandardError) { FakeFetcher.new.import(records) }
+      end
+
+      assert_equal 1, Advisory::OSV.count
+      assert_equal "Keep me", Advisory::OSV.find_by!(identifier: "GHSA-keep-0000-0000").summary
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-test-0001-0001")
+    end
+
+    should "only replace rows for the fetcher source" do
+      create(:advisory, identifier: "GHSA-osv-0000-0000", rubygem_name: "actionpack")
+      other = create(:advisory, identifier: "OTHER-0000-0000", rubygem_name: "actionpack", summary: "Other source")
+      Advisory.where(id: other.id).update_all(type: "Advisory::Other")
+
+      FakeFetcher.new.import(Advisory::OSV::Mapper.call(@document))
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-test-0001-0001", rubygem_name: "actionpack")
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-osv-0000-0000")
+      assert_equal 1, Advisory.connection.select_value(
+        "SELECT COUNT(*) FROM advisories WHERE type = 'Advisory::Other' AND identifier = 'OTHER-0000-0000'"
+      ).to_i
+    end
+  end
+
   context "#download" do
     setup do
       @url = "https://example.test/advisories"

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -25,15 +25,11 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
   end
 
   context "feature flag" do
-    should "use the OSV advisories flag" do
-      assert_equal FeatureFlag::OSV_ADVISORIES, Advisory::OSV::Fetcher.feature_flag
-    end
-
-    should "be disabled by default" do
+    should "follow Advisory::OSV" do
       refute_predicate Advisory::OSV::Fetcher, :enabled?
     end
 
-    should "be enabled when the flag is on" do
+    should "be enabled when the advisory source is enabled" do
       with_feature FeatureFlag::OSV_ADVISORIES do
         assert_predicate Advisory::OSV::Fetcher, :enabled?
       end

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -155,6 +155,22 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
         assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
       end
 
+      should "skip index rows with an unparseable modified timestamp" do
+        newer = @document.merge("id" => "GHSA-new-0000-0000", "modified" => "2026-02-01T00:00:00Z")
+        stub_osv_index(
+          ["not-a-timestamp", "GHSA-bad-0000-0000"],
+          ["2026-02-01T00:00:00Z", newer["id"]],
+          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
+        )
+        stub_osv_document(newer)
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [newer["id"]], documents.pluck("id")
+        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+        assert_not_requested :get, osv_document_url("GHSA-bad-0000-0000")
+      end
+
       should "keep path-like identifiers inside the RubyGems prefix" do
         stub_osv_index(["2026-02-01T00:00:00Z", "../escape"])
         stub_request(:get, "#{Advisory::OSV::Fetcher::BASE_URL}/#{CGI.escapeURIComponent('../escape')}.json")

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
+  setup do
+    @document = {
+      "id" => "GHSA-mm33-5vfq-3mm3",
+      "summary" => "Cross-site Scripting Vulnerability in Action Pack",
+      "modified" => "2024-02-18T05:32:29Z",
+      "published" => "2022-04-27T22:28:59Z",
+      "aliases" => ["CVE-2022-22577"],
+      "database_specific" => { "severity" => "MODERATE" },
+      "affected" => [
+        {
+          "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+          "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"]]
+        },
+        {
+          "package" => { "name" => "rails", "ecosystem" => "RubyGems" },
+          "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"]]
+        }
+      ]
+    }
+  end
+
+  context "feature flag" do
+    should "use the OSV advisories flag" do
+      assert_equal FeatureFlag::OSV_ADVISORIES, Advisory::OSV::Fetcher.feature_flag
+    end
+
+    should "be disabled by default" do
+      refute_predicate Advisory::OSV::Fetcher, :enabled?
+    end
+
+    should "be enabled when the flag is on" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_predicate Advisory::OSV::Fetcher, :enabled?
+      end
+    end
+  end
+
+  context "#fetch" do
+    should "be left for a later ingest step" do
+      assert_raises(NotImplementedError) { Advisory::OSV::Fetcher.new.fetch }
+    end
+  end
+
+  context "#import" do
+    should "upsert one Advisory::OSV row per affected gem" do
+      records = Advisory::OSV::Mapper.call(@document)
+
+      assert_equal 2, Advisory::OSV::Fetcher.new.import(records)
+
+      actionpack = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+      rails = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+
+      assert_equal "Cross-site Scripting Vulnerability in Action Pack", actionpack.summary
+      assert_equal "moderate", actionpack.severity
+      assert_equal ["CVE-2022-22577"], actionpack.aliases
+      assert_equal "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3", actionpack.url
+      assert_equal ["introduced" => "5.2.0", "fixed" => "5.2.7.1"], actionpack.ranges
+      assert_equal "GHSA-mm33-5vfq-3mm3", actionpack.payload["id"]
+      assert_equal actionpack.summary, rails.summary
+    end
+
+    should "update an existing row on a later import" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+
+      updated = @document.merge(
+        "summary" => "Updated summary",
+        "modified" => "2025-01-01T00:00:00Z",
+        "withdrawn" => "2025-01-02T00:00:00Z",
+        "database_specific" => { "severity" => "HIGH" }
+      )
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(updated))
+
+      advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+
+      assert_equal 2, Advisory::OSV.where(identifier: "GHSA-mm33-5vfq-3mm3").count
+      assert_equal "Updated summary", advisory.summary
+      assert_equal "high", advisory.severity
+      assert_equal Time.zone.parse("2025-01-01T00:00:00Z"), advisory.modified_at
+      assert_equal Time.zone.parse("2025-01-02T00:00:00Z"), advisory.withdrawn_at
+    end
+
+    should "allow an advisory for a gem that does not exist yet" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+
+      advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+
+      assert_nil advisory.rubygem
+    end
+
+    should "return zero when there is nothing to import" do
+      assert_equal 0, Advisory::OSV::Fetcher.new.import([])
+    end
+  end
+
+  context "#sync" do
+    should "no-op when the flag is off" do
+      fetcher = Advisory::OSV::Fetcher.new
+      fetcher.stubs(:fetch).returns([@document])
+
+      fetcher.sync
+
+      assert_empty Advisory::OSV.where(identifier: "GHSA-mm33-5vfq-3mm3")
+    end
+
+    should "import fetched documents when the flag is on" do
+      fetcher = Advisory::OSV::Fetcher.new
+      fetcher.stubs(:fetch).returns([@document])
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        fetcher.sync
+      end
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+    end
+  end
+end

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -41,8 +41,189 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
   end
 
   context "#fetch" do
-    should "be left for a later ingest step" do
-      assert_raises(NotImplementedError) { Advisory::OSV::Fetcher.new.fetch }
+    context "when no advisories exist" do
+      should "parse JSON documents from the OSV RubyGems dump" do
+        other = @document.merge("id" => "GHSA-other-0000-0000", "summary" => "Other")
+        stub_osv_dump([@document, other])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal %w[GHSA-mm33-5vfq-3mm3 GHSA-other-0000-0000], documents.pluck("id")
+        assert_equal "Cross-site Scripting Vulnerability in Action Pack", documents.first["summary"]
+        assert_not_requested :get, Advisory::OSV::Fetcher::INDEX_URL
+      end
+
+      should "skip nested paths, non-JSON files, and invalid JSON" do
+        stub_osv_dump(
+          [@document],
+          extra: {
+            "nested/GHSA-nested-0000-0000.json" => { "id" => "GHSA-nested-0000-0000" }.to_json,
+            "README.md" => "not json",
+            "GHSA-bad-0000-0000.json" => "{not json}"
+          }
+        )
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal ["GHSA-mm33-5vfq-3mm3"], documents.pluck("id")
+      end
+
+      should "raise when the dump HTTP request fails" do
+        stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 500, body: "nope")
+
+        assert_raises(Faraday::ServerError) { Advisory::OSV::Fetcher.new.fetch }
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, times: 3
+      end
+
+      should "raise when the dump is not a zip" do
+        stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 200, body: "not a zip")
+
+        error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
+
+        assert_match(/Invalid OSV dump archive/, error.message)
+      end
+
+      should "raise when a dump entry is too large" do
+        stub_osv_dump([@document])
+
+        stub_const(Advisory::OSV::Fetcher, :MAX_ENTRY_BYTES, 1) do
+          error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
+
+          assert_match(/OSV dump entry too large/, error.message)
+        end
+      end
+
+      should "send an identifying user agent" do
+        stub_osv_dump([@document])
+
+        Advisory::OSV::Fetcher.new.fetch
+
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, headers: {
+          "User-Agent" => "RubyGems.org Advisory Fetcher/#{AppRevision.version}"
+        }
+      end
+    end
+
+    context "when advisories already exist" do
+      setup do
+        create(:advisory, identifier: "GHSA-old-0000-0000", modified_at: Time.zone.parse("2026-01-01T00:00:00Z"))
+      end
+
+      should "fetch JSON records at or after the latest modified_at" do
+        newer = @document.merge("id" => "GHSA-new-0000-0000", "modified" => "2026-02-01T00:00:00Z")
+        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
+        stub_osv_index(
+          ["2026-02-01T00:00:00Z", newer["id"]],
+          ["2026-01-01T00:00:00Z", watermark["id"]],
+          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
+        )
+        stub_osv_document(newer)
+        stub_osv_document(watermark)
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [newer["id"], watermark["id"]], documents.pluck("id")
+        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
+      end
+
+      should "re-fetch records that share the latest modified_at" do
+        sibling = @document.merge("id" => "GHSA-same-0000-0000", "modified" => "2026-01-01T00:00:00Z")
+        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
+        stub_osv_index(
+          ["2026-01-01T00:00:00Z", sibling["id"]],
+          ["2026-01-01T00:00:00Z", watermark["id"]],
+          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
+        )
+        stub_osv_document(sibling)
+        stub_osv_document(watermark)
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [sibling["id"], watermark["id"]], documents.pluck("id")
+        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
+      end
+
+      should "not fetch records older than the latest modified_at" do
+        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
+        stub_osv_index(
+          ["2026-01-01T00:00:00Z", watermark["id"]],
+          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
+        )
+        stub_osv_document(watermark)
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [watermark["id"]], documents.pluck("id")
+        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
+      end
+
+      should "keep path-like identifiers inside the RubyGems prefix" do
+        stub_osv_index(["2026-02-01T00:00:00Z", "../escape"])
+        stub_request(:get, "#{Advisory::OSV::Fetcher::BASE_URL}/#{CGI.escapeURIComponent('../escape')}.json")
+          .to_return(status: 404, body: "missing")
+        stub_osv_dump([@document])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [@document["id"]], documents.pluck("id")
+        assert_not_requested :get, "https://osv-vulnerabilities.storage.googleapis.com/escape.json"
+      end
+
+      should "fall back to the full dump when too many records changed" do
+        stub_osv_index(
+          ["2026-03-01T00:00:00Z", "GHSA-new-0000-0001"],
+          ["2026-02-01T00:00:00Z", @document["id"]]
+        )
+        stub_osv_dump([@document])
+
+        stub_const(Advisory::OSV::Fetcher, :MAX_INCREMENTAL_IDS, 1) do
+          documents = Advisory::OSV::Fetcher.new.fetch
+
+          assert_equal [@document["id"]], documents.pluck("id")
+        end
+
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+        assert_not_requested :get, osv_document_url(@document["id"])
+        assert_not_requested :get, osv_document_url("GHSA-new-0000-0001")
+      end
+
+      should "fall back to the full dump when an incremental document is missing" do
+        stub_osv_index(
+          ["2026-02-01T00:00:00Z", "GHSA-new-0000-0000"],
+          ["2026-01-15T00:00:00Z", "GHSA-other-0000-0000"]
+        )
+        stub_request(:get, osv_document_url("GHSA-new-0000-0000")).to_return(status: 404, body: "missing")
+        stub_osv_dump([@document])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [@document["id"]], documents.pluck("id")
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+        assert_not_requested :get, osv_document_url("GHSA-other-0000-0000")
+      end
+
+      should "fall back to the full dump when an incremental document is invalid JSON" do
+        stub_osv_index(["2026-02-01T00:00:00Z", "GHSA-new-0000-0000"])
+        stub_request(:get, osv_document_url("GHSA-new-0000-0000")).to_return(status: 200, body: "{not json}")
+        stub_osv_dump([@document])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [@document["id"]], documents.pluck("id")
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+      end
+
+      should "fall back to the full dump when the index request fails" do
+        stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(status: 500, body: "nope")
+        stub_osv_dump([@document])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [@document["id"]], documents.pluck("id")
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+      end
     end
   end
 
@@ -118,5 +299,73 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
       assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
     end
+
+    should "download the OSV dump and import mapped rows" do
+      stub_osv_dump([@document])
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        Advisory::OSV::Fetcher.new.sync
+      end
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+    end
+
+    should "import only updated documents on a later sync" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+      updated = @document.merge("summary" => "Updated from OSV", "modified" => "2026-03-01T00:00:00Z")
+      stub_osv_index(["2026-03-01T00:00:00Z", updated["id"]])
+      stub_osv_document(updated)
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        Advisory::OSV::Fetcher.new.sync
+      end
+
+      advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+
+      assert_equal "Updated from OSV", advisory.summary
+      assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+    end
+  end
+
+  private
+
+  def stub_osv_dump(documents, extra: {})
+    files = documents.to_h { |doc| ["#{doc.fetch('id')}.json", doc.to_json] }.merge(extra)
+    stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(
+      status: 200,
+      body: osv_dump_zip(files),
+      headers: { "Content-Type" => "application/zip" }
+    )
+  end
+
+  def stub_osv_index(*rows)
+    body = rows.map { |modified, id| "#{modified},#{id}" }.join("\n")
+    stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(
+      status: 200,
+      body: body,
+      headers: { "Content-Type" => "text/csv" }
+    )
+  end
+
+  def stub_osv_document(document)
+    stub_request(:get, osv_document_url(document.fetch("id"))).to_return(
+      status: 200,
+      body: document.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
+  def osv_document_url(id)
+    "#{Advisory::OSV::Fetcher::BASE_URL}/#{id}.json"
+  end
+
+  def osv_dump_zip(files)
+    Zip::OutputStream.write_buffer do |zio|
+      files.each do |name, content|
+        zio.put_next_entry(name)
+        zio.write(content)
+      end
+    end.string
   end
 end

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -37,223 +37,89 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
   end
 
   context "#fetch" do
-    context "when no advisories exist" do
-      should "parse JSON documents from the OSV RubyGems dump" do
-        other = @document.merge("id" => "GHSA-other-0000-0000", "summary" => "Other")
-        stub_osv_dump([@document, other])
+    should "parse JSON documents from the OSV RubyGems dump" do
+      other = @document.merge("id" => "GHSA-other-0000-0000", "summary" => "Other")
+      stub_osv_dump([@document, other])
 
-        documents = Advisory::OSV::Fetcher.new.fetch
+      documents = Advisory::OSV::Fetcher.new.fetch
 
-        assert_equal %w[GHSA-mm33-5vfq-3mm3 GHSA-other-0000-0000], documents.pluck("id")
-        assert_equal "Cross-site Scripting Vulnerability in Action Pack", documents.first["summary"]
-        assert_not_requested :get, Advisory::OSV::Fetcher::INDEX_URL
-      end
+      assert_equal %w[GHSA-mm33-5vfq-3mm3 GHSA-other-0000-0000], documents.pluck("id")
+      assert_equal "Cross-site Scripting Vulnerability in Action Pack", documents.first["summary"]
+    end
 
-      should "skip nested paths, non-JSON files, and invalid JSON" do
-        stub_osv_dump(
-          [@document],
-          extra: {
-            "nested/GHSA-nested-0000-0000.json" => { "id" => "GHSA-nested-0000-0000" }.to_json,
-            "README.md" => "not json",
-            "GHSA-bad-0000-0000.json" => "{not json}"
-          }
-        )
+    should "skip nested paths and non-JSON files" do
+      stub_osv_dump(
+        [@document],
+        extra: {
+          "nested/GHSA-nested-0000-0000.json" => { "id" => "GHSA-nested-0000-0000" }.to_json,
+          "README.md" => "not json"
+        }
+      )
 
-        documents = Advisory::OSV::Fetcher.new.fetch
+      documents = Advisory::OSV::Fetcher.new.fetch
 
-        assert_equal ["GHSA-mm33-5vfq-3mm3"], documents.pluck("id")
-      end
+      assert_equal ["GHSA-mm33-5vfq-3mm3"], documents.pluck("id")
+    end
 
-      should "raise when the dump HTTP request fails" do
-        stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 500, body: "nope")
+    should "raise when a dump entry has invalid JSON" do
+      stub_osv_dump(
+        [],
+        extra: { "GHSA-bad-0000-0000.json" => "{not json}" }
+      )
 
-        assert_raises(Faraday::ServerError) { Advisory::OSV::Fetcher.new.fetch }
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, times: 3
-      end
+      error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
 
-      should "raise when the dump is not a zip" do
-        stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 200, body: "not a zip")
+      assert_match(/Invalid OSV document GHSA-bad-0000-0000\.json/, error.message)
+    end
 
+    should "raise when the dump HTTP request fails" do
+      stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 500, body: "nope")
+
+      assert_raises(Faraday::ServerError) { Advisory::OSV::Fetcher.new.fetch }
+      assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, times: 3
+    end
+
+    should "raise when the dump is not a zip" do
+      stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 200, body: "not a zip")
+
+      error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
+
+      assert_match(/Invalid OSV dump archive/, error.message)
+    end
+
+    should "raise when a dump entry is too large" do
+      stub_osv_dump([@document])
+
+      stub_const(Advisory::OSV::Fetcher, :MAX_ENTRY_BYTES, 1) do
         error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
 
-        assert_match(/Invalid OSV dump archive/, error.message)
-      end
-
-      should "raise when a dump entry is too large" do
-        stub_osv_dump([@document])
-
-        stub_const(Advisory::OSV::Fetcher, :MAX_ENTRY_BYTES, 1) do
-          error = assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.fetch }
-
-          assert_match(/OSV dump entry too large/, error.message)
-        end
-      end
-
-      should "send an identifying user agent" do
-        stub_osv_dump([@document])
-
-        Advisory::OSV::Fetcher.new.fetch
-
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, headers: {
-          "User-Agent" => "RubyGems.org Advisory Fetcher/#{AppRevision.version}"
-        }
+        assert_match(/OSV dump entry too large/, error.message)
       end
     end
 
-    context "when advisories already exist" do
-      setup do
-        create(:advisory, identifier: "GHSA-old-0000-0000", modified_at: Time.zone.parse("2026-01-01T00:00:00Z"))
-      end
+    should "send an identifying user agent" do
+      stub_osv_dump([@document])
 
-      should "fetch JSON records at or after the latest modified_at" do
-        newer = @document.merge("id" => "GHSA-new-0000-0000", "modified" => "2026-02-01T00:00:00Z")
-        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
-        stub_osv_index(
-          ["2026-02-01T00:00:00Z", newer["id"]],
-          ["2026-01-01T00:00:00Z", watermark["id"]],
-          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
-        )
-        stub_osv_document(newer)
-        stub_osv_document(watermark)
+      Advisory::OSV::Fetcher.new.fetch
 
-        documents = Advisory::OSV::Fetcher.new.fetch
+      assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL, headers: {
+        "User-Agent" => "RubyGems.org Advisory Fetcher/#{AppRevision.version}"
+      }
+    end
 
-        assert_equal [newer["id"], watermark["id"]], documents.pluck("id")
-        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
-      end
+    should "always download the full dump even when advisories already exist" do
+      create(:advisory, identifier: "GHSA-old-0000-0000", modified_at: Time.zone.parse("2026-01-01T00:00:00Z"))
+      stub_osv_dump([@document])
 
-      should "re-fetch records that share the latest modified_at" do
-        sibling = @document.merge("id" => "GHSA-same-0000-0000", "modified" => "2026-01-01T00:00:00Z")
-        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
-        stub_osv_index(
-          ["2026-01-01T00:00:00Z", sibling["id"]],
-          ["2026-01-01T00:00:00Z", watermark["id"]],
-          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
-        )
-        stub_osv_document(sibling)
-        stub_osv_document(watermark)
+      documents = Advisory::OSV::Fetcher.new.fetch
 
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [sibling["id"], watermark["id"]], documents.pluck("id")
-        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
-      end
-
-      should "not fetch records older than the latest modified_at" do
-        watermark = @document.merge("id" => "GHSA-old-0000-0000", "modified" => "2026-01-01T00:00:00Z")
-        stub_osv_index(
-          ["2026-01-01T00:00:00Z", watermark["id"]],
-          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
-        )
-        stub_osv_document(watermark)
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [watermark["id"]], documents.pluck("id")
-        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-        assert_not_requested :get, osv_document_url("GHSA-older-0000-0000")
-      end
-
-      should "skip index rows with an unparseable modified timestamp" do
-        newer = @document.merge("id" => "GHSA-new-0000-0000", "modified" => "2026-02-01T00:00:00Z")
-        stub_osv_index(
-          ["not-a-timestamp", "GHSA-bad-0000-0000"],
-          ["2026-02-01T00:00:00Z", newer["id"]],
-          ["2025-12-01T00:00:00Z", "GHSA-older-0000-0000"]
-        )
-        stub_osv_document(newer)
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [newer["id"]], documents.pluck("id")
-        assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-        assert_not_requested :get, osv_document_url("GHSA-bad-0000-0000")
-      end
-
-      should "keep path-like identifiers inside the RubyGems prefix" do
-        stub_osv_index(["2026-02-01T00:00:00Z", "../escape"])
-        stub_request(:get, "#{Advisory::OSV::Fetcher::BASE_URL}/#{CGI.escapeURIComponent('../escape')}.json")
-          .to_return(status: 404, body: "missing")
-        stub_osv_dump([@document])
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [@document["id"]], documents.pluck("id")
-        assert_not_requested :get, "https://osv-vulnerabilities.storage.googleapis.com/escape.json"
-      end
-
-      should "fall back to the full dump when too many records changed" do
-        stub_osv_index(
-          ["2026-03-01T00:00:00Z", "GHSA-new-0000-0001"],
-          ["2026-02-01T00:00:00Z", @document["id"]]
-        )
-        stub_osv_dump([@document])
-
-        stub_const(Advisory::OSV::Fetcher, :MAX_INCREMENTAL_IDS, 1) do
-          documents = Advisory::OSV::Fetcher.new.fetch
-
-          assert_equal [@document["id"]], documents.pluck("id")
-        end
-
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-        assert_not_requested :get, osv_document_url(@document["id"])
-        assert_not_requested :get, osv_document_url("GHSA-new-0000-0001")
-      end
-
-      should "fall back to the full dump when an incremental document is missing" do
-        stub_osv_index(
-          ["2026-02-01T00:00:00Z", "GHSA-new-0000-0000"],
-          ["2026-01-15T00:00:00Z", "GHSA-other-0000-0000"]
-        )
-        stub_request(:get, osv_document_url("GHSA-new-0000-0000")).to_return(status: 404, body: "missing")
-        stub_osv_dump([@document])
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [@document["id"]], documents.pluck("id")
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-        assert_not_requested :get, osv_document_url("GHSA-other-0000-0000")
-      end
-
-      should "fall back to the full dump when an incremental document is invalid JSON" do
-        stub_osv_index(["2026-02-01T00:00:00Z", "GHSA-new-0000-0000"])
-        stub_request(:get, osv_document_url("GHSA-new-0000-0000")).to_return(status: 200, body: "{not json}")
-        stub_osv_dump([@document])
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [@document["id"]], documents.pluck("id")
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-      end
-
-      should "fall back to the full dump when the index request fails" do
-        stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(status: 500, body: "nope")
-        stub_osv_dump([@document])
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [@document["id"]], documents.pluck("id")
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-      end
-
-      should "fall back to the full dump when the index is malformed CSV" do
-        stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(
-          status: 200,
-          body: %("2026-02-01T00:00:00Z,GHSA-new-0000-0000)
-        )
-        stub_osv_dump([@document])
-
-        documents = Advisory::OSV::Fetcher.new.fetch
-
-        assert_equal [@document["id"]], documents.pluck("id")
-        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
-      end
+      assert_equal [@document["id"]], documents.pluck("id")
+      assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
     end
   end
 
   context "#import" do
-    should "upsert one Advisory::OSV row per affected gem" do
+    should "insert one Advisory::OSV row per affected gem" do
       records = Advisory::OSV::Mapper.call(@document)
 
       assert_equal 2, Advisory::OSV::Fetcher.new.import(records)
@@ -269,24 +135,62 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       assert_equal actionpack.summary, rails.summary
     end
 
-    should "update an existing row on a later import" do
+    should "replace the previous snapshot on a later import" do
       Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
 
       updated = @document.merge(
         "summary" => "Updated summary",
         "modified" => "2025-01-01T00:00:00Z",
         "withdrawn" => "2025-01-02T00:00:00Z",
-        "database_specific" => { "severity" => "HIGH" }
+        "database_specific" => { "severity" => "HIGH" },
+        "affected" => [
+          "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+          "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"]]
+        ]
       )
       Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(updated))
 
       advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
 
-      assert_equal 2, Advisory::OSV.where(identifier: "GHSA-mm33-5vfq-3mm3").count
+      assert_equal 1, Advisory::OSV.where(identifier: "GHSA-mm33-5vfq-3mm3").count
       assert_equal "Updated summary", advisory.summary
       assert_equal "high", advisory.severity
       assert_equal Time.zone.parse("2025-01-01T00:00:00Z"), advisory.modified_at
       assert_equal Time.zone.parse("2025-01-02T00:00:00Z"), advisory.withdrawn_at
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+    end
+
+    should "remove a package renamed away from an advisory" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+
+      renamed = @document.merge(
+        "modified" => "2025-01-01T00:00:00Z",
+        "affected" => [
+          "package" => { "name" => "actionpack-renamed", "ecosystem" => "RubyGems" },
+          "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"]]
+        ]
+      )
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(renamed))
+
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack-renamed")
+    end
+
+    should "remove an advisory that left the RubyGems snapshot" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+      other = @document.merge("id" => "GHSA-other-0000-0000", "summary" => "Other")
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(other))
+
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-mm33-5vfq-3mm3")
+      assert Advisory::OSV.exists?(identifier: "GHSA-other-0000-0000", rubygem_name: "actionpack")
+    end
+
+    should "clear all rows when the snapshot maps to nothing" do
+      Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
+
+      assert_equal 0, Advisory::OSV::Fetcher.new.import([])
+      assert_empty Advisory::OSV.all
     end
 
     should "allow an advisory for a gem that does not exist yet" do
@@ -295,10 +199,6 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
 
       assert_nil advisory.rubygem
-    end
-
-    should "return zero when there is nothing to import" do
-      assert_equal 0, Advisory::OSV::Fetcher.new.import([])
     end
   end
 
@@ -324,7 +224,8 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
     end
 
-    should "download the OSV dump and import mapped rows" do
+    should "download the OSV dump and replace mapped rows" do
+      create(:advisory, identifier: "GHSA-stale-0000-0000", rubygem_name: "stale")
       stub_osv_dump([@document])
 
       with_feature FeatureFlag::OSV_ADVISORIES do
@@ -333,22 +234,31 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
 
       assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
       assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
+      assert_nil Advisory::OSV.find_by(identifier: "GHSA-stale-0000-0000")
     end
 
-    should "import only updated documents on a later sync" do
+    should "preserve existing rows when the dump is invalid" do
+      create(:advisory, identifier: "GHSA-keep-0000-0000", rubygem_name: "actionpack")
+      stub_request(:get, Advisory::OSV::Fetcher::DUMP_URL).to_return(status: 200, body: "not a zip")
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_raises(Advisory::Fetcher::Error) { Advisory::OSV::Fetcher.new.sync }
+      end
+
+      assert Advisory::OSV.exists?(identifier: "GHSA-keep-0000-0000", rubygem_name: "actionpack")
+    end
+
+    should "reappear an advisory that returns to the snapshot" do
       Advisory::OSV::Fetcher.new.import(Advisory::OSV::Mapper.call(@document))
-      updated = @document.merge("summary" => "Updated from OSV", "modified" => "2026-03-01T00:00:00Z")
-      stub_osv_index(["2026-03-01T00:00:00Z", updated["id"]])
-      stub_osv_document(updated)
+      Advisory::OSV::Fetcher.new.import([])
+      stub_osv_dump([@document])
 
       with_feature FeatureFlag::OSV_ADVISORIES do
         Advisory::OSV::Fetcher.new.sync
       end
 
-      advisory = Advisory::OSV.find_by!(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
-
-      assert_equal "Updated from OSV", advisory.summary
-      assert_not_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "actionpack")
+      assert Advisory::OSV.exists?(identifier: "GHSA-mm33-5vfq-3mm3", rubygem_name: "rails")
     end
   end
 
@@ -361,27 +271,6 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       body: osv_dump_zip(files),
       headers: { "Content-Type" => "application/zip" }
     )
-  end
-
-  def stub_osv_index(*rows)
-    body = rows.map { |modified, id| "#{modified},#{id}" }.join("\n")
-    stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(
-      status: 200,
-      body: body,
-      headers: { "Content-Type" => "text/csv" }
-    )
-  end
-
-  def stub_osv_document(document)
-    stub_request(:get, osv_document_url(document.fetch("id"))).to_return(
-      status: 200,
-      body: document.to_json,
-      headers: { "Content-Type" => "application/json" }
-    )
-  end
-
-  def osv_document_url(id)
-    "#{Advisory::OSV::Fetcher::BASE_URL}/#{id}.json"
   end
 
   def osv_dump_zip(files)

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -236,6 +236,19 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
         assert_equal [@document["id"]], documents.pluck("id")
         assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
       end
+
+      should "fall back to the full dump when the index is malformed CSV" do
+        stub_request(:get, Advisory::OSV::Fetcher::INDEX_URL).to_return(
+          status: 200,
+          body: %("2026-02-01T00:00:00Z,GHSA-new-0000-0000)
+        )
+        stub_osv_dump([@document])
+
+        documents = Advisory::OSV::Fetcher.new.fetch
+
+        assert_equal [@document["id"]], documents.pluck("id")
+        assert_requested :get, Advisory::OSV::Fetcher::DUMP_URL
+      end
     end
   end
 

--- a/test/models/advisory/osv/fetcher_test.rb
+++ b/test/models/advisory/osv/fetcher_test.rb
@@ -266,7 +266,6 @@ class Advisory::OSV::FetcherTest < ActiveSupport::TestCase
       assert_equal ["CVE-2022-22577"], actionpack.aliases
       assert_equal "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3", actionpack.url
       assert_equal ["introduced" => "5.2.0", "fixed" => "5.2.7.1"], actionpack.ranges
-      assert_equal "GHSA-mm33-5vfq-3mm3", actionpack.payload["id"]
       assert_equal actionpack.summary, rails.summary
     end
 

--- a/test/models/advisory/osv/mapper_test.rb
+++ b/test/models/advisory/osv/mapper_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Advisory::OSV::MapperTest < ActiveSupport::TestCase
+  def document(**overrides)
+    {
+      "id" => "GHSA-mm33-5vfq-3mm3",
+      "summary" => "Cross-site Scripting Vulnerability in Action Pack",
+      "modified" => "2024-02-18T05:32:29Z",
+      "published" => "2022-04-27T22:28:59Z",
+      "aliases" => ["CVE-2022-22577"],
+      "database_specific" => { "severity" => "MODERATE" },
+      "affected" => [
+        "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+        "ranges" => [
+          { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"] },
+          "type" => "ECOSYSTEM", "events" => [{ "introduced" => "6.0.0" }, "last_affected" => "6.0.4.7"]
+        ]
+      ]
+    }.deep_merge(overrides.stringify_keys)
+  end
+
+  context "a RubyGems advisory" do
+    should "map one row per affected gem with normalized ranges" do
+      records = Advisory::OSV::Mapper.call(document)
+
+      assert_equal 1, records.size
+      record = records.first
+
+      assert_equal "GHSA-mm33-5vfq-3mm3", record[:identifier]
+      assert_equal "actionpack", record[:rubygem_name]
+      assert_equal ["CVE-2022-22577"], record[:aliases]
+      assert_equal "Cross-site Scripting Vulnerability in Action Pack", record[:summary]
+      assert_equal "moderate", record[:severity]
+      assert_equal "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3", record[:url]
+      assert_equal Time.zone.parse("2022-04-27T22:28:59Z"), record[:published_at]
+      assert_equal Time.zone.parse("2024-02-18T05:32:29Z"), record[:modified_at]
+      assert_nil record[:withdrawn_at]
+      assert_equal [
+        { "introduced" => "5.2.0", "fixed" => "5.2.7.1" },
+        "introduced" => "6.0.0", "last_affected" => "6.0.4.7"
+      ], record[:ranges]
+      assert_equal "GHSA-mm33-5vfq-3mm3", record[:payload]["id"]
+    end
+
+    should "emit one row per RubyGems package" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            {
+              "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+              "ranges" => ["type" => "ECOSYSTEM", "events" => ["introduced" => "0"]]
+            },
+            {
+              "package" => { "name" => "rails", "ecosystem" => "RubyGems" },
+              "ranges" => ["type" => "ECOSYSTEM", "events" => ["introduced" => "0"]]
+            },
+            {
+              "package" => { "name" => "actionpack", "ecosystem" => "npm" },
+              "ranges" => ["type" => "ECOSYSTEM", "events" => ["introduced" => "1.0.0"]]
+            }
+          ]
+        )
+      )
+
+      assert_equal(%w[actionpack rails], records.pluck(:rubygem_name))
+      assert(records.all? { |r| r[:identifier] == "GHSA-mm33-5vfq-3mm3" })
+    end
+
+    should "merge ranges from multiple affected entries for the same gem" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            {
+              "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+              "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "5.2.0" }, "fixed" => "5.2.7.1"]]
+            },
+            {
+              "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+              "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.2.4"]]
+            }
+          ]
+        )
+      )
+
+      assert_equal 1, records.size
+      assert_equal [
+        { "introduced" => "5.2.0", "fixed" => "5.2.7.1" },
+        "introduced" => "7.0.0", "fixed" => "7.0.2.4"
+      ], records.first[:ranges]
+    end
+
+    should "skip GIT ranges" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+            "ranges" => [
+              { "type" => "GIT", "events" => ["introduced" => "abc123"] },
+              "type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.1"]
+            ]
+          ]
+        )
+      )
+
+      assert_equal ["introduced" => "7.0.0", "fixed" => "7.0.1"], records.first[:ranges]
+    end
+
+    should "treat listed versions as exact ranges when ranges are missing" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "id" => "MAL-2026-9999",
+          "affected" => [
+            "package" => { "name" => "zztxtwtmp12", "ecosystem" => "RubyGems" },
+            "versions" => ["0.0.1"]
+          ]
+        )
+      )
+
+      assert_equal 1, records.size
+      assert_equal "zztxtwtmp12", records.first[:rubygem_name]
+      assert_equal ["introduced" => "0.0.1", "last_affected" => "0.0.1"], records.first[:ranges]
+    end
+
+    should "use versions when only GIT ranges are present" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+            "ranges" => ["type" => "GIT", "events" => ["introduced" => "abc123"]],
+            "versions" => ["7.0.0", "7.0.1"]
+          ]
+        )
+      )
+
+      assert_equal [
+        { "introduced" => "7.0.0", "last_affected" => "7.0.0" },
+        { "introduced" => "7.0.1", "last_affected" => "7.0.1" }
+      ], records.first[:ranges]
+    end
+
+    should "prefer ecosystem ranges over versions" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+            "ranges" => ["type" => "ECOSYSTEM", "events" => [{ "introduced" => "7.0.0" }, "fixed" => "7.0.1"]],
+            "versions" => ["7.0.0"]
+          ]
+        )
+      )
+
+      assert_equal ["introduced" => "7.0.0", "fixed" => "7.0.1"], records.first[:ranges]
+    end
+
+    should "set withdrawn_at when the document is withdrawn" do
+      records = Advisory::OSV::Mapper.call(document("withdrawn" => "2023-06-01T00:00:00Z"))
+
+      assert_equal Time.zone.parse("2023-06-01T00:00:00Z"), records.first[:withdrawn_at]
+    end
+
+    should "fall back to the identifier when summary is missing" do
+      records = Advisory::OSV::Mapper.call(document("summary" => nil))
+
+      assert_equal "GHSA-mm33-5vfq-3mm3", records.first[:summary]
+    end
+
+    should "leave severity blank when the source value is unknown" do
+      records = Advisory::OSV::Mapper.call(document("database_specific" => { "severity" => "SEVERE" }))
+
+      assert_nil records.first[:severity]
+    end
+
+    %w[LOW MODERATE HIGH CRITICAL].each do |value|
+      should "map #{value} severity" do
+        records = Advisory::OSV::Mapper.call(document("database_specific" => { "severity" => value }))
+
+        assert_equal value.downcase, records.first[:severity]
+      end
+    end
+  end
+
+  context "unusable documents" do
+    should "return no records without an id" do
+      assert_empty Advisory::OSV::Mapper.call(document("id" => nil))
+    end
+
+    should "return no records without modified" do
+      assert_empty Advisory::OSV::Mapper.call(document("modified" => nil))
+    end
+
+    should "return no records when no RubyGems packages are listed" do
+      assert_empty Advisory::OSV::Mapper.call(
+        document("affected" => ["package" => { "name" => "lodash", "ecosystem" => "npm" }])
+      )
+    end
+  end
+end

--- a/test/models/advisory/osv/mapper_test.rb
+++ b/test/models/advisory/osv/mapper_test.rb
@@ -91,6 +91,30 @@ class Advisory::OSV::MapperTest < ActiveSupport::TestCase
       ], records.first[:ranges]
     end
 
+    should "split a range with multiple introduced/fixed events" do
+      records = Advisory::OSV::Mapper.call(
+        document(
+          "affected" => [
+            "package" => { "name" => "actionpack", "ecosystem" => "RubyGems" },
+            "ranges" => [
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "1.0.0" },
+                { "fixed" => "1.0.2" },
+                { "introduced" => "3.0.0" },
+                { "fixed" => "3.2.5" }
+              ]
+            ]
+          ]
+        )
+      )
+
+      assert_equal [
+        { "introduced" => "1.0.0", "fixed" => "1.0.2" },
+        { "introduced" => "3.0.0", "fixed" => "3.2.5" }
+      ], records.first[:ranges]
+    end
+
     should "skip GIT ranges" do
       records = Advisory::OSV::Mapper.call(
         document(

--- a/test/models/advisory/osv/mapper_test.rb
+++ b/test/models/advisory/osv/mapper_test.rb
@@ -41,7 +41,6 @@ class Advisory::OSV::MapperTest < ActiveSupport::TestCase
         { "introduced" => "5.2.0", "fixed" => "5.2.7.1" },
         "introduced" => "6.0.0", "last_affected" => "6.0.4.7"
       ], record[:ranges]
-      assert_equal "GHSA-mm33-5vfq-3mm3", record[:payload]["id"]
     end
 
     should "emit one row per RubyGems package" do

--- a/test/models/advisory/osv_test.rb
+++ b/test/models/advisory/osv_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Advisory::OSVTest < ActiveSupport::TestCase
+  context "validations" do
+    setup do
+      @advisory = create(:advisory)
+    end
+
+    subject { @advisory }
+
+    should define_enum_for(:severity)
+      .with_values(low: "low", moderate: "moderate", high: "high", critical: "critical")
+      .backed_by_column_of_type(:string)
+  end
+
+  context "severity" do
+    should "accept each severity value and allow nil" do
+      %w[low moderate high critical].each do |severity|
+        advisory = build(:advisory, severity: severity)
+
+        assert_predicate advisory, :valid?
+      end
+
+      advisory = build(:advisory, severity: nil)
+
+      assert_predicate advisory, :valid?
+    end
+
+    should "reject an unknown severity" do
+      advisory = build(:advisory, severity: "severe")
+
+      refute_predicate advisory, :valid?
+      assert_includes advisory.errors[:severity], "is not included in the list"
+    end
+  end
+end

--- a/test/models/advisory/osv_test.rb
+++ b/test/models/advisory/osv_test.rb
@@ -15,6 +15,12 @@ class Advisory::OSVTest < ActiveSupport::TestCase
       .backed_by_column_of_type(:string)
   end
 
+  context ".feature_flag" do
+    should "use the OSV advisories flag" do
+      assert_equal FeatureFlag::OSV_ADVISORIES, Advisory::OSV.feature_flag
+    end
+  end
+
   context "severity" do
     should "accept each severity value and allow nil" do
       %w[low moderate high critical].each do |severity|
@@ -33,6 +39,73 @@ class Advisory::OSVTest < ActiveSupport::TestCase
 
       refute_predicate advisory, :valid?
       assert_includes advisory.errors[:severity], "is not included in the list"
+    end
+  end
+
+  context "#affects?" do
+    should "match an inclusive introduced and exclusive fixed range" do
+      advisory = build(:advisory, :range)
+
+      refute advisory.affects?("0.9.0")
+      assert advisory.affects?("1.0.0")
+      assert advisory.affects?("1.1.9")
+      refute advisory.affects?("1.2.0")
+    end
+
+    should "match an exact last_affected version" do
+      advisory = build(:advisory, :exact)
+
+      refute advisory.affects?("0.9.0")
+      assert advisory.affects?("1.0.0")
+      refute advisory.affects?("1.0.1")
+    end
+
+    should "treat introduced 0 as an unbounded lower bound" do
+      advisory = build(:advisory, :unfixed)
+
+      assert advisory.affects?("0.0.1")
+      assert advisory.affects?("99.0.0")
+    end
+
+    should "prefer fixed over last_affected when both are present" do
+      advisory = build(:advisory, ranges: ["introduced" => "1.0.0", "fixed" => "1.2.0", "last_affected" => "1.1.0"])
+
+      assert advisory.affects?("1.1.5")
+      refute advisory.affects?("1.2.0")
+    end
+
+    should "match any of multiple ranges" do
+      advisory = build(:advisory, ranges: [
+                         { "introduced" => "5.2.0", "fixed" => "5.2.7.1" },
+                         { "introduced" => "6.0.0", "last_affected" => "6.0.4.7" }
+                       ])
+
+      assert advisory.affects?("5.2.3")
+      refute advisory.affects?("5.2.7.1")
+      assert advisory.affects?("6.0.4.7")
+      refute advisory.affects?("6.0.4.8")
+      refute advisory.affects?("5.1.0")
+    end
+
+    should "accept a Version object" do
+      version = build(:version, number: "1.1.0")
+      advisory = build(:advisory, :range)
+
+      assert advisory.affects?(version)
+    end
+
+    should "skip a range with an invalid bound" do
+      advisory = build(:advisory, ranges: ["introduced" => "1.0.0", "fixed" => "not-a-version"])
+
+      refute advisory.affects?("1.0.0")
+    end
+
+    should "treat a range with only introduced as still affected" do
+      advisory = build(:advisory, ranges: ["introduced" => "2.0.0"])
+
+      refute advisory.affects?("1.9.0")
+      assert advisory.affects?("2.0.0")
+      assert advisory.affects?("9.0.0")
     end
   end
 end

--- a/test/models/advisory/osv_test.rb
+++ b/test/models/advisory/osv_test.rb
@@ -42,6 +42,16 @@ class Advisory::OSVTest < ActiveSupport::TestCase
     end
   end
 
+  context "#malware?" do
+    should "be true for MAL-prefixed identifiers" do
+      assert_predicate build(:advisory, identifier: "MAL-2026-9999"), :malware?
+    end
+
+    should "be false for other identifiers" do
+      refute_predicate build(:advisory, identifier: "GHSA-mm33-5vfq-3mm3"), :malware?
+    end
+  end
+
   context "#affects?" do
     should "match an inclusive introduced and exclusive fixed range" do
       advisory = build(:advisory, :range)

--- a/test/models/advisory_test.rb
+++ b/test/models/advisory_test.rb
@@ -54,32 +54,44 @@ class AdvisoryTest < ActiveSupport::TestCase
     end
   end
 
-  context ".sources" do
+  context ".SOURCES" do
     should "include Advisory::OSV" do
-      assert_includes Advisory.sources, Advisory::OSV
+      assert_includes Advisory::SOURCES, Advisory::OSV
+    end
+  end
+
+  context ".feature_flag" do
+    should "require subclasses to define feature_flag" do
+      assert_raises(NotImplementedError) { Advisory.feature_flag }
     end
   end
 
   context ".enabled_sources" do
+    should "exclude sources whose flag is off" do
+      assert_empty Advisory.enabled_sources
+    end
+
+    should "include Advisory::OSV when its flag is on" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_equal [Advisory::OSV], Advisory.enabled_sources
+      end
+    end
+  end
+
+  context ".visible" do
     setup do
       @advisory = create(:advisory)
     end
 
     should "return none when no source flags are on" do
-      assert_empty Advisory.enabled_sources
+      assert_empty Advisory.visible
     end
 
-    should "return OSV rows when Advisory::OSV is enabled" do
-      with_feature FeatureFlag::OSV_ADVISORIES do
-        assert_equal [@advisory], Advisory.enabled_sources.to_a
-      end
-    end
-
-    should "merge with current to exclude withdrawn" do
+    should "return current rows from enabled sources" do
       create(:advisory, :withdrawn)
 
       with_feature FeatureFlag::OSV_ADVISORIES do
-        assert_equal [@advisory], Advisory.current.merge(Advisory.enabled_sources).to_a
+        assert_equal [@advisory], Advisory.visible.to_a
       end
     end
   end

--- a/test/models/advisory_test.rb
+++ b/test/models/advisory_test.rb
@@ -17,9 +17,6 @@ class AdvisoryTest < ActiveSupport::TestCase
     should validate_presence_of(:url)
     should validate_presence_of(:modified_at)
     should validate_uniqueness_of(:identifier).scoped_to(:type, :rubygem_name)
-    should define_enum_for(:severity)
-      .with_values(low: "low", moderate: "moderate", high: "high", critical: "critical")
-      .backed_by_column_of_type(:string)
   end
 
   context "STI" do
@@ -54,27 +51,6 @@ class AdvisoryTest < ActiveSupport::TestCase
 
       assert_predicate advisory, :valid?
       assert_nil advisory.rubygem
-    end
-  end
-
-  context "severity" do
-    should "accept each severity value and allow nil" do
-      %w[low moderate high critical].each do |severity|
-        advisory = build(:advisory, severity: severity)
-
-        assert_predicate advisory, :valid?
-      end
-
-      advisory = build(:advisory, severity: nil)
-
-      assert_predicate advisory, :valid?
-    end
-
-    should "reject an unknown severity" do
-      advisory = build(:advisory, severity: "severe")
-
-      refute_predicate advisory, :valid?
-      assert_includes advisory.errors[:severity], "is not included in the list"
     end
   end
 end

--- a/test/models/advisory_test.rb
+++ b/test/models/advisory_test.rb
@@ -53,4 +53,54 @@ class AdvisoryTest < ActiveSupport::TestCase
       assert_nil advisory.rubygem
     end
   end
+
+  context ".sources" do
+    should "include Advisory::OSV" do
+      assert_includes Advisory.sources, Advisory::OSV
+    end
+  end
+
+  context ".enabled_sources" do
+    setup do
+      @advisory = create(:advisory)
+    end
+
+    should "return none when no source flags are on" do
+      assert_empty Advisory.enabled_sources
+    end
+
+    should "return OSV rows when Advisory::OSV is enabled" do
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_equal [@advisory], Advisory.enabled_sources.to_a
+      end
+    end
+
+    should "merge with current to exclude withdrawn" do
+      create(:advisory, :withdrawn)
+
+      with_feature FeatureFlag::OSV_ADVISORIES do
+        assert_equal [@advisory], Advisory.current.merge(Advisory.enabled_sources).to_a
+      end
+    end
+  end
+
+  context "#affects?" do
+    should "return false when ranges are empty" do
+      advisory = build(:advisory, ranges: [])
+
+      refute advisory.affects?("1.0.0")
+    end
+
+    should "return false for an invalid version string" do
+      advisory = build(:advisory, :range)
+
+      refute advisory.affects?("not-a-version")
+    end
+
+    should "require subclasses to implement range matching" do
+      assert_raises(NotImplementedError) do
+        Advisory.new.send(:range_includes?, {}, Gem::Version.new("1.0.0"))
+      end
+    end
+  end
 end

--- a/test/models/advisory_test.rb
+++ b/test/models/advisory_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdvisoryTest < ActiveSupport::TestCase
+  context "validations" do
+    setup do
+      @advisory = create(:advisory)
+    end
+
+    subject { @advisory }
+
+    should validate_presence_of(:type)
+    should validate_presence_of(:identifier)
+    should validate_presence_of(:rubygem_name)
+    should validate_presence_of(:summary)
+    should validate_presence_of(:url)
+    should validate_presence_of(:modified_at)
+    should validate_uniqueness_of(:identifier).scoped_to(:type, :rubygem_name)
+    should define_enum_for(:severity)
+      .with_values(low: "low", moderate: "moderate", high: "high", critical: "critical")
+      .backed_by_column_of_type(:string)
+  end
+
+  context "STI" do
+    should "instantiate as Advisory::OSV" do
+      advisory = create(:advisory)
+
+      assert_instance_of Advisory::OSV, advisory
+      assert_equal "Advisory::OSV", advisory.type
+    end
+  end
+
+  context ".current" do
+    should "exclude withdrawn advisories" do
+      current = create(:advisory)
+      create(:advisory, :withdrawn)
+
+      assert_equal [current], Advisory.current.to_a
+    end
+  end
+
+  context "rubygem association" do
+    should "find the gem when it exists" do
+      rubygem = create(:rubygem, name: "actionpack")
+      advisory = create(:advisory, rubygem_name: "actionpack")
+
+      assert_equal rubygem, advisory.rubygem
+      assert_includes rubygem.advisories, advisory
+    end
+
+    should "allow an advisory when the gem does not exist" do
+      advisory = build(:advisory, rubygem_name: "missing-gem")
+
+      assert_predicate advisory, :valid?
+      assert_nil advisory.rubygem
+    end
+  end
+
+  context "severity" do
+    should "accept each severity value and allow nil" do
+      %w[low moderate high critical].each do |severity|
+        advisory = build(:advisory, severity: severity)
+
+        assert_predicate advisory, :valid?
+      end
+
+      advisory = build(:advisory, severity: nil)
+
+      assert_predicate advisory, :valid?
+    end
+
+    should "reject an unknown severity" do
+      advisory = build(:advisory, severity: "severe")
+
+      refute_predicate advisory, :valid?
+      assert_includes advisory.errors[:severity], "is not included in the list"
+    end
+  end
+end

--- a/test/policies/admin/advisory_policy_test.rb
+++ b/test/policies/admin/advisory_policy_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::AdvisoryPolicyTest < AdminPolicyTestCase
+  setup do
+    @advisory = create(:advisory)
+    @admin = create(:admin_github_user, :is_admin)
+    @non_admin = create(:admin_github_user)
+  end
+
+  def test_associations
+    assert_association @admin, @advisory, :rubygem, Admin::RubygemPolicy
+  end
+
+  def test_scope
+    assert_equal [@advisory], policy_scope!(
+      @admin,
+      Advisory
+    ).to_a
+  end
+
+  def test_avo_index
+    assert_authorizes @admin, Advisory, :avo_index?
+
+    refute_authorizes @non_admin, Advisory, :avo_index?
+  end
+
+  def test_avo_show
+    assert_authorizes @admin, @advisory, :avo_show?
+
+    refute_authorizes @non_admin, @advisory, :avo_show?
+  end
+
+  def test_avo_create
+    refute_authorizes @admin, Advisory, :avo_create?
+    refute_authorizes @non_admin, Advisory, :avo_create?
+  end
+
+  def test_avo_update
+    refute_authorizes @admin, @advisory, :avo_update?
+    refute_authorizes @non_admin, @advisory, :avo_update?
+  end
+
+  def test_avo_destroy
+    refute_authorizes @admin, @advisory, :avo_destroy?
+    refute_authorizes @non_admin, @advisory, :avo_destroy?
+  end
+
+  def test_act_on
+    refute_authorizes @admin, @advisory, :act_on?
+    refute_authorizes @non_admin, @advisory, :act_on?
+  end
+end

--- a/test/policies/admin/advisory_policy_test.rb
+++ b/test/policies/admin/advisory_policy_test.rb
@@ -48,7 +48,7 @@ class Admin::AdvisoryPolicyTest < AdminPolicyTestCase
   end
 
   def test_act_on
-    refute_authorizes @admin, @advisory, :act_on?
+    assert_authorizes @admin, @advisory, :act_on?
     refute_authorizes @non_admin, @advisory, :act_on?
   end
 end

--- a/test/policies/admin/rubygem_policy_test.rb
+++ b/test/policies/admin/rubygem_policy_test.rb
@@ -32,4 +32,8 @@ class Admin::RubygemPolicyTest < AdminPolicyTestCase
 
     refute_authorizes @non_admin, @rubygem, :avo_show?
   end
+
+  def test_associations
+    assert_association @admin, @rubygem, :advisories, Admin::AdvisoryPolicy
+  end
 end

--- a/test/system/avo/advisories_test.rb
+++ b/test/system/avo/advisories_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Avo::AdvisoriesSystemTest < ApplicationSystemTestCase
+  include ActiveJob::TestHelper
+
+  test "sync advisories from the index" do
+    Advisory::OSV::Fetcher.any_instance.expects(:fetch).never
+
+    admin_user = create(:admin_github_user, :is_admin)
+    avo_sign_in_as admin_user
+
+    visit avo.resources_advisories_path
+
+    click_button "Actions"
+    click_on "Sync Advisories"
+
+    fill_in "Comment", with: "Warming the advisories table before enabling the public flag"
+    click_button "Sync"
+
+    page.assert_text "Advisory sync job scheduled"
+    page.assert_text "Sync Advisories"
+
+    assert_enqueued_jobs 1, only: SyncAdvisoriesJob
+    assert_enqueued_with(job: SyncAdvisoriesJob, args: [force: true])
+
+    audit = Audit.where(action: "Sync Advisories").sole
+
+    assert_equal admin_user, audit.admin_github_user
+    assert_equal admin_user, audit.auditable
+    assert_equal "Warming the advisories table before enabling the public flag", audit.comment
+  end
+end

--- a/test/system/avo/advisories_test.rb
+++ b/test/system/avo/advisories_test.rb
@@ -16,6 +16,7 @@ class Avo::AdvisoriesSystemTest < ApplicationSystemTestCase
     click_button "Actions"
     click_on "Sync Advisories"
 
+    select "OSV", from: "Source"
     fill_in "Comment", with: "Warming the advisories table before enabling the public flag"
     click_button "Sync"
 
@@ -23,7 +24,7 @@ class Avo::AdvisoriesSystemTest < ApplicationSystemTestCase
     page.assert_text "Sync Advisories"
 
     assert_enqueued_jobs 1, only: SyncAdvisoriesJob
-    assert_enqueued_with(job: SyncAdvisoriesJob, args: [force: true])
+    assert_enqueued_with(job: SyncAdvisoriesJob, args: [source: "Advisory::OSV", force: true])
 
     audit = Audit.where(action: "Sync Advisories").sole
 

--- a/test/unit/avo/actions/sync_advisories_test.rb
+++ b/test/unit/avo/actions/sync_advisories_test.rb
@@ -20,11 +20,19 @@ class SyncAdvisoriesTest < ActiveJob::TestCase
     assert_includes action_classes, Avo::Actions::SyncAdvisories
   end
 
-  should "enqueue a forced advisory sync" do
+  should "enqueue a sync for the selected source" do
     perform_action
 
     assert_enqueued_jobs 1, only: SyncAdvisoriesJob
-    assert_enqueued_with(job: SyncAdvisoriesJob, args: [force: true])
+    assert_enqueued_with(job: SyncAdvisoriesJob, args: [source: "Advisory::OSV", force: true])
+  end
+
+  should "not enqueue when the source is unknown" do
+    perform_action(source: "nope")
+
+    assert_no_enqueued_jobs only: SyncAdvisoriesJob
+    assert_empty Audit.all
+    assert_equal "Unknown advisory source", @action.response.dig(:messages, 0, :body)
   end
 
   should "record an Avo audit against the operator" do
@@ -37,6 +45,7 @@ class SyncAdvisoriesTest < ActiveJob::TestCase
     assert_equal comment, audit.comment
     assert_equal "Sync Advisories", audit.action
     assert_equal @current_user, audit.auditable
+    assert_equal "Advisory::OSV", audit.audited_changes.dig("fields", "source")
     assert_equal "Advisory sync job scheduled", @action.response.dig(:messages, 0, :body)
   end
 
@@ -54,11 +63,11 @@ class SyncAdvisoriesTest < ActiveJob::TestCase
 
   private
 
-  def perform_action(comment: "Warming the advisories table")
+  def perform_action(comment: "Warming the advisories table", source: "Advisory::OSV")
     Advisory::OSV::Fetcher.any_instance.expects(:fetch).never
 
     @action.handle(
-      fields: { comment: },
+      fields: { comment:, source: },
       current_user: @current_user,
       resource: nil,
       records: [],

--- a/test/unit/avo/actions/sync_advisories_test.rb
+++ b/test/unit/avo/actions/sync_advisories_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SyncAdvisoriesTest < ActiveJob::TestCase
+  setup do
+    @current_user = create(:admin_github_user, :is_admin)
+    @action = Avo::Actions::SyncAdvisories.new
+
+    view_context = mock
+    avo = mock
+    view_context.stubs(:avo).returns(avo)
+    avo.stubs(:resources_audit_path).returns("resources_audit_path")
+    Avo::Current.stubs(:view_context).returns(view_context)
+  end
+
+  should "be registered on the advisory resource" do
+    action_classes = Avo::Resources::Advisory.new.get_actions.pluck(:class)
+
+    assert_includes action_classes, Avo::Actions::SyncAdvisories
+  end
+
+  should "enqueue a forced advisory sync" do
+    perform_action
+
+    assert_enqueued_jobs 1, only: SyncAdvisoriesJob
+    assert_enqueued_with(job: SyncAdvisoriesJob, args: [force: true])
+  end
+
+  should "record an Avo audit against the operator" do
+    comment = "Warming the advisories table before enabling the public flag"
+
+    perform_action(comment:)
+
+    audit = Audit.sole
+
+    assert_equal comment, audit.comment
+    assert_equal "Sync Advisories", audit.action
+    assert_equal @current_user, audit.auditable
+    assert_equal "Advisory sync job scheduled", @action.response.dig(:messages, 0, :body)
+  end
+
+  should "be visible to rubygems.org operators on the index" do
+    action_context = Data.define(:current_user, :view).new(current_user: @current_user, view: :index)
+
+    assert action_context.instance_exec(&Avo::Actions::SyncAdvisories.visible)
+  end
+
+  should "not be visible on the show page" do
+    action_context = Data.define(:current_user, :view).new(current_user: @current_user, view: :show)
+
+    refute action_context.instance_exec(&Avo::Actions::SyncAdvisories.visible)
+  end
+
+  private
+
+  def perform_action(comment: "Warming the advisories table")
+    Advisory::OSV::Fetcher.any_instance.expects(:fetch).never
+
+    @action.handle(
+      fields: { comment: },
+      current_user: @current_user,
+      resource: nil,
+      records: [],
+      query: nil
+    )
+  end
+end

--- a/test/unit/avo/actions/sync_advisories_test.rb
+++ b/test/unit/avo/actions/sync_advisories_test.rb
@@ -35,6 +35,21 @@ class SyncAdvisoriesTest < ActiveJob::TestCase
     assert_equal "Unknown advisory source", @action.response.dig(:messages, 0, :body)
   end
 
+  should "error when the sync job fails to enqueue" do
+    SyncAdvisoriesJob.stubs(:perform_later).returns(false)
+
+    perform_action
+
+    assert_no_enqueued_jobs only: SyncAdvisoriesJob
+
+    audit = Audit.sole
+
+    assert_equal @current_user, audit.auditable
+    assert_equal "Failed to enqueue advisory sync job. Another may already be queued", @action.response.dig(:messages, 0, :body)
+    assert_equal :error, @action.response.dig(:messages, 0, :type)
+    assert_equal :keep_modal_open, @action.response[:type]
+  end
+
   should "record an Avo audit against the operator" do
     comment = "Warming the advisories table before enabling the public flag"
 

--- a/test/views/rubygem/advisories_component_test.rb
+++ b/test/views/rubygem/advisories_component_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Rubygem::AdvisoriesComponentTest < ComponentTest
+  def render_page(component)
+    Capybara.string(render(component))
+  end
+
+  def advisory(**attrs)
+    build(:advisory, :unfixed, **attrs)
+  end
+
+  should "render nothing when there are no affected advisories" do
+    page = render_page Rubygem::AdvisoriesComponent.new(
+      advisories: [advisory(ranges: ["introduced" => "2.0.0"])],
+      version: build(:version, number: "1.0.0")
+    )
+
+    refute page.has_css?("[data-testid='gem-advisories']")
+  end
+
+  should "render nothing when advisories are empty" do
+    page = render_page Rubygem::AdvisoriesComponent.new(advisories: [], version: build(:version, number: "1.0.0"))
+
+    refute page.has_css?("[data-testid='gem-advisories']")
+  end
+
+  should "render advisory details and a link" do
+    advisory = advisory(
+      identifier: "GHSA-mm33-5vfq-3mm3",
+      aliases: ["CVE-2022-22577"],
+      summary: "Cross-site Scripting Vulnerability",
+      severity: :moderate,
+      url: "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3"
+    )
+    page = render_page Rubygem::AdvisoriesComponent.new(
+      advisories: [advisory],
+      version: build(:version, number: "1.0.0")
+    )
+
+    assert page.has_css?("[data-testid='gem-advisories']")
+    assert page.has_text?("1 known security vulnerability")
+    assert page.has_text?("moderate")
+    assert page.has_text?("GHSA-mm33-5vfq-3mm3")
+    assert page.has_text?("CVE-2022-22577")
+    assert page.has_text?("Cross-site Scripting Vulnerability")
+    assert page.has_link?("View advisory", href: "https://osv.dev/vulnerability/GHSA-mm33-5vfq-3mm3")
+    assert page.has_css?(".bg-yellow-200")
+  end
+
+  should "use the error style when a high or critical advisory is present" do
+    page = render_page Rubygem::AdvisoriesComponent.new(
+      advisories: [advisory(severity: :critical), advisory(severity: :moderate)],
+      version: build(:version, number: "1.0.0")
+    )
+
+    assert page.has_css?(".bg-red-200")
+    assert page.has_text?("2 known security vulnerabilities")
+  end
+
+  should "sort advisories by severity" do
+    page = render_page Rubygem::AdvisoriesComponent.new(
+      advisories: [
+        advisory(identifier: "GHSA-loww-0000-0001", severity: :low),
+        advisory(identifier: "GHSA-crit-0000-0001", severity: :critical),
+        advisory(identifier: "GHSA-high-0000-0001", severity: :high)
+      ],
+      version: build(:version, number: "1.0.0")
+    )
+
+    text = page.text
+
+    assert_operator text.index("GHSA-crit-0000-0001"), :<, text.index("GHSA-high-0000-0001")
+    assert_operator text.index("GHSA-high-0000-0001"), :<, text.index("GHSA-loww-0000-0001")
+  end
+end

--- a/test/views/rubygem/advisories_component_test.rb
+++ b/test/views/rubygem/advisories_component_test.rb
@@ -59,12 +59,23 @@ class Rubygem::AdvisoriesComponentTest < ComponentTest
     assert page.has_text?("2 known security vulnerabilities")
   end
 
+  should "label malware and use the error style" do
+    page = render_page Rubygem::AdvisoriesComponent.new(
+      advisories: [advisory(identifier: "MAL-2026-9999", severity: nil)],
+      version: build(:version, number: "1.0.0")
+    )
+
+    assert page.has_text?("Malware")
+    assert page.has_css?(".bg-red-200")
+  end
+
   should "sort advisories by severity" do
     page = render_page Rubygem::AdvisoriesComponent.new(
       advisories: [
         advisory(identifier: "GHSA-loww-0000-0001", severity: :low),
         advisory(identifier: "GHSA-crit-0000-0001", severity: :critical),
-        advisory(identifier: "GHSA-high-0000-0001", severity: :high)
+        advisory(identifier: "GHSA-high-0000-0001", severity: :high),
+        advisory(identifier: "MAL-2026-9999", severity: nil)
       ],
       version: build(:version, number: "1.0.0")
     )
@@ -73,5 +84,7 @@ class Rubygem::AdvisoriesComponentTest < ComponentTest
 
     assert_operator text.index("GHSA-crit-0000-0001"), :<, text.index("GHSA-high-0000-0001")
     assert_operator text.index("GHSA-high-0000-0001"), :<, text.index("GHSA-loww-0000-0001")
+    assert_operator text.index("GHSA-crit-0000-0001"), :<, text.index("MAL-2026-9999")
+    assert_operator text.index("MAL-2026-9999"), :<, text.index("GHSA-high-0000-0001")
   end
 end


### PR DESCRIPTION
## Summary

- Store OSV RubyGems advisories and show warnings on gem/version pages for the version being viewed (banner + “vulnerable” on affected versions)
- Behind `:osv_advisories`. Hourly sync when the flag is on; Avo **Sync Advisories** can force-fill the table while it is still off
- More details: [Google Doc](https://docs.google.com/document/d/1_hMaYWMuH-wEg8blvP8AE1BQ-p6jgOyB0iTL3uEXcjw/edit?usp=sharing)
- Issue: https://github.com/rubygems/roadmap/issues/6

-----
<img width="989" height="782" alt="image" src="https://github.com/user-attachments/assets/9419c211-acb0-461f-bcff-011b07b9ba3e" />

-----

## Test plan

- [ ] Flag off: no banner, no “vulnerable”, hourly job does not fetch
- [ ] Avo force-sync with the flag off fills the table
- [ ] Flag on: affected latest version shows the banner and “View advisory”; patched latest does not
- [ ] Versions index marks only affected versions as vulnerable
- [ ] Withdrawn advisories are hidden