### PR TITLE
Remove the `response_time_ms` log attribute from the request log payload

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -26,7 +26,6 @@ ActiveSupport.on_load(:action_controller) do
       request_id: request.uuid,
       method: request.method,
       status_code: response.status,
-      response_time_ms: request.url,
       useragent: request.user_agent,
       url: request.url
     }


### PR DESCRIPTION
- The `http.response_time_ms` log attribute had a value of `request.url`, which was obviously incorrect. The top-level `duration` attribute already contains total timings.