### PR TITLE
Unskip the two pattern tests that are linear now

### DIFF
--- a/test/unit/patterns_test.rb
+++ b/test/unit/patterns_test.rb
@@ -22,14 +22,10 @@ class PatternsTest < ActiveSupport::TestCase
   end
 
   test "VERSION_PATTERN is linear" do
-    skip "regexp is not linear"
-
     assert Regexp.linear_time?(Patterns::VERSION_PATTERN)
   end
 
   test "REQUIREMENT_PATTERN is linear" do
-    skip "regexp is not linear"
-
     assert Regexp.linear_time?(Patterns::REQUIREMENT_PATTERN)
   end
 


### PR DESCRIPTION
- `VERSION_PATTERN` and `REQUIREMENT_PATTERN` just wrap `Gem::Version::VERSION_PATTERN` and `Gem::Requirement::PATTERN`, and both are linear now, so upstream fixed them. The skips have been sat there since PR 4065 in September 2023.