### PR TITLE
Log user IDs and API key IDs for authenticated requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -54,6 +54,7 @@ class Api::BaseController < ApplicationController
     hashed_key = Digest::SHA256.hexdigest(params_key)
     @api_key   = ApiKey.unexpired.find_by_hashed_key(hashed_key)
     return render_unauthorized unless @api_key
+    Current.api_key = @api_key
     set_tags "gemcutter.api_key.owner" => @api_key.owner.to_gid, "gemcutter.user.api_key_id" => @api_key.id
     return render_forbidden(t(:email_not_confirmed)) if @api_key.user&.unconfirmed?
     Current.user = @api_key.user

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -50,6 +50,7 @@ class Api::V1::ApiKeysController < Api::BaseController
     if user.unconfirmed?
       render_forbidden t(:email_not_confirmed)
     elsif user.mfa_gem_signin_authorized?(otp)
+      Current.user = user
       if user.mfa_required_not_yet_enabled?
         render_forbidden t("multifactor_auths.api.mfa_required_not_yet_enabled").chomp
       elsif user.mfa_required_weak_level_enabled?

--- a/app/controllers/api/v1/oidc/api_key_roles_controller.rb
+++ b/app/controllers/api/v1/oidc/api_key_roles_controller.rb
@@ -77,5 +77,6 @@ class Api::V1::OIDC::ApiKeyRolesController < Api::BaseController
 
   def verify_access
     @api_key_role.access_policy.verify_access!(@jwt)
+    Current.user = @api_key_role.user
   end
 end

--- a/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
+++ b/app/controllers/api/v1/oidc/trusted_publisher_controller.rb
@@ -51,6 +51,7 @@ class Api::V1::OIDC::TrustedPublisherController < Api::BaseController
       raise UnsupportedIssuer, "Unsuported issuer for trusted publishing"
     end
     @trusted_publisher = trusted_publisher_class.for_claims(@jwt)
+    Current.api_key_owner = @trusted_publisher
   end
 
   def validate_claims

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -14,6 +14,7 @@ class Api::V1::ProfilesController < Api::BaseController
   def me
     authenticate_or_request_with_http_basic do |username, password|
       if (user = User::WithPrivateFields.authenticate(username.strip, password))
+        Current.user = user
         respond_to do |format|
           format.json { render json: user }
           format.yaml { render yaml: user }

--- a/app/controllers/api/v1/webauthn_verifications_controller.rb
+++ b/app/controllers/api/v1/webauthn_verifications_controller.rb
@@ -45,9 +45,15 @@ class Api::V1::WebauthnVerificationsController < Api::BaseController
   end
 
   def authenticated_user(api_key)
-    return api_key.user if api_key&.user?
+    if api_key&.user?
+      Current.api_key = api_key
+      return Current.user = api_key.user
+    end
+    # Rails treats the block's return value as the auth result;
+    # assigning it to Current.user returns the same value, so auth is
+    # unchanged and the user is recorded for logs.
     authenticate_or_request_with_http_basic do |username, password|
-      User.authenticate(username.strip, password)
+      Current.user = User.authenticate(username.strip, password)
     end
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -31,6 +31,7 @@ class DashboardsController < ApplicationController
     hashed_key = Digest::SHA256.hexdigest(params_key)
     return unless (@api_key = ApiKey.unexpired.find_by_hashed_key(hashed_key))
 
+    Current.api_key = @api_key
     set_tags "gemcutter.api_key.owner" => @api_key.owner.to_gid, "gemcutter.api_key" => @api_key.to_gid
     render plain: "An invalid API key cannot be used. Please delete it and create a new one.", status: :forbidden if @api_key.soft_deleted?
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -101,6 +101,7 @@ class SessionsController < Clearance::SessionsController
   def do_login(two_factor_label:, two_factor_method:, authentication_method:)
     sign_in(@user) do |status|
       if status.success?
+        Current.user = @user
         StatsD.increment "login.success"
         current_user.record_event!(Events::UserEvent::LOGIN_SUCCESS, request:,
           two_factor_method:, two_factor_label:, authentication_method:)

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -3,4 +3,9 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :request
   attribute :user
+  # The ApiKey that authenticated this request, if any.
+  attribute :api_key
+  # The principal a key is being issued to when no key has authenticated the
+  # request yet (OIDC trusted publisher token exchange).
+  attribute :api_key_owner
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -14,7 +14,18 @@ ActiveSupport.on_load(:action_controller) do
       }
     )
     super
-    payload[:rails] = {
+
+    payload[:rails] = log_payload_rails(payload)
+    payload[:http] = log_payload_http
+
+    identity = log_payload_identity
+    payload[:identity] = identity if identity.any?
+
+    payload[:message] ||= log_payload_message(payload)
+  end
+
+  def log_payload_rails(payload)
+    {
       controller: payload.fetch(:controller),
       action: payload.fetch(:action),
       params: request.filtered_parameters.except('controller', 'action', 'format', 'utf8'),
@@ -22,24 +33,32 @@ ActiveSupport.on_load(:action_controller) do
       view_time_ms: payload.fetch(:view_runtime, 0.0),
       db_time_ms: payload.fetch(:db_runtime, 0.0)
     }
-    payload[:http] = {
+  end
+
+  def log_payload_http
+    {
       request_id: request.uuid,
       method: request.method,
       status_code: response.status,
       useragent: request.user_agent,
       url: request.url
     }
+  end
 
-    identity = {
+  def log_payload_identity
+    {
       user_id: Current.user&.id,
       api_key_id: @api_key.is_a?(ApiKey) ? @api_key.id : nil
     }.compact
-    payload[:identity] = identity if identity.any?
+  end
 
-    method_and_path = [request.method, request.path].compact_blank
-    method_and_path_string = method_and_path.empty? ? ' ' : " #{method_and_path.join(' ')} "
+  # e.g. "[200] GET /gems/rails (RubygemsController#show)"
+  def log_payload_message(payload)
+    status = "[#{response.status}]"
+    method_and_path = [request.method, request.path].compact_blank.join(' ').presence
+    controller_action = "(#{payload.fetch(:controller)}##{payload.fetch(:action)})"
 
-    payload[:message] ||= "[#{response.status}]#{method_and_path_string}(#{payload.fetch(:controller)}##{payload.fetch(:action)})"
+    [status, method_and_path, controller_action].compact.join(' ')
   end
 end
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -30,6 +30,12 @@ ActiveSupport.on_load(:action_controller) do
       url: request.url
     }
 
+    identity = {
+      user_id: Current.user&.id,
+      api_key_id: @api_key.is_a?(ApiKey) ? @api_key.id : nil
+    }.compact
+    payload[:identity] = identity if identity.any?
+
     method_and_path = [request.method, request.path].compact_blank
     method_and_path_string = method_and_path.empty? ? ' ' : " #{method_and_path.join(' ')} "
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -46,29 +46,19 @@ ActiveSupport.on_load(:action_controller) do
   end
 
   # Only principals whose credentials were verified are logged; a later 403
-  # does not remove them. Sources:
-  #   user_id              - Current.user (web session, user-owned API key, basic auth)
-  #   api_key_id           - Current.api_key, the key that authenticated the request
-  #   api_key_owner_type/id - the key's polymorphic owner (User or a trusted
-  #                          publisher), or the publisher a key is being issued
-  #                          to during an OIDC token exchange
-  #   admin_github_user_id - the Admin::GitHubUser resolved by AdminAuth
+  # does not remove them. The owner is the authenticating key's polymorphic
+  # owner (User or a trusted publisher) or, during an OIDC token exchange
+  # where no key exists yet, the publisher the key is being issued to.
   def log_payload_identity
     api_key = Current.api_key
-    owner_type, owner_id = log_payload_api_key_owner(api_key)
+    owner = Current.api_key_owner
     {
       user_id: Current.user&.id,
       api_key_id: api_key&.id,
-      api_key_owner_type: owner_type,
-      api_key_owner_id: owner_id,
+      api_key_owner_type: api_key ? api_key.owner_type : owner&.class&.polymorphic_name,
+      api_key_owner_id: api_key ? api_key.owner_id : owner&.id,
       admin_github_user_id: request.get_header(GitHubOAuthable::ADMIN_USER_REQUEST_HEADER)&.id
     }.compact
-  end
-
-  def log_payload_api_key_owner(api_key)
-    return [api_key.owner_type, api_key.owner_id] if api_key
-    owner = Current.api_key_owner
-    [owner.class.polymorphic_name, owner.id] if owner
   end
 
   # e.g. "[200] GET /gems/rails (RubygemsController#show)"

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -45,11 +45,30 @@ ActiveSupport.on_load(:action_controller) do
     }
   end
 
+  # Only principals whose credentials were verified are logged; a later 403
+  # does not remove them. Sources:
+  #   user_id              - Current.user (web session, user-owned API key, basic auth)
+  #   api_key_id           - Current.api_key, the key that authenticated the request
+  #   api_key_owner_type/id - the key's polymorphic owner (User or a trusted
+  #                          publisher), or the publisher a key is being issued
+  #                          to during an OIDC token exchange
+  #   admin_github_user_id - the Admin::GitHubUser resolved by AdminAuth
   def log_payload_identity
+    api_key = Current.api_key
+    owner_type, owner_id = log_payload_api_key_owner(api_key)
     {
       user_id: Current.user&.id,
-      api_key_id: @api_key.is_a?(ApiKey) ? @api_key.id : nil
+      api_key_id: api_key&.id,
+      api_key_owner_type: owner_type,
+      api_key_owner_id: owner_id,
+      admin_github_user_id: request.get_header(GitHubOAuthable::ADMIN_USER_REQUEST_HEADER)&.id
     }.compact
+  end
+
+  def log_payload_api_key_owner(api_key)
+    return [api_key.owner_type, api_key.owner_id] if api_key
+    owner = Current.api_key_owner
+    [owner.class.polymorphic_name, owner.id] if owner
   end
 
   # e.g. "[200] GET /gems/rails (RubygemsController#show)"

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -49,6 +49,8 @@ ActiveSupport.on_load(:action_controller) do
   # does not remove them. The owner is the authenticating key's polymorphic
   # owner (User or a trusted publisher) or, during an OIDC token exchange
   # where no key exists yet, the publisher the key is being issued to.
+  # The admin user is the Admin::GitHubUser that Gemcutter::Middleware::AdminAuth
+  # stores on the request env (see GitHubOAuthable#admin_user_request_header).
   def log_payload_identity
     api_key = Current.api_key
     owner = Current.api_key_owner
@@ -57,7 +59,7 @@ ActiveSupport.on_load(:action_controller) do
       api_key_id: api_key&.id,
       api_key_owner_type: api_key ? api_key.owner_type : owner&.class&.polymorphic_name,
       api_key_owner_id: api_key ? api_key.owner_id : owner&.id,
-      admin_github_user_id: request.get_header(GitHubOAuthable::ADMIN_USER_REQUEST_HEADER)&.id
+      admin_github_user_id: request.get_header("gemcutter.rubygems_admin_oauth_github_user")&.id
     }.compact
   end
 

--- a/lib/github_oauthable.rb
+++ b/lib/github_oauthable.rb
@@ -4,6 +4,10 @@ module GitHubOAuthable
   extend ActiveSupport::Concern
   include SemanticLogger::Loggable
 
+  # Request env key under which Gemcutter::Middleware::AdminAuth stores the
+  # authenticated Admin::GitHubUser (or nil) for admin requests.
+  ADMIN_USER_REQUEST_HEADER = "gemcutter.rubygems_admin_oauth_github_user"
+
   INFO_QUERY = <<~GRAPHQL
     query($organization_name:String!) {
       viewer {
@@ -84,7 +88,7 @@ module GitHubOAuthable
     end
 
     def admin_user_request_header
-      "gemcutter.rubygems_admin_oauth_github_user"
+      ADMIN_USER_REQUEST_HEADER
     end
 
     def fetch_admin_user_info(oauth_token)

--- a/lib/github_oauthable.rb
+++ b/lib/github_oauthable.rb
@@ -4,10 +4,6 @@ module GitHubOAuthable
   extend ActiveSupport::Concern
   include SemanticLogger::Loggable
 
-  # Request env key under which Gemcutter::Middleware::AdminAuth stores the
-  # authenticated Admin::GitHubUser (or nil) for admin requests.
-  ADMIN_USER_REQUEST_HEADER = "gemcutter.rubygems_admin_oauth_github_user"
-
   INFO_QUERY = <<~GRAPHQL
     query($organization_name:String!) {
       viewer {
@@ -88,7 +84,7 @@ module GitHubOAuthable
     end
 
     def admin_user_request_header
-      ADMIN_USER_REQUEST_HEADER
+      "gemcutter.rubygems_admin_oauth_github_user"
     end
 
     def fetch_admin_user_info(oauth_token)

--- a/test/integration/request_log_payload_test.rb
+++ b/test/integration/request_log_payload_test.rb
@@ -63,4 +63,43 @@ class RequestLogPayloadTest < ActionDispatch::IntegrationTest
 
     assert_equal "[404] GET /gems/definitely-not-a-real-gem (RubygemsController#show)", payload[:message]
   end
+
+  test "anonymous request logs no identity" do
+    payload = capture_request_payload { get "/" }
+
+    refute payload.key?(:identity)
+  end
+
+  test "signed-in web request logs the user id only" do
+    user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    payload = capture_request_payload { get dashboard_path }
+
+    assert_equal({ user_id: user.id }, payload[:identity])
+  end
+
+  test "API request logs the user id and api key id" do
+    api_key = create(:api_key, key: "12345", scopes: %w[index_rubygems])
+
+    payload = capture_request_payload do
+      get api_v1_rubygems_path(format: :json), headers: { "HTTP_AUTHORIZATION" => "12345" }
+    end
+
+    assert_response :success
+    assert_equal({ user_id: api_key.user.id, api_key_id: api_key.id }, payload[:identity])
+  end
+
+  test "API request with a trusted-publisher key logs the api key id without a user id" do
+    api_key = create(:api_key, :trusted_publisher, key: "tp-key-12345")
+
+    payload = capture_request_payload do
+      # The response itself may be a 403 (trusted-publisher keys have narrow
+      # scopes); the payload is built after authentication either way.
+      get api_v1_rubygems_path(format: :json), headers: { "HTTP_AUTHORIZATION" => "tp-key-12345" }
+    end
+
+    assert_nil payload[:identity][:user_id]
+    assert_equal api_key.id, payload[:identity][:api_key_id]
+  end
 end

--- a/test/integration/request_log_payload_test.rb
+++ b/test/integration/request_log_payload_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestLogPayloadTest < ActionDispatch::IntegrationTest
+  def capture_request_payload
+    payloads = []
+    subscriber = ActiveSupport::Notifications.subscribe("process_action.action_controller") do |event|
+      payloads << event.payload
+    end
+    yield
+    payloads.sole
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  test "semantic logger is configured with the application name" do
+    assert_equal "rubygems.org", SemanticLogger.application
+  end
+
+  test "payload carries timestamp, env and client network info" do
+    payload = capture_request_payload { get "/" }
+
+    assert_kind_of Time, payload[:timestamp]
+    assert_predicate payload[:timestamp], :utc?
+    assert_equal "test", payload[:env]
+    assert_equal({ client: { ip: "127.0.0.1" } }, payload[:network])
+  end
+
+  test "rails block carries controller, action, params, format and timings" do
+    payload = capture_request_payload { get "/search?query=rails&utf8=%E2%9C%93" }
+
+    rails = payload[:rails]
+
+    assert_equal "SearchesController", rails[:controller]
+    assert_equal "show", rails[:action]
+    # utf8 (and routing keys) are stripped; real query params remain
+    assert_equal({ "query" => "rails" }, rails[:params])
+    assert_equal "html", rails[:format].to_s
+    assert_kind_of Numeric, rails[:view_time_ms]
+    assert_kind_of Numeric, rails[:db_time_ms]
+  end
+
+  test "http block carries request id, method, status and url" do
+    payload = capture_request_payload { get "/" }
+
+    http = payload[:http]
+
+    assert_match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, http[:request_id])
+    assert_equal "GET", http[:method]
+    assert_equal 200, http[:status_code]
+    assert_match %r{\Ahttp://[^/]+/\z}, http[:url]
+  end
+
+  test "message summarizes status, method, path and controller action" do
+    payload = capture_request_payload { get "/" }
+
+    assert_equal "[200] GET / (HomeController#index)", payload[:message]
+  end
+
+  test "message reflects non-success statuses" do
+    payload = capture_request_payload { get "/gems/definitely-not-a-real-gem" }
+
+    assert_equal "[404] GET /gems/definitely-not-a-real-gem (RubygemsController#show)", payload[:message]
+  end
+end

--- a/test/integration/request_log_payload_test.rb
+++ b/test/integration/request_log_payload_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class RequestLogPayloadTest < ActionDispatch::IntegrationTest
+  include AdminHelpers
+
   def capture_request_payload
     payloads = []
     subscriber = ActiveSupport::Notifications.subscribe("process_action.action_controller") do |event|
@@ -87,10 +89,13 @@ class RequestLogPayloadTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_equal({ user_id: api_key.user.id, api_key_id: api_key.id }, payload[:identity])
+    assert_equal(
+      { user_id: api_key.user.id, api_key_id: api_key.id, api_key_owner_type: "User", api_key_owner_id: api_key.user.id },
+      payload[:identity]
+    )
   end
 
-  test "API request with a trusted-publisher key logs the api key id without a user id" do
+  test "API request with a trusted-publisher key logs the api key id and its owner, no user id" do
     api_key = create(:api_key, :trusted_publisher, key: "tp-key-12345")
 
     payload = capture_request_payload do
@@ -99,7 +104,78 @@ class RequestLogPayloadTest < ActionDispatch::IntegrationTest
       get api_v1_rubygems_path(format: :json), headers: { "HTTP_AUTHORIZATION" => "tp-key-12345" }
     end
 
-    assert_nil payload[:identity][:user_id]
-    assert_equal api_key.id, payload[:identity][:api_key_id]
+    assert_equal(
+      { api_key_id: api_key.id, api_key_owner_type: "OIDC::TrustedPublisher::GitHubAction", api_key_owner_id: api_key.owner_id },
+      payload[:identity]
+    )
+  end
+
+  test "web request managing an api key does not log it as the authenticating key" do
+    user = create(:user, remember_token_expires_at: Gemcutter::REMEMBER_FOR.from_now)
+    api_key = create(:api_key, owner: user)
+    post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+    post authenticate_session_path(verify_password: { password: PasswordHelpers::SECURE_TEST_PASSWORD })
+
+    payload = capture_request_payload { get edit_profile_api_key_path(api_key) }
+
+    assert_response :success
+    assert_equal({ user_id: user.id }, payload[:identity])
+  end
+
+  test "sign-in request logs the user id once signed in" do
+    user = create(:user)
+
+    payload = capture_request_payload do
+      post session_path(session: { who: user.handle, password: PasswordHelpers::SECURE_TEST_PASSWORD })
+    end
+
+    assert_response :redirect
+    assert_equal({ user_id: user.id }, payload[:identity])
+  end
+
+  test "basic-auth API request logs the user id" do
+    user = create(:user)
+    auth = ActionController::HttpAuthentication::Basic.encode_credentials(user.email, user.password)
+
+    payload = capture_request_payload do
+      post api_v1_api_key_path, params: { name: "ci-key", index_rubygems: "true" }, headers: { "HTTP_AUTHORIZATION" => auth }
+    end
+
+    assert_response :success
+    assert_equal({ user_id: user.id }, payload[:identity])
+  end
+
+  test "trusted publisher token exchange logs the publisher as the api key owner" do
+    pkey = OpenSSL::PKey::RSA.generate(2048)
+    create(:oidc_provider, issuer: OIDC::Provider::GITHUB_ACTIONS_ISSUER, pkey:)
+    trusted_publisher = create(:oidc_trusted_publisher_github_action)
+    now = Time.now.to_i
+    jwt = JSON::JWT.new(
+      "iss" => OIDC::Provider::GITHUB_ACTIONS_ISSUER, "aud" => Gemcutter::HOST, "jti" => SecureRandom.uuid,
+      "nbf" => now - 60, "iat" => now - 60, "exp" => now + 600,
+      "repository" => trusted_publisher.repository, "repository_owner_id" => trusted_publisher.repository_owner_id,
+      "ref" => "refs/heads/main",
+      "job_workflow_ref" => "#{trusted_publisher.repository}/#{trusted_publisher.workflow_slug}@refs/heads/main"
+    ).sign(pkey.to_jwk)
+
+    payload = capture_request_payload do
+      post api_v1_oidc_trusted_publisher_exchange_token_path, params: { jwt: jwt.to_s }
+    end
+
+    assert_response :created
+    assert_equal(
+      { api_key_owner_type: "OIDC::TrustedPublisher::GitHubAction", api_key_owner_id: trusted_publisher.id },
+      payload[:identity]
+    )
+  end
+
+  test "admin request logs the admin github user id" do
+    admin = create(:admin_github_user, :is_admin)
+    admin_sign_in_as admin
+
+    payload = capture_request_payload { get avo.resources_admin_github_users_path }
+
+    assert_response :success
+    assert_equal admin.id, payload[:identity][:admin_github_user_id]
   end
 end


### PR DESCRIPTION
- Add an `identity` block to the request log payload. Just `user_id` from `Current.user` and `api_key_id`. No handles or emails.

- Datadog traces already tag these IDs, but traces are sampled and may not capture every request when operators need to investigate problems.

- Best reviewed commit by commit, and/or with whitespace disabled, as I moved things around to appease RuboCop and added some new tests.