### PR TITLE
CONTRIBUTING: The Google Group and IRC channel are dead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,7 @@ Once you’re ready:
 
 If you’re looking for things to hack on, please check
 [GitHub Issues](https://github.com/rubygems/rubygems.org/issues). If you’ve
-found bugs or have feature ideas don’t be afraid to pipe up and ask the
-[mailing list](https://groups.google.com/group/rubygems-org) or IRC channel
-(`#rubygems` on `irc.freenode.net`) about them.
+found bugs or have feature ideas, use [GitHub Discussions](https://github.com/rubygems/rubygems.org/discussions).
 
 Acceptance
 ----------


### PR DESCRIPTION
- The #rubygems channel on freenode is now unregistered and empty since freenode's demise.
- The Google Group hasn't had any messages since 2023.
- So, route people to GitHub Discussions.