### PR TITLE
Remove ActiveSupport dependency from compact index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -164,6 +164,10 @@ Style/ClassAndModuleChildren:
     - lib/gemcutter/middleware/hostess.rb
     - lib/gemcutter/middleware/redirector.rb
 
+Rails/Present:
+  Exclude:
+    - lib/compact_index/*.rb
+
 Rails/ThreeStateBooleanColumn:
   Enabled: false
 

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -3,7 +3,7 @@
 module CompactIndex
   module GemVersionMethods
     def version_token
-      return "#{number}-#{content_address}" if content_address.present?
+      return "#{number}-#{content_address}" if content_address?
 
       if platform.nil? || platform == "ruby"
         number
@@ -27,11 +27,15 @@ module CompactIndex
       line = "#{version_token} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
-      line << ",platform:= #{platform}" if content_address.present?
+      line << ",platform:= #{platform}" if content_address?
       line
     end
 
     private
+
+    def content_address?
+      !content_address.nil? && !content_address.empty?
+    end
 
     def ruby_version_line
       join_multiple(ruby_version)


### PR DESCRIPTION
Replace `Object#present?` (ActiveSupport) with a pure-Ruby private predicate in `CompactIndex::GemVersionMethods`, so the vendored `lib/compact_index*` files in the client no longer rely on Rails being loaded. The predicate preserves `present?` semantics for `content_address` (nil or a non-empty hex string), guarding the empty-string case rather than relying on the host application's model validation invariant.

Ref: https://github.com/ruby/rubygems/pull/9773#discussion_r3890778375