### PR TITLE
fix: support keyboard navigation for header search

### DIFF
--- a/app/javascript/controllers/reveal_search_controller.js
+++ b/app/javascript/controllers/reveal_search_controller.js
@@ -3,8 +3,25 @@ import Reveal from "controllers/reveal_controller";
 export default class extends Reveal {
   static targets = ["item", "toggle", "button", "input"];
 
-  // There's nothing here because this is just a copy of the reveal controller
-  // with a different name. This saves us from a name conflict in the header.
+  focus(event) {
+    if (
+      event.key !== "/" ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      event.target.closest(
+        "input, textarea, select, [contenteditable]:not([contenteditable='false'])",
+      )
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    this.show();
+    this.inputTarget.focus();
+  }
+
   toggle() {
     super.toggle();
     if (!this.itemTarget.classList.contains("hidden")) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     <header class="bg-white dark:bg-black">
       <!-- Header Nav -->
       <div class="py-4 px-8 border-b border-neutral-400 dark:border-neutral-800">
-        <div class="flex flex-wrap justify-between max-w-screen-xl mx-auto" data-controller="reveal-search" data-reveal-search-toggle-class="bg-neutral-200 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-200 border">
+        <div class="flex flex-wrap justify-between max-w-screen-xl mx-auto" data-controller="reveal-search" data-action="keydown@window->reveal-search#focus" data-reveal-search-toggle-class="bg-neutral-200 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-200 border">
           <!-- Menu button, Logo, desktop nav, mobile nav dialog -->
           <div class="flex flex-row items-center xl:mr-auto" data-controller="dialog">
             <!-- Mobile Menu Button -->

--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -3,6 +3,71 @@
 require "application_system_test_case"
 
 class NavigationTest < ApplicationSystemTestCase
+  test "slash focuses the header search" do
+    visit stats_path
+
+    find("body").send_keys("/")
+
+    assert_selector "#query:focus"
+  end
+
+  test "slash reveals and focuses the header search on mobile" do
+    page.current_window.resize_to(393, 852)
+    visit stats_path
+
+    assert_no_selector "[data-reveal-search-target='item']", visible: true
+
+    find("body").send_keys("/")
+
+    assert_selector "[data-reveal-search-target='item']", visible: true
+    assert_selector "#query:focus"
+    assert_no_selector "dialog[open]"
+    assert_selector "button[aria-label='Open menu'][aria-expanded='false']"
+  end
+
+  test "slash remains available in editable elements" do
+    visit stats_path
+    page.execute_script <<~JAVASCRIPT
+      document.querySelector("main").insertAdjacentHTML(
+        "afterbegin",
+        '<textarea aria-label="Test editor"></textarea><div contenteditable="true" role="textbox" aria-label="Test content editor"></div>',
+      )
+    JAVASCRIPT
+
+    editor = find("textarea[aria-label='Test editor']")
+    editor.send_keys("/")
+
+    assert_field "Test editor", with: "/"
+    assert_no_selector "#query:focus"
+
+    content_editor = find("[aria-label='Test content editor']")
+    content_editor.send_keys("/")
+
+    assert_equal "/", content_editor.text
+    assert_no_selector "#query:focus"
+  end
+
+  test "modified slash does not focus the header search" do
+    visit stats_path
+
+    page.driver.with_playwright_page do |playwright_page|
+      playwright_page.keyboard.press("Control+/")
+    end
+
+    assert_no_selector "#query:focus"
+  end
+
+  test "tabbing on mobile leaves the navigation menu closed" do
+    page.current_window.resize_to(393, 852)
+    visit stats_path
+
+    find("body").send_keys(:tab)
+
+    assert_selector "button[aria-label='Open menu']:focus"
+    assert_no_selector "dialog[open]"
+    assert_selector "button[aria-label='Open menu'][aria-expanded='false']"
+  end
+
   test "closing the mobile menu with escape updates its expanded state" do
     page.current_window.resize_to(393, 852)
     visit root_path


### PR DESCRIPTION
Issue #5195 reports that keyboard navigation at narrow viewport widths can activate the navigation sidebar instead of leaving the search results usable, and asks for `/` to focus site search. The current responsive header, introduced by the recent layout rewrite, uses separate `dialog` and `reveal-search` Stimulus controllers; its mobile menu opens only through the menu button, but there is no global search shortcut. The remaining implementation should build on that controller boundary while locking in the expected Tab behavior so keyboard focus cannot reopen the historical sidebar failure. The shortcut must work across responsive layouts without stealing `/` from a user who is already typing in an editable control.

## Summary

Wire a window-level keydown action on the header's existing `reveal-search` controller and add a focused shortcut handler to `reveal_search_controller.js`. When an unmodified `/` originates outside an input, textarea, select, or editable element, prevent the browser's default quick-find behavior, reveal the responsive search region when necessary, and focus the controller's existing input target; otherwise leave the event untouched. Keep the mobile-menu `dialog` controller independent, with no new helper or abstraction, and add system coverage in the established navigation test for desktop focus, mobile reveal-and-focus, editable-field opt-out, and ordinary Tab traversal.

## What are the testing steps

- On a desktop-width non-home page, pressing an unmodified `/` outside an editable element focuses the header query field and prevents `/` from being entered elsewhere.
- At a narrow viewport where the header search region starts hidden, pressing `/` reveals that region, focuses its query field, and leaves the mobile navigation dialog closed.
- When focus is in a text/search input or another editable element, typing `/` remains normal input and does not move focus to the header query field; modifier-key combinations likewise do not invoke the shortcut.
- At a narrow viewport, advancing focus with Tab does not open the mobile navigation dialog or change its `aria-expanded="false"` state.

Fixes #5195
