### PR TITLE
Return 422 on failed user registration

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
       flash[:notice] = t(".email_sent")
       redirect_back_or_to root_path
     else
-      render template: "users/new"
+      render template: "users/new", status: :unprocessable_content
     end
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -96,7 +96,7 @@ class UsersControllerTest < ActionController::TestCase
         assert_no_changes -> { User.count } do
           post :create, params: { user: { password: PasswordHelpers::SECURE_TEST_PASSWORD } }
         end
-        assert_response :ok
+        assert_response :unprocessable_entity
         assert page.has_content?("Email address is not a valid email")
       end
     end


### PR DESCRIPTION
### Problem                                                                                                                                           
                                                                                                                                                       
`UsersController#create` rendered the users/new template with no status: on failed save, defaulting to 200 OK. A failed registration reporting success is misleading.                                                                    
                                                                                                                                                       
 ### Fix                                                                                                                                               
                                                                                                                                                       
 Return 422 Unprocessable Entity on validation failure.