### PR TITLE
Avoid organization handle query on unrelated user saves

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
 
   validates :handle, uniqueness: { case_sensitive: false }, allow_nil: true, if: :handle_changed?
   validates :handle, format: { with: Patterns::HANDLE_PATTERN }, length: { within: 2..40 }, allow_nil: true
-  validate :unique_with_org_handle
+  validate :unique_with_org_handle, if: :handle_changed?
 
   validates :twitter_username, format: {
     with: /\A[a-zA-Z0-9_]*\z/,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,6 +65,15 @@ class UserTest < ActiveSupport::TestCase
         assert_predicate build(:user, handle: nil), :valid?
       end
 
+      should "not check organization handles when the handle is unchanged" do
+        user = create(:user, handle: "someuser")
+        create(:organization).update_column(:handle, "someuser")
+
+        user.full_name = "A New Name"
+
+        assert_predicate user, :valid?
+      end
+
       should "show user id if no handle set" do
         user = build(:user, handle: nil, id: 13)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Saving a handled user for an unrelated change still ran the organization handle uniqueness query.

## What is your fix for the problem, implemented in this PR?

Run the cross-model organization handle validation only when the user's handle changes, matching the adjacent user handle uniqueness validation and the corresponding Organization validation.

A regression test simulates a pre-existing cross-model collision and verifies that changing another user attribute remains valid.

## What are the relevant tickets?

N/A

## What are the relevant developer-facing changes?

- Guard `unique_with_org_handle` with `handle_changed?`
- Cover unrelated User saves with a model regression test

## How was this tested?

- `PARALLEL_WORKERS=1 bin/rails test test/models/user_test.rb test/models/organization_test.rb`
- `bundle exec rubocop app/models/user.rb test/models/user_test.rb`
