### PR TITLE
Index case-insensitive Rubygem names

### DIFF
--- a/db/migrate/20260904073906_add_lower_name_index_to_rubygems.rb
+++ b/db/migrate/20260904073906_add_lower_name_index_to_rubygems.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddLowerNameIndexToRubygems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :rubygems, "lower(name)",
+      name: :index_rubygems_on_lower_name,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :rubygems, name: :index_rubygems_on_lower_name, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_04_071618) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_04_073906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -624,6 +624,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_071618) do
     t.string "name"
     t.bigint "organization_id"
     t.datetime "updated_at", precision: nil
+    t.index "lower((name)::text)", name: "index_rubygems_on_lower_name"
     t.index "regexp_replace(upper((name)::text), '[_-]'::text, ''::text, 'g'::text)", name: "dashunderscore_typos_idx"
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
     t.index ["indexed"], name: "index_rubygems_on_indexed"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The case-insensitive Rubygem name uniqueness validation queries with `LOWER(name)`, but the existing name indexes cannot serve that predicate.

## What is your fix for the problem, implemented in this PR?

Add a concurrent expression index on `lower(name)` and update the generated schema.

## What are the test cases for the changes?

- Migrated down and up, confirming concurrent index removal and creation
- Confirmed the index is valid and ready in PostgreSQL
- Confirmed `EXPLAIN` selects the new index for the case-insensitive predicate
- Confirmed repeated schema dumps are byte-stable
- `bin/rails test test/models/rubygem_test.rb`
- `bin/rubocop db/migrate/20260904073906_add_lower_name_index_to_rubygems.rb`
- `bin/ci` (all local style, Brakeman, Rails, and system-test stages passed; the npm advisory request timed out, while a direct `bin/importmap audit` retry passed)
