### PR TITLE
Remove decorative equals in compact index platform requirement

### DIFF
--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -27,7 +27,7 @@ module CompactIndex
       line = "#{version_token} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
-      line << ",platform:= #{platform}" if content_address?
+      line << ",platform:#{platform}" if content_address?
       line
     end
 

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -225,7 +225,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
 
     expected = <<~VERSIONS_FILE
       ---
-      2.9.0-#{content_address} |checksum:#{Version._sha256_hex(version.sha256)},ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:= x86_64-linux-musl,created_at:#{version.created_at.utc.iso8601}
+      2.9.0-#{content_address} |checksum:#{Version._sha256_hex(version.sha256)},ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:x86_64-linux-musl,created_at:#{version.created_at.utc.iso8601}
     VERSIONS_FILE
 
     expected_digest = digest(expected)

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -62,7 +62,7 @@ class CompactIndex::GemVersionV2Test < ActiveSupport::TestCase
       )
 
       assert_equal(
-        "2.9.0-ef716ba7 |checksum:ef716ba7abcdef,ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:= x86_64-linux-musl",
+        "2.9.0-ef716ba7 |checksum:ef716ba7abcdef,ruby:~> 3.2.0,rubygems:>= 4.1.0.beta1,platform:x86_64-linux-musl",
         version.to_line
       )
     end


### PR DESCRIPTION
After looking at the compact index spec https://guides.rubygems.org/rubygems-org-compact-index-api/, I don't think it makes sense for platform to be `platform:= x86_64-linux-musl` as it isn't a version requirement like ruby and rubygems and it's more consistent with checksum and created at requirements.