### PR TITLE
Document maintenance task principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ bin/importmap audit      # JS dependency vulnerability audit
 
 ## Conventions
 
+- For backfills and other updates to existing data, prefer `MaintenanceTasks::Task` over migrations or ad hoc scripts; follow [Maintenance tasks](doc/maintenance-tasks.md) for design and rollout principles.
 - master must stay fast-forwardable; branch off it for every change.
 - Run `bin/ci` locally before pushing — it mirrors CI (lint, security, tests).
 - User-facing strings: add keys to `config/locales/en.yml`, then run `bin/fill-locales` to propagate to other locales.

--- a/doc/maintenance-tasks.md
+++ b/doc/maintenance-tasks.md
@@ -1,0 +1,17 @@
+# Maintenance tasks
+
+## Shape
+
+Keep `collection` narrow, make each `process` call handle one record, and align `count` with the selected collection.
+
+## Safety
+
+The application may update a record before the task processes it. If that could affect the intended change, use an atomic conditional update that checks whether the change still applies, or reload the record under a database lock in a transaction and check before writing. Preserve newer writes, skip legitimately deleted records (including soft deletions), and make reruns harmless.
+
+## Behavior and rollout
+
+When new application behavior requires backfilled data, verify that the required data is present before enabling that behavior. Keep the running application working throughout the backfill, including while it is only partly complete.
+
+## Testing
+
+Test which records the task selects and what it changes, including failures, reruns, intervening application writes, and records deleted after collection. Check what was saved to the database and any other effects the task is responsible for.


### PR DESCRIPTION
## Summary
- Add concise maintenance-task guidance covering shape, safety, rollout, and testing.
- Link it from AGENTS.md for backfills and other updates to existing data.
- Keep framework-owned progress reporting and implementation-specific advice out of the guide.

## Validation
- `bin/prettier --check doc/maintenance-tasks.md` passed.
- `git diff --check` passed.
- Reviewed the complete branch diff; documentation changes only.
- `bin/ci` could not start because Ruby is not installed in the orb (`/usr/bin/env: ruby: No such file or directory`).