### PR TITLE
Eager load associations on Avo index pages

### DIFF
--- a/app/avo/resources/api_key.rb
+++ b/app/avo/resources/api_key.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::ApiKey < Avo::BaseResource
   self.title = :name
-  self.includes = []
+  self.includes = %i[owner api_key_rubygem_scope ownership oidc_id_token]
 
   class ExpiredFilter < Avo::Filters::ScopeBooleanFilter; end
   class TrustedPublisherFilter < Avo::Filters::ScopeBooleanFilter; end

--- a/app/avo/resources/api_key_rubygem_scope.rb
+++ b/app/avo/resources/api_key_rubygem_scope.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::ApiKeyRubygemScope < Avo::BaseResource
   self.title = :cache_key
-  self.includes = []
+  self.includes = %i[api_key ownership]
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/deletion.rb
+++ b/app/avo/resources/deletion.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::Deletion < Avo::BaseResource
-  self.includes = [:version]
+  self.includes = %i[version user]
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/dependency.rb
+++ b/app/avo/resources/dependency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::Dependency < Avo::BaseResource
-  self.includes = []
+  self.includes = %i[version rubygem]
 
   def fields
     field :id, as: :id, link_to_resource: true

--- a/app/avo/resources/link_verification.rb
+++ b/app/avo/resources/link_verification.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::LinkVerification < Avo::BaseResource
-  self.includes = []
+  self.includes = [:linkable]
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/membership.rb
+++ b/app/avo/resources/membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::Membership < Avo::BaseResource
-  self.includes = []
+  self.includes = %i[user organization]
 
   class ConfirmedFilter < Avo::Filters::ScopeBooleanFilter; end
 

--- a/app/avo/resources/oidc_api_key_role.rb
+++ b/app/avo/resources/oidc_api_key_role.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::OIDCApiKeyRole < Avo::BaseResource
   self.title = :token
-  self.includes = []
+  self.includes = %i[provider user]
   self.model_class = ::OIDC::ApiKeyRole
 
   def fields

--- a/app/avo/resources/oidc_id_token.rb
+++ b/app/avo/resources/oidc_id_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::OIDCIdToken < Avo::BaseResource
-  self.includes = []
+  self.includes = %i[api_key_role api_key provider]
   self.model_class = ::OIDC::IdToken
 
   def fields

--- a/app/avo/resources/oidc_pending_trusted_publisher.rb
+++ b/app/avo/resources/oidc_pending_trusted_publisher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::OIDCPendingTrustedPublisher < Avo::BaseResource
-  self.includes = []
+  self.includes = %i[user trusted_publisher]
   self.model_class = ::OIDC::PendingTrustedPublisher
 
   class ExpiredFilter < Avo::Filters::ScopeBooleanFilter; end

--- a/app/avo/resources/oidc_rubygem_trusted_publisher.rb
+++ b/app/avo/resources/oidc_rubygem_trusted_publisher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::OIDCRubygemTrustedPublisher < Avo::BaseResource
-  self.includes = [:trusted_publisher]
+  self.includes = %i[rubygem trusted_publisher]
   self.model_class = ::OIDC::RubygemTrustedPublisher
 
   def fields

--- a/app/avo/resources/organization_invite.rb
+++ b/app/avo/resources/organization_invite.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::OrganizationInvite < Avo::BaseResource
   self.title = :id
-  self.includes = [:invitable]
+  self.includes = %i[invitable user]
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/organization_onboarding.rb
+++ b/app/avo/resources/organization_onboarding.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::OrganizationOnboarding < Avo::BaseResource
   self.title = :organization_name
-  self.includes = [:invites]
+  self.includes = [:created_by]
 
   def actions
     action Avo::Actions::OnboardOrganization

--- a/app/avo/resources/ownership.rb
+++ b/app/avo/resources/ownership.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::Ownership < Avo::BaseResource
   self.title = :cache_key
-  self.includes = []
+  self.includes = %i[user rubygem authorizer]
 
   class ConfirmedFilter < Avo::Filters::ScopeBooleanFilter; end
 

--- a/app/avo/resources/subscription.rb
+++ b/app/avo/resources/subscription.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::Resources::Subscription < Avo::BaseResource
+  self.includes = %i[rubygem user]
+
   def fields
     field :id, as: :id
     field :rubygem_id, as: :number

--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -2,7 +2,7 @@
 
 class Avo::Resources::Version < Avo::BaseResource
   self.title = :full_name
-  self.includes = [:rubygem]
+  self.includes = %i[rubygem pusher pusher_api_key]
   self.search = {
     query: lambda {
              query.where("full_name LIKE ?", "#{params[:q]}%")

--- a/app/avo/resources/webauthn_credential.rb
+++ b/app/avo/resources/webauthn_credential.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::WebauthnCredential < Avo::BaseResource
-  self.includes = []
+  self.includes = [:user]
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/webauthn_verification.rb
+++ b/app/avo/resources/webauthn_verification.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Resources::WebauthnVerification < Avo::BaseResource
-  self.includes = []
+  self.includes = [:user]
 
   def fields
     field :id, as: :id

--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -15,7 +15,6 @@ if Rails.env.local?
       # avo auditing potentially loads things multiple times, but it will be bounded by the size of the audit
       "app/avo/actions/application_action.rb",
       "app/components/avo/fields/audited_changes_field/show_component.html.erb",
-      "app/components/avo/views/resource_index_component.html.erb",
 
       # feature flag management relies on a query per actor
       "config/initializers/flipper"


### PR DESCRIPTION
## Summary
Eager-load associations on Avo index pages so belongs_to / has_one columns don’t N+1.

## Test plan
- [ ] Open a few Avo index tables (API keys, versions, ownerships) and confirm related columns still render
- [ ] Check logs: one preload per association