### PR TITLE
Validate `required_rubygems_version` for content addressable gems

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -137,6 +137,7 @@ class Pusher
       )
 
     version.required_ruby_version = spec.required_ruby_version.to_s
+    version.required_rubygems_version = spec.required_rubygems_version.to_s
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
@@ -261,10 +262,7 @@ class Pusher
   def persist_version
     retries = 0
     begin
-      rubygem.transaction do
-        rubygem.update_attributes_from_gem_specification!(version, spec)
-        version.normalize_content_addressable_gem_metadata!
-      end
+      rubygem.update_attributes_from_gem_specification!(version, spec)
     rescue ActiveRecord::RecordNotUnique => e
       raise e unless e.message.include?("index_versions_number_content_address")
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -6,7 +6,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
   DEFAULT_CONTENT_ADDRESS_LENGTH = 8
   CONTENT_ADDRESS_FORMAT = /\A[0-9a-f]{#{DEFAULT_CONTENT_ADDRESS_LENGTH},64}\z/
-  CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION = ">= 4.1.0.beta1"
+  CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION = ">= 4.1.0.a"
 
   belongs_to :rubygem, touch: true
   has_many :dependencies, lambda {
@@ -53,16 +53,18 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     length: { minimum: 0, maximum: Gemcutter::MAX_TEXT_FIELD_LENGTH },
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
-  validates :sha256, presence: true, if: :content_addressable?
-  validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
-  validates :content_address, absence: true, unless: :content_addressable?
-  validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
-  validates :ruby_abi, absence: true, unless: :platformed?
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },
     if: -> { validation_context == :create || number_changed? || platform_changed? },
     presence: true
+
+  validates :sha256, presence: true, if: :content_addressable?
+  validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
+  validates :content_address, absence: true, unless: :content_addressable?
+  validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
+  validates :ruby_abi, absence: true, unless: :platformed?
+  validate :content_addressable_required_rubygems_version, if: :content_addressable?
 
   validate :unique_canonical_number, on: :create
   validate :platform_and_number_are_unique, on: :create
@@ -499,37 +501,26 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     platform.present? && platform != "ruby"
   end
 
-  def normalize_content_addressable_gem_metadata!
-    return unless content_addressable?
-    return if required_rubygems_version_satisfies_content_addressable_floor?
-    preserved = required_rubygems_version.to_s.split(/\s*,\s*/).filter_map do |req|
-      req = req.strip
-      if req.start_with?("~>")
-        "< #{Gem::Version.new(req[2..].strip).bump}"
-      elsif req.start_with?("<", "!=")
-        req
-      end
-    end
-    update!(required_rubygems_version: [CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, *preserved].join(", "))
+  private
+
+  def content_addressable_required_rubygems_version
+    return if meets_content_addressable_rubygems_floor?
+
+    errors.add(:required_rubygems_version,
+               "must be #{CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION} for content-addressable gems (set required_rubygems_version in the gemspec)")
   end
 
-  def required_rubygems_version_satisfies_content_addressable_floor?
+  def meets_content_addressable_rubygems_floor?
+    floor = Gem::Requirement.new(CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
     requirements = required_rubygems_version.presence&.split(/\s*,\s*/) || [">= 0"]
     requirement = Gem::Requirement.new(requirements)
 
     requirement.requirements.any? do |operator, required_version|
-      case operator
-      when ">=", "~>", "=", ">"
-        Gem::Requirement.new(CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION).satisfied_by?(required_version)
-      else
-        false
-      end
+      [">=", "~>", "=", ">"].include?(operator) && floor.satisfied_by?(required_version)
     end
   rescue Gem::Requirement::BadRequirementError
     false
   end
-
-  private
 
   def update_prerelease
     self[:prerelease] = prerelease

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -36,9 +36,13 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem, name: "sandworm")
         @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+                        required_ruby_version: "~> 3.2.0",
+                        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
+                        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
         @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+                        required_ruby_version: "~> 3.4.0",
+                        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4",
+                        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
         create(:ownership, user: @user, rubygem: @rubygem)
         RubygemFs.instance.store("gems/#{@abi32.full_name}.gem", "")
         RubygemFs.instance.store("gems/#{@abi34.full_name}.gem", "")

--- a/test/functional/api/v2/contents_controller_test.rb
+++ b/test/functional/api/v2/contents_controller_test.rb
@@ -248,11 +248,13 @@ class Api::V2::ContentsControllerTest < ActionController::TestCase
     setup do
       @rubygem = create(:rubygem, name: "skinny-contents")
       @skinny32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                          required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
-                          sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.2"))
+                         required_ruby_version: "~> 3.2.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
+                         sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.2"))
       @skinny34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                          required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
-                          sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.4"))
+                         required_ruby_version: "~> 3.4.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4",
+                         sha256: Digest::SHA2.base64digest("skinny-contents-1.0.0-x86_64-linux-3.4"))
 
       @skinny32.manifest.store_checksums("lib/a.rb" => "aaa11111")
       @skinny34.manifest.store_checksums("lib/a.rb" => "bbb22222")

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -72,9 +72,13 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       setup do
         @rubygem = create(:rubygem, name: "sandworm")
         @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+                        required_ruby_version: "~> 3.2.0",
+                        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
+                        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
         @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+                        required_ruby_version: "~> 3.4.0",
+                        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4",
+                        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
         @multi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
                         required_ruby_version: ">= 3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-multi"),
                         spec_sha256: Digest::SHA2.base64digest("spec-multi"))

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -454,7 +454,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
         number: "1.0.0",
         platform: "arm64-darwin-25",
         required_ruby_version: "~> 3.4.0",
-        required_rubygems_version: ">= 0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
         ruby_abi: "3.4",
         sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4"),
         pusher_api_key: @cutter.api_key
@@ -466,41 +466,6 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       @rubygem.stubs(:update_attributes_from_gem_specification!)
       GemCachePurger.stubs(:call)
       @cutter.stubs(:write_gem)
-    end
-
-    should "set content addressable required rubygems version floor" do
-      assert @cutter.save
-
-      assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @version.reload.required_rubygems_version
-    end
-
-    should "normalize content addressable required rubygems version after applying gemspec metadata" do
-      sequence = sequence("content addressable metadata normalization")
-
-      @rubygem
-        .expects(:update_attributes_from_gem_specification!)
-        .with(@version, @cutter.spec)
-        .in_sequence(sequence)
-
-      @version
-        .expects(:normalize_content_addressable_gem_metadata!)
-        .in_sequence(sequence)
-
-      AfterVersionWriteJob.any_instance.stubs(:perform)
-
-      assert @cutter.save
-    end
-
-    should "roll back version changes when normalize raises" do
-      original = @version.required_rubygems_version
-      @rubygem.expects(:update_attributes_from_gem_specification!).with(@version, @cutter.spec) do |version, _spec|
-        version.update!(required_rubygems_version: "99.0.0")
-      end
-      @version.stubs(:normalize_content_addressable_gem_metadata!)
-        .raises(ActiveRecord::RecordInvalid.new(@version))
-
-      refute @cutter.save
-      assert_equal original, @version.reload.required_rubygems_version
     end
 
     should "include platform and Ruby ABI in success message" do
@@ -544,6 +509,39 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       refute @cutter.save
       assert_equal 409, @cutter.code
       assert_includes @cutter.message, "could not generate a unique content address"
+    end
+
+    should "accept when required_rubygems_version satisfies the floor" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
+      spec = new_gemspec("ca-floor-ok", "1.0.0", "CA floor test", "arm64-darwin-25",
+                        ruby_version: "~> 3.4.0",
+                        rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
+      cutter = Pusher.new(@api_key, build_gem(spec))
+      cutter.logger.level = :info
+
+      assert cutter.pull_spec
+      assert cutter.find
+      assert cutter.validate
+
+      assert_equal "3.4", cutter.version.ruby_abi
+    end
+
+    should "reject with 403 when required_rubygems_version is below the floor" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
+      spec = new_gemspec("ca-floor-bad", "1.0.0", "CA floor test", "arm64-darwin-25",
+                        ruby_version: "~> 3.4.0",
+                        rubygems_version: ">= 0")
+      cutter = Pusher.new(@api_key, build_gem(spec))
+      cutter.logger.level = :info
+
+      assert cutter.pull_spec
+      assert cutter.find
+      refute cutter.validate
+
+      assert_equal 403, cutter.code
+      assert_includes cutter.message,
+                      "must be #{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION} " \
+                      "for content-addressable gems (set required_rubygems_version in the gemspec)"
     end
   end
 

--- a/test/models/concerns/compact_index_versions_test.rb
+++ b/test/models/concerns/compact_index_versions_test.rb
@@ -20,7 +20,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
         sha256: Digest::SHA2.base64digest("skinny-2.9.0-x86_64-linux-musl"),
         created_at: 2.days.ago,
         info_checksum_v2: "skinny-info",
-        ruby_abi: "3.2"
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2"
       )
 
       versions = GemInfo.compact_index_versions(3.days.ago)
@@ -79,7 +79,8 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
     should "return yanked content-addressable versions with a content-addressed token" do
       rubygem = create(:rubygem, name: "skinny-yanked")
       version = create(:version, :yanked, rubygem: rubygem, number: "1.0.0", platform: "x86_64-linux-musl",
-        gem_platform: "x86_64-linux-musl", required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+        gem_platform: "x86_64-linux-musl", required_ruby_version: "~> 3.2.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
         sha256: Digest::SHA2.base64digest("skinny-yanked-1.0.0"), created_at: 10.days.ago,
         yanked_at: 1.day.ago, yanked_info_checksum_v2: "v2yanked")
 
@@ -103,7 +104,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
         sha256: Digest::SHA2.base64digest("skinny-public-2.9.0-x86_64-linux-musl"),
         created_at: @ts,
         info_checksum_v2: "skinny-public-info",
-        ruby_abi: "3.2"
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2"
       )
 
       versions = GemInfo.compact_index_public_versions(@ts)

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -190,7 +190,9 @@ class DeletionTest < ActiveSupport::TestCase
 
   should "record the Ruby ABI for versions targeting a single Ruby ABI" do
     version = create(:version, rubygem: @version.rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("test-2.0.0-3.4"))
+                     required_ruby_version: "~> 3.4.0",
+                     required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4",
+                     sha256: Digest::SHA2.base64digest("test-2.0.0-3.4"))
     deletion = Deletion.new(version: version, user: @user)
     deletion.valid?
 

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -45,7 +45,7 @@ class GemInfoTest < ActiveSupport::TestCase
         required_ruby_version: "~> 3.2.0",
         sha256: Digest::SHA2.base64digest("single-abi-2.9.0-x86_64-linux-musl"),
         info_checksum_v2: "single-abi-info-checksum",
-        ruby_abi: "3.2"
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2"
       )
 
       info = GemInfo.new("single-abi-info").compact_index_info
@@ -94,6 +94,7 @@ class GemInfoTest < ActiveSupport::TestCase
           platform: "x86_64-linux-musl",
           gem_platform: "x86_64-linux-musl",
           required_ruby_version: "~> #{abi}.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           sha256: Digest::SHA2.base64digest("abi-ordering-#{abi}-x86_64-linux-musl"),
           info_checksum_v2: "abi-ordering-checksum",
           ruby_abi: abi,

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -150,6 +150,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.default
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.stubs(:size).returns 5
@@ -195,6 +196,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.default
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -217,6 +219,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.default
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -237,6 +240,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.default
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -260,6 +264,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns Gem::Platform.new("universal-darwin-6000")
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.default
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -282,6 +287,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
 
       @cutter.stubs(:spec).returns spec
@@ -303,7 +309,7 @@ class PusherTest < ActiveSupport::TestCase
       FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        required_ruby_version: "~> 3.3.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -312,6 +318,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.new(Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
       spec.stubs(:metadata).returns({})
 
       @cutter.stubs(:spec).returns spec
@@ -340,6 +347,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
 
       @cutter.stubs(:spec).returns spec
@@ -358,7 +366,7 @@ class PusherTest < ActiveSupport::TestCase
       FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
+        required_ruby_version: "~> 3.4.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -367,6 +375,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:required_rubygems_version).returns Gem::Requirement.new(Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
       spec.stubs(:metadata).returns({})
 
       @cutter.stubs(:spec).returns spec
@@ -381,7 +390,7 @@ class PusherTest < ActiveSupport::TestCase
     end
   end
 
-  context "validating uploaded spec platform attributes" do
+  context "validating uploaded spec content addressable attributes" do
     should "allow content-addressable versions whose uploaded spec keeps platform identity" do
       rubygem = create(:rubygem, name: "sandworm")
       version = create(
@@ -391,6 +400,7 @@ class PusherTest < ActiveSupport::TestCase
         platform: "arm64-darwin-25",
         gem_platform: "arm64-darwin-25",
         required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
         ruby_abi: "3.4",
         sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4")
       )

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -84,7 +84,9 @@ class RubygemTest < ActiveSupport::TestCase
       plain = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
                      required_ruby_version: ">= 3.2")
       abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("abi34-1.0.0"))
+                     required_ruby_version: "~> 3.4.0",
+                     required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4",
+                     sha256: Digest::SHA2.base64digest("abi34-1.0.0"))
 
       assert_equal plain, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl")
       assert_equal abi34, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.4")
@@ -95,11 +97,17 @@ class RubygemTest < ActiveSupport::TestCase
 
     should "mark the latest version for each Ruby ABI per platform" do
       abi32_old = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                         required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-1.0.0"))
+                         required_ruby_version: "~> 3.2.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
+                         sha256: Digest::SHA2.base64digest("abi32-1.0.0"))
       abi32_new = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                         required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-2.0.0"))
+                         required_ruby_version: "~> 3.2.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
+                         sha256: Digest::SHA2.base64digest("abi32-2.0.0"))
       abi33_new = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
-                         required_ruby_version: "~> 3.3.0", ruby_abi: "3.3", sha256: Digest::SHA2.base64digest("abi33-2.0.0"))
+                         required_ruby_version: "~> 3.3.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3",
+                         sha256: Digest::SHA2.base64digest("abi33-2.0.0"))
       plain_ruby = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "ruby")
 
       @rubygem.reorder_versions
@@ -312,7 +320,7 @@ class RubygemTest < ActiveSupport::TestCase
 
       should "not return a skinny ABI variant when no platform or ruby_abi is given" do
         create(:version, rubygem: @rubygem, number: @version.number, platform: "x86_64-linux", gem_platform: "x86_64-linux",
-               required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+               required_ruby_version: "~> 3.2.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
                sha256: Digest::SHA2.base64digest("find-pub-1.0.0-x86_64-linux-3.2"))
 
         assert_equal @jruby_version, @rubygem.find_public_version(@version.number)
@@ -321,7 +329,7 @@ class RubygemTest < ActiveSupport::TestCase
       should "return nil when only skinny ABI variants exist and no ruby_abi is given" do
         @rubygem.versions.update_all(indexed: false)
         create(:version, rubygem: @rubygem, number: @version.number, platform: "x86_64-linux", gem_platform: "x86_64-linux",
-               required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+               required_ruby_version: "~> 3.2.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.2",
                sha256: Digest::SHA2.base64digest("find-pub-only-1.0.0-x86_64-linux-3.2"))
 
         assert_nil @rubygem.find_public_version(@version.number)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -161,7 +161,9 @@ class VersionTest < ActiveSupport::TestCase
 
     should "record the Ruby ABI on the pushed version event" do
       version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                       required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                       required_ruby_version: "~> 3.4.0",
+                       required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                       ruby_abi: "3.4",
                        sha256: Digest::SHA2.base64digest("abi-event-1.0.0"))
 
       pushed = @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
@@ -172,7 +174,9 @@ class VersionTest < ActiveSupport::TestCase
 
     should "not allow a ruby_abi that is not a Ruby minor version" do
       version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                      required_ruby_version: "~> 3.4.0", ruby_abi: "banana",
+                      required_ruby_version: "~> 3.4.0",
+                      required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                      ruby_abi: "banana",
                       sha256: Digest::SHA2.base64digest("abi-format-1.0.0"))
 
       refute_predicate version, :valid?
@@ -189,20 +193,24 @@ class VersionTest < ActiveSupport::TestCase
 
     should "allow duplicate versions with different Ruby ABIs" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow duplicate versions with the same Ruby ABI" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       refute_predicate version, :valid?
 
@@ -240,20 +248,24 @@ class VersionTest < ActiveSupport::TestCase
 
     should "allow canonical number duplicates with different Ruby ABIs" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow canonical number duplicates with the same Ruby ABI" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, ruby_abi: "3.3")
 
       refute_predicate version, :valid?
     end
@@ -627,7 +639,9 @@ class VersionTest < ActiveSupport::TestCase
       should "store the content address for versions targeting a single Ruby ABI" do
         version = create(:version, rubygem: create(:rubygem, name: "addressed"), number: "1.0.0",
                          platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                         required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                         required_ruby_version: "~> 3.4.0",
+                         required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                         ruby_abi: "3.4",
                          sha256: Digest::SHA2.base64digest("addressed-1.0.0"))
 
         assert_equal version.sha256_hex.first(Version::DEFAULT_CONTENT_ADDRESS_LENGTH), version.content_address
@@ -669,7 +683,9 @@ class VersionTest < ActiveSupport::TestCase
       should "reject content addresses that do not match the address format" do
         version = build(:version, rubygem: create(:rubygem, name: "badaddr"), number: "1.0.0",
                         platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                        required_ruby_version: "~> 3.4.0",
+                        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                        ruby_abi: "3.4",
                         sha256: Digest::SHA2.base64digest("badaddr-1.0.0"))
         version.content_address = "not hex!"
 
@@ -682,10 +698,12 @@ class VersionTest < ActiveSupport::TestCase
       setup do
         @rubygem = create(:rubygem, name: "manifest-iso")
         @skinny32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                            required_ruby_version: "~> 3.2.0", ruby_abi: "3.2",
+                            required_ruby_version: "~> 3.2.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                            ruby_abi: "3.2",
                             sha256: Digest::SHA2.base64digest("manifest-iso-1.0.0-x86_64-linux-3.2"))
         @skinny34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
-                            required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                            required_ruby_version: "~> 3.4.0", required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+                            ruby_abi: "3.4",
                             sha256: Digest::SHA2.base64digest("manifest-iso-1.0.0-x86_64-linux-3.4"))
       end
 
@@ -762,6 +780,7 @@ class VersionTest < ActiveSupport::TestCase
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.4.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           ruby_abi: "3.4",
           sha256: Digest::SHA2.base64digest("content addressable gem")
         )
@@ -787,6 +806,7 @@ class VersionTest < ActiveSupport::TestCase
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.3.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           sha256: existing_sha256,
           ruby_abi: "3.3"
         )
@@ -799,6 +819,7 @@ class VersionTest < ActiveSupport::TestCase
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           sha256: colliding_sha256,
           ruby_abi: "3.4"
         )
@@ -820,6 +841,7 @@ class VersionTest < ActiveSupport::TestCase
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.4.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           ruby_abi: "3.4",
           sha256: Digest::SHA2.base64digest("content addressable gem")
         )
@@ -838,6 +860,7 @@ class VersionTest < ActiveSupport::TestCase
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           sha256: nil,
           ruby_abi: "3.4"
         )
@@ -847,117 +870,87 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
-    context "#normalize_content_addressable_gem_metadata!" do
+    context "content-addressable required_rubygems_version floor validation" do
       setup do
         @rubygem = create(:rubygem, name: "sandworm")
-        @content_addressable_version = create(
+        @content_addressable_version = build(
           :version,
           rubygem: @rubygem,
           number: "1.0.0",
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          required_rubygems_version: ">= 0",
+          required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
           ruby_abi: "3.4",
           sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4")
         )
       end
 
-      should "set the content addressable required rubygems version floor" do
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @content_addressable_version.reload.required_rubygems_version
+      should "be valid when required rubygems version meets the floor" do
+        assert_predicate @content_addressable_version, :valid?
       end
 
-      should "set the floor when required rubygems version is blank" do
-        @content_addressable_version.update!(required_rubygems_version: nil)
+      should "be invalid when required rubygems version is below the floor" do
+        @content_addressable_version.required_rubygems_version = ">= 0"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @content_addressable_version.reload.required_rubygems_version
+        refute_predicate @content_addressable_version, :valid?
+        assert_includes @content_addressable_version.errors[:required_rubygems_version],
+                        "must be #{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION} " \
+                        "for content-addressable gems (set required_rubygems_version in the gemspec)"
       end
 
-      should "set the floor and preserve an explicit upper bound when only an upper bound is present" do
-        @content_addressable_version.update!(required_rubygems_version: "< 5")
+      should "be invalid when required rubygems version is blank" do
+        @content_addressable_version.required_rubygems_version = nil
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5", @content_addressable_version.reload.required_rubygems_version
+        refute_predicate @content_addressable_version, :valid?
       end
 
-      should "raise the lower bound to the floor while preserving an existing upper bound" do
-        @content_addressable_version.update!(required_rubygems_version: ">= 3.0, < 5")
+      should "be invalid when only an upper bound is present" do
+        @content_addressable_version.required_rubygems_version = "< 5"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5", @content_addressable_version.reload.required_rubygems_version
+        refute_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve required rubygems version when it is higher than the content addressable floor" do
-        @content_addressable_version.update!(required_rubygems_version: ">= 5.0.0")
+      should "be invalid when lower bound is below the floor even with an upper bound" do
+        @content_addressable_version.required_rubygems_version = ">= 3.0, < 5"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal ">= 5.0.0", @content_addressable_version.reload.required_rubygems_version
+        refute_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve compound required rubygems version when its lower bound satisfies the content addressable floor" do
-        @content_addressable_version.update!(required_rubygems_version: ">= 4.2, < 5")
+      should "be valid when required rubygems version is higher than the floor" do
+        @content_addressable_version.required_rubygems_version = ">= 5.0.0"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal ">= 4.2, < 5", @content_addressable_version.reload.required_rubygems_version
+        assert_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve required rubygems version when requirement only has an = operator and value is greater" do
-        @content_addressable_version.update!(required_rubygems_version: "= 4.2")
+      should "be valid when compound requirement lower bound satisfies the floor" do
+        @content_addressable_version.required_rubygems_version = ">= 4.2, < 5"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "= 4.2", @content_addressable_version.reload.required_rubygems_version
+        assert_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve required rubygems version when requirement only has a ~> operator and value is greater" do
-        @content_addressable_version.update!(required_rubygems_version: "~> 4.2")
+      should "be valid when = operator value satisfies the floor" do
+        @content_addressable_version.required_rubygems_version = "= 4.2"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "~> 4.2", @content_addressable_version.reload.required_rubygems_version
+        assert_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve the implied upper bound from a ~> requirement whose lower bound is below the floor" do
-        @content_addressable_version.update!(required_rubygems_version: "~> 4.0")
+      should "be valid when ~> operator lower bound satisfies the floor" do
+        @content_addressable_version.required_rubygems_version = "~> 4.2"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5",
-                     @content_addressable_version.reload.required_rubygems_version
+        assert_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve the implied upper bound from a three-segment ~> requirement" do
-        @content_addressable_version.update!(required_rubygems_version: "~> 4.0.1")
+      should "be invalid when ~> operator lower bound is below the floor" do
+        @content_addressable_version.required_rubygems_version = "~> 4.0"
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 4.1",
-                     @content_addressable_version.reload.required_rubygems_version
+        refute_predicate @content_addressable_version, :valid?
       end
 
-      should "preserve exclusions alongside the implied upper bound" do
-        @content_addressable_version.update!(required_rubygems_version: "~> 4.0, != 4.1.1")
+      should "not validate required rubygems version floor for non-content-addressable gems" do
+        version = build(:version, rubygem: @rubygem, number: "2.0.0", required_rubygems_version: ">= 3.0", ruby_abi: nil)
 
-        @content_addressable_version.normalize_content_addressable_gem_metadata!
-
-        assert_equal "#{Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION}, < 5, != 4.1.1",
-                     @content_addressable_version.reload.required_rubygems_version
-      end
-
-      should "preserve required rubygems version for versions supporting multiple Ruby ABIs" do
-        version = create(:version, rubygem: @rubygem, number: "2.0.0", required_rubygems_version: ">= 3.0", ruby_abi: nil)
-
-        version.normalize_content_addressable_gem_metadata!
-
-        assert_equal ">= 3.0", version.reload.required_rubygems_version
+        assert_predicate version, :valid?
       end
     end
 
@@ -1093,6 +1086,7 @@ class VersionTest < ActiveSupport::TestCase
         platform: "arm64-darwin-25",
         gem_platform: "arm64-darwin-25",
         required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
         ruby_abi: "3.4",
         sha256: Digest::SHA2.base64digest("content addressable gem")
       )
@@ -1453,6 +1447,7 @@ class VersionTest < ActiveSupport::TestCase
         platform: "x86_64-linux-musl",
         gem_platform: "x86_64-linux-musl",
         required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
         ruby_abi: "3.4",
         sha256: Digest::SHA2.base64digest("second-0.0.2-x86_64-linux-musl"))
     end


### PR DESCRIPTION
We currently set the correct `required_rubygems_version` for content addressable gems during push by normalizing the current value. However in the RubyGems side https://github.com/ruby/rubygems/pull/9773, we decided it would be better to set the `required_rubygems_version` in the gemspec during build. The server shouldn't need to adjust the gemspec value.

So instead of normalizing and injecting `CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION` for `require_rubygems_version`, we should be solely validating the value and raising an error if it doesn't satisfy.

The alternative is to let the gem be registered as a fat gem if `required_rubygems_version` isn't satisfied, but if a gem is platformed and scoped to a Ruby ABI already `~> x.y.0`, there's a high probability that they are creating a content addressable gem, and the gem owner would need to yank and release a new content addressable gem after finding that out.

Also changes `CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION ` to `>= 4.1.0.a` to align with the client requirement.