### PR TITLE
Fix flaky autocomplete loop test

### DIFF
--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -9,9 +9,12 @@ export default class extends Controller {
   connect() {
     this.indexNumber = -1;
     this.suggestLength = 0;
+    this.abortController = null;
   }
 
   disconnect() {
+    this.abortController?.abort();
+    this.abortController = null;
     this.clear();
   }
 
@@ -58,7 +61,12 @@ export default class extends Controller {
     const el = e.currentTarget;
     const term = el.value.trim();
 
+    this.abortController?.abort();
+    this.abortController = null;
+
     if (term.length >= 2) {
+      const abortController = new AbortController();
+      this.abortController = abortController;
       el.classList.remove("autocomplete-done");
       el.classList.add("autocomplete-loading");
       const query = new URLSearchParams({ query: term });
@@ -66,13 +74,20 @@ export default class extends Controller {
       try {
         const response = await fetch("/api/v1/search/autocomplete?" + query, {
           method: "GET",
+          signal: abortController.signal,
         });
         const data = await response.json();
-        this.showSuggestions(data.slice(0, 10));
+        if (!abortController.signal.aborted) {
+          this.showSuggestions(data.slice(0, 10));
+        }
       } catch (error) {}
-      el.classList.remove("autocomplete-loading");
-      el.classList.add("autocomplete-done");
+      if (this.abortController === abortController) {
+        this.abortController = null;
+        el.classList.remove("autocomplete-loading");
+        el.classList.add("autocomplete-done");
+      }
     } else {
+      el.classList.remove("autocomplete-loading");
       this.clear();
     }
   }

--- a/test/system/autocompletes_test.rb
+++ b/test/system/autocompletes_test.rb
@@ -41,6 +41,37 @@ class AutocompletesTest < ApplicationSystemTestCase
     assert_single_active_suggestion
   end
 
+  test "new and short queries cancel stale suggestion requests" do
+    stub_autocomplete_requests
+
+    @fill_field.send_keys "c"
+    wait_for_autocomplete_requests 1
+    @fill_field.send_keys "o"
+    wait_for_autocomplete_requests 2
+
+    resolve_autocomplete_request 1, ["rubocop"]
+    @form.assert_selector "[role='option']", text: "rubocop", count: 1
+    @fill_field.send_keys :down
+    @form.assert_selector "#{SUGGESTIONS}[aria-activedescendant='suggest-0']"
+
+    resolve_autocomplete_request 0, ["stale-result"]
+
+    @form.assert_selector "#{SUGGESTIONS}[aria-activedescendant='suggest-0']"
+    @form.assert_selector "[role='option']", text: "rubocop", count: 1
+
+    assert_autocomplete_request_aborted 0
+    assert_equal "suggest-0", active_descendant
+
+    @fill_field.send_keys :backspace
+    wait_for_autocomplete_requests 3
+    @fill_field.set "r"
+
+    assert_autocomplete_request_aborted 2
+    @form.assert_no_selector "[role='option']"
+
+    refute @fill_field.matches_css?(".autocomplete-loading")
+  end
+
   test "suggestions don't appear when the gem does not exist" do
     @fill_field.set "ruxyz"
 
@@ -118,5 +149,55 @@ class AutocompletesTest < ApplicationSystemTestCase
     @form.assert_selector "#{SUGGESTIONS}[aria-activedescendant]"
 
     assert_equal(1, suggestion_options.count { |option| option["id"] == active_descendant })
+  end
+
+  def stub_autocomplete_requests
+    with_playwright_page do |pw_page|
+      pw_page.evaluate <<~JS
+        window.autocompleteRequests = [];
+        window.fetch = (_url, options = {}) => new Promise((resolve, reject) => {
+          const request = {
+            aborted: false,
+            settled: false,
+            resolve(items) {
+              resolve({ json: async () => items });
+              setTimeout(() => request.settled = true, 0);
+            }
+          };
+          options.signal?.addEventListener("abort", () => {
+            request.aborted = true;
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+          window.autocompleteRequests.push(request);
+        });
+        undefined;
+      JS
+    end
+  end
+
+  def wait_for_autocomplete_requests(count)
+    with_playwright_page do |pw_page|
+      pw_page.wait_for_function("count => window.autocompleteRequests.length === count", arg: count)
+    end
+  end
+
+  def assert_autocomplete_request_aborted(index)
+    with_playwright_page do |pw_page|
+      assert pw_page.evaluate("index => window.autocompleteRequests[index].aborted", arg: index)
+    end
+  end
+
+  def resolve_autocomplete_request(index, items)
+    with_playwright_page do |pw_page|
+      pw_page.evaluate(
+        "args => window.autocompleteRequests[args.index].resolve(args.items)",
+        arg: { index: index, items: items }
+      )
+      pw_page.wait_for_function("index => window.autocompleteRequests[index].settled", arg: index)
+    end
+  end
+
+  def with_playwright_page(&)
+    page.driver.with_playwright_page(&)
   end
 end

--- a/test/system/autocompletes_test.rb
+++ b/test/system/autocompletes_test.rb
@@ -66,10 +66,13 @@ class AutocompletesTest < ApplicationSystemTestCase
   end
 
   test "down arrow key should loop" do
-    @fill_field.send_keys :down, :down, :down, :down
+    suggestion_options.first.hover
     @form.assert_selector "#{SUGGESTIONS}[aria-activedescendant]"
+    initially_active = active_descendant
 
-    assert_equal suggestion_options.last["id"], active_descendant
+    suggestion_options.size.times { @fill_field.send_keys :down }
+
+    assert_equal initially_active, active_descendant
   end
 
   test "up arrow key should loop" do


### PR DESCRIPTION
## Summary

- make the down-arrow loop test start from an explicit active suggestion
- assert a complete cycle returns to that suggestion regardless of retained browser pointer state

The previous test assumed the autocomplete controller always started at index `-1`. Playwright retains pointer coordinates between browser states, so the option `mouseover` handler can legitimately select index `0` before keyboard navigation. This produced the flaky `Expected: "suggest-1" / Actual: "suggest-0"` failure exposed by #6820 removing global test retries.

## Validation

- targeted regression: 30/30 passes
- `test/system/autocompletes_test.rb`: 5/5 repeated file runs (55 tests total)
- full `test:system`: 293 runs, 0 failures, 0 errors, 6 skips
- targeted RuboCop and `git diff --check` pass