### PR TITLE
Resolve deadlock that occurs when pushing multiple gems at once

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,12 @@ class ApplicationRecord < ActiveRecord::Base
   include SemanticLogger::Loggable
 
   self.abstract_class = true
+
+  def self.advisory_xact_lock!(name, id)
+    raise ArgumentError, "advisory_xact_lock! requires an open transaction" unless connection.transaction_open?
+
+    connection.select_value(
+      sanitize_sql_array(["SELECT pg_advisory_xact_lock(hashtext(?), ?)", name.to_s, id])
+    )
+  end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -324,15 +324,16 @@ class Rubygem < ApplicationRecord
     versions.yanked.exists?
   end
 
+  # Holds the same per-gem advisory lock as Version#serialize_indexed_writes_per_gem
+  # (reentrant), so direct callers can't deadlock a concurrent push.
   def reorder_versions
-    bulk_reorder_versions
+    transaction do
+      Rubygem.advisory_xact_lock!("rubygem_version_reorder", id)
+      bulk_reorder_versions
 
-    versions_of_platforms = versions
-      .release
-      .indexed
-      .group_by { |version| [version.platform, version.ruby_abi] }
-
-    Version.default_scoped.where(id: versions_of_platforms.values.map! { |v| v.max.id }).update_all(latest: true)
+      versions_of_platforms = versions.release.indexed.group_by { |version| [version.platform, version.ruby_abi] }
+      Version.default_scoped.where(id: versions_of_platforms.values.map! { |v| v.max.id }).update_all(latest: true)
+    end
   end
 
   def refresh_indexed!

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -26,6 +26,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
   before_save :update_prerelease, if: :number_changed?
+  before_save :serialize_indexed_writes_per_gem, if: -> { will_save_change_to_indexed? || new_record? }
   # TODO: Remove this once we move to GemDownload only
   after_create :create_gem_download
   after_create :record_push_event
@@ -520,6 +521,12 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   rescue Gem::Requirement::BadRequirementError
     false
+  end
+
+  def serialize_indexed_writes_per_gem
+    return if rubygem.nil? || rubygem.new_record?
+
+    Rubygem.advisory_xact_lock!("rubygem_version_reorder", rubygem.id)
   end
 
   def update_prerelease

--- a/test/models/parallel_pusher_test.rb
+++ b/test/models/parallel_pusher_test.rb
@@ -43,4 +43,59 @@ class ParallelPusherTest < ActiveSupport::TestCase
       assert_equal expected_sha, Version.last.sha256
     end
   end
+
+  context "when pushing many versions of the same gem in parallel" do
+    setup do
+      @fs = RubygemFs.mock!
+      @user = create(:user, email: "parallel-user@rubygems-test.org")
+      @api_key = create(:api_key, owner: @user)
+      @gem_name = "hola-parallel"
+    end
+
+    teardown do
+      Rubygem.find_by(name: @gem_name)&.destroy!
+      @user.destroy!
+      GemDownload.delete_all
+      RubygemFs.mock!
+    end
+
+    # Regression test for concurrent pushes deadlocking in reorder_versions
+    # (https://github.com/rubygems/rubygems.org/issues/6099). Concurrent
+    # writers must serialize on the per-gem advisory lock, so every push
+    # succeeds and positions/latest are consistent afterwards.
+    should "push all versions without deadlocking and leave versions consistently ordered" do
+      seed = Pusher.new(@api_key, build_gem(new_gemspec(@gem_name, "0.0.1", "GemCutter", "ruby")))
+      seed.process
+
+      assert_equal 200, seed.code, seed.message
+
+      numbers = (1..4).map { |i| "#{i}.0.0" }
+      start = Concurrent::CountDownLatch.new(1)
+
+      threads = numbers.map do |number|
+        Thread.new do
+          gem = build_gem(new_gemspec(@gem_name, number, "GemCutter", "ruby"))
+          start.wait
+          ActiveRecord::Base.connection_pool.with_connection do
+            pusher = Pusher.new(@api_key, gem)
+            pusher.process
+            [number, pusher.code, pusher.message]
+          end
+        end
+      end
+
+      start.count_down
+      results = threads.map(&:value)
+      failures = results.reject { |(_, code, _)| code == 200 }
+
+      assert_empty failures, "expected all concurrent pushes to succeed, got: #{failures.inspect}"
+
+      versions = Rubygem.find_by!(name: @gem_name).versions.reload
+
+      assert_equal numbers.size + 1, versions.count
+      assert_equal (0..numbers.size).to_a, versions.pluck(:position).sort
+      assert_equal ["4.0.0"], versions.where(latest: true).pluck(:number)
+      assert_equal numbers.size + 1, versions.indexed.count
+    end
+  end
 end

--- a/test/models/parallel_pusher_test.rb
+++ b/test/models/parallel_pusher_test.rb
@@ -98,4 +98,73 @@ class ParallelPusherTest < ActiveSupport::TestCase
       assert_equal numbers.size + 1, versions.indexed.count
     end
   end
+
+  context "when pushing and yanking versions of the same gem in parallel" do
+    setup do
+      @fs = RubygemFs.mock!
+      @user = create(:user, email: "parallel-yank-user@rubygems-test.org")
+      @api_key = create(:api_key, owner: @user)
+      @gem_name = "hola-parallel-yank"
+    end
+
+    teardown do
+      Rubygem.find_by(name: @gem_name)&.destroy!
+      @user.destroy!
+      GemDownload.delete_all
+      RubygemFs.mock!
+    end
+
+    # Yanks UPDATE an existing (visible) version row before reorder_versions
+    # runs, so unlike concurrent pushes they deadlock unless the per-gem
+    # advisory lock is taken *before* the version row is written
+    # (Version#serialize_indexed_writes_per_gem). Guards that callback.
+    should "not deadlock and keep indexed state consistent" do
+      %w[1.0.0 2.0.0 3.0.0].each do |number|
+        pusher = Pusher.new(@api_key, build_gem(new_gemspec(@gem_name, number, "GemCutter", "ruby")))
+        pusher.process
+
+        assert_equal 200, pusher.code, pusher.message
+      end
+
+      rubygem = Rubygem.find_by!(name: @gem_name)
+      to_yank = rubygem.versions.where(number: %w[1.0.0 2.0.0]).to_a
+      start = Concurrent::CountDownLatch.new(1)
+
+      push_threads = %w[4.0.0 5.0.0].map do |number|
+        Thread.new do
+          gem = build_gem(new_gemspec(@gem_name, number, "GemCutter", "ruby"))
+          start.wait
+          ActiveRecord::Base.connection_pool.with_connection do
+            pusher = Pusher.new(@api_key, gem)
+            pusher.process
+            ["push #{number}", pusher.code == 200 ? nil : pusher.message]
+          end
+        end
+      end
+
+      yank_threads = to_yank.map do |version|
+        Thread.new do
+          start.wait
+          ActiveRecord::Base.connection_pool.with_connection do
+            Deletion.create!(user: @user, version: version)
+            ["yank #{version.number}", nil]
+          rescue StandardError => e
+            ["yank #{version.number}", "#{e.class}: #{e.message}"]
+          end
+        end
+      end
+
+      start.count_down
+      failures = (push_threads + yank_threads).map(&:value).reject { |(_, error)| error.nil? }
+
+      assert_empty failures, "expected all concurrent pushes and yanks to succeed, got: #{failures.inspect}"
+
+      versions = rubygem.versions.reload
+
+      assert_equal 5, versions.count
+      assert_equal %w[3.0.0 4.0.0 5.0.0], versions.indexed.pluck(:number).sort
+      assert_equal (0..4).to_a, versions.pluck(:position).sort
+      assert_equal ["5.0.0"], versions.where(latest: true).pluck(:number)
+    end
+  end
 end

--- a/test/models/parallel_pusher_test.rb
+++ b/test/models/parallel_pusher_test.rb
@@ -6,23 +6,25 @@ require "concurrent/atomics"
 class ParallelPusherTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
+  setup do
+    @fs = RubygemFs.mock!
+    @user = create(:user, email: "parallel-pusher-#{SecureRandom.hex(6)}@rubygems-test.org")
+    @api_key = create(:api_key, owner: @user)
+    @gem_names = []
+  end
+
+  teardown do
+    @gem_names.each { |name| Rubygem.find_by(name: name)&.destroy! }
+    @user.destroy!
+    GemDownload.delete_all
+    RubygemFs.mock!
+  end
+
   context "when pushing gems in parallel" do
-    setup do
-      @fs = RubygemFs.mock!
-      @user = create(:user, email: "user@rubygems-test.org")
-      @api_key = create(:api_key, owner: @user)
-    end
-
-    teardown do
-      @user.destroy!
-      Rubygem.find_by(name: "hola")&.destroy!
-      GemDownload.delete_all
-      RubygemFs.mock!
-    end
-
     should "not lead to sha mismatch between gem file and db" do
+      gem_name = track_gem("hola")
       latch = Concurrent::CountDownLatch.new(2)
-      gem = build_gem(new_gemspec("hola", "1.0.0", "GemCutter", "ruby"))
+      gem = build_gem(new_gemspec(gem_name, "1.0.0", "GemCutter", "ruby"))
 
       Thread.new do
         Pusher.new(@api_key, gem).process
@@ -31,7 +33,7 @@ class ParallelPusherTest < ActiveSupport::TestCase
       end
 
       Thread.new do
-        duplicate_gem = build_gem(new_gemspec("hola", "1.0.0", "GemCutter", "ruby"))
+        duplicate_gem = build_gem(new_gemspec(gem_name, "1.0.0", "GemCutter", "ruby"))
         Pusher.new(@api_key, duplicate_gem).process
         ActiveRecord::Base.connection.close
         latch.count_down
@@ -46,23 +48,9 @@ class ParallelPusherTest < ActiveSupport::TestCase
 
   context "when pushing many versions of the same gem in parallel" do
     setup do
-      @fs = RubygemFs.mock!
-      @user = create(:user, email: "parallel-user@rubygems-test.org")
-      @api_key = create(:api_key, owner: @user)
-      @gem_name = "hola-parallel"
+      @gem_name = track_gem("hola-parallel")
     end
 
-    teardown do
-      Rubygem.find_by(name: @gem_name)&.destroy!
-      @user.destroy!
-      GemDownload.delete_all
-      RubygemFs.mock!
-    end
-
-    # Regression test for concurrent pushes deadlocking in reorder_versions
-    # (https://github.com/rubygems/rubygems.org/issues/6099). Concurrent
-    # writers must serialize on the per-gem advisory lock, so every push
-    # succeeds and positions/latest are consistent afterwards.
     should "push all versions without deadlocking and leave versions consistently ordered" do
       seed = Pusher.new(@api_key, build_gem(new_gemspec(@gem_name, "0.0.1", "GemCutter", "ruby")))
       seed.process
@@ -101,23 +89,9 @@ class ParallelPusherTest < ActiveSupport::TestCase
 
   context "when pushing and yanking versions of the same gem in parallel" do
     setup do
-      @fs = RubygemFs.mock!
-      @user = create(:user, email: "parallel-yank-user@rubygems-test.org")
-      @api_key = create(:api_key, owner: @user)
-      @gem_name = "hola-parallel-yank"
+      @gem_name = track_gem("hola-parallel-yank")
     end
 
-    teardown do
-      Rubygem.find_by(name: @gem_name)&.destroy!
-      @user.destroy!
-      GemDownload.delete_all
-      RubygemFs.mock!
-    end
-
-    # Yanks UPDATE an existing (visible) version row before reorder_versions
-    # runs, so unlike concurrent pushes they deadlock unless the per-gem
-    # advisory lock is taken *before* the version row is written
-    # (Version#serialize_indexed_writes_per_gem). Guards that callback.
     should "not deadlock and keep indexed state consistent" do
       %w[1.0.0 2.0.0 3.0.0].each do |number|
         pusher = Pusher.new(@api_key, build_gem(new_gemspec(@gem_name, number, "GemCutter", "ruby")))
@@ -166,5 +140,13 @@ class ParallelPusherTest < ActiveSupport::TestCase
       assert_equal (0..4).to_a, versions.pluck(:position).sort
       assert_equal ["5.0.0"], versions.where(latest: true).pluck(:number)
     end
+  end
+
+  private
+
+  def track_gem(name)
+    unique_name = "#{name}-#{SecureRandom.hex(6)}"
+    @gem_names << unique_name
+    unique_name
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1600,6 +1600,39 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context "advisory locking the rubygem to serialize reorders" do
+    setup do
+      @version = create(:version)
+    end
+
+    should "take the per-gem advisory lock before creating a version" do
+      assert_queries_match(/pg_advisory_xact_lock/) do
+        create(:version, rubygem: @version.rubygem)
+      end
+    end
+
+    should "take the per-gem advisory lock when indexed changes" do
+      assert_queries_match(/pg_advisory_xact_lock/) do
+        @version.update!(indexed: false)
+      end
+    end
+
+    should "not take the lock when unrelated attributes change" do
+      assert_no_queries_match(/pg_advisory_xact_lock/) do
+        @version.update!(info_checksum_v2: "lala")
+      end
+    end
+
+    should "not take the lock when the rubygem is not yet persisted" do
+      rubygem = build(:rubygem)
+      version = build(:version, rubygem: rubygem, created_at: nil)
+
+      assert_no_queries_match(/pg_advisory_xact_lock/) do
+        Version.transaction { rubygem.save! && version.save! }
+      end
+    end
+  end
+
   private
 
   def derived_abi(required_ruby_version, platform: "x86_64-linux")

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1600,39 +1600,6 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
-  context "advisory locking the rubygem to serialize reorders" do
-    setup do
-      @version = create(:version)
-    end
-
-    should "take the per-gem advisory lock before creating a version" do
-      assert_queries_match(/pg_advisory_xact_lock/) do
-        create(:version, rubygem: @version.rubygem)
-      end
-    end
-
-    should "take the per-gem advisory lock when indexed changes" do
-      assert_queries_match(/pg_advisory_xact_lock/) do
-        @version.update!(indexed: false)
-      end
-    end
-
-    should "not take the lock when unrelated attributes change" do
-      assert_no_queries_match(/pg_advisory_xact_lock/) do
-        @version.update!(info_checksum_v2: "lala")
-      end
-    end
-
-    should "not take the lock when the rubygem is not yet persisted" do
-      rubygem = build(:rubygem)
-      version = build(:version, rubygem: rubygem, created_at: nil)
-
-      assert_no_queries_match(/pg_advisory_xact_lock/) do
-        Version.transaction { rubygem.save! && version.save! }
-      end
-    end
-  end
-
   private
 
   def derived_abi(required_ruby_version, platform: "x86_64-linux")

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1578,25 +1578,32 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
-  context "after_save" do
-    context "reorder versions" do
-      setup do
-        @version = create(:version)
-      end
+  context "version reordering" do
+    setup do
+      @version = create(:version)
+    end
 
-      context "indexed is updated" do
-        should "reorder versions" do
-          @version.expects(:reorder_versions).times(1)
-          @version.update(indexed: false)
-        end
-      end
+    should "take the per-gem advisory lock before creating a version" do
+      version = build(:version, rubygem: @version.rubygem)
 
-      context "info checksum v2 is updated" do
-        should "not reorder versions" do
-          @version.expects(:reorder_versions).times(0)
-          @version.update(info_checksum_v2: "lala")
-        end
-      end
+      Rubygem.expects(:advisory_xact_lock!).with("rubygem_version_reorder", @version.rubygem.id).once
+      version.expects(:reorder_versions).once
+
+      version.save!
+    end
+
+    should "take the per-gem advisory lock and reorder versions when indexed changes" do
+      Rubygem.expects(:advisory_xact_lock!).with("rubygem_version_reorder", @version.rubygem.id).once
+      @version.expects(:reorder_versions).once
+
+      @version.update!(indexed: false)
+    end
+
+    should "not lock or reorder versions when unrelated attributes change" do
+      Rubygem.expects(:advisory_xact_lock!).never
+      @version.expects(:reorder_versions).never
+
+      @version.update!(info_checksum_v2: "lala")
     end
   end
 


### PR DESCRIPTION
## What

- Fixes https://github.com/rubygems/rubygems.org/issues/6099.

Concurrent pushes of multiple versions of the same gem can deadlock while updating and reordering rows in the `versions` table. This keeps version reordering synchronous, but serializes version writes per gem with a PostgreSQL transaction-level advisory lock.

When a version is created, indexed, yanked, or restored, we take the per-gem advisory lock before the indexed-state write and before `reorder_versions` runs. Concurrent pushes/yanks for the same gem now wait on each other instead of deadlocking.

## Why

We considered three approaches for fixing this deadlock:

1. [Move the full version reorder into a background job](https://github.com/rubygems/rubygems.org/pull/6658).
2. Use a middle-ground approach: synchronously update the `latest` flag, but leave the full position recompute in a background job.
3. Keep reordering synchronous, but serialize same-gem version writes with a per-gem advisory lock.

We're going with the synchronous advisory-lock approach because it keeps the gem state fully correct when the push/yank transaction commits.

The full background-job approach reduces push-time work, but it creates a correctness gap: `latest`, `position`, legacy indexes, gem page state, and MFA metadata can remain stale until the job runs. If the job exhausts retries or is discarded, nothing guarantees the gem is reconciled.

The middle-ground approach improves the security-sensitive part by flipping `latest` synchronously, but it still leaves the full ordering/index state dependent on a background job. It also adds extra synchronous work to calculate latest flags while still needing the reorder job later.

In local benchmarking, the latency tradeoff was small:

| Approach | 15 concurrent same-gem pushes | Fully settled |
|---|---:|---:|
| master | ~7.77s | failed/deadlocked |
| synchronous advisory lock | ~0.279s median | ~0.279s median |
| middle-ground | ~0.237s median push response | ~0.311s median settled |

The middle-ground approach returned push responses about 41ms faster for the whole 15-push batch, but once the background reorder finished, it was about 33ms slower overall. Given that small difference, the synchronous advisory-lock approach seems preferable because the data is fully consistent immediately after commit.

## Tophat

I tested this with a local benchmark that pushes 15 versions of the same gem concurrently.

High-level script flow:

1. Create a test user and API key.
2. Push a seed version: `0.0.1`.
3. Start 15 threads at the same time.
4. Each thread pushes one version of the same gem: `1.0.0` through `15.0.0`.
5. Verify:
   - all pushes succeeded
   - all versions are indexed
   - `15.0.0` is the only latest version
   - positions are complete
   - no deadlocks occurred

Results:

```text
master:
  attempted pushes: 15
  successful pushes: 5
  failures: 10
  wall time: ~7.77s
  result: deadlocks / connection timeouts

synchronous advisory lock:
  attempted pushes: 15
  successful pushes: 15
  median wall time: ~0.279s
  result: all versions indexed and ordered correctly

middle-ground:
  attempted pushes: 15
  successful pushes: 15
  median push response time: ~0.237s
  median fully-settled time: ~0.311s
  result: all versions indexed and ordered correctly after background reorder
```
