### PR TITLE
Improve content-addressable version display

### DIFF
--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -29,10 +29,10 @@ class RubygemsController < ApplicationController
   end
 
   def show
-    @versions = @rubygem.public_versions.limit(5)
+    @versions = @rubygem.public_versions_with_extra_version
     if @versions.to_a.any?
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
-      add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.slug)
+      add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.display_id)
       render "show"
     else
       add_breadcrumb @rubygem.name

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -10,7 +10,7 @@ class VersionsController < ApplicationController
     @latest_version      = @rubygem.most_recent_version
     @versioned_links     = @rubygem.links(@latest_version) if @latest_version
     @oldest_version_date = @rubygem.versions.oldest_authored_at
-    @versions = @rubygem.versions.by_position.page(@page).per(Gemcutter::VERSIONS_PER_PAGE)
+    @versions = @rubygem.versions.by_display_order.page(@page).per(Gemcutter::VERSIONS_PER_PAGE)
     if @latest_version
       add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
       add_breadcrumb t("breadcrumbs.versions")
@@ -26,9 +26,9 @@ class VersionsController < ApplicationController
     @on_version_page = true
     add_breadcrumb @rubygem.name, rubygem_path(@rubygem.slug)
     if @latest_version == @rubygem.most_recent_version
-      add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.slug)
+      add_breadcrumb t("breadcrumbs.latest_version", version: @latest_version.display_id)
     else
-      add_breadcrumb @latest_version.slug
+      add_breadcrumb @latest_version.display_id
     end
     render "rubygems/show"
     set_surrogate_key "gem/#{@rubygem.name}"

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -178,10 +178,11 @@ class Rubygem < ApplicationRecord
     order(:rubygem_id).by_position.published.select(:rubygem_id, :full_name, :number, :platform)
   }, class_name: "Version", inverse_of: :rubygem
 
-  def public_versions_with_extra_version(extra_version)
-    versions = public_versions.limit(5).to_a
-    versions << extra_version
-    versions.uniq.sort_by(&:position)
+  def public_versions_with_extra_version(extra_version = nil)
+    version_ids = versions.published.by_display_order.limit(5).pluck(:id)
+    version_ids << extra_version.id if extra_version
+
+    versions.where(id: version_ids.uniq).by_display_order.to_a
   end
 
   # NB: this intentionally does not default the platform to ruby.

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -143,6 +143,16 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     order(:position)
   end
 
+  def self.by_display_order
+    reorder(:position)
+      .order(Arel.sql("CASE WHEN platform = 'ruby' THEN 0 ELSE 1 END ASC"))
+      .order(:platform)
+      .order(Arel.sql("CASE WHEN ruby_abi IS NULL THEN 0 ELSE 1 END ASC"))
+      .order(Arel.sql("string_to_array(ruby_abi, '.')::int[] DESC NULLS FIRST"))
+      .order(:content_address)
+      .order(created_at: :desc, id: :desc)
+  end
+
   def self.by_created_at
     order(created_at: :desc)
   end
@@ -266,12 +276,12 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     rubygem.refresh_indexed!
   end
 
-  def previous
-    rubygem.versions.find_by(position: position + 1)
+  def previous_in_display_order
+    adjacent_display_version(1)
   end
 
-  def next
-    rubygem.versions.find_by(position: position - 1)
+  def next_in_display_order
+    adjacent_display_version(-1)
   end
 
   def yanked?
@@ -354,6 +364,12 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def slug
     full_name.delete_prefix("#{rubygem.name}-")
+  end
+
+  def display_id
+    return "#{number}-#{content_address}" if content_addressable?
+
+    number
   end
 
   def downloads_count
@@ -502,6 +518,17 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def adjacent_display_version(offset)
+    versions = rubygem.versions.by_display_order.to_a
+    current_index = versions.index { |version| version.id == id }
+    return unless current_index
+
+    adjacent_index = current_index + offset
+    return if adjacent_index.negative?
+
+    versions[adjacent_index]
+  end
 
   def content_addressable_required_rubygems_version
     return if meets_content_addressable_rubygems_floor?

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,11 +1,11 @@
-<div class="flex flex-wrap justify-between gap-4 border-t border-neutral-200 dark:border-neutral-800 pt-6">
-  <% if latest_version.previous.present? %>
-    <%= link_to t(".previous_version"), rubygem_version_path(rubygem.slug, latest_version.previous.number),
+<div data-testid="version-navigation" class="flex flex-wrap justify-between gap-4 border-t border-neutral-200 dark:border-neutral-800 pt-6">
+  <% if (previous_version = latest_version.previous_in_display_order).present? %>
+    <%= link_to t(".previous_version"), rubygem_version_path(rubygem.slug, previous_version.slug),
           class: "text-b3 text-orange-500 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300" %>
   <% end %>
 
-  <% if latest_version.next.present? %>
-    <%= link_to t(".next_version"), rubygem_version_path(rubygem.slug, latest_version.next.number),
+  <% if (next_version = latest_version.next_in_display_order).present? %>
+    <%= link_to t(".next_version"), rubygem_version_path(rubygem.slug, next_version.slug),
           class: "ml-auto text-b3 text-orange-500 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300" %>
   <% end %>
 </div>

--- a/app/views/rubygems/show.html.erb
+++ b/app/views/rubygems/show.html.erb
@@ -1,6 +1,6 @@
 <% @title = @rubygem.name %>
 <% @title_url = rubygem_path(@rubygem.slug) %>
-<% @subtitle = @latest_version&.slug %>
+<% @subtitle = @latest_version&.display_id %>
 
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, rubygem_versions_path(@rubygem.slug, format: "atom"), {title: "#{@rubygem.name} Version Feed"}) %>
@@ -64,24 +64,8 @@
   <% if @versions.present? %>
     <div class="versions">
       <h3 class="<%= section_heading_class %> mb-2"><%= t ".versions_header" %></h3>
-      <ol data-testid="gem-versions" class="flex flex-col gap-1.5">
-        <% @versions.each do |version| %>
-          <li class="flex flex-wrap items-center gap-x-2">
-            <%= link_to version.number, rubygem_version_path(version.rubygem.slug, version.slug),
-                  class: "font-mono text-c4 px-2 py-0.5 rounded-sm bg-green-200 dark:bg-green-800 text-neutral-900 dark:text-white hover:bg-green-300 dark:hover:bg-green-700" %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version_date_tag(version) %></span>
-            <% if version.platformed? %>
-              <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version.platform %></span>
-            <% end %>
-            <% if version.ruby_abi.present? %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
-            <% end %>
-            <span class="text-b4 text-neutral-700 dark:text-neutral-400">(<%= number_to_human_size(version.size) %>)</span>
-            <% if version.yanked? %>
-              <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t "versions.version.yanked" %></span>
-            <% end %>
-          </li>
-        <% end %>
+      <ol data-testid="gem-versions" class="flex flex-col gap-3">
+        <%= render partial: "versions/grouped_versions", locals: { versions: @versions } %>
       </ol>
       <% if show_all_versions_link?(@rubygem) %>
         <%= link_to t(".show_all_versions", count: @rubygem.versions.count), rubygem_versions_url(@rubygem.slug),

--- a/app/views/versions/_grouped_versions.html.erb
+++ b/app/views/versions/_grouped_versions.html.erb
@@ -1,0 +1,50 @@
+<% row_link_class = "grid w-full items-center gap-x-2 gap-y-1 rounded-sm px-2 py-1 -mx-2 no-underline hover:bg-neutral-100 dark:hover:bg-neutral-800" %>
+<% row_link_style = "grid-template-columns: max-content 10rem 4rem minmax(0, 1fr);" %>
+<% badge_class = "inline-flex w-fit items-center rounded-full px-2 py-0.5 text-c4 font-semibold bg-neutral-200 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300" %>
+<% row_text_class = "text-b4 text-neutral-700 dark:text-neutral-400" %>
+
+<% versions.to_a.group_by(&:number).each_value do |version_group| %>
+  <% representative = version_group.first %>
+  <li class="flex flex-col gap-2">
+    <div>
+      <span class="font-mono text-c4 px-2 py-0.5 rounded-sm bg-green-200 dark:bg-green-800 text-neutral-900 dark:text-white"><%= representative.number %></span>
+    </div>
+
+    <ol class="ml-4 flex flex-col gap-2 border-l border-neutral-300 pl-3 dark:border-neutral-700">
+      <% version_group.group_by(&:platform).each do |platform, platform_versions| %>
+        <li class="flex flex-col gap-1">
+          <h4 class="text-b4 font-semibold text-neutral-900 dark:text-white">
+            <%= platform == "ruby" ? t("versions.version.source_gem") : platform %>
+          </h4>
+
+          <ol class="ml-4 flex flex-col gap-1">
+            <% platform_versions.each do |version| %>
+              <li>
+                <%= link_to rubygem_version_path(version.rubygem.slug, version.slug), class: row_link_class, style: row_link_style do %>
+                  <span class="sr-only"><%= version.display_id %></span>
+                  <% if version.ruby_abi.present? %>
+                    <span class="<%= badge_class %>"><%= t "versions.version.ruby_abi" %> <%= version.ruby_abi %></span>
+                    <span class="<%= row_text_class %>"><%= version_date_tag(version) %></span>
+                    <span class="<%= row_text_class %>">(<%= number_to_human_size(version.size) %>)</span>
+                    <span class="<%= row_text_class %>"><%= t "versions.version.content_address" %>: <%= version.content_address %></span>
+                  <% elsif version.platformed? %>
+                    <span class="<%= badge_class %>"><%= t "versions.version.multi_abi" %></span>
+                    <span class="<%= row_text_class %>"><%= version_date_tag(version) %></span>
+                    <span class="<%= row_text_class %>">(<%= number_to_human_size(version.size) %>)</span>
+                  <% else %>
+                    <span class="<%= badge_class %>"><%= t "versions.version.source_gem" %></span>
+                    <span class="<%= row_text_class %>"><%= version_date_tag(version) %></span>
+                    <span class="<%= row_text_class %>">(<%= number_to_human_size(version.size) %>)</span>
+                  <% end %>
+                  <% if version.yanked? %>
+                    <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t "versions.version.yanked" %></span>
+                  <% end %>
+                <% end %>
+              </li>
+            <% end %>
+          </ol>
+        </li>
+      <% end %>
+    </ol>
+  </li>
+<% end %>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -1,14 +1,20 @@
-<li class="flex flex-wrap items-center gap-x-2">
-  <%= link_to version.number, rubygem_version_path(version.rubygem.slug, version.slug),
+<% badge_class = "inline-flex items-center rounded-full px-2 py-0.5 text-c4 font-semibold bg-neutral-200 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300" %>
+
+<li class="flex flex-wrap items-center gap-x-2 gap-y-1">
+  <%= link_to version.display_id, rubygem_version_path(version.rubygem.slug, version.slug),
         class: "font-mono text-c4 px-2 py-0.5 rounded-sm bg-green-200 dark:bg-green-800 text-neutral-900 dark:text-white hover:bg-green-300 dark:hover:bg-green-700" %>
   <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version_date_tag(version) %></span>
   <% if version.platformed? %>
     <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= version.platform %></span>
   <% end %>
-  <% if version.ruby_abi.present? %>
-    <span class="text-b4 text-neutral-700 dark:text-neutral-400"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
-  <% end %>
   <span class="text-b4 text-neutral-700 dark:text-neutral-400">(<%= number_to_human_size(version.size) %>)</span>
+  <% if version.ruby_abi.present? %>
+    <span class="<%= badge_class %>"><%= t ".ruby_abi" %> <%= version.ruby_abi %></span>
+  <% elsif version.platformed? %>
+    <span class="<%= badge_class %>"><%= t ".multi_abi" %></span>
+  <% else %>
+    <span class="<%= badge_class %>"><%= t ".source_gem" %></span>
+  <% end %>
   <% if version.yanked? %>
     <span class="text-b4 font-semibold text-red-600 dark:text-red-400"><%= t ".yanked" %></span>
   <% end %>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -24,8 +24,8 @@
       <h3 class="<%= section_heading_class %> mb-4" data-testid="versions-count">
         <%= t(".versions_since", count: @versions.total_count, since: nice_date_for(@oldest_version_date)) %>
       </h3>
-      <ol data-testid="gem-versions" class="flex flex-col gap-1.5">
-        <%= render @versions %>
+      <ol data-testid="gem-versions" class="flex flex-col gap-3">
+        <%= render partial: "versions/grouped_versions", locals: { versions: @versions } %>
       </ol>
       <%= paginate @versions, theme: "hammy" %>
     </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1071,6 +1071,9 @@ de:
     version:
       yanked:
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -990,6 +990,9 @@ en:
     version:
       yanked: yanked
       ruby_abi: Ruby ABI
+      content_address: content address
+      multi_abi: multi-abi
+      source_gem: source
   webauthn_credentials:
     callback:
       success: You have successfully registered a security device.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1100,6 +1100,9 @@ es:
     version:
       yanked: borrada
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success: Has dado de alta con éxito un dispositivo de seguridad.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1026,6 +1026,9 @@ fr:
     version:
       yanked: retiré
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1003,6 +1003,9 @@ ja:
     version:
       yanked: ヤンク済み
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success: セキュリティ機器が正常に登録されました。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -983,6 +983,9 @@ nl:
     version:
       yanked: verwijderd
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1006,6 +1006,9 @@ pt-BR:
     version:
       yanked: removida
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -997,6 +997,9 @@ zh-CN:
     version:
       yanked: 已撤回
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success: 您已成功注册一个安全设备。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -985,6 +985,9 @@ zh-TW:
     version:
       yanked: 已被移除
       ruby_abi:
+      content_address:
+      multi_abi:
+      source_gem:
   webauthn_credentials:
     callback:
       success: 您已成功註冊安全裝置。

--- a/test/functional/rubygems_controller_test.rb
+++ b/test/functional/rubygems_controller_test.rb
@@ -247,11 +247,9 @@ class RubygemsControllerTest < ActionController::TestCase
     end
 
     should "render versions in correct order" do
-      assert_select("div.versions > ol > li") do |elements|
-        elements.each_with_index do |elem, index|
-          assert_select elem, "a", @versions[index].number
-        end
-      end
+      page_versions = css_select("[data-testid='gem-versions'] > li > div > span").map(&:text)
+
+      assert_equal @versions.map(&:number), page_versions
     end
   end
 
@@ -420,5 +418,52 @@ class RubygemsControllerTest < ActionController::TestCase
 
       assert page.has_selector?("a[href='#{profile_path(@outside_contributor.display_id)}']")
     end
+  end
+
+  context "On GET to show for a gem with content-addressable versions" do
+    setup do
+      @rubygem = create(:rubygem, name: "content-addressable-ui-test")
+      @newest = create_content_addressable_version(number: "0.2.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @source = create(:version, rubygem: @rubygem, number: "0.1.0")
+      @fat = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "arm64-darwin", gem_platform: "arm64-darwin")
+      @arm64 = create_content_addressable_version(number: "0.1.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @x86 = create_content_addressable_version(number: "0.1.0", platform: "x86_64-linux", ruby_abi: "3.3")
+    end
+
+    should "render grouped versions with content addresses and build type badges" do
+      get :show, params: { id: @rubygem.slug }
+
+      assert_response :success
+      assert_equal %w[0.2.0 0.1.0], version_group_text
+      assert_select "[data-testid='gem-versions'] h4", text: "arm64-darwin"
+      assert_select "[data-testid='gem-versions'] h4", text: "x86_64-linux"
+      [@newest, @arm64, @x86].each do |version|
+        assert_select "[data-testid='gem-versions'] a[href=?]",
+                      rubygem_version_path(@rubygem.slug, version.slug), text: /Ruby ABI #{version.ruby_abi}/
+        assert_select "[data-testid='gem-versions']", text: /content address: #{version.content_address}/
+      end
+      assert_select "[data-testid='gem-versions'] a[href=?]", rubygem_version_path(@rubygem.slug, @source.slug), text: /source/
+      assert_select "[data-testid='gem-versions'] a[href=?]", rubygem_version_path(@rubygem.slug, @fat.slug), text: /multi-abi/
+      assert_select "[data-testid='gem-versions']", text: /Ruby ABI 4.0/
+      assert_select "[data-testid='gem-versions']", text: /single-abi/, count: 0
+    end
+  end
+
+  private
+
+  def create_content_addressable_version(number:, platform:, ruby_abi:)
+    create(:version,
+           rubygem: @rubygem,
+           number: number,
+           platform: platform,
+           gem_platform: platform,
+           ruby_abi: ruby_abi,
+           required_ruby_version: "~> #{ruby_abi}.0",
+           required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+           sha256: Digest::SHA2.base64digest([@rubygem.name, number, platform, ruby_abi].join("-")))
+  end
+
+  def version_group_text
+    css_select("[data-testid='gem-versions'] > li > div > span").map(&:text)
   end
 end

--- a/test/functional/versions_controller_test.rb
+++ b/test/functional/versions_controller_test.rb
@@ -133,7 +133,7 @@ class VersionsControllerTest < ActionController::TestCase
         get :index, params: { rubygem_id: @rubygem.name }
 
         assert_response :success
-        page_versions = css_select("[data-testid='gem-versions'] a").map(&:text)
+        page_versions = css_select("[data-testid='gem-versions'] > li > div > span").map(&:text)
 
         assert_includes page_versions, "1.1.2"
         refute_includes page_versions, "1.1.1"
@@ -143,7 +143,7 @@ class VersionsControllerTest < ActionController::TestCase
         get :index, params: { rubygem_id: @rubygem.name, page: 2 }
 
         assert_response :success
-        page_versions = css_select("[data-testid='gem-versions'] a").map(&:text)
+        page_versions = css_select("[data-testid='gem-versions'] > li > div > span").map(&:text)
 
         refute_includes page_versions, "1.1.2"
         assert_includes page_versions, "1.1.1"
@@ -238,5 +238,58 @@ class VersionsControllerTest < ActionController::TestCase
     should "renders owner gems overview link" do
       assert page.has_selector?("a[href='#{profile_path('johndoe')}']")
     end
+  end
+
+  context "with content-addressable versions" do
+    setup do
+      @rubygem = create(:rubygem, name: "content-addressable-test")
+      @newest = create_content_addressable_version(number: "0.2.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @source = create(:version, rubygem: @rubygem, number: "0.1.0")
+      @fat = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "arm64-darwin", gem_platform: "arm64-darwin")
+      @arm64 = create_content_addressable_version(number: "0.1.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @x86 = create_content_addressable_version(number: "0.1.0", platform: "x86_64-linux", ruby_abi: "3.3")
+    end
+
+    should "use display order" do
+      get :index, params: { rubygem_id: @rubygem.name }
+
+      assert_response :success
+      assert_equal [@newest, @source, @fat, @arm64, @x86].map { |version| rubygem_version_path(@rubygem.slug, version.slug) }, version_link_paths
+    end
+
+    should "link previous and next versions by slug in display order" do
+      get :show, params: { rubygem_id: @rubygem.name, id: @newest.slug }
+
+      assert_response :success
+      assert_select "[data-testid='version-navigation'] a[href=?]",
+                    rubygem_version_path(@rubygem.slug, @source.slug), text: /Previous version/
+      assert_select "[data-testid='version-navigation'] a", text: /Next version/, count: 0
+
+      get :show, params: { rubygem_id: @rubygem.name, id: @fat.slug }
+
+      assert_response :success
+      assert_select "[data-testid='version-navigation'] a[href=?]",
+                    rubygem_version_path(@rubygem.slug, @source.slug), text: /Next version/
+      assert_select "[data-testid='version-navigation'] a[href=?]",
+                    rubygem_version_path(@rubygem.slug, @arm64.slug), text: /Previous version/
+    end
+  end
+
+  private
+
+  def create_content_addressable_version(number:, platform:, ruby_abi:)
+    create(:version,
+           rubygem: @rubygem,
+           number: number,
+           platform: platform,
+           gem_platform: platform,
+           ruby_abi: ruby_abi,
+           required_ruby_version: "~> #{ruby_abi}.0",
+           required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+           sha256: Digest::SHA2.base64digest([@rubygem.name, number, platform, ruby_abi].join("-")))
+  end
+
+  def version_link_paths
+    css_select("[data-testid='gem-versions'] a").pluck("href").uniq
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1255,6 +1255,22 @@ class VersionTest < ActiveSupport::TestCase
     end
   end
 
+  context ".by_display_order" do
+    setup do
+      @rubygem = create(:rubygem, name: "display-order-test")
+      @newest = create_content_addressable_version(@rubygem, number: "0.2.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @source = create(:version, rubygem: @rubygem, number: "0.1.0")
+      @multi_abi = create(:version, rubygem: @rubygem, number: "0.1.0", platform: "arm64-darwin", gem_platform: "arm64-darwin")
+      @arm64_abi_four = create_content_addressable_version(@rubygem, number: "0.1.0", platform: "arm64-darwin", ruby_abi: "4.0")
+      @arm64_abi_three = create_content_addressable_version(@rubygem, number: "0.1.0", platform: "arm64-darwin", ruby_abi: "3.3")
+      @x86_abi_three = create_content_addressable_version(@rubygem, number: "0.1.0", platform: "x86_64-linux", ruby_abi: "3.3")
+    end
+
+    should "return versions in display order" do
+      assert_equal [@newest, @source, @multi_abi, @arm64_abi_four, @arm64_abi_three, @x86_abi_three], @rubygem.versions.by_display_order.to_a
+    end
+  end
+
   context "with a few versions" do
     setup do
       @thin = create(:version, authors: %w[thin], built_at: 1.year.ago)
@@ -1604,6 +1620,18 @@ class VersionTest < ActiveSupport::TestCase
 
   def derived_abi(required_ruby_version, platform: "x86_64-linux")
     Version.ruby_abi_for(platform, required_ruby_version)
+  end
+
+  def create_content_addressable_version(rubygem, number:, platform:, ruby_abi:)
+    create(:version,
+           rubygem: rubygem,
+           number: number,
+           platform: platform,
+           gem_platform: platform,
+           ruby_abi: ruby_abi,
+           required_ruby_version: "~> #{ruby_abi}.0",
+           required_rubygems_version: Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION,
+           sha256: Digest::SHA2.base64digest([rubygem.name, number, platform, ruby_abi].join("-")))
   end
 
   def encoded_sha256_with_hex_prefix(hex_sha256)


### PR DESCRIPTION
## What

- Closes: https://github.com/rubygems/rubygems.org/issues/6826

Improves the web UI for content-addressable gem versions by grouping version lists by version number and platform, showing content addresses with labels, and distinguishing source, multi-abi, and Ruby ABI-specific builds.

The gem page and full versions page now use the same grouped version display, and previous/next version navigation now follows that display order while linking with real version slugs.

## Why

Content-addressable gems can have multiple builds with the same version number. Showing those builds as separate flat rows with only the bare version number made them hard to tell apart, and previous/next links could point to ambiguous bare version URLs like `/versions/0.1.0`.

## Tophat

https://github.com/user-attachments/assets/dd6b8ac3-b3b6-4ddd-af0c-7a22b9dc580a

1. Start the Rails server with `bin/rails s`.

2. Open a Rails console with `bin/rails c`, then run the script below to create deterministic content-addressable test data.

   <details>
   <summary>Rails console script</summary>

   ```ruby
   require "digest/sha2"
   require "securerandom"

   rubygem = Rubygem.find_or_create_by!(name: "content_addressable_test")
   rubygem.versions.destroy_all

   def create_tophat_version(rubygem, number:, platform:, ruby_abi: nil, content_address: nil, date:)
     Version.create!(
       rubygem: rubygem,
       number: number,
       platform: platform,
       gem_platform: Gem::Platform.new(platform).to_s,
       ruby_abi: ruby_abi,
       content_address: content_address,
       authors: ["Tophat"],
       description: "Content-addressable tophat",
       summary: "Content-addressable tophat",
       indexed: true,
       metadata: {},
       built_at: Time.zone.parse(date),
       created_at: Time.zone.parse(date),
       required_ruby_version: ruby_abi ? "~> #{ruby_abi}.0" : ">= 2.0.0",
       required_rubygems_version: ruby_abi ? Version::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION : ">= 2.6.3",
       licenses: ["MIT"],
       requirements: [],
       size: 4096,
       sha256: Digest::SHA2.base64digest("#{rubygem.name}-#{number}-#{platform}-#{ruby_abi || "multi"}-#{SecureRandom.hex}"),
       spec_sha256: Digest::SHA2.base64digest("#{rubygem.name}-#{number}-#{platform}-spec-#{SecureRandom.hex}")
     )
   end

   create_tophat_version(
     rubygem,
     number: "0.2.0",
     platform: "arm64-darwin",
     ruby_abi: "4.0",
     content_address: "a392e9bb",
     date: "2026-09-10"
   )

   create_tophat_version(
     rubygem,
     number: "0.1.0",
     platform: "ruby",
     date: "2026-09-10"
   )

   create_tophat_version(
     rubygem,
     number: "0.1.0",
     platform: "arm64-darwin",
     date: "2026-09-10"
   )

   create_tophat_version(
     rubygem,
     number: "0.1.0",
     platform: "arm64-darwin",
     ruby_abi: "4.0",
     content_address: "14f8165d",
     date: "2026-09-10"
   )

   create_tophat_version(
     rubygem,
     number: "0.1.0",
     platform: "arm64-darwin",
     ruby_abi: "3.3",
     content_address: "ee42b987",
     date: "2026-09-12"
   )

   create_tophat_version(
     rubygem,
     number: "0.1.0",
     platform: "x86_64-linux",
     ruby_abi: "3.3",
     content_address: "6467c2d6",
     date: "2026-09-10"
   )

   rubygem.reload.versions.by_display_order.each do |version|
     puts [
       version.slug,
       "platform=#{version.platform}",
       "ruby_abi=#{version.ruby_abi || "none"}",
       "date=#{version.authored_at.to_date}"
     ].join(" | ")
   end

   puts
   puts "Gem page:"
   puts "http://localhost:3000/gems/#{rubygem.slug}"

   puts
   puts "Versions page:"
   puts "http://localhost:3000/gems/#{rubygem.slug}/versions"

   puts
   puts "Latest version page:"
   puts "http://localhost:3000/gems/#{rubygem.slug}/versions/0.2.0-a392e9bb"
   ```
   </details>

3. Open `http://localhost:3000/gems/content_addressable_test` and confirm the Versions section is grouped by version number, then by platform. The `0.2.0` group should appear before the `0.1.0` group.

4. In the `0.1.0` group, confirm the source build appears first, then the `arm64-darwin` platform group, then the `x86_64-linux` platform group.

5. Under `arm64-darwin`, confirm the `multi-abi` row appears before the Ruby ABI rows. Then confirm the Ruby ABI rows are ordered descending, so `Ruby ABI 4.0` appears before `Ruby ABI 3.3`.

6. Confirm each Ruby ABI row shows its content address with a label, such as `content address: 14f8165d`. Also confirm the `Ruby ABI 3.3` row with content address `ee42b987` shows `September 12, 2026`, while the other rows show `September 10, 2026`.

7. Open `http://localhost:3000/gems/content_addressable_test/versions` and confirm the full versions page uses the same grouped ordering as the gem page.

8. Open `http://localhost:3000/gems/content_addressable_test/versions/0.2.0-a392e9bb` and confirm the URL slug includes the content address. Also confirm the page displays the clean version number in the page context while the Versions section still shows `content address: a392e9bb`.

9. On the latest version page, confirm there is a `Previous version` link and no `Next version` link.

10. Click `Previous version` and confirm it goes to the next item in the visible display order. The link should use the real version slug and should not go to an ambiguous URL like `/versions/0.1.0` when the target is a content-addressable build.

11. Continue clicking `Previous version` and `Next version` on version pages and confirm navigation follows the same order shown in the Versions section.
